### PR TITLE
avoid excessive backtracking when parsing deeply-nested parens

### DIFF
--- a/core/src/test/scala/quasar/sql/SqlParserSpec.scala
+++ b/core/src/test/scala/quasar/sql/SqlParserSpec.scala
@@ -284,6 +284,29 @@ class SQLParserSpec extends Specification with ScalaCheck with DisjunctionMatche
         ArrayLiteral(List(StringLiteral("X"), StringLiteral("Y"))))
     }
 
+    "parse empty set literal" in {
+      parser.parse("()") must beRightDisjunction(
+        SetLiteral(Nil))
+    }
+
+    "parse parenthesized simple expression (which is syntactically identical to a 1-element set literal)" in {
+      parser.parse("(a)") must beRightDisjunction(
+        Ident("a"))
+    }
+
+    "parse 2-element set literal" in {
+      parser.parse("(a, b)") must beRightDisjunction(
+        SetLiteral(List(Ident("a"), Ident("b"))))
+    }
+
+    "parse deeply nested parens" in {
+      // NB: Just a stress-test that the parser can handle a deeply
+      // left-recursive expression with many unneeded parenes, which
+      // happens to be exactly what pprint produces.
+      val q = """(select distinct topArr, topObj from "/demo/demo/nested" where (((((((((((((((search((((topArr)[*])[*])[*], '^.*$', true)) or (search((((topArr)[*])[*]).a, '^.*$', true))) or (search((((topArr)[*])[*]).b, '^.*$', true))) or (search((((topArr)[*])[*]).c, '^.*$', true))) or (search((((topArr)[*]).botObj).a, '^.*$', true))) or (search((((topArr)[*]).botObj).b, '^.*$', true))) or (search((((topArr)[*]).botObj).c, '^.*$', true))) or (search((((topArr)[*]).botArr)[*], '^.*$', true))) or (search((((topObj).midArr)[*])[*], '^.*$', true))) or (search((((topObj).midArr)[*]).a, '^.*$', true))) or (search((((topObj).midArr)[*]).b, '^.*$', true))) or (search((((topObj).midArr)[*]).c, '^.*$', true))) or (search((((topObj).midObj).botArr)[*], '^.*$', true))) or (search((((topObj).midObj).botObj).a, '^.*$', true))) or (search((((topObj).midObj).botObj).b, '^.*$', true))) or (search((((topObj).midObj).botObj).c, '^.*$', true)))"""
+      parser.parse(q).map(pprint) must beRightDisjunction(q)
+    }
+
     "round-trip to SQL and back" ! prop { (node: Expr) =>
       val parsed = parser.parse(pprint(node))
 


### PR DESCRIPTION
SD-1169 #done

Formerly, the parser would always attempt to parse a parenthesized
expression as a set literal, then fail when it turned out to contain
only one expression, and then re-parse it as a single expression. So it
was O(2^n) for certain patterns, including the way the pretty printer
renders long sequences of "or".

A simple fix is just to parse once and then decide based on the number
of sub-expressions whether to parse to SetLiteral or just an expression.

Three new tests (which pass before the fix) just verify the expected
behavior for 0-, 1-, and 2-element parenthesized expressions, and one
new test is the query from the bug report, which used to take at least
many minutes to parse, and now takes well under a second.