### PR TITLE
enable pending tests for sub-select scoping with views

### DIFF
--- a/core/src/test/scala/quasar/compiler.scala
+++ b/core/src/test/scala/quasar/compiler.scala
@@ -954,29 +954,21 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
               "size" -> ObjectProject(Free('tmp0), Constant(Data.Str("size")))))))
     }
 
-    "compile sub-select with ambiguous names" in {
+    "compile sub-select with same un-qualified names" in {
       testLogicalPlanCompile(
         "select city, pop from (select city, pop from zips) temp",
         Let('tmp0,
           Let('tmp1,
             read("zips"),
-            Let('tmp2,
+            Squash(
               makeObj(
                 "city" -> ObjectProject(Free('tmp1), Constant(Data.Str("city"))),
-                "pop" -> ObjectProject(Free('tmp1), Constant(Data.Str("pop")))
-              ),
-              Let('tmp3,
-                Squash(Free('tmp2)),
-                Free('tmp3)))),
-          Let('tmp4,
+                "pop" -> ObjectProject(Free('tmp1), Constant(Data.Str("pop")))))),
+          Squash(
             makeObj(
               "city" -> ObjectProject(Free('tmp0), Constant(Data.Str("city"))),
-              "pop" -> ObjectProject(Free('tmp0), Constant(Data.Str("pop")))
-            ),
-            Let('tmp5,
-              Squash(Free('tmp4)),
-              Free('tmp5)))))
-    }.pendingUntilFixed("SD-1101")
+              "pop" -> ObjectProject(Free('tmp0), Constant(Data.Str("pop")))))))
+    }
 
     "compile simple distinct" in {
       testLogicalPlanCompile(

--- a/it/src/test/scala/quasar/view.scala
+++ b/it/src/test/scala/quasar/view.scala
@@ -137,12 +137,12 @@ class ViewSpecs extends BackendTest with DisjunctionMatchers with SkippedOnUserE
       val query = """select zip from "/view/simpleZips" where city = 'BOULDER' and state = 'CO' order by zip"""
       root.evalResults(QueryRequest(parse(query), None, Variables(Map.empty))).fold[Result](
         e => failure(e.toString),
-        _.runLog.run.run must beRightDisjunction(Vector(Data.Obj(ListMap(
-          "zip" -> Data.Str("80301"),
-          "zip" -> Data.Str("80302"),
-          "zip" -> Data.Str("80303"),
-          "zip" -> Data.Str("80304"))))))
-    }.pendingUntilFixed("SD-1101")
+        _.runLog.run.run must beRightDisjunction(Vector(
+          Data.Obj(ListMap("zip" -> Data.Str("80301"))),
+          Data.Obj(ListMap("zip" -> Data.Str("80302"))),
+          Data.Obj(ListMap("zip" -> Data.Str("80303"))),
+          Data.Obj(ListMap("zip" -> Data.Str("80304"))))))
+    }
 
     "query with view with bad reference" in {
       val query = """select * from "/view/badRef""""


### PR DESCRIPTION
Two tests were marked pending and their assertions were broken; one was just wrong and the other had become out-dated since last week.

This commit provides the proof that getting rid of AnnotatedTree fixed SD-1101.