### PR TITLE
Have Mongo’s JS return Ints when appropriate.

### DIFF
--- a/core/src/main/scala/quasar/physical/mongodb/planner.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/planner.scala
@@ -161,8 +161,10 @@ object MongoDbPlanner extends Planner[Crystallized] with Conversions {
 
       func match {
         case Constantly => Arity1(ι)
-        case Count => Arity1(Select(_, "count"))
-        case Length => Arity1(Select(_, "length"))
+        case Count =>
+          Arity1(expr => Call(ident("NumberLong"), List(Select(expr, "count"))))
+        case Length =>
+          Arity1(expr => Call(ident("NumberLong"), List(Select(expr, "length"))))
         case Sum =>
           Arity1(x =>
             Call(Select(x, "reduce"), List(ident("+"))))
@@ -872,7 +874,7 @@ object MongoDbPlanner extends Planner[Crystallized] with Conversions {
           lift(Arity2(HasWorkflow, HasKeys)).flatMap((distinctBy(_, _)).tupled)
 
         case Length       =>
-          lift(Arity1(HasWorkflow).map(jsExpr1(_, JsFn(JsFn.defaultName, jscore.Select(jscore.Ident(JsFn.defaultName), "length")))))
+          lift(Arity1(HasWorkflow).map(jsExpr1(_, JsFn(JsFn.defaultName, jscore.Call(jscore.ident("NumberLong"), List(jscore.Select(jscore.Ident(JsFn.defaultName), "length")))))))
 
         case Search       => lift(Arity3(HasWorkflow, HasWorkflow, HasWorkflow)).flatMap {
           case (value, pattern, insen) =>

--- a/core/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/core/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -541,7 +541,9 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         $read(Collection("db", "zips")),
         // FIXME: Inline this $simpleMap with the $match (SD-456)
         $simpleMap(NonEmptyList(MapExpr(JsFn(Name("x"), obj(
-          "__tmp4" -> Select(Select(ident("x"), "city"), "length"),
+          "__tmp4" ->
+            Call(ident("NumberLong"),
+              List(Select(Select(ident("x"), "city"), "length"))),
           "__tmp5" -> ident("x"))))),
           ListMap()),
         $match(Selector.And(
@@ -561,7 +563,9 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         $read(Collection("db", "zips")),
         // FIXME: Inline this $simpleMap with the $match (SD-456)
         $simpleMap(NonEmptyList(MapExpr(JsFn(Name("x"), obj(
-          "__tmp8" -> Select(Select(ident("x"), "city"), "length"),
+          "__tmp8" ->
+            Call(ident("NumberLong"),
+              List(Select(Select(ident("x"), "city"), "length"))),
           "__tmp9" -> ident("x"),
           "__tmp10" -> Select(ident("x"), "pop"))))),
           ListMap()),
@@ -1434,7 +1438,8 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             $simpleMap(NonEmptyList(MapExpr(JsFn(Name("x"), obj(
               "1" ->
                 If(Call(ident("isString"), List(Select(ident("x"), "city"))),
-                  Select(Select(ident("x"), "city"), "length"),
+                  Call(ident("NumberLong"),
+                    List(Select(Select(ident("x"), "city"), "length"))),
                   ident("undefined")))))),
               ListMap()),
             $group(
@@ -1841,7 +1846,9 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           $simpleMap(NonEmptyList(
             MapExpr(JsFn(Name("x"), obj(
               "state" -> Select(ident("x"), "state"),
-              "shortest" -> Select(Select(ident("x"), "__tmp6"), "length"))))),
+              "shortest" ->
+                Call(ident("NumberLong"),
+                  List(Select(Select(ident("x"), "__tmp6"), "length"))))))),
             ListMap()),
           $project(
             reshape(
@@ -1859,7 +1866,8 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               obj(
                 "__tmp10" ->
                   If(Call(ident("isString"), List(Select(ident("x"), "city"))),
-                    Select(Select(ident("x"), "city"), "length"),
+                    Call(ident("NumberLong"),
+                      List(Select(Select(ident("x"), "city"), "length"))),
                     ident("undefined")))))),
             ListMap()),
           $group(
@@ -1877,7 +1885,8 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             "0" ->
               If(Call(ident("isString"), List(Select(ident("x"), "city"))),
                 BinOp(jscore.Add,
-                  Select(Select(ident("x"), "city"), "length"),
+                  Call(ident("NumberLong"),
+                    List(Select(Select(ident("x"), "city"), "length"))),
                   jscore.Literal(Js.Num(1, false))),
                 ident("undefined")))))),
             ListMap()),
@@ -2532,7 +2541,8 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             "pop"    -> Select(ident("x"), "pop"),
             "__tmp6" ->
               If(Call(ident("isString"), List(Select(ident("x"), "city"))),
-                Select(Select(ident("x"), "city"), "length"),
+                Call(ident("NumberLong"),
+                  List(Select(Select(ident("x"), "city"), "length"))),
                 ident("undefined")))))),
             ListMap()),
           $sort(NonEmptyList(BsonField.Name("__tmp6") -> Ascending)),
@@ -2550,7 +2560,8 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           $simpleMap(NonEmptyList(MapExpr(JsFn(Name("x"), obj(
             "0" ->
               If(Call(ident("isString"), List(Select(ident("x"), "city"))),
-                Select(Select(ident("x"), "city"), "length"),
+                Call(ident("NumberLong"),
+                  List(Select(Select(ident("x"), "city"), "length"))),
                 ident("undefined")))))),
             ListMap()),
           $project(
@@ -2566,7 +2577,8 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           "city" -> Select(ident("x"), "city"),
           "1" ->
             If(Call(ident("isString"), List(Select(ident("x"), "city"))),
-              Select(Select(ident("x"), "city"), "length"),
+              Call(ident("NumberLong"),
+                List(Select(Select(ident("x"), "city"), "length"))),
               ident("undefined")))))),
           ListMap()),
         $project(
@@ -2736,7 +2748,8 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
                 obj(
                   "0" ->
                     If(Call(ident("isString"), List(Select(ident("x"), "city"))),
-                      Select(Select(ident("x"), "city"), "length"),
+                      Call(ident("NumberLong"),
+                        List(Select(Select(ident("x"), "city"), "length"))),
                       ident("undefined")),
                   "1" ->
                     BinOp(jscore.Eq,
@@ -2779,7 +2792,8 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             NonEmptyList(MapExpr(JsFn(Name("x"), obj(
               "0" ->
                 If(Call(ident("isString"), List(Select(ident("x"), "name"))),
-                  Select(Select(ident("x"), "name"), "length"),
+                  Call(ident("NumberLong"),
+                    List(Select(Select(ident("x"), "name"), "length"))),
                   ident("undefined")),
               "1" ->
                 If(

--- a/it/src/main/resources/tests/longCitiesWithLength.test
+++ b/it/src/main/resources/tests/longCitiesWithLength.test
@@ -1,20 +1,14 @@
 {
-  "name": "long city names in Colorado",
-  "backends": { "mongodb_read_only": "pending" },
-
-  "data": "zips.data",
-
-  "query": "select distinct city, length(city) from zips where state='CO' and length(city) >= 10",
-
-  "predicate": "containsAtLeast",
-
-  "expected": [
-    { "city": "GRAND LAKE",       "1": 10.0 },
-    { "city": "MONTE VISTA",      "1": 11.0 },
-    { "city": "FORT GARLAND",     "1": 12.0 },
-    { "city": "CRESTED BUTTE",    "1": 13.0 },
-    { "city": "PAGOSA SPRINGS",   "1": 14.0 },
-    { "city": "MANITOU SPRINGS",  "1": 15.0 },
-    { "city": "RED FEATHER LAKE", "1": 16.0 }
-  ]
+    "name": "long city names in Colorado",
+    "backends": { "mongodb_read_only": "pending" },
+    "data": "zips.data",
+    "query": "select distinct city, length(city) from zips where state='CO' and length(city) >= 10",
+    "predicate": "containsAtLeast",
+    "expected": [{ "city": "GRAND LAKE",       "1": 10 },
+                 { "city": "MONTE VISTA",      "1": 11 },
+                 { "city": "FORT GARLAND",     "1": 12 },
+                 { "city": "CRESTED BUTTE",    "1": 13 },
+                 { "city": "PAGOSA SPRINGS",   "1": 14 },
+                 { "city": "MANITOU SPRINGS",  "1": 15 },
+                 { "city": "RED FEATHER LAKE", "1": 16 }]
 }

--- a/it/src/main/resources/tests/statesByShortestFirstCity.test
+++ b/it/src/main/resources/tests/statesByShortestFirstCity.test
@@ -1,19 +1,13 @@
 {
-  "name": "states sorted by the length of name of their first city, alphabetically",
-  "description": "combines an aggregate function (min) with a function implemented in JS (length)",
-  "backends": { "mongodb_read_only": "pending" },
-
-  "data": "zips.data",
-
-  "query": "select state, min(city) as first, length(min(city)) as len from zips group by state order by len, first, state limit 5",
-
-  "predicate": "equalsExactly",
-
-  "expected": [
-    { "state": "MI" , "first": "ADA",  "len": 3.0 },
-    { "state": "OK" , "first": "ADA",  "len": 3.0 },
-    { "state": "GA" , "first": "ABAC", "len": 4.0 },
-    { "state": "NE" , "first": "ABIE", "len": 4.0 },
-    { "state": "WY" , "first": "ACME", "len": 4.0 }
-  ]
+    "name": "states sorted by the length of name of their first city, alphabetically",
+    "description": "combines an aggregate function (min) with a function implemented in JS (length)",
+    "backends": { "mongodb_read_only": "pending" },
+    "data": "zips.data",
+    "query": "select state, min(city) as first, length(min(city)) as len from zips group by state order by len, first, state limit 5",
+    "predicate": "equalsExactly",
+    "expected": [{ "state": "MI" , "first": "ADA",  "len": 3 },
+                 { "state": "OK" , "first": "ADA",  "len": 3 },
+                 { "state": "GA" , "first": "ABAC", "len": 4 },
+                 { "state": "NE" , "first": "ABIE", "len": 4 },
+                 { "state": "WY" , "first": "ACME", "len": 4 }]
 }

--- a/it/src/main/resources/tests/zipsByCityLength.test
+++ b/it/src/main/resources/tests/zipsByCityLength.test
@@ -1,18 +1,13 @@
 {
-  "name": "count occurrences of each value of length(city), with filtering",
-  "backends": { "mongodb_read_only": "pending" },
-
-  "data": "zips.data",
-
-  "query": "select length(city) as len, count(*) as cnt
-    from zips
-    where state != 'MI'
-    group by length(city)",
-
-  "predicate": "containsAtLeast",
-  "expected": [
-    { "len": 3.0, "cnt":  127 },
-    { "len": 4.0, "cnt":  927 },
-    { "len": 5.0, "cnt": 2181 }
-  ]
+    "name": "count occurrences of each value of length(city), with filtering",
+    "backends": { "mongodb_read_only": "pending" },
+    "data": "zips.data",
+    "query": "select length(city) as len, count(*) as cnt
+                from zips
+                where state != 'MI'
+                group by length(city)",
+    "predicate": "containsAtLeast",
+    "expected": [{ "len": 3, "cnt":  127 },
+                 { "len": 4, "cnt":  927 },
+                 { "len": 5, "cnt": 2181 }]
 }


### PR DESCRIPTION
Both `Length` and `Count` are defined to return Int, but we’ve just been
using the native JS numbers. This uses Mongo’s `NumberLong` to make sure
the results are integers.