### PR TITLE
Improvements to handling set literals.

### DIFF
--- a/core/src/main/scala/quasar/sql/parser.scala
+++ b/core/src/main/scala/quasar/sql/parser.scala
@@ -184,6 +184,7 @@ class SQLParser extends StandardTokenParsers {
     p ~ rep1(s ~> p) ^^ { case x ~ y => x :: y }
 
   def set_literal: Parser[Expr] =
+    op("(") ~ op(")") ^^^ SetLiteral(Nil) |
     (op("(") ~> rep2sep(expr, op(",")) <~ op(")")) ^^ (SetLiteral(_))
 
   def array_literal: Parser[Expr] =

--- a/core/src/main/scala/quasar/std/array.scala
+++ b/core/src/main/scala/quasar/std/array.scala
@@ -39,22 +39,6 @@ trait ArrayLib extends Library {
     },
     basicUntyper)
 
-  val In = Mapping(
-    "(in)",
-    "Determines whether a value is in a given array.",
-    Type.Bool, Type.Top :: Type.AnyArray ⨿ Type.AnySet :: Nil,
-    noSimplification,
-    partialTyper {
-      case List(Type.Const(x), Type.Const(Data.Arr(arr))) =>
-        Type.Const(Data.Bool(arr.contains(x)))
-      case List(Type.Const(x), Type.Const(Data.Set(set))) =>
-        Type.Const(Data.Bool(set.contains(x)))
-      case List(_,             Type.Const(Data.Arr(_)))   => Type.Bool
-      case List(_,             Type.Const(Data.Set(_)))   => Type.Bool
-      case List(_,             _)                         => Type.Bool
-    },
-    basicUntyper)
-
-  def functions = ArrayLength :: In :: Nil
+  def functions = ArrayLength :: Nil
 }
 object ArrayLib extends ArrayLib

--- a/core/src/main/scala/quasar/std/set.scala
+++ b/core/src/main/scala/quasar/std/set.scala
@@ -197,6 +197,21 @@ trait SetLib extends Library {
     setTyper(partialTyper { case List(s1, _) => s1 }),
     setUntyper(t => success(t :: Type.Top :: Nil)))
 
+  val In = Mapping(
+    "(in)",
+    "Determines whether a value is in a given set.",
+    Type.Bool, Type.Top :: Type.AnySet :: Nil,
+    noSimplification,
+    partialTyper {
+      case List(_,             Type.Const(Data.Set(Nil))) =>
+        Type.Const(Data.Bool(false))
+      case List(Type.Const(x), Type.Const(Data.Set(set))) =>
+        Type.Const(Data.Bool(set.contains(x)))
+      case List(_,             Type.Const(Data.Set(_)))   => Type.Bool
+      case List(_,             _)                         => Type.Bool
+    },
+    basicUntyper)
+
   val Constantly = Mapping("CONSTANTLY", "Always return the same value",
     Type.Bottom, Type.Top :: Type.Top :: Nil,
     noSimplification,
@@ -210,6 +225,10 @@ trait SetLib extends Library {
     },
     setUntyper(t => success(t :: Type.Top :: Nil)))
 
-  def functions = Take :: Drop :: OrderBy :: Filter :: InnerJoin :: LeftOuterJoin :: RightOuterJoin :: FullOuterJoin :: GroupBy :: Distinct :: DistinctBy :: Union :: Intersect :: Except :: Constantly :: Nil
+  def functions =
+    Take :: Drop :: OrderBy :: Filter ::
+      InnerJoin :: LeftOuterJoin :: RightOuterJoin :: FullOuterJoin ::
+      GroupBy :: Distinct :: DistinctBy :: Union :: Intersect :: Except ::
+      In :: Constantly :: Nil
 }
 object SetLib extends SetLib

--- a/core/src/main/scala/quasar/std/set.scala
+++ b/core/src/main/scala/quasar/std/set.scala
@@ -207,7 +207,6 @@ trait SetLib extends Library {
         Type.Const(Data.Bool(false))
       case List(Type.Const(x), Type.Const(Data.Set(set))) =>
         Type.Const(Data.Bool(set.contains(x)))
-      case List(_,             Type.Const(Data.Set(_)))   => Type.Bool
       case List(_,             _)                         => Type.Bool
     },
     basicUntyper)

--- a/core/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/core/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -656,6 +656,11 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             Selector.In(Bson.Arr(List(Bson.Text("AZ"), Bson.Text("CO"))))))))
     }
 
+    "plan filter with field in empty array" in {
+      plan("select * from zips where state in ()") must
+        beWorkflow($pure(Bson.Arr(Nil)))
+    }
+
     "plan filter with field containing constant value" in {
       plan("select * from zips where 43.058514 in loc") must
         beWorkflow(chain(


### PR DESCRIPTION
Progress toward SD-1045.

* Parse `()` as an empty set,
* constant-fold `x IN ()` to `false`, and
* don’t accept arrays for `IN`.

This doesn’t solve the final problem of single-element sets, which would be easy with SD-1078 fixed.