### PR TITLE
Streaming query evaluation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk: oraclejdk8
 sudo: false
 before_install:
 - "./scripts/installMongo mongodb-linux-x86_64-2.6.9 mongo2.6 27018"
-- "./scripts/installMongo mongodb-linux-x86_64-3.0.4 mongo3.0 27019"
+- "./scripts/installMongo mongodb-linux-x86_64-3.0.4 mongo3.0 27019 --auth"
 script: "./scripts/build"
 after_success:
 - "./scripts/publishJarIfMaster"

--- a/core/src/main/scala/quasar/physical/mongodb/evaluator.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/evaluator.scala
@@ -17,18 +17,19 @@
 package quasar.physical.mongodb
 
 import quasar.Predef._
+import quasar.fp._
 import quasar.recursionschemes._, Recursive.ops._
 import quasar._, Errors._, Evaluator._
-import quasar.fs.Path.PathError.NonexistentPathError
+import quasar.fs.Path, Path.PathError.NonexistentPathError
 import quasar.javascript._
 import Workflow._
 
 import com.mongodb._
-import com.mongodb.client.model._
 import scalaz.{Free => FreeM, _}, Scalaz._
 import scalaz.concurrent._
+import scalaz.stream._
 
-trait Executor[F[_]] {
+trait Executor[F[_], C] {
   def generateTempName(dbName: String): F[Collection]
 
   def version: F[List[Int]]
@@ -42,23 +43,50 @@ trait Executor[F[_]] {
   def aggregate(source: Collection, pipeline: workflowtask.Pipeline): F[Unit]
   def mapReduce(source: Collection, dst: Collection, mr: MapReduce): F[Unit]
   def drop(coll: Collection): F[Unit]
-  def rename(src: Collection, dst: Collection): F[Unit]
   def exists(coll: Collection): F[Unit]
+
+  def pureCursor(values: List[Bson]): F[C]
+  def readCursor(source: Col): F[C]
+  def aggregateCursor(source: Col, pipeline: workflowtask.Pipeline): F[C]
+  def mapReduceCursor(source: Col, mr: MapReduce): F[C]
 
   def fail[A](e: EvaluationError): F[A]
 }
 
-class MongoDbEvaluator(impl: MongoDbEvaluatorImpl[StateT[ETask[EvaluationError, ?], SequenceNameGenerator.EvalState, ?]]) extends Evaluator[Crystallized] {
+sealed trait Col {
+  def collection: Collection
+}
+object Col {
+  final case class Tmp(collection: Collection) extends Col
+  final case class User(collection: Collection) extends Col
+}
 
-  implicit val MF: MonadState[StateT[ETask[EvaluationError, ?], ?, ?], SequenceNameGenerator.EvalState] =
-    StateT.stateTMonadState[SequenceNameGenerator.EvalState, ETask[EvaluationError, ?]]
+class MongoDbEvaluator(impl: MongoDbEvaluatorImpl[
+    StateT[EvaluationTask, SequenceNameGenerator.EvalState, ?],
+    Process[EvaluationTask, Data]])
+    extends Evaluator[Crystallized] {
+
+  implicit val MF: MonadState[StateT[EvaluationTask, ?, ?], SequenceNameGenerator.EvalState] =
+    StateT.stateTMonadState[SequenceNameGenerator.EvalState, EvaluationTask]
 
   val name = "MongoDB"
 
-  def execute(physical: Crystallized): ETask[EvaluationError, ResultPath] = for {
-    nameSt <- EitherT.right(SequenceNameGenerator.startUnique)
-    rez    <- impl.execute(physical).eval(nameSt)
-  } yield rez
+  def executeTo(physical: Crystallized, out: Path): EvaluationTask[ResultPath] =
+    Collection.fromPath(out).fold(
+      err => EitherT.left(Task.now(EvalPathError(err))),
+      out => for {
+        nameSt <- EitherT.right(SequenceNameGenerator.startUnique)
+        rez    <- impl.execute(physical, out).eval(nameSt)
+      } yield rez)
+
+  def evaluate(physical: Crystallized): Process[EvaluationTask, Data] = {
+    val v = (for {
+      nameSt <- EitherT.right(SequenceNameGenerator.startUnique)
+      rez    <- impl.evaluate(physical).eval(nameSt)
+    } yield rez).valueOr(
+      err => Process.eval[EvaluationTask, Data](EitherT.left[Task, EvaluationError, Data](Task.now(err))))
+    Process.eval[EvaluationTask, Process[EvaluationTask, Data]](liftE(v)).join
+  }
 
   def compile(workflow: Crystallized) =
     "Mongo" -> MongoDbEvaluator.toJS(workflow).fold(e => "error: " + e.message, s => Cord(s))
@@ -108,21 +136,21 @@ object MongoDbEvaluator {
       (nxtS, wdb) =  findWritableDb(dbNames).run(genSeed)
       exec        <- wdb.run.map(new MongoDbExecutor(client0, nameGen, _)).liftM[EnvErrT]
       _           <- validateVersion(exec).eval(nxtS)
-    } yield new MongoDbEvaluator(MongoDbEvaluatorImpl[ST](exec))
+    } yield new MongoDbEvaluator(MongoDbEvaluatorImpl[ST, Process[EvaluationTask, Data]](exec))
   }
 
   def toJS(physical: Crystallized): EvaluationError \/ String = {
     type EitherState[A] = EitherT[SequenceNameGenerator.SequenceState, EvaluationError, A]
     type WriterEitherState[A] = WriterT[EitherState, Vector[Js.Stmt], A]
 
-    val executor0: Executor[WriterEitherState] = new JSExecutor(SequenceNameGenerator.Gen)
-    val impl = new MongoDbEvaluatorImpl[WriterEitherState] {
+    val executor0: Executor[WriterEitherState, Unit] = new JSExecutor(SequenceNameGenerator.Gen)
+    val impl = new MongoDbEvaluatorImpl[WriterEitherState, Unit] {
+      val F = implicitly[Monad[WriterEitherState]]
       val executor = executor0
     }
-    impl.execute(physical).run.run.eval(SequenceNameGenerator.startSimple).flatMap {
-      case (log, path) => for {
-        col <- Collection.fromPath(path.path).leftMap(EvalPathError(_))
-      } yield Js.Stmts((log :+ Js.Call(Js.Select(JSExecutor.toJsRef(col), "find"), Nil)).toList).pprint(0)
+    // NB: this _always_ renders as if the final result is to be streamed.
+    impl.evaluate(physical).run.run.eval(SequenceNameGenerator.startSimple).map {
+      case (log, _) => Js.Stmts(log.toList).pprint(0)
     }
   }
 
@@ -138,116 +166,165 @@ object MongoDbEvaluator {
   }
 }
 
-trait MongoDbEvaluatorImpl[F[_]] {
+trait MongoDbEvaluatorImpl[F[_], C] {
+  implicit def F: Monad[F]
 
-  protected[mongodb] def executor: Executor[F]
+  protected[mongodb] def executor: Executor[F, C]
 
-  sealed trait Col {
-    def collection: Collection
+  type WT[M[_], A] = WriterT[M, Vector[Col.Tmp], A]
+  type W[       A] = WT[F, A]
+
+  def emit[A](a: F[A]): W[A] = WriterT(a.map(Vector.empty -> _))
+
+  def fail[A](error: EvaluationError): F[A] = executor.fail(error)
+
+  def tempCol(physical: Crystallized): W[Col.Tmp] = {
+    val dbName = physical.op.foldMap {
+      case Fix($Read(Collection(dbName, _))) => List(dbName)
+      case _ => Nil
+    }.headOption.orElse(executor.defaultWritableDB)
+
+    dbName.fold[W[Col.Tmp]](emit(fail(NoDatabase()))) { dbName =>
+      val tmp = executor.generateTempName(dbName).map(Col.Tmp(_))
+      WriterT(tmp.map(col => (Vector(col), col)))
+    }
   }
-  object Col {
-    case class Tmp(collection: Collection) extends Col
-    case class User(collection: Collection) extends Col
-  }
 
-  def execute(physical: Crystallized)(implicit MF: Monad[F]): F[ResultPath] = {
-    type WT[M[_], A] = WriterT[M, Vector[Col.Tmp], A]
-    type W[       A] = WT[F, A]
+  def execute0(task0: workflowtask.WorkflowTask, out: Col, tempCol: W[Col.Tmp]): W[Col] = {
+    import quasar.physical.mongodb.workflowtask._
 
-    def execute0(task0: workflowtask.WorkflowTask): W[Col] = {
-      import quasar.physical.mongodb.workflowtask._
-
-      def emit[A](a: F[A]): W[A] = WriterT(a.map(Vector.empty -> _))
-
-      def fail[A](error: EvaluationError): F[A] = executor.fail(error)
-
-      def tempCol: W[Col.Tmp] = {
-        val dbName = physical.op.foldMap {
-          case Fix($Read(Collection(dbName, _))) => List(dbName)
-          case _ => Nil
-        }.headOption.orElse(executor.defaultWritableDB)
-
-        dbName.fold[W[Col.Tmp]](emit(fail(NoDatabase()))) { dbName =>
-          val tmp = executor.generateTempName(dbName).map(Col.Tmp(_))
-          WriterT(tmp.map(col => (Vector(col), col)))
-        }
-      }
-
-      task0 match {
-        case PureTask(value @ Bson.Doc(_)) =>
-          for {
-            tmp <- tempCol
-            _   <- emit(executor.insert(tmp.collection, value))
-          } yield tmp
-
-        case PureTask(Bson.Arr(value)) =>
-          for {
-            tmp <- tempCol
-            _   <- emit(value.toList.traverse[F, Unit] {
-                          case value @ Bson.Doc(_) => executor.insert(tmp.collection, value)
-                          case v => fail(UnableToStore("MongoDB cannot store anything except documents inside collections: " + v))
-                        })
-          } yield tmp
-
-        case PureTask(v) =>
-          emit(fail(UnableToStore("MongoDB cannot store anything except documents inside collections: " + v)))
-
-        case ReadTask(value) =>
-          emit(executor.exists(value).as(Col.User(value): Col))
-
-        case QueryTask(source, query, skip, limit) =>
-          // TODO: This is an approximation since we're ignoring all fields of "Query" except the selector.
-          execute0(
-            PipelineTask(
-              source,
-              $Match((), query.query) ::
-                skip.map($Skip((), _) :: Nil).getOrElse(Nil) :::
-                limit.map($Limit((), _) :: Nil).getOrElse(Nil)))
-
-        case PipelineTask(source, pipeline) => for {
-          src <- execute0(source)
-          tmp <- tempCol
-          _   <- emit(executor.aggregate(src.collection, pipeline :+ $Out[Unit]((), tmp.collection)))
-        } yield tmp
-
-        case MapReduceTask(source, mapReduce) => for {
-          src <- execute0(source)
-          tmp <- tempCol
-          _   <- emit(executor.mapReduce(src.collection, tmp.collection, mapReduce))
-        } yield tmp
-
-        case FoldLeftTask(head, tail) =>
-          for {
-            head <- execute0(head)
-            _    <- emit(head match {
-              case Col.User(_) => fail(InvalidTask("FoldLeft from simple read: " + head))
-              case _           => ().point[F]
-            })
-            _    <- tail.traverse[W, Unit] {
-              case MapReduceTask(source, mapReduce) => for {
-                src <- execute0(source)
-                _   <- emit(executor.mapReduce(src.collection, head.collection, mapReduce))
-              } yield ()
-              case t => emit(fail(InvalidTask("un-mergable FoldLeft input: " + t)))
-            }
-          } yield head
-      }
+    val execSource: workflowtask.WorkflowTask => W[Col] = {
+      case ReadTask(coll) => emit(executor.exists(coll).as(Col.User(coll)))
+      case t              => tempCol.flatMap(tmp => execute0(t, tmp, tempCol))
     }
 
+    task0 match {
+      case PureTask(value @ Bson.Doc(_)) => for {
+        _ <- emit(executor.insert(out.collection, value))
+      } yield out
+
+      case PureTask(Bson.Arr(value)) =>
+        for {
+          _   <- emit(value.toList.traverse[F, Unit] {
+                        case value @ Bson.Doc(_) => executor.insert(out.collection, value)
+                        case v => fail(UnableToStore("MongoDB cannot store anything except documents inside collections: " + v))
+                      })
+        } yield out
+
+      case PureTask(v) =>
+        emit(fail(UnableToStore("MongoDB cannot store anything except documents inside collections: " + v)))
+
+      case ReadTask(value) =>
+        emit(executor.exists(value).as(Col.User(value): Col))
+
+      case QueryTask(source, query, skip, limit) =>
+        // TODO: This is an approximation since we're ignoring all fields of "Query" except the selector.
+        execute0(
+          PipelineTask(
+            source,
+            $Match((), query.query) ::
+              skip.map($Skip((), _) :: Nil).getOrElse(Nil) :::
+              limit.map($Limit((), _) :: Nil).getOrElse(Nil)), out, tempCol)
+
+      case PipelineTask(source, pipeline) => for {
+        src <- execSource(source)
+        _   <- emit(executor.aggregate(src.collection, pipeline :+ $Out[Unit]((), out.collection)))
+      } yield out
+
+      case MapReduceTask(source, mapReduce) => for {
+        src <- execSource(source)
+        _   <- emit(executor.mapReduce(src.collection, out.collection, mapReduce))
+      } yield out
+
+      case FoldLeftTask(head, tail) =>
+        for {
+          head <- execute0(head, out, tempCol)
+          _    <- emit(head match {
+            case Col.User(_) => fail(InvalidTask("FoldLeft from simple read: " + head))
+            case _           => ().point[F]
+          })
+          _    <- tail.traverse[W, Unit] {
+            case MapReduceTask(source, mapReduce) => for {
+              src <- execSource(source)
+              _   <- emit(executor.mapReduce(src.collection, out.collection, mapReduce))
+            } yield ()
+            case t => emit(fail(InvalidTask("un-mergable FoldLeft input: " + t)))
+          }
+        } yield out
+    }
+  }
+
+  def execute(physical: Crystallized, out: Collection): F[ResultPath] =
     for {
-      dst <- execute0(Workflow.task(physical)).run
+      dst <- execute0(Workflow.task(physical), Col.User(out), tempCol(physical)).run
       (temps, dstCol) = dst
       _   <- temps.collect {
                 case tmp @ Col.Tmp(coll) => if (tmp != dstCol) executor.drop(coll)
                                             else ().point[F]
       }.sequenceU
-    } yield dstCol match { case Col.User(coll) => ResultPath.User(coll.asPath); case Col.Tmp(coll) => ResultPath.Temp(coll.asPath) }
+    } yield dstCol match {
+      case Col.User(coll) => ResultPath.User(coll.asPath)
+      case Col.Tmp(coll) => ResultPath.Temp(coll.asPath)
+    }
+
+  def evaluate(physical: Crystallized): F[C] = {
+    import quasar.physical.mongodb.workflowtask._
+
+    val tempGen = tempCol(physical)
+
+    def cleanup(temps: Vector[Col.Tmp], dst: Col): F[Unit] =
+      temps.traverse(c =>
+        if (c == dst) ().point[F]
+        else executor.drop(c.collection)).map(κ(()))
+
+    Workflow.task(physical) match {
+      case PureTask(Bson.Arr(bson)) =>
+        executor.pureCursor(bson)
+      case PureTask(bson) =>
+        executor.pureCursor(bson :: Nil)
+
+      case ReadTask(src) =>
+        executor.exists(src) *> executor.readCursor(Col.User(src))
+
+      case PipelineTask(ReadTask(src), pipeline) =>
+        executor.exists(src) *> executor.aggregateCursor(Col.User(src), pipeline)
+
+      case MapReduceTask(ReadTask(src), mapReduce) =>
+        executor.exists(src) *> executor.mapReduceCursor(Col.User(src), mapReduce)
+
+
+      case PipelineTask(src, pipeline) => for {
+        t   <- tempGen.flatMap(tmp => execute0(src, tmp, tempGen)).run
+        (temps, dstCol) = t
+        _   <- cleanup(temps, dstCol)
+        cur <- executor.aggregateCursor(dstCol, pipeline)
+      } yield cur
+
+      case MapReduceTask(src, mapReduce) => for {
+        t <- tempGen.flatMap(tmp => execute0(src, tmp, tempGen)).run
+        (temps, dstCol) = t
+        _   <- cleanup(temps, dstCol)
+        cur <- executor.mapReduceCursor(dstCol, mapReduce)
+      } yield cur
+
+      // NB: the last command in this case merges the output into a result
+      // collection, so it simply can't be streamed
+      case task @ FoldLeftTask(_, _) => for {
+        t <- tempGen.flatMap(tmp => execute0(task, tmp, tempGen)).run
+        (temps, dstCol) = t
+        _   <- cleanup(temps, dstCol)
+        cur <- executor.readCursor(dstCol)
+      } yield cur
+    }
   }
 }
 
 object MongoDbEvaluatorImpl {
-  def apply[F[_]](exec: Executor[F]): MongoDbEvaluatorImpl[F] =
-    new MongoDbEvaluatorImpl[F] { val executor = exec }
+  def apply[F[_], C](exec: Executor[F, C])(implicit F0: Monad[F]): MongoDbEvaluatorImpl[F, C] =
+    new MongoDbEvaluatorImpl[F, C] {
+      val F = F0
+      val executor = exec
+    }
 }
 
 trait NameGenerator[F[_]] {
@@ -275,7 +352,7 @@ object SequenceNameGenerator {
 class MongoDbExecutor[S](client: MongoClient,
                          nameGen: NameGenerator[State[S, ?]],
                          val defaultWritableDB: Option[String])
-    extends Executor[StateT[EvaluationTask, S, ?]] {
+    extends Executor[StateT[EvaluationTask, S, ?], Process[EvaluationTask, Data]] {
 
   type MT[F[_], A] = StateT[F, S, A]
   type M[A]        = MT[EvaluationTask, A]
@@ -303,7 +380,7 @@ class MongoDbExecutor[S](client: MongoClient,
           "mapReduce" -> Bson.Text(source.collectionName),
           "map"       -> Bson.JavaScript(mr.map),
           "reduce"    -> Bson.JavaScript(mr.reduce))
-        ++ mr.bson(dst).value)).mapK(_.leftMap{
+        ++ mr.bson(Some(dst)).value)).mapK(_.leftMap{
           case CommandFailed(s) if s.contains("ns doesn't exist" ) =>
             EvalPathError(NonexistentPathError(source.asPath.asAbsolute,None))
           case other => other
@@ -311,11 +388,53 @@ class MongoDbExecutor[S](client: MongoClient,
 
   def drop(coll: Collection) = liftMongo(mongoCol(coll).drop())
 
-  def rename(src: Collection, dst: Collection) =
+  def pureCursor(values: List[Bson]) =
+    liftTask(Task.now(Process.emitAll(values.map(BsonCodec.toData))))
+
+  def readCursor(source: Col) =
+    fromCursor(Task.delay { mongoCol(source.collection).find() }, source)
+
+  def aggregateCursor(source: Col, pipeline: workflowtask.Pipeline) = {
+    import scala.collection.JavaConverters._
+    import scala.Predef.boolean2Boolean
+
+    fromCursor(Task.delay {
+      mongoCol(source.collection)
+        .aggregate(pipeline.map(_.bson.repr).asJava)
+        .allowDiskUse(true)
+    }, source)
+  }
+
+  def mapReduceCursor(source: Col, mr: MapReduce) = {
+    implicit class CursorOp[A](a: A) {
+      def app[B](b: Option[B])(f: (A, B) => A) = b.fold(a)(f(a, _))
+    }
+
+    fromCursor(Task.delay {
+      mongoCol(source.collection)
+        .mapReduce(mr.map.pprint(0), mr.reduce.pprint(0))
+        .app(mr.selection)((c, q) => c.filter(q.bson.repr))
+        .app(mr.limit)((c, l) => c.limit(l.toInt))
+        .app(mr.finalizer)((c, f) => c.finalizeFunction(f.pprint(0)))
+        .scope(Bson.Doc(mr.scope).repr)
+        .app(mr.verbose)((c, v) => c.verbose(v))
+    }, source)
+  }
+
+  private def fromCursor(cursor: Task[com.mongodb.client.MongoIterable[org.bson.Document]], source: Col): M[Process[EvaluationTask, Data]] = {
+    val t = new (ETask[Backend.ResultError, ?] ~> EvaluationTask) {
+      def apply[A](t: ETask[Backend.ResultError, A]) =
+        t.leftMap(EvalResultError(_))
+    }
+    val cleanup: EvaluationTask[Unit] = source match {
+      case Col.Tmp(coll) => MongoWrapper.liftTask(Task.delay { mongoCol(coll).drop() })
+      case Col.User(_) => liftE(Task.now(()))
+    }
     liftMongo(
-      mongoCol(src).renameCollection(
-        new MongoNamespace(dst.databaseName, dst.collectionName),
-        new RenameCollectionOptions().dropTarget(true)))
+      MongoWrapper(client).readCursor(cursor)
+          .translate[EvaluationTask](t) ++
+        Process.eval_(cleanup))
+  }
 
   def fail[A](e: EvaluationError): M[A] =
     MonadError[ETask, EvaluationError].raiseError[A](e).liftM[MT]
@@ -368,7 +487,7 @@ private[mongodb] trait LoggerT[F[_]] {
 }
 
 class JSExecutor[F[_]: Monad](nameGen: NameGenerator[F])
-    extends Executor[LoggerT[F]#Rec] {
+    extends Executor[LoggerT[F]#Rec, Unit] {
   import Js._
   import JSExecutor._
 
@@ -387,14 +506,20 @@ class JSExecutor[F[_]: Monad](nameGen: NameGenerator[F])
 
   def mapReduce(source: Collection, dst: Collection, mr: MapReduce) =
     write(Call(Select(toJsRef(source), "mapReduce"),
-      List(mr.map, mr.reduce, mr.bson(dst).toJs)))
+      List(mr.map, mr.reduce, mr.bson(Some(dst)).toJs)))
 
   def drop(coll: Collection) =
     write(Call(Select(toJsRef(coll), "drop"), Nil))
 
-  def rename(src: Collection, dst: Collection) =
-    write(Call(Select(toJsRef(src), "renameCollection"),
-      List(Str(dst.collectionName), Bool(true))))
+  def pureCursor(values: List[Bson]) =
+    write(Bson.Arr(values).toJs)
+  def readCursor(source: Col) =
+    write(Call(Select(toJsRef(source.collection), "find"), Nil))
+  def aggregateCursor(source: Col, pipeline: workflowtask.Pipeline) =
+    aggregate(source.collection, pipeline)
+  def mapReduceCursor(source: Col, mr: MapReduce) =
+    write(Call(Select(toJsRef(source.collection), "mapReduce"),
+      List(mr.map, mr.reduce, mr.bson(None).toJs)))
 
   def fail[A](e: EvaluationError) =
     WriterT[LoggerT[F]#EitherF, Vector[Js.Stmt], A](

--- a/core/src/main/scala/quasar/physical/mongodb/filesystem.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/filesystem.scala
@@ -24,7 +24,6 @@ import quasar.fs._, Path._
 import scalaz._, Scalaz._
 import scalaz.concurrent._
 import scalaz.stream._
-import scalaz.stream.io._
 
 trait MongoDbFileSystem extends PlannerBackend[Workflow.Crystallized] {
   protected def server: MongoWrapper
@@ -32,30 +31,20 @@ trait MongoDbFileSystem extends PlannerBackend[Workflow.Crystallized] {
   val ChunkSize = 1000
 
   def scan0(path: Path, offset: Long, limit: Option[Long]):
-      Process[ETask[ResultError, ?], Data] =
+      Process[ETask[ResultError, ?], Data] = {
+    val skipper = (it: com.mongodb.client.FindIterable[org.bson.Document]) => it.skip(offset.toInt)
+    // NB As per the MondoDB documentation, we inverse the value of limit in order to retrieve a single batch.
+    // The documentation around this is very confusing, but it would appear that proceeding this way allows us
+    // to retrieve the data in a single batch. Behavior of the limit parameter on large datasets is tested in
+    // FileSystemSpecs and appears to work as expected.
+    val limiter = (it: com.mongodb.client.FindIterable[org.bson.Document]) => limit.map(v => it.limit(-v.toInt)).getOrElse(it)
+
+    val skipperAndLimiter = skipper andThen limiter
+
     Collection.fromPath(path).fold(
       e => Process.eval[ETask[ResultError, ?], Data](EitherT.left(Task.now(ResultPathError(e)))),
-      col => {
-        val skipper = (it: com.mongodb.client.FindIterable[org.bson.Document]) => it.skip(offset.toInt)
-        // NB As per the MondoDB documentation, we inverse the value of limit in order to retrieve a single batch.
-        // The documentation around this is very confusing, but it would appear that proceeding this way allows us
-        // to retrieve the data in a single batch. Behavior of the limit parameter on large datasets is tested in
-        // FileSystemSpecs and appears to work as expected.
-        val limiter = (it: com.mongodb.client.FindIterable[org.bson.Document]) => limit.map(v => it.limit(-v.toInt)).getOrElse(it)
-
-        val skipperAndLimiter = skipper andThen limiter
-
-        resource(server.get(col).map(c => skipperAndLimiter(c.find()).iterator))(
-          cursor => Task.delay(cursor.close()))(
-          cursor => Task.delay {
-            if (cursor.hasNext) {
-              val obj = cursor.next
-              ignore(obj.remove("_id"))
-              BsonCodec.toData(Bson.fromRepr(obj))
-            }
-            else throw Cause.End.asThrowable
-          }).translate[ETask[ResultError, ?]](liftE[ResultError])
-      })
+      col => server.readCursor(server.get(col).map(c => skipperAndLimiter(c.find()))))
+  }
 
   def count0(path: Path): ProcessingTask[Long] = {
     val p = swapT(Collection.fromPath(path).map(server.get(_).map(_.count)))

--- a/core/src/main/scala/quasar/physical/mongodb/mapreduce.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/mapreduce.scala
@@ -38,11 +38,11 @@ final case class MapReduce(
 
   import MapReduce._
 
-  def bson(dst: Collection): Bson.Doc =
+  def bson(dst: Option[Collection]): Bson.Doc =
     Bson.Doc(ListMap(
       (// "map" -> Bson.JavaScript(map) ::
        //  "reduce" -> Bson.JavaScript(reduce) ::
-        Some("out" -> out.getOrElse(WithAction(Action.Replace, None, None)).bson(dst)) ::
+        dst.map(d => "out" -> out.getOrElse(WithAction(Action.Replace, None, None)).bson(d)) ::
         selection.map("query" -> _.bson) ::
         limit.map("limit" -> Bson.Int64(_)) ::
         finalizer.map("finalize" -> Bson.JavaScript(_)) ::

--- a/core/src/main/scala/quasar/physical/mongodb/workflowtask/ast.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/workflowtask/ast.scala
@@ -60,21 +60,22 @@ object WorkflowTaskF {
   // final case class EvalTaskF[A](source: A, code: Js.FuncDecl)
   //     extends WorkflowTaskF[A]
 
-  implicit def WorkflowTaskFTraverse: Traverse[WorkflowTaskF] =
-    new Traverse[WorkflowTaskF] {
-      def traverseImpl[G[_], A, B](fa: WorkflowTaskF[A])(f: A => G[B])(implicit G: Applicative[G]):
-          G[WorkflowTaskF[B]] =
-        fa match {
-          case PureTaskF(bson) => G.point(PureTaskF[B](bson))
-          case ReadTaskF(coll) => G.point(ReadTaskF[B](coll))
-          case QueryTaskF(src, query, skip, limit) =>
-            f(src).map(QueryTaskF(_, query, skip, limit))
-          case PipelineTaskF(src, pipe) => f(src).map(PipelineTaskF(_, pipe))
-          case MapReduceTaskF(src, mr) => f(src).map(MapReduceTaskF(_, mr))
-          case FoldLeftTaskF(h, t) =>
-            (f(h) |@| t.traverse(f))(FoldLeftTaskF(_, _))
-        }
-    }
+  // NB: currently unused, and hurts coverage
+  // implicit def WorkflowTaskFTraverse: Traverse[WorkflowTaskF] =
+  //   new Traverse[WorkflowTaskF] {
+  //     def traverseImpl[G[_], A, B](fa: WorkflowTaskF[A])(f: A => G[B])(implicit G: Applicative[G]):
+  //         G[WorkflowTaskF[B]] =
+  //       fa match {
+  //         case PureTaskF(bson) => G.point(PureTaskF[B](bson))
+  //         case ReadTaskF(coll) => G.point(ReadTaskF[B](coll))
+  //         case QueryTaskF(src, query, skip, limit) =>
+  //           f(src).map(QueryTaskF(_, query, skip, limit))
+  //         case PipelineTaskF(src, pipe) => f(src).map(PipelineTaskF(_, pipe))
+  //         case MapReduceTaskF(src, mr) => f(src).map(MapReduceTaskF(_, mr))
+  //         case FoldLeftTaskF(h, t) =>
+  //           (f(h) |@| t.traverse(f))(FoldLeftTaskF(_, _))
+  //       }
+  //   }
 
   implicit def WorkflowTaskRenderTree(implicit RC: RenderTree[Collection], RO: RenderTree[WorkflowF[Unit]], RJ: RenderTree[Js], RS: RenderTree[Selector]):
       RenderTree ~> λ[α => RenderTree[WorkflowTaskF[α]]] =

--- a/core/src/main/scala/quasar/planner.scala
+++ b/core/src/main/scala/quasar/planner.scala
@@ -37,7 +37,6 @@ trait Planner[PhysicalPlan] {
 
   def queryPlanner(showNative: PhysicalPlan => (String, Cord))(implicit RA: RenderTree[PhysicalPlan]):
       QueryRequest => EitherT[(Vector[quasar.PhaseResult], ?), CompilationError, PhysicalPlan] = { req =>
-
     // TODO: Factor these things out as individual WriterT functions that can be composed.
     for {
       select     <- withTree("SQL AST")(\/-(req.query))

--- a/core/src/main/scala/quasar/query.scala
+++ b/core/src/main/scala/quasar/query.scala
@@ -16,12 +16,8 @@
 
 package quasar
 
-import quasar.Predef._
-
 import quasar.sql.Expr
-import quasar.fs.Path
 
 final case class QueryRequest(
   query:      Expr,
-  out:        Option[Path],
   variables:  Variables)

--- a/core/src/main/scala/quasar/repl/repl.scala
+++ b/core/src/main/scala/quasar/repl/repl.scala
@@ -206,6 +206,9 @@ object Repl {
     final case class EProcessingError(e: ProcessingError) extends EngineError {
       def message = e.message
     }
+    final case class EEvaluationError(e: EvaluationError) extends EngineError {
+      def message = e.message
+    }
     final case class EDataEncodingError(e: DataEncodingError)
         extends EngineError {
       def message = e.message
@@ -247,6 +250,13 @@ object Repl {
       case _                       => None
     }
   }
+  object EEvaluationError {
+    def apply(error: EvaluationError): EngineError = EngineError.EEvaluationError(error)
+    def unapply(obj: EngineError): Option[EvaluationError] = obj match {
+      case EngineError.EEvaluationError(error) => Some(error)
+      case _                       => None
+    }
+  }
   object EDataEncodingError {
     def apply(error: DataEncodingError): EngineError = EngineError.EDataEncodingError(error)
     def unapply(obj: EngineError): Option[DataEncodingError] = obj match {
@@ -281,26 +291,51 @@ object Repl {
 
     import state.printer
 
-    SQLParser.parseInContext(Query(query), state.path).fold(
-      e => EitherT.left(Task.now(EParsingError(e))),
-      expr => {
-        val (log, resultT) = state.backend.eval(QueryRequest(expr, name.map(Path(_)), Variables.fromMap(state.variables))).run
-        for {
-          _ <- liftE[EngineError](state.debugLevel match {
-            case DebugLevel.Silent  => Task.now(())
-            case DebugLevel.Normal  => printer(log.takeRight(1).mkString("\n\n") + "\n")
-            case DebugLevel.Verbose => printer(log.mkString("\n\n") + "\n")
-          })
-          result <- resultT.fold[EngineTask[(ProcessingError \/ IndexedSeq[Data], Double)]] (
-            e => EitherT.left(Task.now(ECompilationError(e))),
-            resT => liftE[EngineError](timeIt(resT.runLog.run)))
-          (results, elapsed) = result
-          _   <- liftE(printer("Query time: " + elapsed + "s"))
-          _   <- results.fold[EngineTask[Unit]](
-            e => EitherT.left(Task.now(EProcessingError(e))),
-            res => liftE(printer(summarize(state.summaryCount)(res.take(state.summaryCount + 1)))))
-        } yield ()
-      })
+    def printLog(log: Vector[PhaseResult]) =
+      state.debugLevel match {
+        case DebugLevel.Silent  => Task.now(())
+        case DebugLevel.Normal  => printer(log.takeRight(1).mkString("\n\n") + "\n")
+        case DebugLevel.Verbose => printer(log.mkString("\n\n") + "\n")
+      }
+
+    def expr = SQLParser.parseInContext(Query(query), state.path).leftMap(EParsingError(_))
+    def out = name.fold[EngineError \/ Option[Path]](
+        \/-(None))(
+        path => Path(path).from(state.path).bimap(EPathError(_), _.some))
+
+    ((expr |@| out) { case (expr, out) =>
+      val req = QueryRequest(expr, Variables.fromMap(state.variables))
+      out match {
+        case Some(out) =>
+          val (log, outT) = state.backend.run(req, out).run
+          for {
+            _   <- liftE[EngineError](printLog(log))
+            out <- outT.fold[EngineTask[(EvaluationError \/ ResultPath, Double)]] (
+              e => EitherT.left(Task.now(ECompilationError(e))),
+              resT => liftE[EngineError](timeIt(resT.run)))
+            (outPath, elapsed) = out
+            _   <- liftE(printer("Query time: " + elapsed + "s"))
+            _   <- outPath.fold[EngineTask[Unit]](
+              e => EitherT.left(Task.now(EEvaluationError(e))),
+              p => liftE(printer(
+                if (p.path == out) "Source file: " + p.path.simplePathname
+                else "Wrote file: " + p.path.simplePathname)))
+          } yield ()
+        case None =>
+          val (log, resultT) = state.backend.eval(req).run
+          for {
+            _ <- liftE[EngineError](printLog(log))
+            result <- resultT.fold[EngineTask[(ProcessingError \/ IndexedSeq[Data], Double)]] (
+              e => EitherT.left(Task.now(ECompilationError(e))),
+              resT => liftE[EngineError](timeIt(resT.runLog.run)))
+            (results, elapsed) = result
+            _   <- liftE(printer("Query time: " + elapsed + "s"))
+            _   <- results.fold[EngineTask[Unit]](
+              e => EitherT.left(Task.now(EProcessingError(e))),
+              res => liftE(printer(summarize(state.summaryCount)(res.take(state.summaryCount + 1)))))
+          } yield ()
+      }
+    }).fold(e => EitherT.left(Task.now(e)), ι)
   }
 
   def ls(state: RunState, path: Option[Path]): PathTask[Unit] = {

--- a/core/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/core/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -54,7 +54,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
   def plan(query: String): Either[CompilationError, Crystallized] =
     SQLParser.parseInContext(Query(query), Path("/db/")).fold(
       e => scala.sys.error("parsing error: " + e.message),
-      expr => queryPlanner(QueryRequest(expr, None, Variables(Map()))).run._2).toEither
+      expr => queryPlanner(QueryRequest(expr, Variables(Map()))).run._2).toEither
 
   def plan(logical: Fix[LogicalPlan]): Either[PlannerError, Crystallized] =
     (for {
@@ -65,7 +65,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
   def planLog(query: String): ParsingError \/ Vector[PhaseResult] =
     for {
       expr <- SQLParser.parseInContext(Query(query), Path("/db/"))
-    } yield queryPlanner(QueryRequest(expr, None, Variables(Map()))).run._1
+    } yield queryPlanner(QueryRequest(expr, Variables(Map()))).run._1
 
   def beWorkflow(wf: Workflow) = beRight(equalToWorkflow(wf))
 

--- a/it/src/main/resources/tests/3WayJoin.test
+++ b/it/src/main/resources/tests/3WayJoin.test
@@ -1,5 +1,6 @@
 {
     "name": "perform 3-way inner equi-join",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "zips.data",
     "query": "select z1.city, z2.state from zips z1 join zips z2 on z1._id = z2._id join zips z3 on z2._id = z3._id",
     "predicate": "containsAtLeast",

--- a/it/src/main/resources/tests/LocationCount.test
+++ b/it/src/main/resources/tests/LocationCount.test
@@ -1,6 +1,6 @@
 {
     "name": "job postings by city ",
-    "backends": { "mongodb_2_6": "pending", "mongodb_3_0": "pending" },
+    "backends": { "mongodb_2_6": "pending", "mongodb_3_0": "pending", "mongodb_read_only": "pending" },
     "data": "jobs_jobinfo.data",
     "query": "select count(PositionHeader.PositionLocation.LocationCity) as counter,
               PositionHeader.PositionLocation.LocationCity as location

--- a/it/src/main/resources/tests/concatArray.test
+++ b/it/src/main/resources/tests/concatArray.test
@@ -1,5 +1,6 @@
 {
     "name": "concat known array structure",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "zips.data",
     "query": "select [ city, pop ] from zips",
     "predicate": "containsAtLeast",

--- a/it/src/main/resources/tests/concatArrayWithLiteral.test
+++ b/it/src/main/resources/tests/concatArrayWithLiteral.test
@@ -1,5 +1,6 @@
 {
     "name": "concat unknown with literal array",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "zips.data",
     "query": "select loc || [1, 2], city from zips",
     "predicate": "containsAtLeast",

--- a/it/src/main/resources/tests/concatArrayWithUnknown.test
+++ b/it/src/main/resources/tests/concatArrayWithUnknown.test
@@ -1,5 +1,6 @@
 {
     "name": "concat array with unknown structure",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "zips.data",
     "query": "select city, state, loc || [ pop ] from zips",
     "predicate": "containsAtLeast",

--- a/it/src/main/resources/tests/concatFieldAndConstant.test
+++ b/it/src/main/resources/tests/concatFieldAndConstant.test
@@ -1,5 +1,6 @@
 {
     "name": "concat field with constant array",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "zips.data",
     "query": "select array_concat(make_array(pop), array_concat(make_array(1), make_array(2))) from zips",
     "predicate": "containsAtLeast",

--- a/it/src/main/resources/tests/countDistinctStar.test
+++ b/it/src/main/resources/tests/countDistinctStar.test
@@ -1,5 +1,6 @@
 {
   "name": "count distinct *",
+  "backends": { "mongodb_read_only": "pending" },
   "data": "olympics.data",
   "query": "select count(distinct *) from olympics",
   "predicate": "equalsExactly",

--- a/it/src/main/resources/tests/distinctStar.test
+++ b/it/src/main/resources/tests/distinctStar.test
@@ -1,5 +1,6 @@
 {
     "name": "distinct *",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "cities.data",
     "query": "select distinct * from cities where city = 'BOSTON'",
     "predicate": "equalsExactly",

--- a/it/src/main/resources/tests/doubleFlatten.test
+++ b/it/src/main/resources/tests/doubleFlatten.test
@@ -1,5 +1,6 @@
 {
     "name": "flatten a flattened field",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "slamengine_commits.data",
     "query": "select parents[*]{*} from slamengine_commits",
     "predicate": "containsAtLeast",

--- a/it/src/main/resources/tests/doubleFlattenWithIntervening.test
+++ b/it/src/main/resources/tests/doubleFlattenWithIntervening.test
@@ -1,5 +1,6 @@
 {
     "name": "double flatten with intervening field",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "nested.data",
     "query": "select topObj{*}.botObj{*} from nested",
     "predicate": "containsExactly",

--- a/it/src/main/resources/tests/fakeObjectId.test
+++ b/it/src/main/resources/tests/fakeObjectId.test
@@ -1,5 +1,6 @@
 {
     "name": "convert a field to ObjectId",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "objectids.data",
     "query": "select oid(bar) from objectids",
     "predicate": "equalsInitial",

--- a/it/src/main/resources/tests/fieldOrder.test
+++ b/it/src/main/resources/tests/fieldOrder.test
@@ -1,6 +1,6 @@
 {
     "name": "reduced expressions which trigger bad field ordering (#598)",
-    "backends": { "mongodb_2_6": "pending", "mongodb_3_0": "pending" },
+    "backends": { "mongodb_2_6": "pending", "mongodb_3_0": "pending", "mongodb_read_only": "pending" },
 
     "data": "zips.data",
 

--- a/it/src/main/resources/tests/filter.test
+++ b/it/src/main/resources/tests/filter.test
@@ -1,5 +1,6 @@
 {
   "name": "filter with pipeline and JS",
+  "backends": { "mongodb_read_only": "pending" },
 
   "data": "smallZips.data",
 

--- a/it/src/main/resources/tests/filterByJsWithOnlyReducing.test
+++ b/it/src/main/resources/tests/filterByJsWithOnlyReducing.test
@@ -1,5 +1,6 @@
 {
   "name": "filter by JS expression, with only reducing projections",
+  "backends": { "mongodb_read_only": "pending" },
 
   "data": "zips.data",
 

--- a/it/src/main/resources/tests/filterOnFieldComparison.test
+++ b/it/src/main/resources/tests/filterOnFieldComparison.test
@@ -1,5 +1,6 @@
 {
     "name": "filter on field comparison",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "zips.data",
     "query": "select * from zips where pop < loc[1] limit 10",
     "predicate": "containsExactly",

--- a/it/src/main/resources/tests/filterWithComplexNot.test
+++ b/it/src/main/resources/tests/filterWithComplexNot.test
@@ -1,5 +1,7 @@
 {
     "name": "filter with complex query involving not",
+    "backends": { "mongodb_read_only": "pending" },
+
     "query": "select _id as zip from zips
               where not (city not like 'BOULD%' or state != 'CO' or (pop between 20000 and 40000 and loc[1] != 40.017235))",
 

--- a/it/src/main/resources/tests/flattenArrayProjection.test
+++ b/it/src/main/resources/tests/flattenArrayProjection.test
@@ -1,5 +1,6 @@
 {
     "name": "flatten an object resulting from an array projection",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "slamengine_commits.data",
     "query": "select parents[0]{*} from slamengine_commits",
     "predicate": "containsAtLeast",

--- a/it/src/main/resources/tests/flattenGroupedObject.test
+++ b/it/src/main/resources/tests/flattenGroupedObject.test
@@ -1,5 +1,6 @@
 {
     "name": "flatten a grouped object with filter",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "slamengine_commits.data",
     "query": "select distinct commit{*}, count(*) from slamengine_commits where commit{*} like 'http%' group by committer.login",
     "predicate": "containsAtLeast",

--- a/it/src/main/resources/tests/flattenNestedObject.test
+++ b/it/src/main/resources/tests/flattenNestedObject.test
@@ -1,5 +1,6 @@
 {
     "name": "flatten an object inside a field projection",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "slamengine_commits.data",
     "query": "select commit.author{*} from slamengine_commits",
     "predicate": "containsAtLeast",

--- a/it/src/main/resources/tests/flattenObject.test
+++ b/it/src/main/resources/tests/flattenObject.test
@@ -1,5 +1,6 @@
 {
     "name": "flatten object",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "usa_factbook.data",
     "query": "select geo{*} from usa_factbook",
     "predicate": "containsExactly",

--- a/it/src/main/resources/tests/groupedJoin.test
+++ b/it/src/main/resources/tests/groupedJoin.test
@@ -1,5 +1,6 @@
 {
     "name": "count grouped joined tables",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "slamengine_commits.data",
     "query": "SELECT p.author.login, COUNT(*) FROM slamengine_commits p INNER JOIN slamengine_commits c ON p.sha = c.sha GROUP BY p.author.login",
     "predicate": "containsExactly",

--- a/it/src/main/resources/tests/guardedExpression.test
+++ b/it/src/main/resources/tests/guardedExpression.test
@@ -1,5 +1,6 @@
 {
   "name": "regex on non-string field",
+  "backends": { "mongodb_read_only": "pending" },
   "data": "zips.data",
   "query": "select distinct * from zips where pop ~* 'foo'",
   "predicate": "equalsExactly",

--- a/it/src/main/resources/tests/idNotAliased.test
+++ b/it/src/main/resources/tests/idNotAliased.test
@@ -1,6 +1,6 @@
 {
     "name": "select _id explicitly",
-    "backends": { "mongodb_2_6": "pending", "mongodb_3_0": "pending" },
+    "backends": { "mongodb_2_6": "pending", "mongodb_3_0": "pending", "mongodb_read_only": "pending" },
     "data": "zips.data",
     "query": "select _id from zips where city = 'BOULDER' and state = 'CO'",
     "predicate": "containsExactly",

--- a/it/src/main/resources/tests/innerEquiJoin.test
+++ b/it/src/main/resources/tests/innerEquiJoin.test
@@ -1,5 +1,6 @@
 {
     "name": "perform inner equi-join",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "zips.data",
     "query": "select zips.city, z2.state from zips join zips z2 on zips._id = z2._id",
     "predicate": "containsAtLeast",

--- a/it/src/main/resources/tests/innerEquiJoinWithWildcard.test
+++ b/it/src/main/resources/tests/innerEquiJoinWithWildcard.test
@@ -1,5 +1,6 @@
 {
     "name": "perform inner equi-join with wildcard",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "zips.data",
     "query": "select * from zips join zips z2 on zips._id = z2._id",
     "predicate": "containsAtLeast",

--- a/it/src/main/resources/tests/joinWithMultipleConditions.test
+++ b/it/src/main/resources/tests/joinWithMultipleConditions.test
@@ -1,5 +1,6 @@
 {
     "name": "join with multiple conditions",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "slamengine_commits.data",
     "query": "select l.sha as child, l.author.login as c_auth, r.sha as parent, r.author.login as p_auth from slamengine_commits l join slamengine_commits r on r.sha = l.parents[0].sha and l.author.login = r.author.login",
     "predicate": "containsAtLeast",

--- a/it/src/main/resources/tests/joinWithReversedCondition.test
+++ b/it/src/main/resources/tests/joinWithReversedCondition.test
@@ -1,5 +1,6 @@
 {
     "name": "join with reversed condition and complex condition expression",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "slamengine_commits.data",
     "query": "select l.sha as child, l.author.login as c_auth, r.sha as parent, r.author.login as p_auth from slamengine_commits l join slamengine_commits r on r.sha = l.parents[0].sha",
     "predicate": "containsAtLeast",

--- a/it/src/main/resources/tests/jsWithNonJsFilter.test
+++ b/it/src/main/resources/tests/jsWithNonJsFilter.test
@@ -1,5 +1,6 @@
 {
     "name": "filter on JS with non-JS",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "zips.data",
     "query": "select city, pop from zips where length(city) < 4 and pop < 20000",
     "predicate": "containsAtLeast",

--- a/it/src/main/resources/tests/longCitiesWithLength.test
+++ b/it/src/main/resources/tests/longCitiesWithLength.test
@@ -1,5 +1,6 @@
 {
   "name": "long city names in Colorado",
+  "backends": { "mongodb_read_only": "pending" },
 
   "data": "zips.data",
 

--- a/it/src/main/resources/tests/matchRegexPatternWithExpressions.test
+++ b/it/src/main/resources/tests/matchRegexPatternWithExpressions.test
@@ -1,5 +1,6 @@
 {
   "name": "regexes in expressions and filter, with fields and constants providing the pattern",
+  "backends": { "mongodb_read_only": "pending" },
 
   "data": "zips.data",
 

--- a/it/src/main/resources/tests/multitypeFlatten.test
+++ b/it/src/main/resources/tests/multitypeFlatten.test
@@ -1,5 +1,6 @@
 {
     "name": "flatten a single field as both object and array",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "nested_foo.data",
     "query": "select * from nested_foo where (
                 foo{*} LIKE '%15%' OR

--- a/it/src/main/resources/tests/negatedRegex.test
+++ b/it/src/main/resources/tests/negatedRegex.test
@@ -1,5 +1,6 @@
 {
     "name": "negate matches in filter and projection",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "zips.data",
     "query": "select city, city !~ 'A' from zips where city !~ 'CHI'",
     "predicate": "containsAtLeast",

--- a/it/src/main/resources/tests/null/nullTestExprsWithMissing.test
+++ b/it/src/main/resources/tests/null/nullTestExprsWithMissing.test
@@ -1,6 +1,6 @@
 {
     "name": "expressions with `= null` and `is null`, with missing fields (pending #465)",
-    "backends": { "mongodb_2_6": "pending", "mongodb_3_0": "pending" },
+    "backends": { "mongodb_2_6": "pending", "mongodb_3_0": "pending", "mongodb_read_only": "pending" },
     "data": "nullsWithMissing.data",
     "query": "select name,
                      val, val = null, val is null, val is not null,

--- a/it/src/main/resources/tests/orderJoinByAlias.test
+++ b/it/src/main/resources/tests/orderJoinByAlias.test
@@ -1,5 +1,6 @@
 {
     "name": "order join by alias",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "zips.data",
     "query": "select z1._id as zip, z2.pop / 1000 as popK from zips z1 inner join zips z2 on z1._id = z2._id order by popK desc",
     "predicate": "equalsInitial",

--- a/it/src/main/resources/tests/orderedWildcardWithProjection.test
+++ b/it/src/main/resources/tests/orderedWildcardWithProjection.test
@@ -1,5 +1,6 @@
 {
     "name": "wildcard with projection and synthetic field",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "zips.data",
     "query": "select *, pop * 10 from zips order by pop / 10 desc",
     "predicate": "equalsInitial",

--- a/it/src/main/resources/tests/projectCaseInsensitiveRegex.test
+++ b/it/src/main/resources/tests/projectCaseInsensitiveRegex.test
@@ -1,5 +1,6 @@
 {
     "name": "case-insensitive regex in projections",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "zips.data",
     "query": "select city, city ~* 'boU', city !~* 'Bou' from zips",
     "NB": "Should also test `doesNotContain`, see SD-577.",

--- a/it/src/main/resources/tests/projectFieldWithFlatten.test
+++ b/it/src/main/resources/tests/projectFieldWithFlatten.test
@@ -1,5 +1,6 @@
 {
     "name": "project unrelated field with object flatten",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "usa_factbook.data",
     "query": "select intro from usa_factbook where geo{*}.text = '19,924 km'",
     "predicate": "containsExactly",

--- a/it/src/main/resources/tests/projectFromConcattedArray.test
+++ b/it/src/main/resources/tests/projectFromConcattedArray.test
@@ -1,5 +1,6 @@
 {
     "name": "project from concatted array",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "zips.data",
     "query": "select (loc || [1, 2])[1] from zips",
     "predicate": "containsAtLeast",

--- a/it/src/main/resources/tests/projectIndexFromGroup.test
+++ b/it/src/main/resources/tests/projectIndexFromGroup.test
@@ -1,5 +1,6 @@
 {
     "name": "project index from group",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "slamengine_commits.data",
     "query": "select parents[0].sha, count(*) as count from slamengine_commits group by parents[0].sha",
     "predicate": "containsAtLeast",

--- a/it/src/main/resources/tests/projectIndexFromGroupWithFilter.test
+++ b/it/src/main/resources/tests/projectIndexFromGroupWithFilter.test
@@ -1,5 +1,6 @@
 {
     "name": "project index from group with filter",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "slamengine_commits.data",
     "query": "select parents[0].sha, count(*) as count from slamengine_commits where parents[0].sha like '5%' group by parents[0].sha",
     "predicate": "containsExactly",

--- a/it/src/main/resources/tests/projectIndexWithObjectFlatten.test
+++ b/it/src/main/resources/tests/projectIndexWithObjectFlatten.test
@@ -1,5 +1,6 @@
 {
     "name": "project index with object flatten",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "slamengine_commits.data",
     "query": "select parents[0], commit{*} from slamengine_commits",
     "predicate": "containsAtLeast",

--- a/it/src/main/resources/tests/selectArrayElement.test
+++ b/it/src/main/resources/tests/selectArrayElement.test
@@ -1,5 +1,6 @@
 {
     "name": "select array element",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "zips.data",
     "query": "select city, loc[0] from zips",
     "predicate": "containsAtLeast",

--- a/it/src/main/resources/tests/servlet.test
+++ b/it/src/main/resources/tests/servlet.test
@@ -1,6 +1,6 @@
 {
     "name": "servlets with and without init-param (pending #465, #467)",
-    "backends": { "mongodb_2_6": "pending", "mongodb_3_0": "pending" },
+    "backends": { "mongodb_2_6": "pending", "mongodb_3_0": "pending", "mongodb_read_only": "pending" },
     "data": "webapp.data",
     "query": "select \"servlet-name\", \"init-param\" is not null from webapp where \"init-param\" is null or \"init-param\".\"betaServer\"",
     "predicate": "containsExactly",

--- a/it/src/main/resources/tests/shortCities.test
+++ b/it/src/main/resources/tests/shortCities.test
@@ -1,5 +1,6 @@
 {
     "name": "shortest city names",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "zips.data",
     "query": "select distinct city from zips order by length(city), city limit 5",
     "predicate": "equalsExactly",

--- a/it/src/main/resources/tests/simpleJsFilter.test
+++ b/it/src/main/resources/tests/simpleJsFilter.test
@@ -1,5 +1,6 @@
 {
     "name": "filter on simple JS",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "zips.data",
     "query": "select city from zips where length(city) < 4",
     "predicate": "containsAtLeast",

--- a/it/src/main/resources/tests/simpleProjectWithOneRenamed.test
+++ b/it/src/main/resources/tests/simpleProjectWithOneRenamed.test
@@ -1,7 +1,7 @@
 {
   "name": "simple $project with one renamed field and one unchanged (see #598)",
 
-  "backends": { "mongodb_2_6": "pending", "mongodb_3_0": "pending" },
+  "backends": { "mongodb_2_6": "pending", "mongodb_3_0": "pending", "mongodb_read_only": "pending" },
 
   "data": "zips.data",
 

--- a/it/src/main/resources/tests/sortByJS.test
+++ b/it/src/main/resources/tests/sortByJS.test
@@ -1,5 +1,6 @@
 {
   "name": "sort by JS expression with filter",
+  "backends": { "mongodb_read_only": "pending" },
 
   "data": "zips.data",
 

--- a/it/src/main/resources/tests/sortWildcardOnExpression.test
+++ b/it/src/main/resources/tests/sortWildcardOnExpression.test
@@ -1,5 +1,6 @@
 {
     "name": "sort wildcard on expression",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "zips.data",
     "query": "select * from zips order by pop/10 desc",
     "predicate": "equalsInitial",

--- a/it/src/main/resources/tests/statesByShortestFirstCity.test
+++ b/it/src/main/resources/tests/statesByShortestFirstCity.test
@@ -1,6 +1,7 @@
 {
   "name": "states sorted by the length of name of their first city, alphabetically",
   "description": "combines an aggregate function (min) with a function implemented in JS (length)",
+  "backends": { "mongodb_read_only": "pending" },
 
   "data": "zips.data",
 

--- a/it/src/main/resources/tests/time.test
+++ b/it/src/main/resources/tests/time.test
@@ -1,5 +1,6 @@
 {
   "name": "filter on time_of_day",
+  "backends": { "mongodb_read_only": "pending" },
 
   "data": "days.data",
 

--- a/it/src/main/resources/tests/tripleFlatten.test
+++ b/it/src/main/resources/tests/tripleFlatten.test
@@ -1,5 +1,6 @@
 {
     "name": "triple flatten with mixed content",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "nested.data",
     "query": "select topObj{*}{*}{*} from nested",
     "NB": "containsExactly has a bug that gets confused on duplicate results (#732).",

--- a/it/src/main/resources/tests/undefinedJsInExpr.test
+++ b/it/src/main/resources/tests/undefinedJsInExpr.test
@@ -1,5 +1,6 @@
 {
     "name": "propagate undefined and null in JS",
+    "backends": { "mongodb_read_only": "pending" },
     "data": "zips.data",
     "query": "select distinct length(meh), meh.mep, length(meh.mep) from zips",
     "predicate": "containsExactly",

--- a/it/src/main/resources/tests/wildcardWithExtraProjections.test
+++ b/it/src/main/resources/tests/wildcardWithExtraProjections.test
@@ -1,5 +1,6 @@
 {
   "name": "wildcard with additional projections (and filtering)",
+  "backends": { "mongodb_read_only": "pending" },
   "data": "zips.data",
   "query": "select *, concat(city, concat(', ', state)), city = 'BOULDER' from zips where city like 'BOULDER%'",
   "predicate": "containsExactly",

--- a/it/src/main/resources/tests/zipsByCityLength.test
+++ b/it/src/main/resources/tests/zipsByCityLength.test
@@ -1,5 +1,6 @@
 {
   "name": "count occurrences of each value of length(city), with filtering",
+  "backends": { "mongodb_read_only": "pending" },
 
   "data": "zips.data",
 

--- a/it/src/main/scala/quasar/Interactive.scala
+++ b/it/src/main/scala/quasar/Interactive.scala
@@ -143,7 +143,11 @@ package object interactive {
           err => Process.fail( new RuntimeException("error loading: " + err.message)),
           j => Process.eval(Task.now(j))
         ))
-        backend.save(path, data)
+        for {
+          _ <- liftE(Task.delay(println("loading: " + path.simplePathname)))
+          _ <- backend.save(path, data)
+          _ <- liftE(Task.delay(println("...done")))
+        } yield ()
       }
     }
   }
@@ -163,10 +167,6 @@ package object interactive {
    *  @param prefix The path under which to store the collection materialized from the data file
    *  @param file file from which to the load the data
    */
-  def loadFile(backend: Backend, prefix: Path, file: File): ProcessingTask[Unit] = {
-    for {
-    _ <- liftE(Task.delay(println("loading: " + file)))
-    _ <- loadData(backend, prefix, DataSource.fromFile(file))
-    } yield ()
-  }
+  def loadFile(backend: Backend, prefix: Path, file: File): ProcessingTask[Unit] =
+    loadData(backend, prefix, DataSource.fromFile(file))
 }

--- a/it/src/main/scala/quasar/Interactive.scala
+++ b/it/src/main/scala/quasar/Interactive.scala
@@ -71,8 +71,8 @@ package object interactive {
     val parser = new SQLParser()
     for {
       sql <- Task.fromDisjunction(parser.parse(Query(query)).leftMap(parseError => new scala.Exception("Parse error" + parseError.message)))
-      query = QueryRequest(sql, Some(destinationPath), Variables(Map()))
-      resultPath <- backend.run(query).fold(
+      query = QueryRequest(sql, Variables(Map()))
+      resultPath <- backend.run(query, destinationPath).fold(
         err => Task.fail(new scala.Exception(err.message)),
         a => a.run.flatMap(either => Task.fromDisjunction(either.leftMap(e => new scala.Exception("Evaluation error" + e.message))))
       )._2
@@ -102,7 +102,7 @@ package object interactive {
     val parser = new SQLParser()
     parser.parse(Query(query)).fold(
       err => throw new scala.Exception("Parser Error" + err.message),
-      sql => backend.eval(QueryRequest(sql, None, Variables(Map())))
+      sql => backend.eval(QueryRequest(sql, Variables(Map())))
     )
   }
 

--- a/it/src/test/scala/quasar/ErrorConditions.scala
+++ b/it/src/test/scala/quasar/ErrorConditions.scala
@@ -13,7 +13,7 @@ import Errors._
 
 class ErrorConditions extends BackendTest with NoTimeConversions with DisjunctionMatchers {
 
-  backendShould { (prefix, backend, backendName) =>
+  backendShould { (prefix, _, backend, backendName) =>
     "Backend" should {
       "error out consistently" in {
         def testQueryOnMissingCollection(produceQueryFromCollectionPath: String => String) = {

--- a/it/src/test/scala/quasar/InteractiveTest.scala
+++ b/it/src/test/scala/quasar/InteractiveTest.scala
@@ -23,25 +23,28 @@ class InteractiveTest extends BackendTest with NoTimeConversions with Disjunctio
       listings must contain(FilesystemNode(file, None))
     }
 
-    "Interactive" should {
-      "load test data correctly" in {
-        interactive.withTemp(backend, prefix) { tempFile =>
-          interactive.delete(backend, prefix ++ tempFile).run
-          assertNotThere(tempFile)
-          interactive.loadData(backend, prefix ++ tempFile, interactive.zips.run.content).run.run
-          assertThere(tempFile)
+    // NB: this test has nothing interesting to say about read-only
+    // connections at present.
+    if (name != TestConfig.MONGO_READ_ONLY)
+      "Interactive" should {
+        "load test data correctly" in {
+          interactive.withTemp(backend, prefix) { tempFile =>
+            interactive.delete(backend, prefix ++ tempFile).run
+            assertNotThere(tempFile)
+            interactive.loadData(backend, prefix ++ tempFile, interactive.zips.run.content).run.run
+            assertThere(tempFile)
+          }
+        }
+        "load file correctly" in {
+          val collName = "zips"
+          val path = prefix ++ Path(collName)
+          val file = new File(s"it/src/main/resources/tests/$collName.data")
+          interactive.delete(backend, path).run
+          assertNotThere(path)
+          interactive.loadFile(backend,prefix, file).run.run
+          assertThere(Path(collName))
         }
       }
-      "load file correctly" in {
-        val collName = "zips"
-        val path = prefix ++ Path(collName)
-        val file = new File(s"it/src/main/resources/tests/$collName.data")
-        interactive.delete(backend, path).run
-        assertNotThere(path)
-        interactive.loadFile(backend,prefix, file).run.run
-        assertThere(Path(collName))
-      }
-    }
     ()
   }
 }

--- a/it/src/test/scala/quasar/InteractiveTest.scala
+++ b/it/src/test/scala/quasar/InteractiveTest.scala
@@ -11,7 +11,7 @@ import quasar.specs2.DisjunctionMatchers
 
 class InteractiveTest extends BackendTest with NoTimeConversions with DisjunctionMatchers {
 
-  backendShould { (prefix, backend, name) =>
+  backendShould { (prefix, _, backend, name) =>
 
     def assertNotThere(file: Path) = {
       val listings = interactive.ls(backend, prefix).run

--- a/it/src/test/scala/quasar/backendtest.scala
+++ b/it/src/test/scala/quasar/backendtest.scala
@@ -185,8 +185,8 @@ trait BackendTest extends Specification {
     *                 identifying the backend in messages as well as a list of fully qualified paths to the test data
     *                 requested (in the same order as supplied)
     */
-  def backendShould(data: DataSource*)(runTests: (Path, Backend, BackendName, List[Path]) => Unit): Unit =
-    backendShould0(data: _*) { case (p, _, b, n, ps) => runTests(p, b, n, ps) }
+  def backendShould(data: DataSource*)(runTests: (Path, Backend, Backend, BackendName, List[Path]) => Unit): Unit =
+    backendShould0(data: _*) { case (p, i, t, n, ps) => runTests(p, i, t, n, ps) }
 
   /** Run the supplied tests against all backends.
     *

--- a/it/src/test/scala/quasar/backendtest.scala
+++ b/it/src/test/scala/quasar/backendtest.scala
@@ -16,6 +16,8 @@ import scalaz.concurrent._
 
 import argonaut._
 
+final case class BackendName(name: String)
+
 object TestConfig {
 
   /** The path prefix under which test data may be found as well as where tests
@@ -29,28 +31,40 @@ object TestConfig {
     */
   val TestPathPrefixEnvName = "QUASAR_TEST_PATH_PREFIX"
 
-  val MONGO_2_6 = "mongodb_2_6"
-  val MONGO_3_0 = "mongodb_3_0"
-  lazy val backendNames: List[String] = List(MONGO_2_6, MONGO_3_0)
+  val MONGO_2_6 = BackendName("mongodb_2_6")
+  val MONGO_3_0 = BackendName("mongodb_3_0")
+  val MONGO_READ_ONLY = BackendName("mongodb_read_only")
+  lazy val backendNames: List[BackendName] = List(MONGO_2_6, MONGO_3_0, MONGO_READ_ONLY)
+
+  def envName(b: BackendName) = "QUASAR_" + b.name.toUpperCase
+  def insertEnvName(b: BackendName) = envName(b) + "_INSERT"
 
   private def fail[A](msg: String): Task[A] = Task.fail(new RuntimeException(msg))
 
-  def backendEnvName(backend: String): String = "QUASAR_" + backend.toUpperCase
-
   /** Read the value of an environment variable. */
-  def readEnv(name: String): OptionT[Task, String] =
+  def readEnv(varName: String): OptionT[Task, String] =
     Task.delay(System.getenv).liftM[OptionT]
-      .flatMap(env => OptionT(Task.delay(Option(env.get(name)))))
+      .flatMap(env => OptionT(Task.delay(Option(env.get(varName)))))
 
   /** Load backend config from environment variable.
     *
     * Fails if it cannot parse the config and returns None if there is no config.
     */
-  def loadConfig(name: String): OptionT[Task, MountConfig] =
-    readEnv(backendEnvName(name)).flatMapF(value =>
+  def loadConfig(envVar: String): OptionT[Task, MountConfig] =
+    readEnv(envVar).flatMapF(value =>
       Parse.decodeEither[MountConfig](value).fold(
-        e => fail("Failed to parse $" + backendEnvName(name) + ": " + e),
+        e => fail("Failed to parse $" + envVar + ": " + e),
         _.point[Task]))
+
+  /** Load a pair of backend configs, the first for inserting test data, and
+    * the second for actually running tests. If no config is specified for
+    * inserting, then the test config is just returned twice.
+    */
+  def loadConfigPair(name: BackendName): OptionT[Task, (MountConfig, MountConfig)] = {
+    OptionT((loadConfig(insertEnvName(name)).run |@| loadConfig(envName(name)).run) { (c1, c2) =>
+      c2.map(c2 => (c1.getOrElse(c2), c2))
+    })
+  }
 
   /** Returns the absolute path within a backend to the directory containing test
     * data.
@@ -71,17 +85,21 @@ trait BackendTest extends Specification {
   sequential  // makes it easier to clean up
   args.report(showtimes=true)
 
-  lazy val AllBackends: Task[NonEmptyList[(String, Backend)]] = {
-    def backendNamed(name: String): OptionT[Task, Backend] =
-      TestConfig.loadConfig(name).flatMapF(bcfg =>
-        BackendDefinitions.All(bcfg).fold(
+  lazy val AllBackends: Task[NonEmptyList[(BackendName, (Backend, Backend))]] = {
+    def backendNamed(name: BackendName): OptionT[Task, (Backend, Backend)] = {
+      def mount(cfg: MountConfig) =
+        BackendDefinitions.All(cfg).fold(
           e => Task.fail(new RuntimeException(
-            "Invalid config for backend " + name + ": " + bcfg + ", error: " + e.message)),
-          Task.now(_)).join)
+            "Invalid config for backend " + name + ": " + cfg + ", error: " + e.message)),
+          Task.now(_)).join
+
+      TestConfig.loadConfigPair(name).flatMapF { case (icfg, tcfg) =>
+        Applicative[Task].tuple2(mount(icfg), mount(tcfg)) }
+    }
 
     def noBackendsFound: Throwable = new RuntimeException(
       "No backend to test. Consider setting one of these environment variables: " +
-      TestConfig.backendNames.map(TestConfig.backendEnvName).mkString(", ")
+      TestConfig.backendNames.map(TestConfig.envName).mkString(", ")
     )
 
     TestConfig.backendNames
@@ -117,17 +135,17 @@ trait BackendTest extends Specification {
     *                 identifying the backend in messages as well as a list of fully qualified paths to the test data
     *                 requested (in the same order as supplied)
     */
-  def backendShould(data: DataSource*)(runTests: (Path, Backend, String, List[Path]) => Unit): Unit = {
+  private def backendShould0(data: DataSource*)(runTests: (Path, Backend, Backend, BackendName, List[Path]) => Unit): Unit = {
     import interactive._
     val dataSources = data.toList
     val emptyNameMessage = "Every Source of data must have a name so that we know where to temporarly store it"
     scala.Predef.require(dataSources.all(_.name != ""), emptyNameMessage)
     (TestConfig.testDataPathPrefix |@| AllBackends)((dir, backends) =>
-      backends.traverse_ { case (n, b) =>
+      backends.traverse_ { case (n, (ib, tb)) =>
         val loadAll = dataSources.map(source =>
-          safeTaskToNormalTask[ProcessingError].apply(loadData(b, dir,source))
+          safeTaskToNormalTask[ProcessingError].apply(loadData(ib, dir, source))
         )
-        val deleteData = Monad[Task].sequence(dataSources.map(source => delete(b,dir ++ Path(source.name))))
+        val deleteData = Monad[Task].sequence(dataSources.map(source => delete(ib, dir ++ Path(source.name))))
         val filesPaths = dataSources.map(source => dir ++ Path(source.name))
         for {
           _ <- Monad[Task].sequence(loadAll)
@@ -141,7 +159,7 @@ trait BackendTest extends Specification {
                                                                    // "constructed" but before they are run,
                                                                    // resulting in no more data when the tests are
                                                                    // actually run
-          _ <- Task.delay(n should runTests(dir, b, n, filesPaths))//.onFinish(_ => deleteData.void)
+          _ <- Task.delay(n.name should runTests(dir, ib, tb, n, filesPaths))//.onFinish(_ => deleteData.void)
         } yield ()
       }
     ).join.run
@@ -152,13 +170,37 @@ trait BackendTest extends Specification {
     * If the fixture fails to load any backends for some reason, an exception is
     * thrown stating so.
     *
+    * @param data A list of data sources to use in this test. The data will be loaded if
+    *             not already loaded and deleted at the end of the test. Currently, the data is actually
+    *             NOT deleted at the end of the test, but that is an undesired behavior that should hopefully
+    *             be fixed in the future.
+    *             Currently as well, the sources must have a non-empty [[String]] as a description
+    *             in order for the fixture to derive a [[Path]] at which to store the data. Eventually, this path
+    *             location could be randomized since we provide the paths as an argument for the body, so it should
+    *             not hardcode any [[String]]s in theory. Under such circumstances, a [[DataSource]] with a empty string
+    *             description would be accepted without issues.
     * @param runTests A function that accepts a path prefix under which both test
     *                 data may be found and tests may use as a sandbox, a backend
     *                 (filesystem) and an associated name for purposes of
+    *                 identifying the backend in messages as well as a list of fully qualified paths to the test data
+    *                 requested (in the same order as supplied)
+    */
+  def backendShould(data: DataSource*)(runTests: (Path, Backend, BackendName, List[Path]) => Unit): Unit =
+    backendShould0(data: _*) { case (p, _, b, n, ps) => runTests(p, b, n, ps) }
+
+  /** Run the supplied tests against all backends.
+    *
+    * If the fixture fails to load any backends for some reason, an exception is
+    * thrown stating so.
+    *
+    * @param runTests A function that accepts a path prefix under which both test
+    *                 data may be found and tests may use as a sandbox, a backend
+    *                 (filesystem) for inserting test data, another backend to be
+    *                 tested, and an associated name for purposes of
     *                 identifying the backend in messages.
     */
-  def backendShould(runTests: (Path, Backend, String) => Unit): Unit =
-    backendShould(){ case (p, b, n, _) => runTests(p,b,n)}
+  def backendShould(runTests: (Path, Backend, Backend, BackendName) => Unit): Unit =
+    backendShould0(){ case (p, ib, tb, n, _) => runTests(p,ib,tb,n)}
 
   def deleteTempFiles(backend: Backend, dir: Path): Task[Unit] =
     backend.ls(dir).run.flatMap(_.fold(

--- a/it/src/test/scala/quasar/fs/filesystem.scala
+++ b/it/src/test/scala/quasar/fs/filesystem.scala
@@ -31,10 +31,16 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
     case x => x must beNull
   }
 
-  backendShould(interactive.zips.run) { (prefix, fs, _, files) =>
+  backendShould(interactive.zips.run) { (prefix, insertFs, fs, name, files) =>
     val relPrefix = prefix.asRelative
     val TestDir = relPrefix ++ testRootDir ++ genTempDir.run
     val ZipsDir = files.head
+
+    implicit class SkippedOnReadOnly[T: org.specs2.execute.AsResult](t: => T) {
+      def skippedOnReadOnly: org.specs2.execute.Result =
+        if (name == TestConfig.MONGO_READ_ONLY) org.specs2.execute.Skipped("test of write behavior")
+        else org.specs2.execute.AsResult(t)
+    }
 
     "FileSystem" should {
       // Run the task to create a single FileSystem instance for each run (I guess)
@@ -71,7 +77,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           before must not(contain(FilesystemNode(tmp, None)))
           after must contain(FilesystemNode(tmp, None))
         }).fold(_ must beNull, ι).run
-      }
+      }.skippedOnReadOnly
 
       "allow duplicate saves" in {
         (for {
@@ -84,7 +90,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           before must contain(FilesystemNode(tmp, None))
           after must contain(FilesystemNode(tmp, None))
         }).fold(_ must beNull, ι).run
-      }
+      }.skippedOnReadOnly
 
       "fail duplicate creates" in {
         (for {
@@ -97,7 +103,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           after must_== before
           rez must beLeftDisjunction(PPathError(ExistingPathError(TestDir ++ tmp, Some("can’t be created, because it already exists"))))
         }).fold(_ must beNull, ι).run
-      }
+      }.skippedOnReadOnly
 
       "fail initial replace" in {
         (for {
@@ -109,7 +115,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           after must_== before
           rez must beLeftDisjunction(PPathError(NonexistentPathError(TestDir ++ tmp, Some("can’t be replaced, because it doesn’t exist"))))
         }).fold(_ must beNull, ι).run
-      }
+      }.skippedOnReadOnly
 
       "replace one" in {
         (for {
@@ -122,7 +128,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           before must contain(FilesystemNode(tmp, None))
           after must contain(FilesystemNode(tmp, None))
         }).fold(_ must beNull, ι).run
-      }
+      }.skippedOnReadOnly
 
       "save one (subdir)" in {
         (for {
@@ -135,7 +141,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           before must not(contain(FilesystemNode(tmp, None)))
           after must contain(FilesystemNode(tmp, None))
         }).fold(_ must beNull, ι).run
-      }
+      }.skippedOnReadOnly
 
       "save one with error" in {
         val badJson = Data.Int(1)
@@ -150,7 +156,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           rez must beLeftDisjunction
           after must_== before
         }).fold(_ must beNull, ι).run
-      }
+      }.skippedOnReadOnly
 
       "save many (approx. 10 MB in 1K docs)" in {
         val sizeInMB = 10.0
@@ -175,7 +181,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
         } yield {
           after must contain(FilesystemNode(tmp, None))
         }).fold(_ must beNull, ι).run
-      }
+      }.skippedOnReadOnly
 
       "append one" in {
         val json = Data.Obj(ListMap("a" ->Data.Int(1)))
@@ -188,7 +194,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           rez.size must_== 0
           saved.size must_== 1
         }).fold(_ must beNull, ι).run
-      }
+      }.skippedOnReadOnly
 
       "append with one ok and one error" in {
         val json1 = Data.Obj(ListMap("a" ->Data.Int(1)))
@@ -202,7 +208,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           rez.size must_== 1
           saved.size must_== 1
         }).fold(_ must beNull, ι).run
-      }
+      }.skippedOnReadOnly
 
       "move file" in {
         (for {
@@ -215,7 +221,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           after must not(contain(FilesystemNode(tmp1, None)))
           after must contain(FilesystemNode(tmp2, None))
         }).fold(_ must beNull, ι).run
-      }
+      }.skippedOnReadOnly
 
       "error: move file to existing path" in {
         (for {
@@ -230,7 +236,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           after must contain(FilesystemNode(tmp1, None))
           after must contain(FilesystemNode(tmp2, None))
         }).fold(_ must beNull, ι).run
-      }
+      }.skippedOnReadOnly
 
       "move file to existing path with Overwrite semantics" in {
         (for {
@@ -244,7 +250,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           after must not(contain(FilesystemNode(tmp1, None)))
           after must contain(FilesystemNode(tmp2, None))
         }).fold(_ must beNull, ι).run
-      }
+      }.skippedOnReadOnly
 
       "move file to itself (NOP)" in {
         (for {
@@ -255,7 +261,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
         } yield {
           after must contain(FilesystemNode(tmp1, None))
         }).fold(_ must beNull, ι).run
-      }
+      }.skippedOnReadOnly
 
       "move dir" in {
         (for {
@@ -271,7 +277,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           after must not(contain(FilesystemNode(tmpDir1, None)))
           after must contain(FilesystemNode(tmpDir2, None))
         }).fold(_ must beNull, ι).run
-      }
+      }.skippedOnReadOnly
 
       "move dir with destination given as file path" in {
         (for {
@@ -287,7 +293,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           after must not(contain(FilesystemNode(tmpDir1, None)))
           after must contain(FilesystemNode(tmpDir2.asDir, None))
         }).fold(_ must beNull, ι).run
-      }
+      }.skippedOnReadOnly
 
       "move missing dir to new (also missing) location (NOP)" in {
         (for {
@@ -299,7 +305,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           after must not(contain(FilesystemNode(tmpDir1, None)))
           after must not(contain(FilesystemNode(tmpDir2, None)))
         }).fold(_ must beNull, ι).run
-      }
+      }.skippedOnReadOnly
 
       "delete file" in {
         (for {
@@ -310,7 +316,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
         } yield {
           after must not(contain(FilesystemNode(tmp, None)))
         }).fold(_ must beNull, ι).run
-      }
+      }.skippedOnReadOnly
 
       "delete file but not sibling" in {
         val tmp1 = Path("file1")
@@ -327,7 +333,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           after must not(contain(FilesystemNode(tmp1, None)))
           after must contain(FilesystemNode(tmp2, None))
         }).fold(_ must beNull, ι).run
-      }
+      }.skippedOnReadOnly
 
       "delete dir" in {
         (for {
@@ -341,7 +347,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
         } yield {
           after must not(contain(FilesystemNode(tmpDir, None)))
         }).fold(_ must beNull, ι).run
-      }
+      }.skippedOnReadOnly
 
       "delete database" in {
         // NB: Because this operates on a DB, it can’t run within `TestDir`.
@@ -359,7 +365,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           create must contain(FilesystemNode(db, None))
           delete must_== before
         }).fold(skipUnlessAuthorized, ι).run
-      }
+      }.skippedOnReadOnly
 
       "delete all databases" in {
         // NB: Because this operates on a DB, it can’t run within `TestDir`.
@@ -378,7 +384,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           before must contain(FilesystemNode(db2, None))
           after must_== Set()
         }).fold(skipUnlessAuthorized, ι).run
-      }.skippedOnUserEnv("This could destroy user data.")
+      }.skippedOnUserEnv("This could destroy user data.").skippedOnReadOnly
 
       "delete missing file (not an error)" in {
         (for {
@@ -387,7 +393,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
         } yield {
           rez must beRightDisjunction
         }).run
-      }
+      }.skippedOnReadOnly
 
       "read large data and count" in {
         val COUNT = 10000
@@ -395,7 +401,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
 
         (for {
           tmp <- genTempFile
-          _   <- fs.save(TestDir ++ tmp, data).run
+          _   <- insertFs.save(TestDir ++ tmp, data).run
 
           ds  <- fs.scan(TestDir ++ tmp, 0, None).map(_ => 1).sum.runLast.run
         } yield {
@@ -409,7 +415,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
 
         (for {
           tmp <- genTempFile
-          _   <- fs.save(TestDir ++ tmp, data).run
+          _   <- insertFs.save(TestDir ++ tmp, data).run
 
           t   = fs.scan(TestDir ++ tmp, 0, None).map(_ => 1).sum.runLast
           ds1  <- t.run
@@ -450,7 +456,7 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
 
         (for {
           tmp <- genTempFile
-          _   <- fs.save(TestDir ++ tmp, manyDocs(COUNT)).run
+          _   <- insertFs.save(TestDir ++ tmp, manyDocs(COUNT)).run
 
           ds = fs.scan(TestDir ++ tmp, 0, None).map(encode)
           ds1 = ds.translate[ProcessingTask](convertError(PResultError(_)))
@@ -465,7 +471,9 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
       import quasar.sql.{Expr, Query, SQLParser}
 
       def parse(query: String) =
-        liftE[ProcessingError](SQLParser.parseInContext(Query(query), TestDir).fold(e => Task.fail(new RuntimeException(e.message)), Task.now))
+        liftE[ProcessingError](SQLParser.parseInContext(Query(query), TestDir).fold(
+          e => Task.fail(new RuntimeException(e.message)),
+          Task.now))
       def eval(fs: Backend, query: Expr): ProcessingTask[IndexedSeq[Data]] =
         fs.eval(QueryRequest(query, Variables(Map()))).run._2.fold(
           e => liftE(Task.fail(new RuntimeException(e.message))),
@@ -474,6 +482,12 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
         fs.run(QueryRequest(query, Variables(Map())), out).run._2.fold(
           e => liftE(Task.fail(new RuntimeException(e.message))),
           _.leftMap(PEvalError(_)))
+      def stripId(ds: IndexedSeq[Data]) = ds.map {
+        case Data.Obj(values) =>
+          val values1: Map[String, Data] = values.map { case ("value", Data.Obj(values2)) => "value" -> Data.Obj(values2 - "_id"); case d => d }
+          Data.Obj(values1)
+        case d => d
+      }
 
       "leave no temps behind" in {
         (for {
@@ -483,15 +497,17 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
           before <- fs.lsAll(Path.Root).leftMap(PPathError(_))
 
           // NB: this query *does* use temps (not streamable)
-          expr   <- parse("select a.a, b.a from " + tmp.simplePathname + " a, " + tmp.simplePathname + " b")
+          expr   <- parse("select *, a+1 from " + tmp.simplePathname + " order by a")
           rez    <- eval(fs, expr)
 
           after  <- fs.lsAll(Path.Root).leftMap(PPathError(_))
         } yield {
-          rez must_== Vector(Data.Obj(ListMap("0" -> Data.Int(1), "1" -> Data.Int(1))))
+          stripId(rez) must_== Vector(
+            Data.Obj(ListMap("value" -> Data.Obj(ListMap(
+              "a" -> Data.Int(1), "1" -> Data.Int(2))))))
           after must contain(exactly(before.toList: _*))
         }).fold(_ must beNull, ι).run
-      }
+      }.skippedOnReadOnly
 
       "leave only the output behind" in {
         (for {
@@ -502,18 +518,21 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers with SkippedO
 
           outReq <- liftE(genTempFile)
           // NB: this query *does* use temps (not streamable)
-          expr   <- parse("select a from " + tmp.simplePathname)
+          expr   <- parse("select *, a+1 from " + tmp.simplePathname + " order by a")
           outAct <- run(fs, expr, TestDir ++ outReq)
           rez    <- fs.scan(outAct.path, 0, None).runLog.leftMap(PResultError(_))
 
           after  <- fs.lsAll(Path.Root).leftMap(PPathError(_))
         } yield {
-          outAct.path must_== outReq
-          rez must_== Vector(Data.Obj(ListMap("0" -> Data.Int(1), "1" -> Data.Int(1))))
+          outAct.path.asRelative must_== TestDir ++ outReq
+          stripId(rez) must_== Vector(
+            Data.Obj(ListMap("value" -> Data.Obj(ListMap(
+              "a" -> Data.Int(1), "1" -> Data.Int(2))))))
           after must contain(exactly(FilesystemNode(TestDir ++ outReq, None) :: before.toList: _*))
         }).fold(_ must beNull, ι).run
-      }
+      }.skippedOnReadOnly
     }
+
     val cleanup = step {
       deleteTempFiles(fs, TestDir).run
     }

--- a/it/src/test/scala/quasar/regression.scala
+++ b/it/src/test/scala/quasar/regression.scala
@@ -16,18 +16,16 @@ import org.specs2.execute._
 import org.specs2.matcher._
 import org.specs2.mutable._
 import org.specs2.specification.{Example}
+import pathy.Path.FileName
 import scalaz.{Failure => _, _}, Scalaz._
 import scalaz.stream._
 import scalaz.concurrent._
 
-import pathy.Path.FileName
-
 class RegressionSpec extends BackendTest {
-
   implicit val codec = DataCodec.Precise
   implicit val ED = EncodeJson[Data](codec.encode(_).fold(err => scala.sys.error(err.message), ι))
 
-  backendShould { (prefix, backend, backendName) =>
+  backendShould { (prefix, insertBackend, testBackend, backendName) =>
 
     val tmpDir = prefix ++ testRootDir ++ genTempDir.run
 
@@ -39,29 +37,31 @@ class RegressionSpec extends BackendTest {
     }
 
     def runQuery(query: String, vars: Map[String, String]):
-        EvaluationTask[(Vector[PhaseResult], ResultPath)] =
+        Task[(Vector[PhaseResult], Process[ProcessingTask, Data])] =
       for {
-        expr <- liftE[EvaluationError](SQLParser.parseInContext(Query(query), tmpDir).fold(e => Task.fail(new RuntimeException(e.message)), Task.now))
-        t <- liftE(genTempFile.map(file =>
-          backend.run {
-            QueryRequest(
-              query     = expr,
-              out       = Some(tmpDir ++ file),
-              variables = Variables.fromMap(vars))
-          }))
-          (log, outT) = t.run
-        out <- outT.fold(e => liftE[EvaluationError](Task.fail(new RuntimeException(e.message))), ι)
-          _ <- liftE(Task.delay(println(query)))
-      } yield (log, out)
+        expr <- SQLParser.parseInContext(Query(query), tmpDir).fold(e => Task.fail(new RuntimeException(e.message)), Task.now)
+        _ <- Task.delay(println(query))
+        t <- {
+          val (ps, v) = testBackend.eval(
+              QueryRequest(
+                query     = expr,
+                out       = None,
+                variables = Variables.fromMap(vars))
+              ).run
+          v.fold(
+            ce => Task.fail(new RuntimeException(ce.message)),
+            pr => Task.now((ps, pr)))
+        }
+      } yield t
 
     def verifyExists(name: String): Task[Result] =
-      backend.exists(dataPath(name)).fold(_ must beNull, _ must beTrue)
+      testBackend.exists(dataPath(name)).fold(_ must beNull, _ must beTrue)
 
-    def verifyExpected(outPath: Path, exp: ExpectedResult)(implicit E: EncodeJson[Data]): ETask[ResultError, Result] = {
-      val clean: Process[ETask[ResultError, ?], Json] =
-        backend.scan(outPath, 0, None).map(x => deleteFields(exp.ignoredFields)(E.encode(x)))
+    def verifyExpected(actual: Process[ETask[ProcessingError, ?], Data], exp: ExpectedResult)(implicit E: EncodeJson[Data]): ETask[ProcessingError, Result] = {
+      val clean: Process[ETask[ProcessingError, ?], Json] =
+        actual.map(x => deleteFields(exp.ignoredFields)(E.encode(x)))
 
-      exp.predicate[ETask[ResultError, ?]](exp.rows.toVector, clean)
+      exp.predicate[ETask[ProcessingError, ?]](exp.rows.toVector, clean)
     }
 
     def optionalMapGet[A, B](m: Option[Map[A, B]], key: A, noneDefault: B, missingDefault: B): B = m match {
@@ -74,18 +74,16 @@ class RegressionSpec extends BackendTest {
       example  <- StreamT((decodeTest(testFile) flatMap { test =>
                       // The data file should be in the same directory as the testFile
                       val dataFile = test.data.map(name => new File(testFile.getParent, name))
-                      val loadDataFileIfProvided = dataFile.map(interactive.loadFile(backend, tmpDir, _))
+                      val loadDataFileIfProvided = dataFile.map(interactive.loadFile(insertBackend, tmpDir, _))
                                                       .getOrElse(().point[ProcessingTask])
                       Task.delay {
                         (test.name + " [" + testFile.getPath + "]") in {
                           def runTest = (for {
                             _ <- loadDataFileIfProvided
-                            out <- runQuery(test.query, test.variables).leftMap(PEvalError(_))
-                            (log, outPath) = out
+                            out <- liftE[EvaluationError](runQuery(test.query, test.variables)).leftMap(PEvalError(_))
+                            (log, outP) = out
                             // _ = println(test.name + "\n" + log.last)
-                            _   <- liftE(test.data.fold(Task.now[Result](success))(verifyExists(_)))
-                            rez <- verifyExpected(outPath.path, test.expected).leftMap(PResultError(_))
-                            _   <- backend.delete(outPath.path).leftMap(PPathError(_))
+                            rez <- verifyExpected(outP, test.expected)
                           } yield rez).run.run.fold(e => Failure("path error: " + e.message), ι)
                           test.backends.get(backendName) match {
                             case Some(SkipDirective.Skip)    => skipped
@@ -100,7 +98,7 @@ class RegressionSpec extends BackendTest {
     examples.toStream.run.toList
 
     val cleanup = step {
-      deleteTempFiles(backend, tmpDir).run
+      deleteTempFiles(insertBackend, tmpDir).run
     }
   }
 
@@ -141,7 +139,7 @@ class RegressionSpec extends BackendTest {
 
 case class RegressionTest(
                            name:       String,
-                           backends:   Map[String, SkipDirective],
+                           backends:   Map[BackendName, SkipDirective],
                            data:       Option[String],
                            query:      String,
                            variables:  Map[String, String],
@@ -158,8 +156,8 @@ object RegressionTest {
     DecodeJson(c => for {
       name          <-  (c --\ "name").as[String]
       backends      <-  if ((c --\ "backends").succeeded)
-                          ((c --\ "backends").as[Map[String, SkipDirective]])
-                        else ok(Map[String, SkipDirective]())
+                          ((c --\ "backends").as[Map[String, SkipDirective]]).map(_.mapKeys(BackendName(_)))
+                        else ok(Map[BackendName, SkipDirective]())
       data          <-  optional[String](c --\ "data")
       query         <-  (c --\ "query").as[String]
       variables     <-  orElse(c --\ "variables", Map.empty[String, String])

--- a/it/src/test/scala/quasar/regression.scala
+++ b/it/src/test/scala/quasar/regression.scala
@@ -43,11 +43,7 @@ class RegressionSpec extends BackendTest {
         _ <- Task.delay(println(query))
         t <- {
           val (ps, v) = testBackend.eval(
-              QueryRequest(
-                query     = expr,
-                out       = None,
-                variables = Variables.fromMap(vars))
-              ).run
+              QueryRequest(expr, Variables.fromMap(vars))).run
           v.fold(
             ce => Task.fail(new RuntimeException(ce.message)),
             pr => Task.now((ps, pr)))

--- a/it/src/test/scala/quasar/view.scala
+++ b/it/src/test/scala/quasar/view.scala
@@ -25,7 +25,7 @@ class ViewSpecs extends BackendTest with DisjunctionMatchers with SkippedOnUserE
     new sql.SQLParser().parse(sql.Query(query))
       .valueOr(e => scala.sys.error("bad query: " + e))
 
-  backendShould(interactive.zips.run) { (prefix, backend, backendName, files) =>
+  backendShould(interactive.zips.run) { (prefix, _, backend, backendName, files) =>
     val relPrefix = prefix.asRelative
     val TestDir = relPrefix ++ testRootDir ++ genTempDir.run
     val ZipsPath = Path("/mnt/") ++ files.head

--- a/it/src/test/scala/quasar/view.scala
+++ b/it/src/test/scala/quasar/view.scala
@@ -115,7 +115,7 @@ class ViewSpecs extends BackendTest with DisjunctionMatchers with SkippedOnUserE
 
     "trivial query referring to a view" in {
       val query = """select * from "/view/smallCities""""
-      root.evalResults(QueryRequest(parse(query), None, Variables(Map.empty))).fold[Result](
+      root.evalResults(QueryRequest(parse(query), Variables(Map.empty))).fold[Result](
         e => failure(e.toString),
         _.take(1).runLog.run.run must beRightDisjunction(Vector(Data.Obj(ListMap(
           "City" -> Data.Str("AARON"),
@@ -127,7 +127,7 @@ class ViewSpecs extends BackendTest with DisjunctionMatchers with SkippedOnUserE
     "less-trivial query referring to a view" in {
       // Refers to the shape created in the view query
       val query = """select City || ', ' || St from "/view/smallCities" where Size < 500"""
-      root.evalResults(QueryRequest(parse(query), None, Variables(Map.empty))).fold[Result](
+      root.evalResults(QueryRequest(parse(query), Variables(Map.empty))).fold[Result](
         e => failure(e.toString),
         _.take(1).runLog.run.run must beRightDisjunction(Vector(Data.Obj(ListMap(
           "0" -> Data.Str("AARON, KY")))))
@@ -136,7 +136,7 @@ class ViewSpecs extends BackendTest with DisjunctionMatchers with SkippedOnUserE
 
     "query with view referencing a view" in {
       val query = """select max("1") from "/view/smallCityCounts""""
-      root.evalResults(QueryRequest(parse(query), None, Variables(Map.empty))).fold[Result](
+      root.evalResults(QueryRequest(parse(query), Variables(Map.empty))).fold[Result](
         e => failure(e.toString),
         _.runLog.run.run must beRightDisjunction(Vector(Data.Obj(ListMap(
           "0" -> Data.Int(428))))))
@@ -146,7 +146,7 @@ class ViewSpecs extends BackendTest with DisjunctionMatchers with SkippedOnUserE
       // NB: the composed query ends up with references to city, state, and zip in
       // both the source table and the subquery result.
       val query = """select zip from "/view/simpleZips" where city = 'BOULDER' and state = 'CO' order by zip"""
-      root.evalResults(QueryRequest(parse(query), None, Variables(Map.empty))).fold[Result](
+      root.evalResults(QueryRequest(parse(query), Variables(Map.empty))).fold[Result](
         e => failure(e.toString),
         _.runLog.run.run must beRightDisjunction(Vector(
           Data.Obj(ListMap("zip" -> Data.Str("80301"))),
@@ -157,7 +157,7 @@ class ViewSpecs extends BackendTest with DisjunctionMatchers with SkippedOnUserE
 
     "query with view with bad reference" in {
       val query = """select * from "/view/badRef""""
-      root.evalResults(QueryRequest(parse(query), None, Variables(Map.empty))).fold[Result](
+      root.evalResults(QueryRequest(parse(query), Variables(Map.empty))).fold[Result](
         e => failure(e.toString),
         _.runLog.run.run must beLeftDisjunction(
           PEvalError(EvalPathError(NonexistentPathError(Path("/test/nonexistent"), None)))))

--- a/scripts/build
+++ b/scripts/build
@@ -44,7 +44,9 @@ cp "$QUASAR_WEB_JAR_PATH" "$QUASAR_TEMP_JAR"
 if [[ ${LOCAL_MONGODB:-} == "true" ]] ; then
   export QUASAR_TEST_PATH_PREFIX="/${QUASAR_MONGODB_TESTDB}/"
   export QUASAR_MONGODB_2_6="{\"mongodb\": {\"connectionUri\": \"mongodb://${QUASAR_MONGODB_HOST_2_6}\"}}"
-  export QUASAR_MONGODB_3_0="{\"mongodb\": {\"connectionUri\": \"mongodb://${QUASAR_MONGODB_HOST_3_0}\"}}"
+  export QUASAR_MONGODB_3_0="{\"mongodb\": {\"connectionUri\": \"mongodb://quasar-dbOwner:quasar@${QUASAR_MONGODB_HOST_3_0}/${QUASAR_MONGODB_TESTDB}\"}}"
+  export QUASAR_MONGODB_READ_ONLY="{\"mongodb\": {\"connectionUri\": \"mongodb://quasar-read:quasar@${QUASAR_MONGODB_HOST_3_0}/${QUASAR_MONGODB_TESTDB}\"}}"
+  export QUASAR_MONGODB_READ_ONLY_INSERT="{\"mongodb\": {\"connectionUri\": \"mongodb://quasar-dbOwner:quasar@${QUASAR_MONGODB_HOST_3_0}/${QUASAR_MONGODB_TESTDB}\"}}"
 
   echo "Using local MongoDB config"
 fi

--- a/scripts/installMongo
+++ b/scripts/installMongo
@@ -9,6 +9,7 @@ IFS=$'\n\t'       # http://redsymbol.net/articles/unofficial-bash-strict-mode/
 MONGO_VERSION=$1
 MONGO_DIR=$2
 MONGO_PORT=$3
+AUTH=${4-}
 
 CACHE_DIR=cache
 
@@ -23,6 +24,21 @@ tar -zxf $CACHE_DIR/$MONGO_VERSION.tgz
 mv $MONGO_VERSION $MONGO_DIR
 
 mkdir -p $MONGO_DIR-data
+
+# Start with auth disabled and create users:
 $MONGO_DIR/bin/mongod --dbpath $MONGO_DIR-data --port $MONGO_PORT > /dev/null &
+
+if [[ $AUTH ]]
+then
+  sleep 1s
+
+  $MONGO_DIR/bin/mongo localhost:$MONGO_PORT/quasar-test --eval 'db.createUser({"user": "quasar-dbOwner", "pwd": "quasar", "roles": [ "dbOwner" ]})'
+  $MONGO_DIR/bin/mongo localhost:$MONGO_PORT/quasar-test --eval 'db.createUser({"user": "quasar-read", "pwd": "quasar", "roles": [ "read" ]})'
+  $MONGO_DIR/bin/mongod --dbpath $MONGO_DIR-data --shutdown
+
+  # start again with auth this time:
+  $MONGO_DIR/bin/mongod --dbpath $MONGO_DIR-data --port $MONGO_PORT --auth > /dev/null &
+
+fi
 
 sleep 5s

--- a/web/src/test/scala/quasar/api/fs.scala
+++ b/web/src/test/scala/quasar/api/fs.scala
@@ -126,8 +126,9 @@ object Mock {
     }
     val evaluator = new Evaluator[Plan] {
       val name = "Stub"
-      def execute(physical: Plan) =
-        EitherT.right(Task.now(ResultPath.Temp(Path("tmp/out"))))
+      def executeTo(physical: Plan, out: Path) =
+        EitherT.right(Task.now(ResultPath.User(out)))
+      def evaluate(physical: Plan) = Process.emit(Data.Obj(ListMap("7" -> Data.Str("ok"))))
       def compile(physical: Plan) = "Stub" -> Cord(physical.toString)
     }
     val RP = PlanRenderTree
@@ -1136,7 +1137,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
 
           result() must beRightDisjunction((
             readableContentType,
-            List(Json("0" := "ok"))))
+            List(Json("7" := "ok"))))
         }
       }
 


### PR DESCRIPTION
This probably all gets squashed down to three commits before all's said and done (the first two here, followed by everything else squashed), but I think the way they're broken out here may aid understanding.

The upshot is about half of our regression test queries can now run on a read-only connection; the remainder are marked as "pending" for the new MONGO_READ_ONLY test configuration.

