### PR TITLE
Introduce FunctorT and TraverseT.

### DIFF
--- a/core/src/main/scala/quasar/RenderTree.scala
+++ b/core/src/main/scala/quasar/RenderTree.scala
@@ -124,9 +124,7 @@ final case class RenderedTree(nodeType: List[String], label: Option[String], chi
 }
 object RenderedTree {
   implicit val RenderedTreeShow: Show[RenderedTree] = new Show[RenderedTree] {
-    override def show(t: RenderedTree) = {
-      t.draw.mkString("\n")
-    }
+    override def show(t: RenderedTree) = t.draw.mkString("\n")
   }
 
   implicit val RenderedTreeEncodeJson: EncodeJson[RenderedTree] = EncodeJson {

--- a/core/src/main/scala/quasar/compiler.scala
+++ b/core/src/main/scala/quasar/compiler.scala
@@ -540,7 +540,7 @@ object Compiler {
     val keys: List[Fix[LogicalPlan]] = boundCata(tree)(keysƒ)._2
 
     // Step 1: annotate nodes containing the keys.
-    val ann: Cofree[LogicalPlan, Boolean] = boundAttribute(tree)(keys contains _)
+    val ann: Cofree[LogicalPlan, Boolean] = boundAttribute(tree)(keys.contains)
 
     // Step 2: transform from the top, inserting Arbitrary where a key is not
     // otherwise reduced.

--- a/core/src/main/scala/quasar/compiler.scala
+++ b/core/src/main/scala/quasar/compiler.scala
@@ -527,7 +527,7 @@ object Compiler {
       def groupedKeys(t: LogicalPlan[Fix[LogicalPlan]], newSrc: Fix[LogicalPlan]): Option[List[Fix[LogicalPlan]]] = {
         t match {
           case InvokeF(set.GroupBy, List(src, structural.MakeArrayN(keys))) =>
-            Some(keys.map(_.transform(t => if (t ≟ src) newSrc else t)))
+            Some(keys.map(_.transCataT(t => if (t ≟ src) newSrc else t)))
           case InvokeF(Sifting(_, _, _, _, _, _, _), src :: _) =>
             groupedKeys(src.unFix, newSrc)
           case _ => None

--- a/core/src/main/scala/quasar/physical/mongodb/optimize/optimize.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/optimize/optimize.scala
@@ -128,7 +128,7 @@ package object optimize {
     }
 
     def reorderOps(wf: Workflow): Workflow = {
-      val reordered = wf.transCata(simply(reorderOpsƒ))
+      val reordered = wf.transCata(once(reorderOpsƒ))
       if (reordered == wf) wf else reorderOps(reordered)
     }
 

--- a/core/src/main/scala/quasar/physical/mongodb/planner.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/planner.scala
@@ -45,7 +45,7 @@ object MongoDbPlanner extends Planner[Crystallized] with Conversions {
   import Planner._
   import WorkflowBuilder._
 
-  import quasar.recursionschemes._, Recursive.ops._
+  import quasar.recursionschemes._, Recursive.ops._, TraverseT.ops._
 
   import agg._
   import array._
@@ -594,8 +594,8 @@ object MongoDbPlanner extends Planner[Crystallized] with Conversions {
       }
     }
 
-    val HasKeys: Ann => OutputM[List[WorkflowBuilder]] = _ match {
-      case MakeArrayN.Attr(array) => array.map(_.head._2).sequence
+    val HasKeys: Ann => OutputM[List[WorkflowBuilder]] = {
+      case MakeArrayN.Attr(array) => array.traverse(_.head._2)
       case n                      => n.head._2.map(List(_))
     }
 
@@ -1016,7 +1016,7 @@ object MongoDbPlanner extends Planner[Crystallized] with Conversions {
 
   import Planner._
 
-  val annotateƒ = zipPara(
+  val annotateƒ = zipPara[Fix, LogicalPlan](
     selectorƒ[OutputM[WorkflowBuilder]],
     liftPara(jsExprƒ[OutputM[WorkflowBuilder]]))
 
@@ -1096,11 +1096,11 @@ object MongoDbPlanner extends Planner[Crystallized] with Conversions {
     def liftError[A](ea: PlannerError \/ A): M[A] =
       swizzle(stateT[PlannerError \/ ?, NameGen, A](ea))
 
-    val wfƒ = workflowƒ andThen (_.map(_.map(normalize <<< (_.unFix))))
+    val wfƒ = workflowƒ ⋙ (_ ∘ (_ ∘ (_ ∘ normalize)))
 
     (for {
       cleaned <- log("Logical Plan (reduced typechecks)")(liftError(logical.cataM[PlannerError \/ ?, Fix[LogicalPlan]](Optimizer.assumeReadObjƒ)))
-      align <- log("Logical Plan (aligned joins)")       (liftError(Corecursive[Fix].apo[LogicalPlan, Fix[LogicalPlan]](cleaned)(elideJoinCheckƒ).cataM(alignJoinsƒ <<< Recursive[Fix].project <<< repeatedly(Optimizer.simplifyƒ))))
+      align <- log("Logical Plan (aligned joins)")       (liftError(Corecursive[Fix].apo(cleaned)(elideJoinCheckƒ).cataM(alignJoinsƒ ⋘ repeatedly(Optimizer.simplifyƒ))))
       prep <- log("Logical Plan (projections preferred)")(Optimizer.preferProjections(align).point[M])
       wb   <- log("Workflow Builder")                    (swizzle(swapM(lpParaZygoHistoS(prep)(annotateƒ, wfƒ))))
       wf1  <- log("Workflow (raw)")                      (swizzle(build(wb)))

--- a/core/src/main/scala/quasar/planner.scala
+++ b/core/src/main/scala/quasar/planner.scala
@@ -19,7 +19,7 @@ package quasar
 import quasar.Predef._
 import quasar.fp._
 import quasar.fs.Path._
-import quasar.recursionschemes._, Recursive.ops._
+import quasar.recursionschemes._, FunctorT.ops._
 
 import scalaz.{Tree => _, _}, Scalaz._
 
@@ -48,7 +48,7 @@ trait Planner[PhysicalPlan] {
       tree       <- withTree("Variables Substituted")(Variables.substVars[Unit](tree(select), req.variables).leftMap(CSemanticError(_)))
       tree       <- withTree("Annotated Tree")(AllPhases(tree).disjunction.leftMap(ManyErrors(_)))
       logical    <- withTree("Logical Plan")(Compiler.compile(tree).leftMap(CSemanticError(_)))
-      simplified <- withTree("Simplified")(\/-(logical.cata(repeatedly(Optimizer.simplifyƒ))))
+      simplified <- withTree("Simplified")(\/-(logical.transCata(repeatedly(Optimizer.simplifyƒ))))
       checked    <- withTree("Typechecked")(LogicalPlan.ensureCorrectTypes(simplified).disjunction.leftMap(ManyErrors(_)))
       physical   <- plan(checked).leftMap(CPlannerError(_))
       _          <- withTree("Physical Plan")(\/-(physical))

--- a/core/src/main/scala/quasar/recursionschemes/FunctorT.scala
+++ b/core/src/main/scala/quasar/recursionschemes/FunctorT.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014 - 2015 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.recursionschemes
+
+import quasar.Predef._
+import quasar.fp._
+
+import scalaz._, Scalaz._
+import simulacrum.{typeclass, op}
+
+@typeclass trait FunctorT[T[_[_]]] {
+  // NB: this could perhaps also be called `transCata`
+  @op("∘") def map[F[_], G[_]](t: T[F])(f: F[T[F]] => G[T[G]]): T[G]
+
+  def transform[F[_]: Functor](t: T[F])(f: T[F] => T[F]): T[F] =
+    f(map(t)(_.map(transform(_)(f))))
+
+  def topDownTransform[F[_]: Functor](t: T[F])(f: T[F] => T[F]): T[F] =
+    map(f(t))(_.map(topDownTransform(_)(f)))
+
+  def topDownCata[F[_]: Functor, A](t: T[F], a: A)(f: (A, T[F]) => (A, T[F])):
+      T[F] = {
+    val (a0, tf) = f(a, t)
+    map(tf)(_.map(topDownCata(_, a0)(f)))
+  }
+
+  def transCata[F[_]: Functor, G[_]](t: T[F])(f: F[T[G]] => G[T[G]]): T[G] =
+    map(t)(ft => f(ft.map(transCata(_)(f))))
+
+  def transAna[F[_], G[_]: Functor](t: T[F])(f: F[T[F]] => G[T[F]]): T[G] =
+    map(t)(ft => f(ft).map(transAna(_)(f)))
+
+  def transPara[F[_]: Functor, G[_]](t: T[F])(f: F[(T[F], T[G])] => G[T[G]]):
+      T[G] =
+    map(t)(ft => f(ft.map(tf => (tf, transPara(tf)(f)))))
+
+  def transApo[F[_], G[_]: Functor](t: T[F])(f: F[T[F]] => G[T[G] \/ T[F]]):
+      T[G] =
+    map(t)(ft => f(ft).map(_.fold(ι, transApo(_)(f))))
+
+  def trans[F[_], G[_]: Functor](t: T[F])(f: F ~> G): T[G] =
+    map(t)(f(_).map(trans(_)(f)))
+}

--- a/core/src/main/scala/quasar/recursionschemes/TraverseT.scala
+++ b/core/src/main/scala/quasar/recursionschemes/TraverseT.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014 - 2015 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.recursionschemes
+
+import quasar.Predef._
+
+import scalaz._, Scalaz._
+import simulacrum.typeclass
+
+@typeclass trait TraverseT[T[_[_]]] extends FunctorT[T] {
+  def traverse[M[_]: Applicative, F[_], G[_]](t: T[F])(f: F[T[F]] => M[G[T[G]]]): M[T[G]]
+
+  def map[F[_], G[_]](t: T[F])(f: F[T[F]] => G[T[G]]) = traverse[Id, F, G](t)(f)
+
+  def transformM[F[_]: Traverse, M[_]: Monad](t: T[F])(f: T[F] => M[T[F]]): M[T[F]] =
+    traverse(t)(_.traverse(transformM(_)(f))).flatMap(f)
+
+  def topDownTransformM[F[_]: Traverse, M[_]: Monad](t: T[F])(f: T[F] => M[T[F]]): M[T[F]] =
+    f(t).flatMap(traverse(_)(_.traverse(transformM(_)(f))))
+
+  def topDownCataM[F[_]: Traverse, M[_]: Monad, A](
+    t: T[F], a: A)(
+    f: (A, T[F]) => M[(A, T[F])]):
+      M[T[F]] =
+    f(a, t).flatMap { case (a, tf) =>
+      traverse(tf)(_.traverse(topDownCataM(_, a)(f)))
+    }
+
+  def transCataM[M[_]: Monad, F[_]: Traverse, G[_]](t: T[F])(f: F[T[G]] => M[G[T[G]]]): M[T[G]] =
+    traverse(t)(_.traverse(transCataM(_)(f)).flatMap(f))
+}

--- a/core/src/main/scala/quasar/recursionschemes/package.scala
+++ b/core/src/main/scala/quasar/recursionschemes/package.scala
@@ -273,16 +273,13 @@ package object recursionschemes {
   /** Repeatedly applies the function to the result as long as it returns Some.
     * Finally returns the last non-None value (which may be the initial input).
     */
-  def repeatedly[T[_[_]], F[_]](f: F[T[F]] => Option[F[T[F]]]):
-      F[T[F]] => F[T[F]] =
+  def repeatedly[A](f: A => Option[A]): A => A =
     expr => f(expr).fold(expr)(repeatedly(f))
 
   /** Converts a failable fold into a non-failable, by simply returning the
     * argument upon failure.
     */
-  def simply[T[_[_]], F[_]](f: F[T[F]] => Option[F[T[F]]]):
-      F[T[F]] => F[T[F]] =
-    expr => f(expr).getOrElse(expr)
+  def once[A](f: A => Option[A]): A => A = expr => f(expr).getOrElse(expr)
 
   def count[T[_[_]]: Recursive, F[_]: Functor: Foldable](form: T[F]): F[(T[F], Int)] => Int =
     e => e.foldRight(if (e.map(_._1) == form.project) 1 else 0)(_._2 + _)

--- a/core/src/main/scala/quasar/std/library.scala
+++ b/core/src/main/scala/quasar/std/library.scala
@@ -26,12 +26,10 @@ import quasar.recursionschemes._
 import Validation.{success, failure}
 
 trait Library {
-  protected val noSimplification: Func.Simplifier = κ(None)
-
-  protected def partialSimplifier(
-    f: PartialFunction[List[Fix[LogicalPlan]], Fix[LogicalPlan]]):
-      Func.Simplifier =
-    f.lift
+  protected val noSimplification: Func.Simplifier = new Func.Simplifier {
+    def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
+      None
+  }
 
   protected def constTyper(codomain: Type): Func.Typer = { args =>
     Validation.success(codomain)

--- a/core/src/main/scala/quasar/std/library.scala
+++ b/core/src/main/scala/quasar/std/library.scala
@@ -17,18 +17,24 @@
 package quasar.std
 
 import quasar.Predef._
-
-import scalaz._
 import quasar.fp._
 import quasar.{Func, LogicalPlan, Type, SemanticError}
-import quasar.recursionschemes._
+import quasar.recursionschemes._, Recursive.ops._
 
-import Validation.{success, failure}
+import scalaz._, Scalaz._, Validation.{success, failure}
 
 trait Library {
   protected val noSimplification: Func.Simplifier = new Func.Simplifier {
     def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
       None
+  }
+
+  object IsInvoke {
+    def unapply[T[_[_]]: Recursive](lp: LogicalPlan[T[LogicalPlan]]):
+        Option[(Func, List[LogicalPlan[T[LogicalPlan]]])] = lp match {
+      case LogicalPlan.InvokeF(func, args) => (func, args.map(_.project)).some
+      case _                               => None
+    }
   }
 
   protected def constTyper(codomain: Type): Func.Typer = { args =>

--- a/core/src/main/scala/quasar/std/relations.scala
+++ b/core/src/main/scala/quasar/std/relations.scala
@@ -17,7 +17,7 @@
 package quasar.std
 
 import quasar.Predef._
-import quasar.recursionschemes._, Recursive.ops._
+import quasar.recursionschemes._
 import quasar.{Data, Func, LogicalPlan, Type, Mapping, SemanticError}, LogicalPlan._
 
 import scalaz._, Scalaz._, NonEmptyList.nel, Validation.{success, failure}
@@ -121,14 +121,9 @@ trait RelationsLib extends Library {
     new Func.Simplifier {
       def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
-          case InvokeF(_, List(l, r)) => l.project match {
-            case ConstantF(Data.True) => r.project.some
-            case _                    => r.project match {
-              case ConstantF(Data.True) => l.project.some
-              case _                    => None
-            }
-          }
-          case _ => None
+          case IsInvoke(_, List(ConstantF(Data.True), r)) => r.some
+          case IsInvoke(_, List(l, ConstantF(Data.True))) => l.some
+          case _                                          => None
         }
     },
     partialTyper {
@@ -146,14 +141,9 @@ trait RelationsLib extends Library {
     new Func.Simplifier {
       def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
-          case InvokeF(_, List(l, r)) => l.project match {
-            case ConstantF(Data.False) => r.project.some
-            case _                    => r.project match {
-              case ConstantF(Data.False) => l.project.some
-              case _                     => None
-            }
-          }
-          case _ => None
+          case IsInvoke(_, List(ConstantF(Data.False), r)) => r.some
+          case IsInvoke(_, List(l, ConstantF(Data.False))) => l.some
+          case _                                           => None
         }
     },
     partialTyper {
@@ -180,12 +170,9 @@ trait RelationsLib extends Library {
     new Func.Simplifier {
       def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
-          case InvokeF(_, List(t, c, a)) => t.project match {
-            case ConstantF(Data.True)  => c.project.some
-            case ConstantF(Data.False) => a.project.some
-            case _                     => None
-          }
-          case _ => None
+          case IsInvoke(_, List(ConstantF(Data.True),  c, _)) => c.some
+          case IsInvoke(_, List(ConstantF(Data.False), _, a)) => a.some
+          case _                                              => None
         }
     },
     partialTyper {
@@ -202,14 +189,9 @@ trait RelationsLib extends Library {
     new Func.Simplifier {
       def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
-          case InvokeF(_, List(first, second)) => first.project match {
-            case ConstantF(Data.Null) => second.project.some
-            case _                    => second.project match {
-              case ConstantF(Data.Null) => first.project.some
-              case _                    => None
-            }
-          }
-          case _ => None
+          case IsInvoke(_, List(ConstantF(Data.Null), second)) => second.some
+          case IsInvoke(_, List(first, ConstantF(Data.Null)))  => first.some
+          case _                                               => None
         }
     },
     partialTyper {

--- a/core/src/main/scala/quasar/std/set.scala
+++ b/core/src/main/scala/quasar/std/set.scala
@@ -18,11 +18,10 @@ package quasar.std
 
 import quasar.Predef._
 import quasar.fp._
-import quasar.recursionschemes._
+import quasar.recursionschemes._, Recursive.ops._
 import quasar._, LogicalPlan._
 
-import scalaz._, NonEmptyList.nel, Validation.{success, failure}
-import scalaz.syntax.applicative._
+import scalaz._, Scalaz._, NonEmptyList.nel, Validation.{success, failure}
 
 trait SetLib extends Library {
   // NB: MRA should make this go away, as we insert dimensiality adjustements
@@ -53,8 +52,14 @@ trait SetLib extends Library {
 
   val Drop = Sifting("(OFFSET)", "Drops the first N elements from a set",
     Type.Top, Type.Top :: Type.Int :: Nil,
-    partialSimplifier {
-      case List(set, Fix(ConstantF(Data.Int(n)))) if n == 0 => set
+    new Func.Simplifier {
+      def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) = orig match {
+        case InvokeF(_, List(set, count)) => count.project match {
+          case ConstantF(Data.Int(n)) if n == 0 => set.project.some
+          case _ => None
+        }
+        case _ => None
+      }
     },
     setTyper(partialTyper {
       case Type.Set(t) :: _ :: Nil => t
@@ -70,8 +75,15 @@ trait SetLib extends Library {
 
   val Filter = Sifting("WHERE", "Filters a set to include only elements where a projection is true",
     Type.Top, Type.Top :: Type.Bool :: Nil,
-    partialSimplifier {
-      case List(set, Fix(ConstantF(Data.True))) => set
+    new Func.Simplifier {
+      def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
+        orig match {
+          case InvokeF(_, List(set, cond)) => cond.project match {
+            case ConstantF(Data.True) => set.project.some
+            case _ => None
+          }
+          case _ => None
+        }
     },
     setTyper(partialTyper {
       case _   :: Type.Const(Data.False) :: Nil => Type.Const(Data.Set(Nil))

--- a/core/src/main/scala/quasar/std/set.scala
+++ b/core/src/main/scala/quasar/std/set.scala
@@ -18,7 +18,7 @@ package quasar.std
 
 import quasar.Predef._
 import quasar.fp._
-import quasar.recursionschemes._, Recursive.ops._
+import quasar.recursionschemes._
 import quasar._, LogicalPlan._
 
 import scalaz._, Scalaz._, NonEmptyList.nel, Validation.{success, failure}
@@ -54,10 +54,8 @@ trait SetLib extends Library {
     Type.Top, Type.Top :: Type.Int :: Nil,
     new Func.Simplifier {
       def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) = orig match {
-        case InvokeF(_, List(set, count)) => count.project match {
-          case ConstantF(Data.Int(n)) if n == 0 => set.project.some
-          case _ => None
-        }
+        case IsInvoke(_, List(set, ConstantF(Data.Int(n)))) if n == 0 =>
+          set.some
         case _ => None
       }
     },
@@ -78,11 +76,8 @@ trait SetLib extends Library {
     new Func.Simplifier {
       def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
-          case InvokeF(_, List(set, cond)) => cond.project match {
-            case ConstantF(Data.True) => set.project.some
-            case _ => None
-          }
-          case _ => None
+          case IsInvoke(_, List(set, ConstantF(Data.True))) => set.some
+          case _                                            => None
         }
     },
     setTyper(partialTyper {

--- a/core/src/main/scala/quasar/std/string.scala
+++ b/core/src/main/scala/quasar/std/string.scala
@@ -18,8 +18,8 @@ package quasar.std
 
 import quasar.Predef._
 import quasar.{Data, Func, LogicalPlan, Type, Mapping, SemanticError}, LogicalPlan._, SemanticError._
-
-import quasar.recursionschemes._
+import quasar.fp._
+import quasar.recursionschemes._, Recursive.ops._, FunctorT.ops._
 
 import scalaz._, Scalaz._, NonEmptyList.nel, Validation.{success, failure}
 
@@ -36,9 +36,18 @@ trait StringLib extends Library {
   // TODO: variable arity
   val Concat = Mapping("concat", "Concatenates two (or more) string values",
     Type.Str, Type.Str :: Type.Str :: Nil,
-    partialSimplifier {
-      case List(Fix(ConstantF(Data.Str(""))), other) => other
-      case List(other, Fix(ConstantF(Data.Str("")))) => other
+    new Func.Simplifier {
+      def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
+        orig match {
+          case InvokeF(f, List(first, second)) => first.project match {
+            case ConstantF(Data.Str("")) => second.project.some
+            case _ => second.project match {
+              case ConstantF(Data.Str("")) => first.project.some
+              case _ => None
+            }
+          }
+          case _ => None
+        }
     },
     stringApply(_ + _),
     basicUntyper)
@@ -111,12 +120,19 @@ trait StringLib extends Library {
     "substring",
     "Extracts a portion of the string",
     Type.Str, Type.Str :: Type.Int :: Type.Int :: Nil,
-    partialSimplifier {
-      case List(Fix(ConstantF(Data.Str(str))), Fix(ConstantF(Data.Int(from))), for0) if 0 < from =>
-        Substring(
-          Constant(Data.Str(str.substring(from.intValue))),
-          Constant(Data.Int(0)),
-          for0)
+    new Func.Simplifier {
+      def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
+        orig match {
+          case InvokeF(f, List(str0, from0, for0)) => (str0.project, from0.project) match {
+            case (ConstantF(Data.Str(str)), ConstantF(Data.Int(from))) if 0 < from =>
+              InvokeF(f, List(
+                str0 ∘ κ(ConstantF[T[LogicalPlan]](Data.Str(str.substring(from.intValue)))),
+                from0 ∘ κ(ConstantF[T[LogicalPlan]](Data.Int(0))),
+                for0)).some
+            case _ => None
+          }
+          case _ => None
+        }
     },
     partialTyperV {
       case List(

--- a/core/src/main/scala/quasar/std/string.scala
+++ b/core/src/main/scala/quasar/std/string.scala
@@ -39,14 +39,9 @@ trait StringLib extends Library {
     new Func.Simplifier {
       def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
-          case InvokeF(f, List(first, second)) => first.project match {
-            case ConstantF(Data.Str("")) => second.project.some
-            case _ => second.project match {
-              case ConstantF(Data.Str("")) => first.project.some
-              case _ => None
-            }
-          }
-          case _ => None
+          case IsInvoke(_, List(ConstantF(Data.Str("")), second)) => second.some
+          case IsInvoke(_, List(first, ConstantF(Data.Str(""))))  => first.some
+          case _                                                  => None
         }
     },
     stringApply(_ + _),

--- a/core/src/test/scala/quasar/helpers.scala
+++ b/core/src/test/scala/quasar/helpers.scala
@@ -2,7 +2,7 @@ package quasar
 
 import quasar.Predef._
 
-import quasar.recursionschemes._
+import quasar.recursionschemes._, FunctorT.ops._
 import quasar.sql.{SQLParser, Query}
 import quasar.std._
 import quasar.fs._
@@ -27,7 +27,9 @@ trait CompilerHelpers extends Specification with TermLogicalPlanMatchers {
   }
 
   def compileExp(query: String): Fix[LogicalPlan] =
-    compile(query).fold(e => throw new RuntimeException("could not compile query for expected value: " + query + "; " + e), v => v)
+    compile(query).fold(
+      e => throw new RuntimeException("could not compile query for expected value: " + query + "; " + e),
+      _.transCata(repeatedly(Optimizer.simplifyƒ)))
 
   def testLogicalPlanCompile(query: String, expected: Fix[LogicalPlan]) = {
     compile(query).toEither must beRight(equalToPlan(expected))

--- a/core/src/test/scala/quasar/matchers.scala
+++ b/core/src/test/scala/quasar/matchers.scala
@@ -24,7 +24,7 @@ trait TermLogicalPlanMatchers {
   case class equalToPlan(expected: Fix[LogicalPlan])
       extends Matcher[Fix[LogicalPlan]] {
     def apply[S <: Fix[LogicalPlan]](s: Expectable[S]) = {
-      val normed = FunctorT[Cofree[?[_], Fix[LogicalPlan]]].transCata(attrSelf(s.value))(repeatedly[Cofree[?[_], Fix[LogicalPlan]], LogicalPlan](Optimizer.simplifyƒ[Cofree[?[_], Fix[LogicalPlan]]]))
+      val normed = FunctorT[Cofree[?[_], Fix[LogicalPlan]]].transCata(attrSelf(s.value))(repeatedly(Optimizer.simplifyƒ[Cofree[?[_], Fix[LogicalPlan]]]))
       val diff = (Recursive[Cofree[?[_], Fix[LogicalPlan]]].forget(normed).render diff expected.render).shows
       result(
         expected ≟ Recursive[Cofree[?[_], Fix[LogicalPlan]]].forget(normed),

--- a/core/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/core/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -3,7 +3,7 @@ package quasar.physical.mongodb
 import quasar.Predef._
 import quasar.RenderTree, RenderTree.ops._
 import quasar.fp._
-import quasar.recursionschemes._, Recursive.ops._
+import quasar.recursionschemes._, Recursive.ops._, FunctorT.ops._
 import quasar._
 import quasar.fs.Path
 import quasar.javascript._
@@ -58,7 +58,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
 
   def plan(logical: Fix[LogicalPlan]): Either[PlannerError, Crystallized] =
     (for {
-      simplified <- emit(Vector.empty, \/-(logical.cata(repeatedly(Optimizer.simplifyƒ))))
+      simplified <- emit(Vector.empty, \/-(logical.transCata(repeatedly(Optimizer.simplifyƒ))))
       phys       <- MongoDbPlanner.plan(simplified)
     } yield phys).run._2.toEither
 

--- a/core/src/test/scala/quasar/physical/mongodb/workflowbuilder.scala
+++ b/core/src/test/scala/quasar/physical/mongodb/workflowbuilder.scala
@@ -3,7 +3,7 @@ package quasar.physical.mongodb
 import quasar.Predef._
 import quasar.RenderTree
 import quasar.fp._
-import quasar.recursionschemes._, Recursive.ops._
+import quasar.recursionschemes._, FunctorT.ops._
 import quasar._; import Planner._
 import quasar.javascript._
 import quasar.specs2._
@@ -97,7 +97,7 @@ class WorkflowBuilderSpec
         city   <- lift(projectField(read, "city"))
         array  <- arrayConcat(makeArray(city), pureArr)
         state2 <- lift(projectIndex(array, 2))
-      } yield state2.cata(normalize)).evalZero
+      } yield state2.transCata(normalize)).evalZero
 
       op must beRightDisjunction(ExprBuilder(read, $literal(Bson.Int32(1)).right))
     }
@@ -454,7 +454,7 @@ class WorkflowBuilderSpec
               BsonField.Name("__tmp") -> -\/(jscore.JsFn(jscore.Name("x"), jscore.Literal(Js.Bool(true)))))),
           ListMap(
             BsonField.Name("0") -> \/-($var(DocField(BsonField.Name("__tmp"))))))
-        val exp = DocBuilder(
+        val exp = DocBuilderF(
           readFoo,
           ListMap(
             BsonField.Name("0") -> -\/(jscore.JsFn(jscore.Name("y"), jscore.Literal(Js.Bool(true))))))
@@ -470,7 +470,7 @@ class WorkflowBuilderSpec
               BsonField.Name("__tmp") -> \/-($var(DocField(BsonField.Name("foo")))))),
           ListMap(
             BsonField.Name("0") -> \/-($toLower($var(DocField(BsonField.Name("__tmp")))))))
-        val exp = DocBuilder(
+        val exp = DocBuilderF(
           readFoo,
           ListMap(
             BsonField.Name("0") -> \/-($toLower($var(DocField(BsonField.Name("foo")))))))
@@ -486,7 +486,7 @@ class WorkflowBuilderSpec
               BsonField.Name("__tmp") -> -\/(jscore.JsFn(jscore.Name("x"), jscore.Literal(Js.Str("ABC")))))),
           ListMap(
             BsonField.Name("0") -> \/-($toLower($var(DocField(BsonField.Name("__tmp")))))))
-        val exp = DocBuilder(
+        val exp = DocBuilderF(
           readFoo,
           ListMap(
             BsonField.Name("0") -> -\/(jscore.JsFn(jscore.Name("x"),
@@ -505,7 +505,7 @@ class WorkflowBuilderSpec
               BsonField.Name("__tmp") -> \/-($$ROOT))),
           ListMap(
             BsonField.Name("foo") -> \/-($var(DocField(BsonField.Name("__tmp") \ BsonField.Name("foo"))))))
-        val exp = DocBuilder(
+        val exp = DocBuilderF(
           readFoo,
           ListMap(
             BsonField.Name("foo") -> \/-($var(DocField(BsonField.Name("foo"))))))
@@ -523,7 +523,7 @@ class WorkflowBuilderSpec
             BsonField.Name("0") -> -\/(jscore.JsFn(jscore.Name("x"),
               jscore.Select(jscore.Select(jscore.ident("x"), "__tmp"), "length")))))
 
-        val exp = DocBuilder(
+        val exp = DocBuilderF(
           readFoo,
           ListMap(
             BsonField.Name("0") -> -\/(jscore.JsFn(jscore.Name("y"),
@@ -543,7 +543,7 @@ class WorkflowBuilderSpec
             BsonField.Name("__tmp3") -> -\/(jscore.JsFn(jscore.Name("x"),
               jscore.Arr(List(jscore.Select(jscore.ident("x"), "__tmp0")))))))
 
-        val exp = DocBuilder(
+        val exp = DocBuilderF(
           readFoo,
           ListMap(
             BsonField.Name("__tmp3") -> -\/(jscore.JsFn(jscore.Name("x"),
@@ -572,7 +572,7 @@ class WorkflowBuilderSpec
               BsonField.Name("__tmp8") -> \/-($field("__tmp7", "city")),
               BsonField.Name("__tmp9") -> \/-($field("__tmp6"))))
 
-        val exp = DocBuilder(
+        val exp = DocBuilderF(
           readFoo,
           ListMap(
             BsonField.Name("__tmp8") -> \/-($field("city")),

--- a/core/src/test/scala/quasar/recursionschemes/spec.scala
+++ b/core/src/test/scala/quasar/recursionschemes/spec.scala
@@ -155,7 +155,7 @@ class FixplateSpecs extends Specification with ScalaCheck with ScalazMatchers {
     case _      => None
   }
 
-  val addOneƒ: Exp[Fix[Exp]] => Exp[Fix[Exp]] = simply(addOneOptƒ)
+  val addOneƒ: Exp[Fix[Exp]] => Exp[Fix[Exp]] = once(addOneOptƒ)
 
   val simplifyƒ: Exp[Fix[Exp]] => Option[Exp[Fix[Exp]]] = {
     case Mul(Fix(Num(0)), Fix(Num(_))) => Num(0).some


### PR DESCRIPTION
This makes the compiler tests more robust to compiler changes. On failure, we
display both the normalized diff and the original (un-normalized)
result.

`TraverseT` (and `FunctorT`) is a generalization of
`Recursive with Corecursive` providing `traverse` (and `map`) for types
that can’t implement one of `Recursive` or `Corecursive` (EG, `Free` and `Cofree`).

Transformations have been moved from the `Recursive` type class to the
new type classes, and some existing algebras have been generalized from
`Fix` to `T[_[_]]`.