### PR TITLE
Fix test failures in CompileAndQueryServiceSpec

### DIFF
--- a/core/src/main/scala/quasar/fp/free/Interpreter.scala
+++ b/core/src/main/scala/quasar/fp/free/Interpreter.scala
@@ -9,11 +9,11 @@ import scalaz.stream.Process
 import scala.collection.IndexedSeq
 
 /** Provides a range of natural transformations that can be derived from the natural transformation of a term
-  * of an algebra into the desired [[Monad]]
-  * @param interpretTerm A natural transformation from the Algebra into the desired [[Monad]] from which
+  * of an algebra into the desired `Monad`
+  * @param interpretTerm A natural transformation from the Algebra into the desired `Monad` from which
   *                      many other natural transformations can be derived
-  * @tparam F The type of the [[Functor]] that represents the algebra to be interpreted
-  * @tparam M The [[Monad]] into which to translate the [[Free]] Algebra
+  * @tparam F The type of the `Functor` that represents the algebra to be interpreted
+  * @tparam M The `Monad` into which to translate the `Free` Algebra
   */
 class Interpreter[F[_]: Functor, M[_]: Monad](val interpretTerm: F ~> M) {
   type Program[A] = Free[F,A]
@@ -43,11 +43,11 @@ class Interpreter[F[_]: Functor, M[_]: Monad](val interpretTerm: F ~> M) {
   }
 }
 
-/** Extends Interpreter to provide a version with better type inference for commonly used [[MonadTrans]]
-  * @param interpretTerm A natural transformation from the Algebra into the desired [[Monad]] from which
+/** Extends Interpreter to provide a version with better type inference for commonly used `MonadTrans`
+  * @param interpretTerm A natural transformation from the Algebra into the desired `Monad` from which
   *                      many other natural transformations can be derived
-  * @tparam F The type of the [[Functor]] that represents the algebra to be interpreted
-  * @tparam M The [[Monad]] into which to translate the [[Free]] Algebra
+  * @tparam F The type of the `Functor` that represents the algebra to be interpreted
+  * @tparam M The `Monad` into which to translate the `Free` Algebra
   */
 // https://github.com/puffnfresh/wartremover/issues/149
 @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.NonUnitStatements"))

--- a/core/src/main/scala/quasar/fs/InMemory.scala
+++ b/core/src/main/scala/quasar/fs/InMemory.scala
@@ -4,6 +4,7 @@ package fs
 import quasar.Predef._
 import quasar.fp._
 import quasar.recursionschemes.Fix
+import quasar.Planner.UnsupportedPlan
 
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
@@ -19,22 +20,29 @@ object InMemory {
   import ReadFile._, WriteFile._, ManageFile._, QueryFile._
   import FileSystemError._, PathError2._
 
-  type FM = Map[AFile, Vector[Data]]
+  type FileMap = Map[AFile, Vector[Data]]
   type RM = Map[ReadHandle, Reading]
   type WM = Map[WriteHandle, AFile]
+  type QueryResponses = Map[Fix[LogicalPlan],Vector[Data]]
 
   type InMemoryFs[A]  = State[InMemState, A]
   type InMemStateR[A] = (InMemState, A)
 
   final case class Reading(f: AFile, start: Natural, lim: Option[Positive], pos: Int)
 
-  final case class InMemState(seq: Long, fm: FM, rm: RM, wm: WM)
+  /** Represents the current state of the InMemoryFilesystem
+    * @param seq Represents the next available uid for a ReadHandle or WriteHandle
+    * @param contents The mapping of Data associated with each file in the Filesystem
+    * @param rm Currently open [[quasar.fs.ReadFile.ReadHandle]]s
+    * @param wm Currently open [[quasar.fs.WriteFile.WriteHandle]]s
+    */
+  final case class InMemState(seq: Long, contents: FileMap, rm: RM, wm: WM, queryResps: QueryResponses)
 
   object InMemState {
-    val empty = InMemState(0, Map.empty, Map.empty, Map.empty)
+    val empty = InMemState(0, Map.empty, Map.empty, Map.empty, Map.empty)
 
-    def fromFiles(files: FM): InMemState =
-      empty copy (fm = files)
+    def fromFiles(files: FileMap): InMemState =
+      empty copy (contents = files)
   }
 
   val readFile: ReadFile ~> InMemoryFs = new (ReadFile ~> InMemoryFs) {
@@ -125,20 +133,28 @@ object InMemory {
 
   val queryFile: QueryFile ~> InMemoryFs = new (QueryFile ~> InMemoryFs) {
     def apply[A](qf: QueryFile[A]) = qf match {
-      case ExecutePlan(_, out) =>
-        (Vector(unsupported), ResultFile.User(out).right[FileSystemError])
-          .point[InMemoryFs]
+      case ExecutePlan(lp, out) =>
+        val noSupportMsg = "In Memory interpreter does not currently support this plan"
+        queryResponsesL.st.flatMap { queryResponses =>
+          val result = queryResponses.get(lp).cata(
+            data => fileL(out) assigno Some(data) map(
+              previousData => (previousData ? ResultFile.User(out) | ResultFile.Temp(out)).right[FileSystemError]),
+            PlannerError(lp, UnsupportedPlan(lp.unFix, Some(noSupportMsg))).left[ResultFile].point[InMemoryFs])
+          val phase = lookup(lp,queryResponses)
+          result.map((Vector(phase),_))
+        }
 
-      case Explain(_, _) =>
-        (Vector(unsupported), none[FileSystemError])
-          .point[InMemoryFs]
+      case Explain(lp, _) =>
+        queryResponsesL.st.map( queryResps =>
+          (Vector(lookup(lp, queryResps)), none[FileSystemError])
+        )
 
       case ListContents(dir) =>
         ls(dir)
     }
 
-    private val unsupported: PhaseResult =
-      PhaseResult.Detail("InMemory", "Unsupported")
+    private def lookup(lp: Fix[LogicalPlan],queries: QueryResponses): PhaseResult =
+      PhaseResult.Detail("Lookup in Memory", s"Lookup $lp in $queries")
   }
 
   val fileSystem: FileSystem ~> InMemoryFs =
@@ -168,11 +184,11 @@ object InMemory {
   private def nextSeq: InMemoryFs[Long] =
     seqL <%= (_ + 1)
 
-  private val fmL: InMemState @> FM =
-    Lens.lensg(s => m => s.copy(fm = m), _.fm)
+  private val contentsL: InMemState @> FileMap =
+    Lens.lensg(s => newContents => s.copy(contents = newContents), _.contents)
 
   private def fileL(f: AFile): InMemState @> Option[Vector[Data]] =
-    Lens.mapVLens(f) <=< fmL
+    Lens.mapVLens(f) <=< contentsL
 
   //----
 
@@ -181,6 +197,9 @@ object InMemory {
 
   private val rmL: InMemState @> RM =
     Lens.lensg(s => m => s.copy(rm = m), _.rm)
+
+  private val queryResponsesL: InMemState @> QueryResponses =
+    Lens.lensg(s => newQueryResps => s.copy(queryResps = newQueryResps), _.queryResps)
 
   private def readingL(h: ReadHandle): InMemState @> Option[Reading] =
     Lens.mapVLens(h) <=< rmL
@@ -212,7 +231,7 @@ object InMemory {
 
   private def moveDir(src: ADir, dst: ADir, s: MoveSemantics): InMemoryFs[FileSystemError \/ Unit] =
     for {
-      m     <- fmL.st
+      m     <- contentsL.st
       sufxs =  m.keys.toStream.map(_ relativeTo src).unite
       files =  sufxs map (src </> _) zip (sufxs map (dst </> _))
       r0    <- files.traverseU { case (sf, df) => EitherT(moveFile(sf, df, s)) }.run
@@ -239,7 +258,7 @@ object InMemory {
 
   private def deleteDir(d: ADir): InMemoryFs[FileSystemError \/ Unit] =
     for {
-      m  <- fmL.st
+      m  <- contentsL.st
       ss =  m.keys.toStream.map(_ relativeTo d).unite
       r0 <- ss.traverseU(f => EitherT(deleteFile(d </> f))).run
       r1 =  r0 flatMap (_.nonEmpty either (()) or PathError(PathNotFound(d)))
@@ -249,7 +268,7 @@ object InMemory {
     (fileL(f) <:= None) map (_.void \/> PathError(PathNotFound(f)))
 
   private def ls(d: ADir): InMemoryFs[FileSystemError \/ Set[Node]] =
-    fmL.st map (
+    contentsL.st map (
       _.keys.toList.map(_ relativeTo d).unite.toNel
         .map(_ foldMap (f => Node.fromFirstSegmentOf(f).toSet))
         .toRightDisjunction(PathError(PathNotFound(d))))

--- a/core/src/main/scala/quasar/fs/QueryFile.scala
+++ b/core/src/main/scala/quasar/fs/QueryFile.scala
@@ -20,7 +20,7 @@ object QueryFile {
     extends QueryFile[(PhaseResults, Option[FileSystemError])]
 
   /** TODO: While this is a bit better in one dimension here in `QueryFile`,
-    *       @mossprescott points out it is still a bit of a stretch to include
+    *       mossprescott points out it is still a bit of a stretch to include
     *       in this algebra. We need to revisit this and probably add algebras
     *       over multiple dimensions to better organize these (and other)
     *       operations.

--- a/core/src/test/scala/quasar/fs/WriteFileSpec.scala
+++ b/core/src/test/scala/quasar/fs/WriteFileSpec.scala
@@ -63,7 +63,7 @@ class WriteFileSpec extends Specification with ScalaCheck with FileSystemFixture
         val p = (write.append(f, xs.toProcess) ++ write.save(f, ys.toProcess)).drain ++ read.scanAll(f)
 
         MemFixTask.runLogWithWrites(ws.toList, p).run
-          .leftMap(_.fm.keySet)
+          .leftMap(_.contents.keySet)
           .run(emptyMem)
           .run must_== ((Set(f), \/.right(xs)))
       }
@@ -100,7 +100,7 @@ class WriteFileSpec extends Specification with ScalaCheck with FileSystemFixture
         val p = (write.append(f, xs.toProcess) ++ write.replace(f, ys.toProcess)).drain ++ read.scanAll(f)
 
         MemFixTask.runLogWithWrites(ws.toList, p).run
-          .leftMap(_.fm.keySet)
+          .leftMap(_.contents.keySet)
           .run(emptyMem)
           .run must_== ((Set(f), \/.right(xs)))
       }

--- a/web/src/main/scala/quasar/api/services/package.scala
+++ b/web/src/main/scala/quasar/api/services/package.scala
@@ -22,7 +22,7 @@ package object services {
   def fileSystemErrorResponse(error: FileSystemError): Task[Response] =
     error match {
       case Case.PathError(e) => pathErrorResponse(e)
-      case Case.PlannerError(_, _) => BadRequest("Planner error")
+      case Case.PlannerError(_, _) => BadRequest(error.shows)
       case Case.UnknownReadHandle(handle) => InternalServerError(s"Unknown read handle: $handle")
       case Case.UnknownWriteHandle(handle) => InternalServerError(s"Unknown write handle: $handle")
       case Case.PartialWrite(numFailed) => InternalServerError(s"Failed to write $numFailed records")
@@ -33,7 +33,6 @@ package object services {
   def pathErrorResponse(error: PathError2): Task[Response] =
     error match {
       case PathError2.Case.PathExists(path) => Conflict(s"$path already exists")
-      // TODO: Adjust definition of `AbsPath` in order to avoid this fold...
       case PathError2.Case.PathNotFound(path) => NotFound(s"${posixCodec.printPath(path)}: doesn't exist")
       case PathError2.Case.InvalidPath(path, reason) => BadRequest(s"$path is an invalid path because $reason")
     }

--- a/web/src/test/scala/quasar/api/services/CompileAndQueryServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/CompileAndQueryServiceSpec.scala
@@ -4,20 +4,23 @@ package services
 
 import Predef._
 
-import argonaut._, Argonaut._
+import argonaut._
 
 import org.http4s.server.HttpService
 import org.http4s._
 import org.scalacheck.Arbitrary
 import org.specs2.ScalaCheck
+import org.specs2.matcher.MatchResult
 import org.specs2.mutable.Specification
 
 import pathy.Path._
+import pathy.scalacheck.AbsFileOf
 import pathy.scalacheck.PathyArbitrary._
 import quasar.fs._
 import quasar.fs.InMemory._
 
 import Fixture._
+import quasar.std.IdentityLib
 
 import scalaz.concurrent.Task
 import scalaz.stream.Process
@@ -32,22 +35,23 @@ class CompileAndQueryServiceSpec extends Specification with FileSystemFixture wi
 
   import posixCodec.printPath
 
-  def compile(state: InMemState): HttpService = compileService[FileSystem](runStatefully(state).run.compose(fileSystem))
-  def query(state: InMemState): HttpService = service[FileSystem](runStatefully(state).run.compose(fileSystem))
+  def compileService(state: InMemState): HttpService =
+    services.query.compileService[FileSystem](runStatefully(state).run.compose(fileSystem))
+  def queryService(state: InMemState): HttpService = service[FileSystem](runStatefully(state).run.compose(fileSystem))
 
-  def post(service: InMemState => HttpService)(path: ADir,
+  def post[A:EntityDecoder](service: InMemState => HttpService)(path: ADir,
             query: Option[String],
             destination: Option[AFile],
             state: InMemState,
             status: Status,
-            response: String) = {
+            response: A => MatchResult[scala.Any]) = {
     val baseReq = Request(uri = Uri(path = printPath(path)), method = Method.POST)
     val reqWithQuery = query.map(query => baseReq.withBody(query).run).getOrElse(baseReq)
     val req = destination.map(destination =>
       reqWithQuery.copy(headers = Headers(Header("Destination", printPath(destination))))
     ).getOrElse(reqWithQuery)
     val actualResponse = service(state)(req).run
-    actualResponse.as[String].run must_== response
+    response(actualResponse.as[A].run)
     actualResponse.status must_== status
   }
 
@@ -63,15 +67,16 @@ class CompileAndQueryServiceSpec extends Specification with FileSystemFixture wi
     actualResponse.status must_== status
   }
 
+  def selectAllLP(file: AFile) = LogicalPlan.Invoke(IdentityLib.Squash,List(LogicalPlan.Read(quasar.fs.convert(file))))
   def selectAll(from: FileName) = "select * from \"" + from.value + "\""
 
   "Compile and Query Service" should {
     def testBoth[A](test: (InMemState => HttpService) => Unit) = {
       "Compile" should {
-        test(compile)
+        test(compileService)
       }
       "Query" should {
-        test(query)
+        test(queryService)
       }
     }
     testBoth { service =>
@@ -97,12 +102,12 @@ class CompileAndQueryServiceSpec extends Specification with FileSystemFixture wi
         "be 400 for query error" ! prop { filesystem: SingleFileMemState =>
           get(service)(
             path = filesystem.parent,
-            query = Some("select data where"),
+            query = Some("select date where"),
             state = filesystem.state,
             status = Status.BadRequest,
             response = "keyword 'case' expected; `where'"
           )
-        }.pendingUntilFixed("TODO: Debug")
+        }
       }
 
       () // TODO: Remove after upgrading to specs2 3.x
@@ -112,63 +117,65 @@ class CompileAndQueryServiceSpec extends Specification with FileSystemFixture wi
   "Query" should {
     "execute a simple query" >> {
       "GET" ! prop { filesystem: SingleFileMemState =>
-        get(query)(
+        val query = selectAll(filesystem.filename)
+        get(queryService)(
           path = filesystem.parent,
-          query = Some(selectAll(filesystem.filename)),
-          state = filesystem.state,
+          query = Some(query),
+          state = filesystem.state.copy(queryResps = Map(selectAllLP(filesystem.file) -> filesystem.contents)),
           status = Status.Ok,
           response = jsonReadableLine.encode(Process.emitAll(filesystem.contents): Process[Task, Data]).runLog.run.mkString("")
         )
-      }.pendingUntilFixed("TODO: Debug")
-      "POST" ! prop { (filesystem: SingleFileMemState, destination: AFile) =>
-        post(query)(
+      }
+      "POST" ! prop { (filesystem: SingleFileMemState, destination: AbsFileOf[AlphaCharacters]) =>
+        post[Json](queryService)(
           path = filesystem.parent,
           query = Some(selectAll(filesystem.filename)),
-          destination = Some(destination),
-          state = filesystem.state,
+          destination = Some(destination.path),
+          state = filesystem.state.copy(queryResps = Map(selectAllLP(filesystem.file) -> filesystem.contents)),
           status = Status.Ok,
-          response = Json("out" := printPath(destination)).spaces2
+          response = json => json.field("out").flatMap(_.string).map(_ must_== printPath(destination.path))
+            .getOrElse(ko("Missing out field on json response"))
         )
-      }.pendingUntilFixed("TODO: Debug")
+      }
       "POST (error conditions)" >> {
         "be 404 for missing directory" ! prop { (dir: ADir, destination: AFile, filename: FileName) =>
-          post(query)(
+          post[String](queryService)(
             path = dir,
             query = Some(selectAll(filename)),
             destination = Some(destination),
             state = InMemState.empty,
             status = Status.NotFound,
-            response = "???"
+            response = _ must_== "???"
           )
         }.pendingUntilFixed("SD-773")
         "be 400 with missing query" ! prop { (filesystem: SingleFileMemState, destination: AFile) =>
-          post(query)(
+          post[String](queryService)(
             path = filesystem.parent,
             query = None,
             destination = Some(destination),
             state = filesystem.state,
             status = Status.BadRequest,
-            response = "The body of the POST must contain a query"
+            response = _ must_== "The body of the POST must contain a query"
           )
         }
         "be 400 with missing Destination header" ! prop { filesystem: SingleFileMemState =>
-          post(query)(
+          post[String](queryService)(
             path = filesystem.parent,
             query = Some(selectAll(filesystem.filename)),
             destination = None,
             state = filesystem.state,
             status = Status.BadRequest,
-            response = "The 'Destination' header must be specified"
+            response = _ must_== "The 'Destination' header must be specified"
           )
         }
         "be 400 for query error" ! prop { (filesystem: SingleFileMemState, destination: AFile) =>
-          post(query)(
+          post[String](queryService)(
             path = filesystem.parent,
             query = Some("select date where"),
             destination = Some(destination),
             state = filesystem.state,
             status = Status.BadRequest,
-            response = "keyword 'case' expected; `where'"
+            response = _ must_== "keyword 'case' expected; `where'"
           )
         }
       }
@@ -178,12 +185,12 @@ class CompileAndQueryServiceSpec extends Specification with FileSystemFixture wi
     "plan simple query" ! prop { filesystem: SingleFileMemState =>
       // Representation of the directory as a string without the leading slash
       val pathString = printPath(filesystem.file).drop(1)
-      get(compile)(
+      get(compileService)(
         path = filesystem.parent,
         query = Some(selectAll(filesystem.filename)),
         state = filesystem.state,
         status = Status.Ok,
-        response = "InMemory\nUnsupported"
+        response = "Lookup in Memory\nLookup Squash(Read(Path(\"" + pathString + "\"))) in Map()"
       )
     }
   }

--- a/web/src/test/scala/quasar/api/services/DataServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/DataServiceSpec.scala
@@ -2,10 +2,10 @@ package quasar
 package api
 package services
 
-import jawn.{FContext, Facade, AsyncParser}
 import org.http4s.server.middleware.GZip
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
+import pathy.scalacheck.AbsFileOf
 import quasar.Data
 import quasar.Predef._
 import quasar.api.MessageFormat.JsonContentType
@@ -49,10 +49,11 @@ class DataServiceSpec extends Specification with ScalaCheck with FileSystemFixtu
   "Data Service" should {
     "GET" >> {
       "respond with NotFound" >> {
-        "if file does not exist" ! prop { file: AFile =>
-          val response = service(InMemState.empty)(Request(uri = Uri(path = printPath(file)))).run
+        "if file does not exist" ! prop { file: AbsFileOf[AlphaCharacters] =>
+          val pathString = printPath(file.path)
+          val response = service(InMemState.empty)(Request(uri = Uri(path = pathString))).run
           response.status must_== Status.NotFound
-          response.as[String].run must_== s"${printPath(file)}: doesn't exist"
+          response.as[String].run must_== s"$pathString: doesn't exist"
         }
       }
       "respond with file data" >> {


### PR DESCRIPTION
- InMemState now has pre-canned responses for queries
- other minor improvements
- Remove scaladoc links in Interpreter causing doc generation failures
- Various fixes in CompileAndQueryServiceSpec in order to make all tests pass