### PR TITLE
[SD-1146] Implement Explain for MongoDB interpreter

### DIFF
--- a/core/src/main/scala/quasar/fs/chroot.scala
+++ b/core/src/main/scala/quasar/fs/chroot.scala
@@ -122,8 +122,9 @@ object chroot {
           Coyoneda.lift(ExecutePlan(lp.translate(rebasePlan), rebase(out, prefix)))
             .map(_.map(_.bimap(stripPathError(prefix), resultFile.modify(stripPrefix(prefix)))))
 
-        case Explain(lp) =>
-          Coyoneda.lift(Explain(lp.translate(rebasePlan)))
+        case Explain(lp, out) =>
+          Coyoneda.lift(Explain(lp.translate(rebasePlan), rebase(out, prefix)))
+            .map(_.map(_ leftMap stripPathError(prefix)))
 
         case ListContents(d) =>
           Coyoneda.lift(ListContents(rebase(d, prefix)))

--- a/core/src/main/scala/quasar/physical/mongodb/fs/queryfile.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/fs/queryfile.scala
@@ -27,25 +27,24 @@ object queryfile {
 
   val interpret: EnvErr2T[MongoDbIO, QueryFile ~> MongoQuery] =
     WorkflowExecutor.mongoDb map { execMongo =>
-      val execJs = WorkflowExecutor.javaScript
-
       new (QueryFile ~> MongoQuery) {
         def apply[A](qf: QueryFile[A]) = qf match {
           case ExecutePlan(lp, out) =>
             (for {
               _      <- checkPathsExist(lp)
-              wf     <- convertP(lp)(MongoDbPlanner.plan(lp))
-              dst    <- EitherT(Collection.fromPathy(out)
-                                  .leftMap(PathError)
-                                  .point[F])
               salt   <- liftG(MongoDbIO.liftTask(NameGenerator.salt)
                                 .liftM[WorkflowExecErrT])
               prefix =  s"tmp.gen_${salt}"
-              _      <- writeJsLog(wf, dst, execJs) run prefix
-              coll   <- execWorkflow(wf, dst, execMongo) run prefix
+              coll   <- planWorkflow(lp, out)
+                          .flatMap { case (wf, dst) => execWorkflow(wf, dst, execMongo) }
+                          .run(prefix)
             } yield ResultFile.User(coll.asFile)).run.run
 
-          case Explain(lp) => ???
+          case Explain(lp, out) =>
+            planWorkflow(lp, out)
+              .run("tmp.gen")
+              .run.map(_.swap.toOption)
+              .run
 
           case ListContents(dir) =>
             (dirName(dir) match {
@@ -84,34 +83,47 @@ object queryfile {
   private type W[A, B]  = WriterT[MongoQuery, A, B]
   private type GE[A, B] = EitherT[F, A, B]
 
+  private type PrefixRT[X[_], A] = ReaderT[X, String, A]
+
   private val liftG: MongoQuery ~> G =
     liftMT[F, FileSystemErrT] compose liftMT[MongoQuery, PhaseResultT]
+
+  private def planWorkflow(
+    lp: Fix[LogicalPlan],
+    out: AFile
+  ): PrefixRT[G, (Crystallized, Collection)] = for {
+    wf  <- convertP(lp)(MongoDbPlanner.plan(lp))
+             .liftM[PrefixRT]
+    dst <- EitherT(
+             Collection.fromPathy(out)
+               .leftMap(PathError)
+               .point[F])
+             .liftM[PrefixRT]: PrefixRT[G, Collection]
+    _   <- writeJsLog(wf, dst)
+  } yield (wf, dst)
 
   private def convertP(lp: Fix[LogicalPlan]): P ~> G =
     new (P ~> G) {
       def apply[A](pa: P[A]) = {
         val r = pa.leftMap(PlannerError(lp, _)).run
-        val f: F[FileSystemError \/ A] = WriterT(r.point[MongoQuery])
-        EitherT(f)
+        EitherT(WriterT(r.point[MongoQuery]): F[FileSystemError \/ A])
       }
     }
 
-  private def writeJsLog(
-    wf: Crystallized,
-    dst: Collection,
-    execJs: WorkflowExecutor[JavaScriptLog]
-  ) = ReaderT[G, String, Unit] { tmpPrefix =>
-    val (stmts, r) =
-      execJs.execute(wf, dst).run.run(tmpPrefix).eval(0).run
+  private def writeJsLog(wf: Crystallized, dst: Collection) =
+    ReaderT[G, String, Unit] { tmpPrefix =>
+      val (stmts, r) =
+        WorkflowExecutor.javaScript
+          .execute(wf, dst).run.run(tmpPrefix).eval(0).run
 
-    def phaseR: PhaseResult =
-      PhaseResult.Detail("MongoDB", Js.Stmts(stmts.toList).pprint(0))
+      def phaseR: PhaseResult =
+        PhaseResult.Detail("MongoDB", Js.Stmts(stmts.toList).pprint(0))
 
-    r.fold(
-      err => liftG(err.raiseError[MongoE, Unit]),
-      _   => (MonadTell[W, PhaseResults].tell(Vector(phaseR)): F[Unit])
-               .liftM[FileSystemErrT])
-  }
+      r.fold(
+        err => liftG(err.raiseError[MongoE, Unit]),
+        _   => (MonadTell[W, PhaseResults].tell(Vector(phaseR)): F[Unit])
+                 .liftM[FileSystemErrT])
+    }
 
   private def execWorkflow(
     wf: Crystallized,

--- a/web/src/main/scala/quasar/api/server.scala
+++ b/web/src/main/scala/quasar/api/server.scala
@@ -53,7 +53,6 @@ class ServerOps[WC: CodecJson, SC](
   configOps: ConfigOps[WC],
   defaultWC: WC,
   val webConfigLens: WebConfigLens[WC, SC]) {
-  import webConfigLens._
   import ServerOps._
 
   // NB: This is a terrible thing.

--- a/web/src/test/scala/quasar/api/services/CompileAndQueryServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/CompileAndQueryServiceSpec.scala
@@ -183,7 +183,7 @@ class CompileAndQueryServiceSpec extends Specification with FileSystemFixture wi
         query = Some(selectAll(filesystem.filename)),
         state = filesystem.state,
         status = Status.Ok,
-        response = "InMemory\nPlan(logical: Squash(Read(Path(\"" + pathString + "\"))))"
+        response = "InMemory\nUnsupported"
       )
     }
   }


### PR DESCRIPTION
Makes some minor modifications to the `Explain` constructor and adds the implementation for MongoDB.

An output file is added to the `Explain` constructor as, in this PR, there is no support for streaming queries and it seemed to make sense to handle this in one spot rather than have each backend have to do it. Note that the client API does not require an output file as either the first one from the LP is used or a placeholder is used.