### PR TITLE
Enable view creation and interpretation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ you probably want to install MongoDB locally and point Quasar to that one. Insta
 allow you to run the integration tests offline as well as make the tests run as fast as possible.
 
 In order to install MongoDB locally you can either use something like Homebrew or simply go to the MongDB website and follow the
-instructions that can be found there. 
+instructions that can be found there.
 
 Once we have a MongoDB instance handy, we need to set a few
 environment variables in order to inform Quasar about where to find the backends required in order to run the integration tests.
@@ -138,6 +138,25 @@ For example, say a MongoDB instance is running on the default port on the same m
 Then the filesystem will contain the paths `/local/test/` and `/local/students/cs101`, among others.
 
 A database can be mounted at any directory path, but database mount paths must not be nested inside each other.
+
+#### View mounts
+
+If the mount's key is "view" then the mount represents a "virtual" file, defined by a SQL query. When the file's contents are read or referred to, the query is executed to generate the current result on-demand. A view can be used to create dynamic data that combines analysis and formatting of existing files without creating temporary results that need to be manually regenerated when sources are updated.
+
+For example, given the above MongoDB mount, an additional view could be defined in this way:
+
+```json
+  "mountings": {
+    ...,
+    "/simpleZips": {
+      "view": {
+        "connectionUri": "sql2:///?q=select+_id+as+zip,+city,+state+from+\"/local/test/zips\""
+      }
+    }
+  }
+```
+
+A view can be mounted at any file path. If a view's path is nested inside the path of a database mount, it will appear alongside the other files in the database. A view will "shadow" any actual file that would otherwise be mapped to the same path. Any attempt to write data to a view will result in an error.
 
 
 ## REPL Usage
@@ -364,6 +383,8 @@ unchanged.
 
 If an error occurs when reading data from the request body, the response contains a summary in the common `error` field, and a separate array of error messages about specific values under `details`.
 
+Fails if the path identifies a view.
+
 ### POST /data/fs/[path]
 
 Appends data to the specified path, formatted as one JSON object per line in the same format as above.
@@ -372,14 +393,20 @@ was done.
 
 If an error occurs when reading data from the request body, the response contains a summary in the common `error` field, and a separate array of error messages about specific values under `details`.
 
+Fails if the path identifies a view.
+
 ### DELETE /data/fs/[path]
 
 Removes all data at the specified path. Single files are deleted atomically.
+
+Fails if the path identifies a view (views may be added and deleted through the `/mount` API).
 
 ### MOVE /data/fs/[path]
 
 Moves data from one path to another within the same backend. The new path must
 be provided in the "Destination" request header. Single files are moved atomically.
+
+Fails if either the request of destination path identifies a view (views may be added and deleted through the `/mount` API).
 
 ### GET /mount/fs/[path]
 

--- a/core/src/main/scala/quasar/backend.scala
+++ b/core/src/main/scala/quasar/backend.scala
@@ -508,9 +508,8 @@ object Backend {
     scala.Ordering[Path].on(_.path)
 
   def test(config: MountConfig): ETask[EnvironmentError, Unit] = config match {
-    // NB: for now, this prevents users from creating views through the API,
-    // but allows tests to run. See SD-1101.
-    case ViewConfig(_) => EitherT.left(Task.now(InvalidConfig("view creation not supported")))
+    // NB: can't meaningfully test the view query in isolation
+    case ViewConfig(_) => liftE(Task.now(()))
 
     case _ =>
       for {

--- a/core/src/main/scala/quasar/config/config.scala
+++ b/core/src/main/scala/quasar/config/config.scala
@@ -161,6 +161,7 @@ trait ConfigOps[C] {
                   case InvalidConfig(message) => InvalidConfig("Failed to parse " + path + ": " + message)
                   case e => e
                 }))
+      _      <- liftE[EnvironmentError](Task.delay { println("Read config from path: " + strPath) })
     } yield config
 
   }

--- a/web/src/test/scala/quasar/api/fs.scala
+++ b/web/src/test/scala/quasar/api/fs.scala
@@ -350,12 +350,14 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
     }
 
-    "return empty for missing path" in {
+    "be 404 with missing sub-directory" in {
       withServer(backends1, config1) { client =>
         val path = metadata(client) / "foo" / "baz" / ""
-        val meta = Http(path OK asJson)
+        val meta = Http(path)
 
-        meta() must beRightDisjunction((jsonContentType, List(Json("children" := List[Json]()))))
+        val resp = meta()
+        resp.getStatusCode must_== 404
+        resp.getResponseBody must_== ""
       }
     }
 
@@ -1841,7 +1843,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       (forCfg(Some(Server.webConfigLens.wcPort.set(port)(config))) *> exec).runFor(timeoutMillis)
     }
 
-    "be capable of providing it's name and version" in {
+    "be capable of providing its name and version" in {
       withServer(noBackends, config1) { client =>
         val req = (client / "server" / "info").GET
         val result = Http(req OK as.String)


### PR DESCRIPTION
- construct the ViewBackend wrapping the regular filesystem and interpreting all requests involving views
- allow views to be created through the API
- update the README with details on view configuration and affected APIs

This completes SD-976 and SD-977.