### PR TITLE
Various LIKE fixes.

### DIFF
--- a/core/src/main/scala/quasar/physical/mongodb/planner.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/planner.scala
@@ -208,7 +208,7 @@ object MongoDbPlanner extends Planner[Crystallized] with Conversions {
               Select(
                 New(Name("RegExp"), List(
                   pattern,
-                  If(insen, Literal(Js.Str("i")), Literal(Js.Str(""))))),
+                  If(insen, Literal(Js.Str("im")), Literal(Js.Str("m"))))),
                 "test"),
               List(field)))
         case Extract =>
@@ -497,7 +497,7 @@ object MongoDbPlanner extends Planner[Crystallized] with Conversions {
             x => Selector.ElemMatch(\/-(Selector.In(Bson.Arr(List(x))))))
 
         case (Search, List(_, patt, IsBool(b))) =>
-          stringOp(Selector.Regex(_, b, false, false, false), patt)
+          stringOp(Selector.Regex(_, b, true, false, false), patt)
 
         case (Between, _ :: IsBson(lower) :: IsBson(upper) :: Nil) =>
           \/-(({ case List(f) => Selector.And(
@@ -881,7 +881,7 @@ object MongoDbPlanner extends Planner[Crystallized] with Conversions {
                 jscore.Select(
                   jscore.New(jscore.Name("RegExp"), List(
                     p,
-                    jscore.If(i, jscore.Literal(Js.Str("i")), jscore.Literal(Js.Str(""))))),
+                    jscore.If(i, jscore.Literal(Js.Str("im")), jscore.Literal(Js.Str("m"))))),
                   "test"),
                 List(v))
             })

--- a/core/src/main/scala/quasar/sql/package.scala
+++ b/core/src/main/scala/quasar/sql/package.scala
@@ -145,7 +145,8 @@ package object sql {
       case InvokeFunctionF(name, args) =>
         import quasar.std.StdLib.string
         (name, args) match {
-          case (string.Like.name, (_, value) :: (_, pattern) :: (StringLiteral(""), _) :: Nil) => "(" + value + ") like (" + pattern + ")"
+          case (string.Like.name, (_, value) :: (_, pattern) :: (StringLiteral("\\"), _) :: Nil) =>
+            "(" + value + ") like (" + pattern + ")"
           case (string.Like.name, (_, value) :: (_, pattern) :: (_, esc) :: Nil) =>
             "(" + value + ") like (" + pattern + ") escape (" + esc + ")"
           case _ => name + "(" + args.map(_._2).mkString(", ") + ")"

--- a/core/src/test/scala/quasar/compiler.scala
+++ b/core/src/test/scala/quasar/compiler.scala
@@ -281,6 +281,18 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
         compileExp("select case pop when 0 then 'nobody' else null end from zips"))
     }
 
+    "have ~~ as alias for LIKE" in {
+      testLogicalPlanCompile(
+                   "select pop from zips where city ~~ '%BOU%'",
+        compileExp("select pop from zips where city LIKE '%BOU%'"))
+    }
+
+    "have !~~ as alias for NOT LIKE" in {
+      testLogicalPlanCompile(
+                   "select pop from zips where city !~~ '%BOU%'",
+        compileExp("select pop from zips where city NOT LIKE '%BOU%'"))
+    }
+
     "compile array length" in {
       testLogicalPlanCompile(
         "select array_length(bar, 1) from foo",

--- a/core/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/core/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -627,7 +627,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
              Selector.Type(BsonType.Text)),
            Selector.Doc(
              BsonField.Name("bar") ->
-               Selector.Regex("^A\\..*$", false, false, false, false))))))
+               Selector.Regex("^A\\..*$", false, true, false, false))))))
     }
 
     "plan filter with LIKE and OR" in {
@@ -640,12 +640,12 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
                Selector.Doc(BsonField.Name("bar") ->
                  Selector.Type(BsonType.Text)),
                Selector.Doc(BsonField.Name("bar") ->
-                 Selector.Regex("^A.*$", false, false, false, false))),
+                 Selector.Regex("^A.*$", false, true, false, false))),
              Selector.And(
                Selector.Doc(BsonField.Name("bar") ->
                  Selector.Type(BsonType.Text)),
                Selector.Doc(BsonField.Name("bar") ->
-                 Selector.Regex("^Z.*$", false, false, false, false)))))))
+                 Selector.Regex("^Z.*$", false, true, false, false)))))))
     }
 
     "plan filter with field in constant array" in {
@@ -688,7 +688,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           Selector.Doc(
             BsonField.Name("city") -> Selector.Type(BsonType.Text)),
           Selector.Doc(
-            BsonField.Name("city") -> Selector.Regex("^B[AEIOU]+LD.*", false, false, false, false))))))
+            BsonField.Name("city") -> Selector.Regex("^B[AEIOU]+LD.*", false, true, false, false))))))
     }
 
     "plan filter with ~*" in {
@@ -698,7 +698,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           Selector.Doc(
             BsonField.Name("city") -> Selector.Type(BsonType.Text)),
           Selector.Doc(
-            BsonField.Name("city") -> Selector.Regex("^B[AEIOU]+LD.*", true, false, false, false))))))
+            BsonField.Name("city") -> Selector.Regex("^B[AEIOU]+LD.*", true, true, false, false))))))
     }
 
     "plan filter with !~" in {
@@ -708,7 +708,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           Selector.Doc(
             BsonField.Name("city") -> Selector.Type(BsonType.Text)),
           Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
-            BsonField.Name("city") -> Selector.NotExpr(Selector.Regex("^B[AEIOU]+LD.*", false, false, false, false))))))))
+            BsonField.Name("city") -> Selector.NotExpr(Selector.Regex("^B[AEIOU]+LD.*", false, true, false, false))))))))
     }
 
     "plan filter with !~*" in {
@@ -718,7 +718,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           Selector.Doc(
             BsonField.Name("city") -> Selector.Type(BsonType.Text)),
           Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
-            BsonField.Name("city") -> Selector.NotExpr(Selector.Regex("^B[AEIOU]+LD.*", true, false, false, false))))))))
+            BsonField.Name("city") -> Selector.NotExpr(Selector.Regex("^B[AEIOU]+LD.*", true, true, false, false))))))))
     }
 
     "plan filter with alternative ~" in {
@@ -726,13 +726,13 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         $read(Collection("db", "a")),
         $simpleMap(NonEmptyList(MapExpr(JsFn(Name("x"), obj(
           "__tmp10" -> Call(
-            Select(New(Name("RegExp"), List(Select(ident("x"), "pattern"), jscore.Literal(Js.Str("")))), "test"),
+            Select(New(Name("RegExp"), List(Select(ident("x"), "pattern"), jscore.Literal(Js.Str("m")))), "test"),
             List(jscore.Literal(Js.Str("foo")))),
           "__tmp11" -> ident("x"),
           "__tmp12" -> Select(ident("x"), "pattern"),
           "__tmp13" -> Select(ident("x"), "target"),
           "__tmp14" -> Call(
-            Select(New(Name("RegExp"), List(Select(ident("x"), "pattern"), jscore.Literal(Js.Str("")))), "test"),
+            Select(New(Name("RegExp"), List(Select(ident("x"), "pattern"), jscore.Literal(Js.Str("m")))), "test"),
             List(Select(ident("x"), "target"))))))),
           ListMap()),
         $match(
@@ -1893,13 +1893,13 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           obj(
             "0" -> If(Call(ident("isString"), List(Select(ident("x"), "foo"))),
               Call(
-                Select(New(Name("RegExp"), List(jscore.Literal(Js.Str("bar.*")), jscore.Literal(Js.Str("")))), "test"),
+                Select(New(Name("RegExp"), List(jscore.Literal(Js.Str("bar.*")), jscore.Literal(Js.Str("m")))), "test"),
                 List(Select(ident("x"), "foo"))),
               ident("undefined")),
             "1" -> jscore.Literal(Js.Bool(true)),
             "2" -> If(Call(ident("isString"), List(Select(ident("x"), "regex"))),
               Call(
-                Select(New(Name("RegExp"), List(Select(ident("x"), "regex"), jscore.Literal(Js.Str("")))), "test"),
+                Select(New(Name("RegExp"), List(Select(ident("x"), "regex"), jscore.Literal(Js.Str("m")))), "test"),
                 List(jscore.Literal(Js.Str("baz")))),
               ident("undefined")),
             "3" ->
@@ -1908,7 +1908,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
                   Call(ident("isString"), List(Select(ident("x"), "regex"))),
                   Call(ident("isString"), List(Select(ident("x"), "target")))),
                 Call(
-                  Select(New(Name("RegExp"), List(Select(ident("x"), "regex"), jscore.Literal(Js.Str("")))), "test"),
+                  Select(New(Name("RegExp"), List(Select(ident("x"), "regex"), jscore.Literal(Js.Str("m")))), "test"),
                   List(Select(ident("x"), "target"))),
                 ident("undefined")))))),
           ListMap()),
@@ -2180,9 +2180,9 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             Selector.Doc(
               BsonField.Name("__tmp21") \ BsonField.Name("__tmp16") \ BsonField.Name("id") -> Selector.Type(BsonType.Text)),
             Selector.Doc(
-              BsonField.Name("__tmp21") \ BsonField.Name("__tmp16") \ BsonField.Name("id") -> Selector.Regex("^.*Dr.*$", false, false, false, false))),
+              BsonField.Name("__tmp21") \ BsonField.Name("__tmp16") \ BsonField.Name("id") -> Selector.Regex("^.*Dr.*$", false, true, false, false))),
           Selector.Doc(
-            BsonField.Name("__tmp20") -> Selector.Regex("^.*Dr.*$", false, false, false, false)))),
+            BsonField.Name("__tmp20") -> Selector.Regex("^.*Dr.*$", false, true, false, false)))),
         $project(
           reshape("value" -> $field("__tmp21", "__tmp17")),
           ExcludeId)))

--- a/it/src/main/resources/tests/multilineLike.test
+++ b/it/src/main/resources/tests/multilineLike.test
@@ -1,0 +1,7 @@
+{
+    "name": "match LIKE with multiple lines",
+    "data": "slamengine_commits.data",
+    "query": "select count(*) from slamengine_commits where commit.message like 'Merge%'",
+    "predicate": "equalsExactly",
+    "expected": [{ "0": 13 }]
+}


### PR DESCRIPTION
* Treat all regexes as multiline (SD-1100 #done),
* change default LIKE escape char from none to `\\`, and
* add `~~` and `!~~` as aliases for `LIKE` and `NOT LIKE`.