### PR TITLE
Split /metadata's "type" field into "type" and "mount".

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,14 +345,15 @@ SQL<sup>2</sup> supports variables inside queries (`SELECT * WHERE pop < :cutoff
 
 ### GET /metadata/fs/[path]
 
-Retrieves metadata about the files, directories, and mounts at the specified path.
+Retrieves metadata about the files, directories, and mounts which are children of the specified directory path. If the path names a file, the result is empty.
 
 ```json
 {
   "children": [
-    {"name": "test", "type": "mount"},
     {"name": "foo", "type": "directory"},
-    {"name": "bar", "type": "file"}
+    {"name": "bar", "type": "file"},
+    {"name": "test", "type": "directory", "mount": "mongodb"},
+    {"name": "baz", "type": "file", "mount": "view"}
   ]
 }
 ```

--- a/core/src/main/scala/quasar/physical/mongodb/filesystem.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/filesystem.scala
@@ -148,7 +148,7 @@ trait MongoDbFileSystem extends PlannerBackend[Workflow.Crystallized] {
   def ls0(dir: Path): PathTask[Set[FilesystemNode]] = liftP(for {
     cols <- server.collections
     allPaths = cols.map(_.asPath)
-  } yield allPaths.map(_.rebase(dir).toOption.map(p => FilesystemNode(p.head, Plain))).foldMap(_.toSet))
+  } yield allPaths.map(_.rebase(dir).toOption.map(p => FilesystemNode(p.head, None))).foldMap(_.toSet))
 }
 
 sealed trait RenameSemantics

--- a/core/src/main/scala/quasar/repl/repl.scala
+++ b/core/src/main/scala/quasar/repl/repl.scala
@@ -305,7 +305,7 @@ object Repl {
 
   def ls(state: RunState, path: Option[Path]): PathTask[Unit] = {
     def suffix(node: FilesystemNode) = node match {
-      case FilesystemNode(_, Mount)   => "@"
+      case FilesystemNode(_, Some(typ))            => "@ (" + typ + ")"
       case FilesystemNode(path, _) if path.pureDir => "/"
       case _ => ""
     }

--- a/it/src/test/scala/quasar/InteractiveTest.scala
+++ b/it/src/test/scala/quasar/InteractiveTest.scala
@@ -4,7 +4,7 @@ import java.io.File
 
 import Predef._
 import org.specs2.time.NoTimeConversions
-import quasar.Backend.{FilesystemNode, Plain}
+import quasar.Backend.{FilesystemNode}
 import quasar.fs.Path
 import quasar.specs2.DisjunctionMatchers
 
@@ -15,12 +15,12 @@ class InteractiveTest extends BackendTest with NoTimeConversions with Disjunctio
 
     def assertNotThere(file: Path) = {
       val listings = interactive.ls(backend, prefix).run
-      listings must not contain (FilesystemNode(file, Plain))
+      listings must not contain (FilesystemNode(file, None))
     }
 
     def assertThere(file: Path) = {
       val listings = interactive.ls(backend, prefix).run
-      listings must contain(FilesystemNode(file, Plain))
+      listings must contain(FilesystemNode(file, None))
     }
 
     "Interactive" should {

--- a/it/src/test/scala/quasar/fs/filesystem.scala
+++ b/it/src/test/scala/quasar/fs/filesystem.scala
@@ -40,7 +40,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
       // Run the task to create a single FileSystem instance for each run (I guess)
 
       "list root" in {
-        fs.ls(Path(".")).map(_ must contain(FilesystemNode(relPrefix, Plain))).run.run must beRightDisjunction
+        fs.ls(Path(".")).map(_ must contain(FilesystemNode(relPrefix, None))).run.run must beRightDisjunction
       }
 
       "count" in {
@@ -68,8 +68,8 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           _      <- fs.save(TestDir ++ tmp, oneDoc)
           after  <- fs.ls(TestDir).leftMap(PPathError(_))
         } yield {
-          before must not(contain(FilesystemNode(tmp, Plain)))
-          after must contain(FilesystemNode(tmp, Plain))
+          before must not(contain(FilesystemNode(tmp, None)))
+          after must contain(FilesystemNode(tmp, None))
         }).fold(_ must beNull, ι).run
       }
 
@@ -81,8 +81,8 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           _      <- fs.save(TestDir ++ tmp, oneDoc)
           after  <- fs.ls(TestDir).leftMap(PPathError(_))
         } yield {
-          before must contain(FilesystemNode(tmp, Plain))
-          after must contain(FilesystemNode(tmp, Plain))
+          before must contain(FilesystemNode(tmp, None))
+          after must contain(FilesystemNode(tmp, None))
         }).fold(_ must beNull, ι).run
       }
 
@@ -119,8 +119,8 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           _      <- fs.replace(TestDir ++ tmp, anotherDoc)
           after  <- fs.ls(TestDir).leftMap(PPathError(_))
         } yield {
-          before must contain(FilesystemNode(tmp, Plain))
-          after must contain(FilesystemNode(tmp, Plain))
+          before must contain(FilesystemNode(tmp, None))
+          after must contain(FilesystemNode(tmp, None))
         }).fold(_ must beNull, ι).run
       }
 
@@ -132,8 +132,8 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           _      <- fs.save(TestDir ++ tmpDir ++ tmp, oneDoc)
           after  <- fs.ls(TestDir ++ tmpDir).leftMap(PPathError(_))
         } yield {
-          before must not(contain(FilesystemNode(tmp, Plain)))
-          after must contain(FilesystemNode(tmp, Plain))
+          before must not(contain(FilesystemNode(tmp, None)))
+          after must contain(FilesystemNode(tmp, None))
         }).fold(_ must beNull, ι).run
       }
 
@@ -173,7 +173,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           after <- fs.ls(TestDir).leftMap(PPathError(_))
           _     <- fs.delete(TestDir ++ tmp).leftMap(PPathError(_)) // clean up this one eagerly, since it's a large file
         } yield {
-          after must contain(FilesystemNode(tmp, Plain))
+          after must contain(FilesystemNode(tmp, None))
         }).fold(_ must beNull, ι).run
       }
 
@@ -212,8 +212,8 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           _     <- fs.move(TestDir ++ tmp1, TestDir ++ tmp2, FailIfExists).leftMap(PPathError(_))
           after <- fs.ls(TestDir).leftMap(PPathError(_))
         } yield {
-          after must not(contain(FilesystemNode(tmp1, Plain)))
-          after must contain(FilesystemNode(tmp2, Plain))
+          after must not(contain(FilesystemNode(tmp1, None)))
+          after must contain(FilesystemNode(tmp2, None))
         }).fold(_ must beNull, ι).run
       }
 
@@ -227,8 +227,8 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           after <- fs.ls(TestDir).leftMap(PPathError(_))
         } yield {
           rez must beLeftDisjunction
-          after must contain(FilesystemNode(tmp1, Plain))
-          after must contain(FilesystemNode(tmp2, Plain))
+          after must contain(FilesystemNode(tmp1, None))
+          after must contain(FilesystemNode(tmp2, None))
         }).fold(_ must beNull, ι).run
       }
 
@@ -241,8 +241,8 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           _     <- fs.move(TestDir ++ tmp1, TestDir ++ tmp2, Overwrite).leftMap(PPathError(_))
           after <- fs.ls(TestDir).leftMap(PPathError(_))
         } yield {
-          after must not(contain(FilesystemNode(tmp1, Plain)))
-          after must contain(FilesystemNode(tmp2, Plain))
+          after must not(contain(FilesystemNode(tmp1, None)))
+          after must contain(FilesystemNode(tmp2, None))
         }).fold(_ must beNull, ι).run
       }
 
@@ -253,7 +253,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           _     <- fs.move(TestDir ++ tmp1, TestDir ++ tmp1, FailIfExists).leftMap(PPathError(_))
           after <- fs.ls(TestDir).leftMap(PPathError(_))
         } yield {
-          after must contain(FilesystemNode(tmp1, Plain))
+          after must contain(FilesystemNode(tmp1, None))
         }).fold(_ must beNull, ι).run
       }
 
@@ -268,8 +268,8 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           _       <- fs.move(TestDir ++ tmpDir1, TestDir ++ tmpDir2, FailIfExists).leftMap(PPathError(_))
           after   <- fs.ls(TestDir).leftMap(PPathError(_))
         } yield {
-          after must not(contain(FilesystemNode(tmpDir1, Plain)))
-          after must contain(FilesystemNode(tmpDir2, Plain))
+          after must not(contain(FilesystemNode(tmpDir1, None)))
+          after must contain(FilesystemNode(tmpDir2, None))
         }).fold(_ must beNull, ι).run
       }
 
@@ -284,8 +284,8 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           _       <- fs.move(TestDir ++ tmpDir1, TestDir ++ tmpDir2, FailIfExists).leftMap(PPathError(_))
           after   <- fs.ls(TestDir).leftMap(PPathError(_))
         } yield {
-          after must not(contain(FilesystemNode(tmpDir1, Plain)))
-          after must contain(FilesystemNode(tmpDir2.asDir, Plain))
+          after must not(contain(FilesystemNode(tmpDir1, None)))
+          after must contain(FilesystemNode(tmpDir2.asDir, None))
         }).fold(_ must beNull, ι).run
       }
 
@@ -296,8 +296,8 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           _       <- fs.move(TestDir ++ tmpDir1, TestDir ++ tmpDir2, FailIfExists).leftMap(PPathError(_))
           after   <- fs.ls(TestDir).leftMap(PPathError(_))
         } yield {
-          after must not(contain(FilesystemNode(tmpDir1, Plain)))
-          after must not(contain(FilesystemNode(tmpDir2, Plain)))
+          after must not(contain(FilesystemNode(tmpDir1, None)))
+          after must not(contain(FilesystemNode(tmpDir2, None)))
         }).fold(_ must beNull, ι).run
       }
 
@@ -308,7 +308,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           _     <- fs.delete(TestDir ++ tmp).leftMap(PPathError(_))
           after <- fs.ls(TestDir).leftMap(PPathError(_))
         } yield {
-          after must not(contain(FilesystemNode(tmp, Plain)))
+          after must not(contain(FilesystemNode(tmp, None)))
         }).fold(_ must beNull, ι).run
       }
 
@@ -323,9 +323,9 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           _      <- fs.delete(TestDir ++ tmpDir ++ tmp1).leftMap(PPathError(_))
           after  <- fs.ls(TestDir ++ tmpDir).leftMap(PPathError(_))
         } yield {
-          before must contain(FilesystemNode(tmp1, Plain))
-          after must not(contain(FilesystemNode(tmp1, Plain)))
-          after must contain(FilesystemNode(tmp2, Plain))
+          before must contain(FilesystemNode(tmp1, None))
+          after must not(contain(FilesystemNode(tmp1, None)))
+          after must contain(FilesystemNode(tmp2, None))
         }).fold(_ must beNull, ι).run
       }
 
@@ -339,7 +339,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           _      <- fs.delete(TestDir ++ tmpDir).leftMap(PPathError(_))
           after  <- fs.ls(TestDir).leftMap(PPathError(_))
         } yield {
-          after must not(contain(FilesystemNode(tmpDir, Plain)))
+          after must not(contain(FilesystemNode(tmpDir, None)))
         }).fold(_ must beNull, ι).run
       }
 
@@ -355,8 +355,8 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           _      <- fs.delete(db).leftMap(PPathError(_))
           delete <- fs.ls(Path.Root).leftMap(PPathError(_))
         } yield {
-          before must not contain(FilesystemNode(db, Plain))
-          create must contain(FilesystemNode(db, Plain))
+          before must not contain(FilesystemNode(db, None))
+          create must contain(FilesystemNode(db, None))
           delete must_== before
         }).fold(skipUnlessAuthorized, ι).run
       }
@@ -374,8 +374,8 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           _      <- fs.delete(Path.Root).leftMap(PPathError(_))
           after  <- fs.ls(Path.Root).leftMap(PPathError(_))
         } yield {
-          before must contain(FilesystemNode(db1, Plain))
-          before must contain(FilesystemNode(db2, Plain))
+          before must contain(FilesystemNode(db1, None))
+          before must contain(FilesystemNode(db2, None))
           after must_== Set()
         }).fold(skipUnlessAuthorized, ι).run
       }.skippedOnUserEnv("This could destroy user data.")
@@ -505,7 +505,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           after  <- fs.lsAll(Path.Root).leftMap(PPathError(_))
         } yield {
           rez must_== Vector(Data.Obj(ListMap("a" -> Data.Int(1))))
-          after must contain(exactly(FilesystemNode(TestDir ++ out, Plain) :: before.toList: _*))
+          after must contain(exactly(FilesystemNode(TestDir ++ out, None) :: before.toList: _*))
         }).fold(_ must beNull, ι).run
       }
     }

--- a/web/src/main/scala/quasar/api/fs.scala
+++ b/web/src/main/scala/quasar/api/fs.scala
@@ -184,11 +184,9 @@ final case class FileSystemApi[WC, SC](
 
   implicit def FilesystemNodeEncodeJson = EncodeJson[FilesystemNode] { fsn =>
     Json(
-      "name" := fsn.path.simplePathname,
-      "type" := (fsn.typ match {
-        case Mount => "mount"
-        case Plain => fsn.path.file.fold("directory")(κ("file"))
-      }))
+      (("name" := fsn.path.simplePathname) ::
+        ("type" := fsn.path.file.fold("directory")(κ("file"))) ::
+        fsn.mountType.toList.map("mount" := _)): _*)
   }
 
   implicit val QueryDecoder = new QueryParamDecoder[Query] {

--- a/web/src/test/scala/quasar/api/fs.scala
+++ b/web/src/test/scala/quasar/api/fs.scala
@@ -165,7 +165,7 @@ object Mock {
     def move0(src: Path, dst: Path, semantics: Backend.MoveSemantics) = ().point[Backend.PathTask]
 
     def ls0(dir: Path): Backend.PathTask[Set[Backend.FilesystemNode]] = {
-      val children = files.keys.toList.map(_.rebase(dir).toOption.map(p => Backend.FilesystemNode(p.head, Backend.Plain))).flatten
+      val children = files.keys.toList.map(_.rebase(dir).toOption.map(p => Backend.FilesystemNode(p.head, None))).flatten
       children.toSet.point[Backend.PathTask]
     }
 
@@ -369,11 +369,11 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
           jsonContentType,
           List(
             Json("children" := List(
-              Json("name" := "badPath1", "type" := "mount"),
-              Json("name" := "badPath2", "type" := "mount"),
-              Json("name" := "empty",    "type" := "mount"),
-              Json("name" := "foo",      "type" := "mount"),
-              Json("name" := "large",    "type" := "mount"),
+              Json("name" := "badPath1", "type" := "directory", "mount" := "mongodb"),
+              Json("name" := "badPath2", "type" := "directory", "mount" := "mongodb"),
+              Json("name" := "empty",    "type" := "directory", "mount" := "mongodb"),
+              Json("name" := "foo",      "type" := "directory", "mount" := "mongodb"),
+              Json("name" := "large",    "type" := "directory", "mount" := "mongodb"),
               Json("name" := "non",      "type" := "directory"))))))
       }
     }
@@ -418,7 +418,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
           jsonContentType,
           List(
             Json("children" := List(
-              Json("name" := "mounting", "type" := "mount"))))))
+              Json("name" := "mounting", "type" := "directory", "mount" := "mongodb"))))))
       }
     }
 
@@ -1487,9 +1487,8 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
           configs()(0).mountings.get(Path("/local/view1")) must beSome(
             ViewConfig(expr))
 
-          // TODO: metadata not available for views yet (see SD-978)
-          // val metadataExists = Http(viewMetadata)
-          // metadataExists().getStatusCode must_== 200
+          val metadataExists = Http(viewMetadata)
+          metadataExists().getStatusCode must_== 200
         }
       }
 
@@ -1660,9 +1659,8 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
 
           configs()(0).mountings.get(Path("/local/view1")) must beSome
 
-          // TODO: metadata not available for views yet (see SD-978)
-          // val metadataExists = Http(localMetadata)
-          // metadataExists().getStatusCode must_== 200
+          val metadataExists = Http(localMetadata)
+          metadataExists().getStatusCode must_== 200
         }
       }
 


### PR DESCRIPTION
SD-978 #done

This allows a client to identify views as both a kind of mount and a kind of file.

Also fixed the listing of directories which are mounts but also contain overlayed views, and where a view appears at the same path as an actual file.