### PR TITLE
handle variable bindings in views

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ For example, given the above MongoDB mount, an additional view could be defined 
     ...,
     "/simpleZips": {
       "view": {
-        "connectionUri": "sql2:///?q=select+_id+as+zip,+city,+state+from+\"/local/test/zips\""
+        "connectionUri": "sql2:///?q=select%20_id%20as%20zip%2C%20city%2C%20state%20from%20%22%2Flocal%2Ftest%2Fzips%22%20where%20pop%20%3C%20%3Acutoff&var.cutoff=1000"
       }
     }
   }
@@ -158,6 +158,7 @@ For example, given the above MongoDB mount, an additional view could be defined 
 
 A view can be mounted at any file path. If a view's path is nested inside the path of a database mount, it will appear alongside the other files in the database. A view will "shadow" any actual file that would otherwise be mapped to the same path. Any attempt to write data to a view will result in an error.
 
+SQL<sup>2</sup> supports variables inside queries (`SELECT * WHERE pop < :cutoff`). Values for these variables, which can be any expression, should be specified as additional parameters in the connectionUri using the variable name prefixed by `var.` (e.g. `var.cutoff=1000`). Failure to specify valid values for all variables used inside a query will result in an error when the mount is created or used. These values use the same syntax as the query itself; notably, strings should be surrounded by single quotes. Some acceptable values are `123`, `'CO'`, and `DATE '2015-07-06'`.
 
 ## REPL Usage
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,9 @@
 import sbt._
 import Keys._
+import CustomKeys._
 import de.heikoseeberger.sbtheader.license.Apache2_0
 import de.heikoseeberger.sbtheader.HeaderPlugin
 import scoverage._
-
-val scalazVersion  = "7.1.4"
-val slcVersion     = "0.4"
-val monocleVersion = "1.1.1"
-val pathyVersion   = "0.0.3"
 
 // Exclusive execution settings
 lazy val ExclusiveTests = config("exclusive") extend Test
@@ -81,29 +77,37 @@ lazy val standardSettings = Defaults.defaultSettings ++ Seq(
   ),
   console <<= console in Test, // console alias test:console
   initialCommands in (Test, console) := """ammonite.repl.Repl.run("prompt.update(\"λ \")")""",
+
+  scalazVersion  := "7.1.4",
+  slcVersion     := "0.4",
+  monocleVersion := "1.1.1",
+  pathyVersion   := "0.0.3",
+  http4sVersion  := "0.10.1",
+
   libraryDependencies ++= Seq(
-    "org.scalaz"        %% "scalaz-core"               % scalazVersion  % "compile, test",
-    "org.scalaz"        %% "scalaz-concurrent"         % scalazVersion  % "compile, test",
-    "org.scalaz.stream" %% "scalaz-stream"             % "0.7.3a"       % "compile, test",
-    "com.github.julien-truffaut" %% "monocle-core"     % monocleVersion % "compile, test",
-    "com.github.julien-truffaut" %% "monocle-generic"  % monocleVersion % "compile, test",
-    "com.github.julien-truffaut" %% "monocle-macro"    % monocleVersion % "compile, test",
-    "com.github.scopt"  %% "scopt"                     % "3.3.0"        % "compile, test",
-    "org.threeten"      %  "threetenbp"                % "1.2"          % "compile, test",
-    "org.mongodb"       %  "mongo-java-driver"         % "3.1.0"        % "compile, test",
-    "org.mongodb"       %  "mongodb-driver-async"      % "3.1.0"        % "compile, test",
-    "io.argonaut"       %% "argonaut"                  % "6.1"          % "compile, test",
-    "org.jboss.aesh"    %  "aesh"                      % "0.55"         % "compile, test",
-    "org.typelevel"     %% "shapeless-scalaz"          % slcVersion     % "compile, test",
-    "com.slamdata"      %% "pathy-core"                % pathyVersion   % "compile",
-    "com.github.mpilquist" %% "simulacrum"             % "0.4.0"        % "compile, test",
-    "com.slamdata"      %% "pathy-scalacheck"          % pathyVersion   % "test",
-    "org.scalaz"        %% "scalaz-scalacheck-binding" % scalazVersion  % "test",
-    "org.specs2"        %% "specs2-core"               % "2.4"          % "test",
-    "org.scalacheck"    %% "scalacheck"                % "1.11.6"       % "test" force(),
-    "org.typelevel"     %% "scalaz-specs2"             % "0.3.0"        % "test",
-    "org.typelevel"     %% "shapeless-scalacheck"      % slcVersion     % "test",
-    "net.databinder.dispatch" %% "dispatch-core"       % "0.11.1"       % "test"),
+    "org.scalaz"        %% "scalaz-core"               % scalazVersion.value  % "compile, test",
+    "org.scalaz"        %% "scalaz-concurrent"         % scalazVersion.value  % "compile, test",
+    "org.scalaz.stream" %% "scalaz-stream"             % "0.7.3a"             % "compile, test",
+    "com.github.julien-truffaut" %% "monocle-core"     % monocleVersion.value % "compile, test",
+    "com.github.julien-truffaut" %% "monocle-generic"  % monocleVersion.value % "compile, test",
+    "com.github.julien-truffaut" %% "monocle-macro"    % monocleVersion.value % "compile, test",
+    "com.github.scopt"  %% "scopt"                     % "3.3.0"              % "compile, test",
+    "org.threeten"      %  "threetenbp"                % "1.2"                % "compile, test",
+    "org.mongodb"       %  "mongo-java-driver"         % "3.1.0"              % "compile, test",
+    "org.mongodb"       %  "mongodb-driver-async"      % "3.1.0"              % "compile, test",
+    "io.argonaut"       %% "argonaut"                  % "6.1"                % "compile, test",
+    "org.jboss.aesh"    %  "aesh"                      % "0.55"               % "compile, test",
+    "org.typelevel"     %% "shapeless-scalaz"          % slcVersion.value     % "compile, test",
+    "com.slamdata"      %% "pathy-core"                % pathyVersion.value   % "compile",
+    "com.github.mpilquist" %% "simulacrum"             % "0.4.0"              % "compile, test",
+    "org.http4s"        %% "http4s-core"               % http4sVersion.value  % "compile",
+    "com.slamdata"      %% "pathy-scalacheck"          % pathyVersion.value   % "test",
+    "org.scalaz"        %% "scalaz-scalacheck-binding" % scalazVersion.value  % "test",
+    "org.specs2"        %% "specs2-core"               % "2.4"                % "test",
+    "org.scalacheck"    %% "scalacheck"                % "1.11.6"             % "test" force(),
+    "org.typelevel"     %% "scalaz-specs2"             % "0.3.0"              % "test",
+    "org.typelevel"     %% "shapeless-scalacheck"      % slcVersion.value     % "test",
+    "net.databinder.dispatch" %% "dispatch-core"       % "0.11.1"             % "test"),
   licenses += ("Apache 2", url("http://www.apache.org/licenses/LICENSE-2.0")))
 
 // Using a Seq of desired warts instead of Warts.allBut due to an incremental compilation issue.

--- a/core/src/main/scala/quasar/evaluator.scala
+++ b/core/src/main/scala/quasar/evaluator.scala
@@ -18,6 +18,7 @@ package quasar
 
 import quasar.Predef._
 import quasar.Backend.ResultError
+import quasar.Planner.CompilationError
 import quasar.config.FsPath.FsPathError
 import quasar.fs._, Path._
 import quasar.Errors._
@@ -96,6 +97,9 @@ object Evaluator {
       def message = error.message
     }
     final case class EnvEvalError(error: EvaluationError) extends EnvironmentError {
+      def message = error.message
+    }
+    final case class EnvCompError(error: CompilationError) extends EnvironmentError {
       def message = error.message
     }
     final case class EnvWriteError(error: Backend.ProcessingError) extends EnvironmentError {
@@ -187,6 +191,13 @@ object Evaluator {
     def apply(error: EvaluationError): EnvironmentError = EnvironmentError.EnvEvalError(error)
     def unapply(obj: EnvironmentError): Option[EvaluationError] = obj match {
       case EnvironmentError.EnvEvalError(error) => Some(error)
+      case _                       => None
+    }
+  }
+  object EnvCompError {
+    def apply(error: CompilationError): EnvironmentError = EnvironmentError.EnvCompError(error)
+    def unapply(obj: EnvironmentError): Option[CompilationError] = obj match {
+      case EnvironmentError.EnvCompError(error) => Some(error)
       case _                       => None
     }
   }

--- a/core/src/main/scala/quasar/mounter.scala
+++ b/core/src/main/scala/quasar/mounter.scala
@@ -52,7 +52,7 @@ object Mounter {
     }
 
     val (views, nonViews) = unzipDisj(mountings.toList.map {
-      case (path, cfg @ ViewConfig(_)) => -\/((path, cfg));
+      case (path, cfg @ ViewConfig(_, _)) => -\/((path, cfg));
       case pair => \/-(pair)
     })
     nonViews.foldLeftM(NestedBackend(Map()): Backend)(rec).map(root =>

--- a/core/src/main/scala/quasar/package.scala
+++ b/core/src/main/scala/quasar/package.scala
@@ -1,6 +1,6 @@
 import quasar.Predef.{Long, String, Vector}
 import quasar.fp._
-import quasar.recursionschemes._, Fix._, Recursive.ops._, FunctorT.ops._
+import quasar.recursionschemes._, Fix._, FunctorT.ops._
 import quasar.sql._
 
 import scalaz._
@@ -38,7 +38,7 @@ package object quasar {
     for {
       ast         <- phase("SQL AST", query.right)
       substAst    <- phase("Variables Substituted",
-                           ast.cataM[SemanticError \/ ?, Expr](Variables.substVarsƒ(vars)) leftMap (_.wrapNel))
+                        Variables.substVars(ast, vars) leftMap (_.wrapNel))
       annTree     <- phase("Annotated Tree", AllPhases(substAst))
       logical     <- phase("Logical Plan", Compiler.compile(annTree) leftMap (_.wrapNel))
       simplified  <- phase("Simplified", logical.transCata(repeatedly(Optimizer.simplifyƒ)).right)

--- a/core/src/main/scala/quasar/planner.scala
+++ b/core/src/main/scala/quasar/planner.scala
@@ -19,7 +19,7 @@ package quasar
 import quasar.Predef._
 import quasar.fp._
 import quasar.fs.Path._
-import quasar.recursionschemes._, Fix._, Recursive.ops._, FunctorT.ops._
+import quasar.recursionschemes._, Fix._, FunctorT.ops._
 import quasar.sql._
 
 import scalaz._, Scalaz._
@@ -40,7 +40,7 @@ trait Planner[PhysicalPlan] {
     // TODO: Factor these things out as individual WriterT functions that can be composed.
     for {
       select     <- withTree("SQL AST")(\/-(req.query))
-      tree       <- withTree("Variables Substituted")(select.cataM[SemanticError \/ ?, Expr](Variables.substVarsƒ(req.variables)).leftMap(CSemanticError(_)))
+      tree       <- withTree("Variables Substituted")(Variables.substVars(select, req.variables).leftMap(CSemanticError(_)))
       tree       <- withTree("Annotated Tree")(AllPhases(tree).leftMap(ManyErrors(_)))
       logical    <- withTree("Logical Plan")(Compiler.compile(tree).leftMap(CSemanticError(_)))
       simplified <- withTree("Simplified")(\/-(logical.transCata(repeatedly(Optimizer.simplifyƒ))))

--- a/core/src/main/scala/quasar/variables.scala
+++ b/core/src/main/scala/quasar/variables.scala
@@ -17,7 +17,7 @@
 package quasar
 
 import quasar.Predef._
-import quasar.recursionschemes._
+import quasar.recursionschemes._, Recursive.ops._
 import quasar.SemanticError._
 import quasar.sql._
 
@@ -40,4 +40,7 @@ object Variables {
           .leftMap(VariableParseError(VarName(name), varValue, _)))
     case x => Fix(x).right
   }
+
+  def substVars(expr: Expr, variables: Variables): SemanticError \/ Expr =
+    expr.cataM[SemanticError \/ ?, Expr](substVarsƒ(variables))
 }

--- a/project/CustomKeys.scala
+++ b/project/CustomKeys.scala
@@ -1,0 +1,10 @@
+import sbt._
+import Keys._
+
+object CustomKeys {
+  val scalazVersion  = settingKey[String]("The scalaz version used for building.")
+  val slcVersion     = settingKey[String]("The slc version used for building.")
+  val monocleVersion = settingKey[String]("The monocle version used for building.")
+  val pathyVersion   = settingKey[String]("The pathy version used for building.")
+  val http4sVersion  = settingKey[String]("The http4s version used for building.")
+}

--- a/web/build.sbt
+++ b/web/build.sbt
@@ -1,15 +1,15 @@
+import CustomKeys._
+
 name := "Web"
 
 mainClass in Compile := Some("quasar.api.Server")
 
-val http4sVersion     = "0.10.1"
-
 libraryDependencies ++= Seq(
-  "org.http4s"           %% "http4s-dsl"          % http4sVersion % "compile, test",
-  "org.http4s"           %% "http4s-argonaut"     % http4sVersion % "compile, test"
+  "org.http4s"           %% "http4s-dsl"          % http4sVersion.value % "compile, test",
+  "org.http4s"           %% "http4s-argonaut"     % http4sVersion.value % "compile, test"
     // TODO: remove once jawn-streamz is in agreement with http4s on scalaz-stream version
     exclude("org.scalaz.stream", "scalaz-stream_2.11"),
-  "org.http4s"           %% "http4s-blaze-server" % http4sVersion % "compile, test",
+  "org.http4s"           %% "http4s-blaze-server" % http4sVersion.value % "compile, test",
   "com.github.tototoshi" %% "scala-csv"           % "1.1.2",
   "org.scodec"           %% "scodec-scalaz"       % "1.1.0"
 )


### PR DESCRIPTION
SD-1143 #done

Accept variable bindings in the connectionUri for a view mount. These are parsed out to a Variables map in ViewConfig (so they can be re-serialied later), and substituted into the view query when it is mounted. Unbound variables lead to errors 1) when a view mount is added through the API and 2) whenever a view query is evaluated through Backend's methods.

A few new bits and pieces:
- Yet another error wrapper to embed CompilationError in EnvironmentError.
- A convenience `substVars()` which doesn't need type annotations, since it's now being used in a third place.
- Replace `rewriteRelations()` with `rewriteRelationsM()`.