### PR TITLE
import Fix._

### DIFF
--- a/web/src/test/scala/quasar/api/fs.scala
+++ b/web/src/test/scala/quasar/api/fs.scala
@@ -3,7 +3,7 @@ package quasar.api
 import quasar.Predef._
 import quasar.RenderTree.ops._
 import quasar.api.Mock.ActionType
-import quasar.recursionschemes._, Recursive.ops._, FunctorT.ops._
+import quasar.recursionschemes._, Fix._, Recursive.ops._, FunctorT.ops._
 import quasar.fp._
 import quasar._, Backend._, Evaluator._
 import quasar.config._


### PR DESCRIPTION
This fixes the compile on master.

Obviously, it's not safe to merge without rebasing, but github said it was fine, so I got lazy. Not sure why this additional import is now necessary, but it certainly fixes the compile.