### PR TITLE
fix /metadata 404 response body

### DIFF
--- a/web/src/main/scala/quasar/api/fs.scala
+++ b/web/src/main/scala/quasar/api/fs.scala
@@ -385,7 +385,7 @@ final case class FileSystemApi[WC, SC](
       bknd.exists(path).fold(
         handlePathError,
         x =>
-          if (!x) NotFound()
+          if (!x) NotFound(errorBody("There is no file/directory at " + path, None))
           else if (path.pureDir)
             bknd.ls(path).fold(
               handlePathError,

--- a/web/src/test/scala/quasar/api/fs.scala
+++ b/web/src/test/scala/quasar/api/fs.scala
@@ -340,7 +340,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
 
         val resp = meta()
         resp.getStatusCode must_== 404
-        resp.getResponseBody must_== ""
+        resp.getResponseBody must_== """{"error":"There is no file/directory at /missing"}"""
       }
     }
 
@@ -360,7 +360,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
 
         val resp = meta()
         resp.getStatusCode must_== 404
-        resp.getResponseBody must_== ""
+        resp.getResponseBody must_== """{"error":"There is no file/directory at /foo/baz/"}"""
       }
     }
 
@@ -433,7 +433,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
         val resp = meta()
 
         resp.getStatusCode must_== 404
-        resp.getResponseBody must_== ""
+        resp.getResponseBody must_== """{"error":"There is no file/directory at /foo"}"""
       }
     }
 


### PR DESCRIPTION
Was empty, now has valid JSON with `{ "error": "There is no file/directory at path ..."}`

Note: this fixes only the request which was changed to a 404 in a recent commit. A quick search shows several other occurrences of `NotFound()` which we might want to address, probably in our existing "improve error messages" ticket ([SD-824](https://slamdata.atlassian.net/browse/SD-824)).