### PR TITLE
[SD-1170] Mounting algebra

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ lazy val standardSettings = Defaults.defaultSettings ++ Seq(
     // "-Ywarn-numeric-widen",
     "-Ywarn-unused-import",
     "-Ywarn-value-discard"),
-  scalacOptions in (Compile, console) --= Seq(
+  scalacOptions in (Test, console) --= Seq(
     "-Yno-imports",
     "-Ywarn-unused-import"
   ),

--- a/core/src/main/scala/quasar/EnvironmentError.scala
+++ b/core/src/main/scala/quasar/EnvironmentError.scala
@@ -4,97 +4,55 @@ import Predef._
 import quasar.fs.PathError2
 
 import argonaut._, Argonaut._
-
 import monocle._
-
 import scalaz._
 import scalaz.syntax.show._
 
 sealed trait EnvironmentError2
 
 object EnvironmentError2 {
-  object Case {
-    final case class ConnectionFailed(message: String)
-      extends EnvironmentError2
-    final case class PathError(error: PathError2)
-      extends EnvironmentError2
-    final case class InsufficientPermissions(message: String)
-      extends EnvironmentError2
-    final case class InvalidConfig(message: String)
-      extends EnvironmentError2
-    final case class InvalidCredentials(message: String)
-      extends EnvironmentError2
-    final case class UnsupportedVersion(backendName: String, version: List[Int])
-      extends EnvironmentError2
-  }
-
-  val ConnectionFailed: String => EnvironmentError2 =
-    Case.ConnectionFailed(_)
-
-  val PathError: PathError2 => EnvironmentError2 =
-    Case.PathError(_)
-
-  val InsufficientPermissions: String => EnvironmentError2 =
-    Case.InsufficientPermissions(_)
-
-  val InvalidConfig: String => EnvironmentError2 =
-    Case.InvalidConfig(_)
-
-  val InvalidCredentials: String => EnvironmentError2 =
-    Case.InvalidCredentials(_)
-
-  val UnsupportedVersion: (String, List[Int]) => EnvironmentError2 =
-    Case.UnsupportedVersion(_, _)
+  final case class ConnectionFailed private[quasar] (message: String)
+    extends EnvironmentError2
+  final case class InsufficientPermissions private[quasar] (message: String)
+    extends EnvironmentError2
+  final case class InvalidCredentials private[quasar] (message: String)
+    extends EnvironmentError2
+  final case class UnsupportedVersion private[quasar] (backendName: String, version: List[Int])
+    extends EnvironmentError2
 
   val connectionFailed: Prism[EnvironmentError2, String] =
     Prism[EnvironmentError2, String] {
-      case Case.ConnectionFailed(msg) => Some(msg)
+      case ConnectionFailed(msg) => Some(msg)
       case _ => None
-    } (ConnectionFailed)
-
-  val pathError: Prism[EnvironmentError2, PathError2] =
-    Prism[EnvironmentError2, PathError2] {
-      case Case.PathError(err) => Some(err)
-      case _ => None
-    } (PathError)
+    } (ConnectionFailed(_))
 
   val insufficientPermissions: Prism[EnvironmentError2, String] =
     Prism[EnvironmentError2, String] {
-      case Case.InsufficientPermissions(msg) => Some(msg)
+      case InsufficientPermissions(msg) => Some(msg)
       case _ => None
-    } (InsufficientPermissions)
-
-  val invalidConfig: Prism[EnvironmentError2, String] =
-    Prism[EnvironmentError2, String] {
-      case Case.InvalidConfig(msg) => Some(msg)
-      case _ => None
-    } (InvalidConfig)
+    } (InsufficientPermissions(_))
 
   val invalidCredentials: Prism[EnvironmentError2, String] =
     Prism[EnvironmentError2, String] {
-      case Case.InvalidCredentials(msg) => Some(msg)
+      case InvalidCredentials(msg) => Some(msg)
       case _ => None
-    } (InvalidCredentials)
+    } (InvalidCredentials(_))
 
   val unsupportedVersion: Prism[EnvironmentError2, (String, List[Int])] =
     Prism[EnvironmentError2, (String, List[Int])] {
-      case Case.UnsupportedVersion(name, version) => Some((name, version))
+      case UnsupportedVersion(name, version) => Some((name, version))
       case _ => None
-    } (UnsupportedVersion.tupled)
+    } ((UnsupportedVersion(_, _)).tupled)
 
   implicit val environmentErrorShow: Show[EnvironmentError2] =
     Show.shows {
-      case Case.ConnectionFailed(msg) =>
+      case ConnectionFailed(msg) =>
         s"Connection failed: $msg"
-      case Case.PathError(error) =>
-        error.shows
-      case Case.InsufficientPermissions(msg) =>
+      case InsufficientPermissions(msg) =>
         s"Insufficient permissions: $msg"
-      case Case.InvalidConfig(msg) =>
-        s"Invalid configuration: $msg"
-      case Case.InvalidCredentials(msg) =>
+      case InvalidCredentials(msg) =>
         s"Invalid credentials: $msg"
-      case Case.UnsupportedVersion(name, version) =>
+      case UnsupportedVersion(name, version) =>
         s"Unsupported $name version: ${version.mkString(".")}"
     }
 
@@ -103,11 +61,11 @@ object EnvironmentError2 {
       Json(("error" := message) :: detail.toList.map("errorDetail" := _): _*)
 
     EncodeJson[EnvironmentError2] {
-      case Case.ConnectionFailed(msg) =>
+      case ConnectionFailed(msg) =>
         format("Connection failed.", Some(msg))
-      case Case.InsufficientPermissions(msg) =>
+      case InsufficientPermissions(msg) =>
         format("Database user does not have permissions on database.", Some(msg))
-      case Case.InvalidCredentials(msg) =>
+      case InvalidCredentials(msg) =>
         format("Invalid username and/or password specified.", Some(msg))
       case err =>
         format(err.shows, None)

--- a/core/src/main/scala/quasar/NameGenerator.scala
+++ b/core/src/main/scala/quasar/NameGenerator.scala
@@ -3,7 +3,6 @@ package quasar
 import quasar.Predef._
 
 import simulacrum.typeclass
-
 import scalaz._
 import scalaz.concurrent.Task
 import scalaz.syntax.functor._

--- a/core/src/main/scala/quasar/fp/package.scala
+++ b/core/src/main/scala/quasar/fp/package.scala
@@ -347,7 +347,7 @@ trait SKI {
 }
 object SKI extends SKI
 
-package object fp extends TreeInstances with ListMapInstances with EitherTInstances with OptionTInstances with StateTInstances with WriterTInstances with ToCatchableOps with PartialFunctionOps with JsonOps with ProcessOps with QFoldableOps with SKI {
+package object fp extends TreeInstances with ListMapInstances with EitherTInstances with OptionTInstances with StateTInstances with WriterTInstances with ToCatchableOps with PartialFunctionOps with JsonOps with ProcessOps with QFoldableOps with PrismInstances with SKI {
   sealed trait Polymorphic[F[_], TC[_]] {
     def apply[A: TC]: TC[F[A]]
   }

--- a/core/src/main/scala/quasar/fp/prism.scala
+++ b/core/src/main/scala/quasar/fp/prism.scala
@@ -1,0 +1,24 @@
+package quasar.fp
+
+import monocle.Prism
+import scalaz._
+
+trait PrismInstances {
+  import Liskov.<~<
+
+  // TODO: See if we can implement this once for all tuples using shapeless.
+  implicit class PrismOps[A, B](prism: Prism[A, B]) {
+    def apply(b: B): A = prism.reverseGet(b)
+
+    def apply[C, D](c: C, d: D)(implicit ev: (C, D) <~< B): A =
+      apply(ev((c, d)))
+
+    def apply[C, D, E](c: C, d: D, e: E)(implicit ev: (C, D, E) <~< B): A =
+      apply(ev((c, d, e)))
+
+    def apply[C, D, E, F](c: C, d: D, e: E, f: F)(implicit ev: (C, D, E, F) <~< B): A =
+      apply(ev((c, d, e, f)))
+  }
+}
+
+object prism extends PrismInstances

--- a/core/src/main/scala/quasar/mount/ConnectionUri.scala
+++ b/core/src/main/scala/quasar/mount/ConnectionUri.scala
@@ -1,0 +1,20 @@
+package quasar.mount
+
+import quasar.Predef._
+
+import argonaut._
+import scalaz._
+import scalaz.std.string._
+
+final case class ConnectionUri(value: String) extends scala.AnyVal
+
+object ConnectionUri {
+  implicit val connectionUriShow: Show[ConnectionUri] =
+    Show.showFromToString
+
+  implicit val connectionUriOrder: Order[ConnectionUri] =
+    Order.orderBy(_.value)
+
+  implicit val connectionUriCodecJson: CodecJson[ConnectionUri] =
+    CodecJson.derived[String].xmap(ConnectionUri(_))(_.value)
+}

--- a/core/src/main/scala/quasar/mount/FileSystemType.scala
+++ b/core/src/main/scala/quasar/mount/FileSystemType.scala
@@ -1,0 +1,19 @@
+package quasar.mount
+
+import quasar.Predef._
+
+import argonaut._, Argonaut._
+import scalaz._, Scalaz._
+
+final case class FileSystemType(value: String) extends scala.AnyVal
+
+object FileSystemType {
+  implicit val fileSystemTypeOrder: Order[FileSystemType] =
+    Order.orderBy(_.value)
+
+  implicit val fileSystemTypeShow: Show[FileSystemType] =
+    Show.showFromToString
+
+  implicit val fileSystemTypeCodecJson: CodecJson[FileSystemType] =
+    CodecJson.derived[String].xmap(FileSystemType(_))(_.value)
+}

--- a/core/src/main/scala/quasar/mount/MapMounter.scala
+++ b/core/src/main/scala/quasar/mount/MapMounter.scala
@@ -1,0 +1,132 @@
+package quasar.mount
+
+import quasar.Predef._
+import quasar.{EnvironmentError2, Variables}
+import quasar.fs.{Path => _, _}
+import quasar.fp._
+import quasar.sql.Expr
+
+import pathy.Path._
+import scalaz._, Scalaz._
+
+object MapMounter {
+  type VCfg                 = (Expr, Variables)
+  type FsCfg                = (FileSystemType, ConnectionUri)
+  type ViewMounts           = Map[AFile, VCfg]
+  type FsMounts             = Map[ADir, FsCfg]
+  type MapMounterT[F[_], A] = StateT[F, Mounts, A]
+  type MountR               = Either3[String, EnvironmentError2, Unit]
+
+  final case class Mounts(view: ViewMounts, fs: FsMounts)
+
+  object Mounts {
+    val empty: Mounts = Mounts(Map.empty, Map.empty)
+  }
+
+  /** `Mounting` interpreter using in-memory maps to maintain state.
+    *
+    * @param mount Handles the actual mounting of the mount described by the
+    *              config. Returns `Left3` if the config is invalid, `Middle3`
+    *              if there was a failure during mounting and `Right3` if mounting
+    *              succeded.
+    */
+  def apply[F[_]: Monad](
+    mount: MountConfig2 => F[MountR]
+  ): Mounting ~> MapMounterT[F, ?] =
+    new MapMounter(mount)
+}
+
+private final class MapMounter[F[_]: Monad](
+  mount0: MountConfig2 => F[MapMounter.MountR]
+) extends (Mounting ~> MapMounter.MapMounterT[F, ?]) {
+
+  import MapMounter._, Mounting._, MountConfig2._
+
+  type Mnt[A]  = MapMounterT[F, A]
+  type MntE[A] = MntErrT[Mnt, A]
+
+  def apply[A](m: Mounting[A]) = m match {
+    case Lookup(path) =>
+      refineType(path)
+        .fold(fsMntL, viewMntL)
+        .st.lift[F]
+
+    case MountView(loc, query, vars) =>
+      OptionT[Mnt, VCfg](viewL(loc).st.lift[F])
+        .as(pathExists(loc))
+        .toLeft(())
+        .flatMap(κ(mountView(loc, query, vars)))
+        .run
+
+    case MountFileSystem(loc, typ, uri) =>
+      OptionT[Mnt, FsCfg](fsL(loc).st.lift[F])
+        .as(pathExists(loc))
+        .toLeft(())
+        .flatMap(κ(mountFileSystem(loc, typ, uri)))
+        .run
+
+    case Unmount(path) =>
+      refineType(path)
+        .fold(fsMntL, viewMntL)
+        .assigno(None)
+        .map(_.void \/> pathNotFound(path))
+        .lift[F]
+  }
+
+  val pathNotFound = MountingError.pathError composePrism PathError2.pathNotFound
+  val pathExists = MountingError.pathError composePrism PathError2.pathExists
+  val invalidPath = MountingError.pathError composePrism PathError2.invalidPath
+
+  val viewsL: Mounts @> ViewMounts =
+    Lens.lensu((m, vs) => m.copy(view = vs), _.view)
+
+  def viewL(f: AFile): Mounts @> Option[VCfg] =
+    Lens.mapVLens(f) <=< viewsL
+
+  def viewMntL(f: AFile): Mounts @> Option[MountConfig2] =
+    viewL(f).xmapB(_ map (viewConfig(_)))(_ flatMap viewConfig.getOption)
+
+  val fssL: Mounts @> FsMounts =
+    Lens.lensu((m, f) => m.copy(fs = f), _.fs)
+
+  def fsL(d: ADir): Mounts @> Option[FsCfg] =
+    Lens.mapVLens(d) <=< fssL
+
+  def fsMntL(d: ADir): Mounts @> Option[MountConfig2] =
+    fsL(d).xmapB(_ map (fileSystemConfig(_)))(_ flatMap fileSystemConfig.getOption)
+
+  def mountView(loc: AFile, query: Expr, vars: Variables): MntE[Unit] =
+    mount(viewConfig(query, vars)) *>
+      liftPure(viewL(loc).assign((query, vars).some).void)
+
+  def mountFileSystem(loc: ADir, typ: FileSystemType, uri: ConnectionUri): MntE[Unit] = {
+    val checkOverlaps: MntE[Unit] =
+      EitherT(ensureNoOverlaps(loc).lift[F]: Mnt[MountingError \/ Unit])
+
+    checkOverlaps                         *>
+    mount(fileSystemConfig(typ, uri))     <*
+    liftPure(fsL(loc) := (typ, uri).some)
+  }
+
+  def mount(cfg: MountConfig2): MntE[Unit] =
+    EitherT[Mnt, MountingError, Unit](
+      mount0(cfg).map(_.fold(
+        s => MountingError.invalidConfig(cfg, s).left,
+        e => MountingError.environmentError(e).left,
+        _ => ().right)).liftM[MapMounterT])
+
+  def liftPure[A](a: State[Mounts, A]): MntE[A] =
+    (a.lift[F]: Mnt[A]).liftM[MntErrT]
+
+  def ensureNoOverlaps(d0: ADir): State[Mounts, MountingError \/ Unit] =
+    fssL.st map { fss =>
+      fss.keys.toList.traverseU_(d1 =>
+        d1.relativeTo(d0)
+          .as("existing mount below: " + posixCodec.printPath(d1))
+          .toLeftDisjunction(()) *>
+        d0.relativeTo(d1)
+          .as("existing mount above: " + posixCodec.printPath(d1))
+          .toLeftDisjunction(())
+      ) leftMap (invalidPath(d0, _))
+    }
+}

--- a/core/src/main/scala/quasar/mount/MountConfig.scala
+++ b/core/src/main/scala/quasar/mount/MountConfig.scala
@@ -1,0 +1,65 @@
+package quasar.mount
+
+import quasar.Predef._
+import quasar.Variables
+import quasar.config
+import quasar.fp.prism._
+import quasar.sql._
+
+import argonaut._, Argonaut._
+import monocle.Prism
+import scalaz._
+
+/** Configuration for a mount, currently either a view or a filesystem. */
+sealed trait MountConfig2
+
+object MountConfig2 {
+  final case class ViewConfig private[mount] (query: Expr, vars: Variables)
+    extends MountConfig2
+
+  final case class FileSystemConfig private[mount] (typ: FileSystemType, uri: ConnectionUri)
+    extends MountConfig2
+
+  val viewConfig: Prism[MountConfig2, (Expr, Variables)] =
+    Prism[MountConfig2, (Expr, Variables)] {
+      case ViewConfig(query, vars) => Some((query, vars))
+      case _                       => None
+    } ((ViewConfig(_, _)).tupled)
+
+  val fileSystemConfig: Prism[MountConfig2, (FileSystemType, ConnectionUri)] =
+    Prism[MountConfig2, (FileSystemType, ConnectionUri)] {
+      case FileSystemConfig(typ, uri) => Some((typ, uri))
+      case _                          => None
+    } ((FileSystemConfig(_, _)).tupled)
+
+  implicit val mountConfigShow: Show[MountConfig2] =
+    Show.showFromToString
+
+/** TODO: Equal[sql.Expr]
+  implicit val mountConfigEqual: Equal[MountConfig2] =
+    Equal.equalBy[MountConfig2, Expr \/ (FileSystemType, Json)] {
+      case ViewConfig(query)           => query.left
+      case FileSystemConfig(typ, json) => (typ, json).right
+    }
+*/
+
+  implicit val mountConfigCodecJson: CodecJson[MountConfig2] =
+    CodecJson({
+      case ViewConfig(query, vars) =>
+        Json("view" := config.ViewConfig(query, vars))
+
+      case FileSystemConfig(typ, uri) =>
+        Json(typ.value := Json("connectionUri" := uri))
+    }, c => c.fields match {
+      case Some("view" :: Nil) =>
+        (c --\ "view").as[config.ViewConfig]
+          .map(vc => viewConfig(vc.query, vc.variables))
+
+      case Some(t :: Nil) =>
+        (c --\ t --\ "connectionUri").as[ConnectionUri]
+          .map(fileSystemConfig(FileSystemType(t), _))
+
+      case _ =>
+        DecodeResult.fail(s"invalid config: ${c.focus}", c.history)
+    })
+}

--- a/core/src/main/scala/quasar/mount/Mounting.scala
+++ b/core/src/main/scala/quasar/mount/Mounting.scala
@@ -1,0 +1,123 @@
+package quasar.mount
+
+import quasar.Predef._
+import quasar.Variables
+import quasar.fp._
+import quasar.fs.{Path => _, _}
+import quasar.sql._
+
+import monocle.Prism
+import monocle.std.{disjunction => D}
+import pathy._, Path._
+import scalaz._
+import scalaz.syntax.std.option._
+import scalaz.syntax.apply._
+import scalaz.syntax.monadError._
+
+sealed trait Mounting[A]
+
+object Mounting {
+  final case class Lookup(path: APath)
+    extends Mounting[Option[MountConfig2]]
+
+  final case class MountView(loc: AFile, query: Expr, vars: Variables)
+    extends Mounting[MountingError \/ Unit]
+
+  final case class MountFileSystem(loc: ADir, typ: FileSystemType, uri: ConnectionUri)
+    extends Mounting[MountingError \/ Unit]
+
+  final case class Unmount(path: APath)
+    extends Mounting[MountingError \/ Unit]
+
+  final class Ops[S[_]](implicit S0: Functor[S], S1: MountingF :<: S) {
+    import MountConfig2._
+
+    type F[A] = Free[S, A]
+    type M[A] = EitherT[F, MountingError, A]
+
+    /** Returns the mount configuration for the given mount path or nothing
+      * if the path does not refer to a mount.
+      */
+    def lookup(path: APath): OptionT[F, MountConfig2] =
+      OptionT(lift(Lookup(path)))
+
+    /** Create a view mount at the given location. */
+    def mountView(loc: AFile, query: Expr, vars: Variables): M[Unit] =
+      EitherT(lift(MountView(loc, query, vars)))
+
+    /** Create a filesystem mount at the given location. */
+    def mountFileSystem(loc: ADir, typ: FileSystemType, uri: ConnectionUri): M[Unit] =
+      EitherT(lift(MountFileSystem(loc, typ, uri)))
+
+    /** Attempt to create a mount described by the given configuration at the
+      * given location.
+      */
+    def mount(loc: APath, config: MountConfig2): M[Unit] =
+      config match {
+        case ViewConfig(query, vars) =>
+          D.right.getOption(refineType(loc)) cata (file =>
+              mountView(file, query, vars),
+              invalidPath(loc, "view mount location must be a file")
+                .raiseError[E, Unit])
+
+        case FileSystemConfig(typ, uri) =>
+          D.left.getOption(refineType(loc)) cata (dir =>
+            mountFileSystem(dir, typ, uri),
+            invalidPath(loc, "filesytem mount location must be a directory")
+              .raiseError[E, Unit])
+      }
+
+    /** Remount `src` at `dst`, results in an error if there is no mount at
+      * `src`.
+      */
+    def remount[T](src: Path[Abs,T,Sandboxed], dst: Path[Abs,T,Sandboxed]): M[Unit] =
+      modify(src, dst, ι)
+
+    /** Replace the mount at the given path with one described by the
+      * provided config.
+      */
+    def replace(loc: APath, config: MountConfig2): M[Unit] =
+      modify(loc, loc, κ(config))
+
+    /** Remove the mount at the given path. */
+    def unmount(path: APath): M[Unit] =
+      EitherT(lift(Unmount(path)))
+
+    ////
+
+    private type E[A, B] = EitherT[F, A, B]
+
+    private val mErr: MonadError[E, MountingError] =
+      MonadError[E, MountingError]
+
+    private val notFound: Prism[MountingError, APath] =
+      MountingError.pathError composePrism PathError2.pathNotFound
+
+    private val invalidPath: Prism[MountingError, (APath, String)] =
+      MountingError.pathError composePrism PathError2.invalidPath
+
+    private def modify[T](
+      src: Path[Abs,T,Sandboxed],
+      dst: Path[Abs,T,Sandboxed],
+      f: MountConfig2 => MountConfig2
+    ): M[Unit] = {
+      import mErr._
+
+      for {
+        cfg <- lookup(src) toRight notFound(src)
+        _   <- unmount(src)
+        _   <- handleError(mount(dst, f(cfg))) { err =>
+                 mount(src, cfg) *> raiseError(err)
+               }
+      } yield ()
+    }
+
+    private def lift[A](m: Mounting[A]): F[A] =
+      Free.liftF(S1.inj(Coyoneda.lift(m)))
+  }
+
+  object Ops {
+    implicit def apply[S[_]](implicit S0: Functor[S], S1: MountingF :<: S): Ops[S] =
+      new Ops[S]
+  }
+}

--- a/core/src/main/scala/quasar/mount/MountingError.scala
+++ b/core/src/main/scala/quasar/mount/MountingError.scala
@@ -1,0 +1,38 @@
+package quasar.mount
+
+import quasar.Predef._
+import quasar.EnvironmentError2
+import quasar.fs._
+
+import monocle.Prism
+
+sealed trait MountingError
+
+object MountingError {
+  final case class PathError private[mount] (err: PathError2)
+    extends MountingError
+
+  final case class EnvironmentError private[mount] (err: EnvironmentError2)
+    extends MountingError
+
+  final case class InvalidConfig private[mount] (config: MountConfig2, reason: String)
+    extends MountingError
+
+  val pathError: Prism[MountingError, PathError2] =
+    Prism[MountingError, PathError2] {
+      case PathError(err) => Some(err)
+      case _ => None
+    } (PathError(_))
+
+  val environmentError: Prism[MountingError, EnvironmentError2] =
+    Prism[MountingError, EnvironmentError2] {
+      case EnvironmentError(err) => Some(err)
+      case _ => None
+    } (EnvironmentError(_))
+
+  val invalidConfig: Prism[MountingError, (MountConfig2, String)] =
+    Prism[MountingError, (MountConfig2, String)] {
+      case InvalidConfig(cfg, reason) => Some((cfg, reason))
+      case _ => None
+    } ((InvalidConfig(_, _)).tupled)
+}

--- a/core/src/main/scala/quasar/mount/package.scala
+++ b/core/src/main/scala/quasar/mount/package.scala
@@ -1,0 +1,8 @@
+package quasar
+
+import scalaz.{Coyoneda, EitherT}
+
+package object mount {
+  type MountingF[A] = Coyoneda[Mounting, A]
+  type MntErrT[F[_], A] = EitherT[F, MountingError, A]
+}

--- a/core/src/main/scala/quasar/physical/mongodb/MongoDbIOWorkflowExecutor.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/MongoDbIOWorkflowExecutor.scala
@@ -1,8 +1,8 @@
-package quasar
-package physical
-package mongodb
+package quasar.physical.mongodb
 
 import quasar.Predef._
+import quasar.{EnvironmentError2, EnvErr2T}
+import quasar.fp.prism._
 import quasar.fs.Positive
 import quasar.physical.mongodb.workflowtask._
 
@@ -10,7 +10,6 @@ import java.lang.IllegalArgumentException
 
 import com.mongodb._
 import org.bson.Document
-
 import scalaz._, Scalaz._
 
 /** Implementation class for a WorkflowExecutor in the `MongoDbIO` monad. */
@@ -46,13 +45,13 @@ private[mongodb] object MongoDbWorkflowExecutor {
     new (MongoDbIO ~> EnvErr2T[MongoDbIO, ?]) {
       def apply[A](m: MongoDbIO[A]) = EitherT(m.attemptMongo.run flatMap {
         case -\/(ex: MongoSocketOpenException) =>
-          ConnectionFailed(ex.getMessage).left.point[MongoDbIO]
+          connectionFailed(ex.getMessage).left.point[MongoDbIO]
 
         case -\/(ex: MongoSocketException) =>
-          ConnectionFailed(ex.getMessage).left.point[MongoDbIO]
+          connectionFailed(ex.getMessage).left.point[MongoDbIO]
 
         case -\/(ex) if ex.getMessage contains "Command failed with error 18: 'auth failed'" =>
-          InvalidCredentials(ex.getMessage).left.point[MongoDbIO]
+          invalidCredentials(ex.getMessage).left.point[MongoDbIO]
 
         case -\/(ex) =>
           MongoDbIO.fail(ex)

--- a/core/src/main/scala/quasar/physical/mongodb/WorkflowExecutor.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/WorkflowExecutor.scala
@@ -1,9 +1,9 @@
-package quasar
-package physical
-package mongodb
+package quasar.physical.mongodb
 
 import quasar.Predef._
+import quasar.{EnvironmentError2, EnvErr2T, SeqNameGeneratorT}
 import quasar.{NameGenerator => QNameGenerator}
+import quasar.fp.prism._
 import quasar.javascript._
 import quasar.physical.mongodb.workflowtask._
 
@@ -67,7 +67,7 @@ trait WorkflowExecutor[F[_]] {
 
     def tempColl: N[Collection] =
       for {
-        tmp <- NameGenerator[M].prefixedName("wf.").liftM[TempsT]
+        tmp <- QNameGenerator[M].prefixedName("wf.").liftM[TempsT]
         col =  Collection(dst.databaseName, tmp)
         _   <- wroteTo(col, true) // assume we'll write to this collection
       } yield col
@@ -182,7 +182,7 @@ object WorkflowExecutor {
       if (v >= MinMongoDbVersion)
         (new MongoDbWorkflowExecutor: WorkflowExecutor[MongoDbIO]).point[M]
       else
-        UnsupportedVersion("MongoDB", v).raiseError[E, WorkflowExecutor[MongoDbIO]]
+        unsupportedVersion("MongoDB", v).raiseError[E, WorkflowExecutor[MongoDbIO]]
     }
   }
 

--- a/core/src/test/scala/quasar/mount/MapMounterSpec.scala
+++ b/core/src/test/scala/quasar/mount/MapMounterSpec.scala
@@ -1,0 +1,56 @@
+package quasar.mount
+
+import quasar.Predef._
+import quasar.EnvironmentError2
+import quasar.fp._
+
+import pathy.Path._
+import scalaz._, Scalaz._
+import scalaz.concurrent.Task
+
+class MapMounterSpec extends MountingSpec[MountingF] {
+  import MapMounter.{Mounts, MountR}, MountConfig2._
+
+  val invalidUri = ConnectionUri(uriA.value + "INVALID")
+  val unsuppUri  = ConnectionUri(uriB.value + "VERSION")
+  val unsuppErr  = EnvironmentError2.unsupportedVersion("DB", List(1,2,3))
+
+  val doMount: MountConfig2 => MountR = {
+    case FileSystemConfig(`dbType`, `invalidUri`) => Either3.left3("invalid URI")
+    case FileSystemConfig(`dbType`, `unsuppUri`)  => Either3.middle3(unsuppErr)
+    case _                                        => Either3.right3(())
+  }
+
+  def interpName = "MapMounter"
+
+  def interpret = {
+    val mm = MapMounter[Id](doMount)
+    val ref = TaskRef(Mounts.empty).run
+
+    val interp0: Mounting ~> Task = new (Mounting ~> Task) {
+      def apply[A](m: Mounting[A]) = ref.modifyS(mm(m).run)
+    }
+
+    Coyoneda.liftTF(interp0)
+  }
+
+  "Handling mounts" should {
+    "result in an invalid config when mount returns a string" >>* {
+      val loc = rootDir </> dir("fs")
+      val cfg = MountConfig2.fileSystemConfig(dbType, invalidUri)
+
+      mnt.mountFileSystem(loc, dbType, invalidUri)
+        .run.tuple(mnt.lookup(loc).run)
+        .map(_ must_== ((MountingError.invalidConfig(cfg, "invalid URI").left, None)))
+    }
+
+    "result in an environment error when mount returns an error" >>* {
+      val loc = rootDir </> dir("fs2")
+      val cfg = MountConfig2.fileSystemConfig(dbType, unsuppUri)
+
+      mnt.mountFileSystem(loc, dbType, unsuppUri)
+        .run.tuple(mnt.lookup(loc).run)
+        .map(_ must_== ((MountingError.environmentError(unsuppErr).left, None)))
+    }
+  }
+}

--- a/core/src/test/scala/quasar/mount/MountingSpec.scala
+++ b/core/src/test/scala/quasar/mount/MountingSpec.scala
@@ -1,0 +1,349 @@
+package quasar.mount
+
+import quasar.Predef._
+import quasar.Variables
+import quasar.fp.prism._
+import quasar.fs.{APath, ADir, AFile, PathError2}
+import quasar.recursionschemes.Fix
+import quasar.specs2.DisjunctionMatchers
+import quasar.sql
+
+import monocle.function.Field1
+import monocle.std.{disjunction => D}
+import monocle.std.tuple2._
+import org.specs2.execute._
+import org.specs2.mutable
+import org.specs2.specification._
+import pathy.Path._
+import scalaz._, Scalaz._
+import scalaz.concurrent.Task
+
+abstract class MountingSpec[S[_]](implicit S0: Functor[S], S1: MountingF :<: S)
+  extends mutable.Specification with DisjunctionMatchers {
+
+  import MountConfig2.{viewConfig, fileSystemConfig}
+
+  def interpName: String
+  def interpret: S ~> Task
+
+  val mnt = Mounting.Ops[S]
+  // NB: Without the explicit imports, scalac complains of an import cycle
+  import mnt.{F, M, lookup, mountView, mountFileSystem, remount, replace, unmount}
+
+  implicit class StrOps(s: String) {
+    def >>*[A: AsResult](a: => F[A]): Example =
+      s >> a.foldMap(interpret).run
+  }
+
+  val noVars   = Variables.fromMap(Map.empty)
+  val exprA    = Fix(sql.StringLiteralF[sql.Expr]("A"))
+  val exprB    = Fix(sql.StringLiteralF[sql.Expr]("B"))
+  val viewCfgA = viewConfig(exprA, noVars)
+  val viewCfgB = viewConfig(exprB, noVars)
+
+  val dbType   = FileSystemType("db")
+  val uriA     = ConnectionUri("db://example.com/A")
+  val uriB     = ConnectionUri("db://example.com/B")
+  val fsCfgA   = fileSystemConfig(dbType, uriA)
+  val fsCfgB   = fileSystemConfig(dbType, uriB)
+
+  val invalidPath = MountingError.pathError composePrism
+                    PathError2.invalidPath  composeLens
+                    Field1.first
+
+  val notFound = MountingError.pathError composePrism
+                 PathError2.pathNotFound
+
+  val pathExists = MountingError.pathError composePrism
+                   PathError2.pathExists
+
+  def maybeInvalid[A](dj: MountingError \/ A): Option[APath] =
+    D.left composeOptional invalidPath getOption dj
+
+  def maybeNotFound[A](dj: MountingError \/ A): Option[APath] =
+    D.left composePrism notFound getOption dj
+
+  def maybeExists[A](dj: MountingError \/ A): Option[APath] =
+    D.left composePrism pathExists getOption dj
+
+  def mountViewNoVars(loc: AFile, query: sql.Expr): M[Unit] =
+    mountView(loc, query, noVars)
+
+  s"$interpName mounting interpreter" should {
+    "lookup" >> {
+      "returns a view config when asked for an existing view path" >>* {
+        val f = rootDir </> dir("d1") </> file("f1")
+
+        (mountViewNoVars(f, exprA).toOption *> lookup(f))
+          .run map (_ must beSome(viewCfgA))
+      }
+
+      "returns a filesystem config when asked for an existing fs path" >>* {
+        val d = rootDir </> dir("d1")
+
+        (mountFileSystem(d, dbType, uriA).toOption *> lookup(d))
+          .run map (_ must beSome(fsCfgA))
+      }
+
+      "returns none when nothing mounted at the requested path" >>* {
+        val f = rootDir </> dir("d2") </> file("f2")
+        val d = rootDir </> dir("d3")
+
+        lookup(f).run.tuple(lookup(d).run)
+          .map(_ must_== ((None, None)))
+      }
+    }
+
+    "mountViewNoVars" >> {
+      "allow mounting a view at a file path" >>* {
+        val f = rootDir </> file("f1")
+
+        (mountViewNoVars(f, exprA).toOption *> lookup(f))
+          .run map (_ must beSome(viewCfgA))
+      }
+
+      "allow mounting a view above another view" >>* {
+        val f1 = rootDir </> dir("d1") </> dir("d2") </> file("f1")
+        val f2 = rootDir </> dir("d1") </> file("d2")
+
+        val r = (
+          mountViewNoVars(f1, exprA) *>
+          mountViewNoVars(f2, exprB)
+        ).toOption *> lookup(f2)
+
+        r.run map (_ must beSome(viewCfgB))
+      }
+
+      "allow mounting a view below another view" >>* {
+        val f1 = rootDir </> dir("d1") </> file("d2")
+        val f2 = rootDir </> dir("d1") </> dir("d2") </> file("f2")
+
+        val r = (
+          mountViewNoVars(f1, exprA) *>
+          mountViewNoVars(f2, exprB)
+        ).toOption *> lookup(f2)
+
+        r.run map (_ must beSome(viewCfgB))
+      }
+
+      "allow mounting a view above a filesystem" >>* {
+        val d = rootDir </> dir("d1") </> dir("db")
+        val f = rootDir </> file("d1")
+
+        val r = (
+          mountFileSystem(d, dbType, uriA) *>
+          mountViewNoVars(f, exprA)
+        ).toOption *> lookup(f)
+
+        r.run map (_ must beSome(viewCfgA))
+      }
+
+      "allow mounting a view at a file with the same name as an fs mount" >>* {
+        val d = rootDir </> dir("d1")
+        val f = rootDir </> file("d1")
+
+        val r = (
+          mountFileSystem(d, dbType, uriA) *>
+          mountViewNoVars(f, exprA)
+        ).toOption *> lookup(f)
+
+        r.run map (_ must beSome(viewCfgA))
+      }
+
+      "allow mounting a view below a filesystem" >>* {
+        val d = rootDir </> dir("d1")
+        val f = rootDir </> dir("d1") </> file("f1")
+
+        val r = (
+          mountFileSystem(d, dbType, uriA) *>
+          mountViewNoVars(f, exprA)
+        ).toOption *> lookup(f)
+
+        r.run map (_ must beSome(viewCfgA))
+      }
+
+      "fail when a view is already mounted at the file path" >>* {
+        val f = rootDir </> dir("d1") </> file("f1")
+
+        (mountViewNoVars(f, exprA) *> mountViewNoVars(f, exprB)).run map { r =>
+          maybeExists(r) must beSome(f)
+        }
+      }
+    }
+
+    "mountFileSystem" >> {
+      def mountFF(d1: ADir, d2: ADir): M[Unit] =
+        mountFileSystem(d1, dbType, uriA) *> mountFileSystem(d2, dbType, uriB)
+
+      def mountVF(f: AFile, d: ADir): OptionT[F, MountConfig2] =
+        (mountViewNoVars(f, exprA) *> mountFileSystem(d, dbType, uriA))
+          .toOption *> lookup(d)
+
+      "mounts a filesystem at a directory" >>* {
+        val d = rootDir </> dir("d1")
+
+        (mountFileSystem(d, dbType, uriA).toOption *> lookup(d))
+          .run map (_ must beSome(fsCfgA))
+      }
+
+      "fail when mounting above an existing fs mount" >>* {
+        val d1 = rootDir </> dir("d1")
+        val d2 = d1 </> dir("d2")
+
+        mountFF(d2, d1).run map (dj => maybeInvalid(dj) must beSome(d1))
+      }
+
+      "fail when mounting at an existing fs mount" >>* {
+        val d = rootDir </> dir("exists")
+
+        mountFF(d, d).run.tuple(lookup(d).run) map { case (dj, cfg) =>
+          maybeExists(dj).tuple(cfg) must beSome((d, fsCfgA))
+        }
+      }
+
+      "fail when mounting below an existing fs mount" >>* {
+        val d1 = rootDir </> dir("d1")
+        val d2 = d1 </> dir("d2")
+
+        mountFF(d1, d2).run map (dj => maybeInvalid(dj) must beSome(d2))
+      }
+
+      "succeed when mounting above an existing view mount" >>* {
+        val d = rootDir </> dir("d1")
+        val f = d </> file("view")
+
+        mountVF(f, d).run map (_ must beSome(fsCfgA))
+      }
+
+      "succeed when mounting at a dir with same name as existing view mount" >>* {
+        val f = rootDir </> dir("d2") </> file("view")
+        val d = rootDir </> dir("d2") </> dir("view")
+
+        mountVF(f, d).run map (_ must beSome(fsCfgA))
+      }
+
+      "succeed when mounting below an existing view mount" >>* {
+        val f = rootDir </> dir("d2") </> file("view")
+        val d = rootDir </> dir("d2") </> dir("view") </> dir("db")
+
+        mountVF(f, d).run map (_ must beSome(fsCfgA))
+      }
+    }
+
+    "mount" >> {
+      "succeeds when loc and config agree" >>* {
+        val f = rootDir </> file("view")
+
+        (mnt.mount(f, viewCfgA).toOption *> lookup(f))
+          .run map (_ must beSome(viewCfgA))
+      }
+
+      "fails when using a dir for a view" >>* {
+        mnt.mount(rootDir, viewCfgA)
+          .run map (dj => maybeInvalid(dj) must beSome(rootDir[Sandboxed]))
+      }
+
+      "fails when using a file for a filesystem" >>* {
+        val f = rootDir </> file("foo")
+        mnt.mount(f, fsCfgA).run map (dj => maybeInvalid(dj) must beSome(f))
+      }
+    }
+
+    "remount" >> {
+      "moves the mount at src to dst" >>* {
+        val d1 = rootDir </> dir("d1")
+        val d2 = rootDir </> dir("d2")
+
+        val r =
+          (mnt.mount(d1, fsCfgA) *> remount(d1, d2))
+            .run *> (lookup(d1).run.tuple(lookup(d2).run))
+
+        r map (_ must_== ((None, Some(fsCfgA))))
+      }
+
+      "succeeds when src == dst" >>* {
+        val d = rootDir </> dir("srcdst")
+
+        val r =
+          (mnt.mount(d, fsCfgB) *> remount(d, d))
+            .toOption *> lookup(d)
+
+        r.run map (_ must beSome(fsCfgB))
+      }
+
+      "fails if there is no mount at src" >>* {
+        val d = rootDir </> dir("dne")
+
+        remount(d, rootDir).run map (dj => maybeNotFound(dj) must beSome(d))
+      }
+
+      "restores the mount at src if mounting fails at dst" >>* {
+        val f1 = rootDir </> file("f1")
+        val f2 = rootDir </> file("f2")
+
+        val r =
+          mountViewNoVars(f1, exprA) *>
+          mountViewNoVars(f2, exprB) *>
+          remount(f1, f2)
+
+        r.run.tuple(lookup(f1).run) map { case (dj, cfg) =>
+          maybeExists(dj).tuple(cfg) must beSome((f2, viewCfgA))
+        }
+      }
+    }
+
+    "replace" >> {
+      "replaces the mount at the location with a new one" >>* {
+        val d = rootDir </> dir("replace")
+
+        val r =
+          (mnt.mount(d, fsCfgA) *> replace(d, fsCfgB))
+            .toOption *> lookup(d)
+
+        r.run map (_ must beSome(fsCfgB))
+      }
+
+      "fails if there is no mount at the given src location" >>* {
+        val f = rootDir </> dir("dne") </> file("f1")
+
+        replace(f, viewCfgA).run map (dj => maybeNotFound(dj) must beSome(f))
+      }
+
+      "restores the previous mount if mounting the new config fails" >>* {
+        val f = rootDir </> file("f1")
+        val r = mountViewNoVars(f, exprA) *> replace(f, fsCfgB)
+
+        r.run.tuple(lookup(f).run) map { case (dj, cfg) =>
+          maybeInvalid(dj).tuple(cfg) must beSome((f, viewCfgA))
+        }
+      }
+    }
+
+    "unmount" >> {
+      "should remove an existing view mount" >>* {
+        val f = rootDir </> file("tounmount")
+
+        val r =
+          (mountViewNoVars(f, exprA) *> unmount(f))
+            .toOption *> lookup(f)
+
+        r.run map (_ must beNone)
+      }
+
+      "should remove an existing fs mount" >>* {
+        val d = rootDir </> dir("tounmount")
+
+        val r =
+          (mountFileSystem(d, dbType, uriB) *> unmount(d))
+            .toOption *> lookup(d)
+
+        r.run map (_ must beNone)
+      }
+
+      "should fail when nothing mounted at path" >>* {
+        val f = rootDir </> dir("nothing") </> file("there")
+        unmount(f).run map (dj => maybeNotFound(dj) must beSome(f))
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a `Mounting` algebra describing the operations of managing filesystem mounts. A spec is included, implemented in terms of the algebra that describes how an interpreter of the algebra must behave.

A single interpreter is also defined, that maintains mount state in memory, allowing effectful mounting via a callback function.