### PR TITLE
Optimize apparent cross joins

### DIFF
--- a/core/src/main/scala/quasar/RenderTree.scala
+++ b/core/src/main/scala/quasar/RenderTree.scala
@@ -30,6 +30,7 @@ final case class RenderedTree(nodeType: List[String], label: Option[String], chi
   def simpleType: Option[String] = nodeType.headOption
 
   def relabel(f: String => String) = this.copy(label = label.map(f))
+  def retype(f: List[String] => List[String]) = this.copy(nodeType = f(nodeType))
 
   /**
    A tree that describes differences between two trees:

--- a/core/src/main/scala/quasar/compiler.scala
+++ b/core/src/main/scala/quasar/compiler.scala
@@ -527,7 +527,7 @@ object Compiler {
       (Fix(t.map(_._1)),
         groupedKeys(t.map(_._1), Fix(t.map(_._1))).getOrElse(t.foldMap(_._2)))
     }
-    val keys: List[Fix[LogicalPlan]] = boundCata(tree)(keysƒ)._2
+    val keys: List[Fix[LogicalPlan]] = tree.boundCata(keysƒ)._2
 
     // Step 1: annotate nodes containing the keys.
     val ann: Cofree[LogicalPlan, Boolean] = boundAttribute(tree)(keys.contains)

--- a/core/src/main/scala/quasar/compiler.scala
+++ b/core/src/main/scala/quasar/compiler.scala
@@ -26,13 +26,13 @@ import quasar.SemanticAnalysis._, quasar.SemanticError._
 
 import org.threeten.bp.{Instant, LocalDate, LocalTime, Duration}
 import scalaz.{Tree => _, _}, Scalaz._
-import shapeless.contrib.scalaz.instances.deriveEqual
 
 trait Compiler[F[_]] {
   import identity._
   import set._
   import string._
   import structural._
+  import JoinDir._
 
   // HELPERS
   private type M[A] = EitherT[F, SemanticError, A]
@@ -104,14 +104,6 @@ trait Compiler[F[_]] {
     def freshName(prefix: String)(implicit m: Monad[F]): CompilerM[Symbol] =
       read[CompilerState, Int](_.nameGen).map(n => Symbol(prefix + n.toString)) <*
         mod((s: CompilerState) => s.copy(nameGen = s.nameGen + 1))
-  }
-
-  sealed trait JoinDir
-  final case object Left extends JoinDir {
-    override def toString: String = "left"
-  }
-  final case object Right extends JoinDir {
-    override def toString: String = "right"
   }
 
   private def read[A, B](f: A => B)(implicit m: Monad[F]):
@@ -191,8 +183,8 @@ trait Compiler[F[_]] {
       case _: NamedRelation[_] => term
       case JoinRelation(left, right, _, _) =>
         Fix(ObjectConcat(
-          flattenJoins(Fix(ObjectProject(term, LogicalPlan.Constant(Data.Str("left")))), left),
-          flattenJoins(Fix(ObjectProject(term, LogicalPlan.Constant(Data.Str("right")))), right)))
+          flattenJoins(Left.projectFrom(term), left),
+          flattenJoins(Right.projectFrom(term), right)))
     }
 
     def buildJoinDirectionMap(relations: SqlRelation[CoExpr]):
@@ -213,10 +205,7 @@ trait Compiler[F[_]] {
         case (name, dirs) =>
           name -> dirs.foldRight(
             joined)(
-            (dir, acc) =>
-            Fix(ObjectProject(
-              acc,
-              LogicalPlan.Constant(Data.Str(dir.toString)))))
+            (dir, acc) => dir.projectFrom(acc))
       }
 
     def tableContext(joined: Fix[LogicalPlan], relations: SqlRelation[CoExpr]):
@@ -324,7 +313,7 @@ trait Compiler[F[_]] {
             case (_,    Splice(_)) => None
             case (name, _)         => Some(name)
           }
-        
+
         val projs = projections.map(_.expr)
 
         val syntheticNames: List[String] =
@@ -488,6 +477,23 @@ trait Compiler[F[_]] {
   }
 }
 
+sealed trait JoinDir {
+  def projectFrom(t: Fix[LogicalPlan]): Fix[LogicalPlan]
+}
+object JoinDir {
+  import structural._
+
+  final case object Left extends JoinDir {
+    def projectFrom(t: Fix[LogicalPlan]) =
+      Fix(ObjectProject(t, LogicalPlan.Constant(Data.Str("left"))))
+  }
+
+  final case object Right extends JoinDir {
+    def projectFrom(t: Fix[LogicalPlan]) =
+      Fix(ObjectProject(t, LogicalPlan.Constant(Data.Str("right"))))
+  }
+}
+
 object Compiler {
   import LogicalPlan._
 
@@ -499,6 +505,9 @@ object Compiler {
       SemanticError \/ Fix[LogicalPlan] =
     trampoline.compile(tree).run
 
+  /** Emulate SQL semantics by reducing any projection which trivially
+    * matches a key in the "group by".
+    */
   def reduceGroupKeys(tree: Fix[LogicalPlan]): Fix[LogicalPlan] = {
     // Step 0: identify key expressions, and rewrite them by replacing the
     // group source with the source at the point where they might appear.

--- a/core/src/main/scala/quasar/compiler.scala
+++ b/core/src/main/scala/quasar/compiler.scala
@@ -546,6 +546,6 @@ object Compiler {
           else t.tail
       }
     }
-    Corecursive[Fix].ana(ann)(rewriteƒ)
+    ann.ana(rewriteƒ)
   }
 }

--- a/core/src/main/scala/quasar/config/config.scala
+++ b/core/src/main/scala/quasar/config/config.scala
@@ -199,7 +199,7 @@ trait ConfigOps[C] {
         }
       }
 
-    path.cata(p => load(Task.now(p)), load(defaultPath).orElse(load(alternatePath)))
+    path.cata(p => load(Task.now(p)), load(defaultPath).fixedOrElse(load(alternatePath)))
   }
 
   def loadAndTest(path: FsPath[File, Sandboxed])(implicit D: DecodeJson[C]): EnvTask[C] =

--- a/core/src/main/scala/quasar/logicalplan.scala
+++ b/core/src/main/scala/quasar/logicalplan.scala
@@ -184,13 +184,13 @@ object LogicalPlan {
 
       def initial[A] = Map[Symbol, A]()
 
-      def bindings[A](t: LogicalPlan[Fix[LogicalPlan]], b: G[A])(f: LogicalPlan[Fix[LogicalPlan]] => A): G[A] =
+      def bindings[T[_[_]]: Recursive, A](t: LogicalPlan[T[LogicalPlan]], b: G[A])(f: LogicalPlan[T[LogicalPlan]] => A): G[A] =
         t match {
-          case LetF(ident, form, _) => b + (ident -> f(form.unFix))
+          case LetF(ident, form, _) => b + (ident -> f(form.project))
           case _                    => b
         }
 
-      def subst[A](t: LogicalPlan[Fix[LogicalPlan]], b: G[A]): Option[A] =
+      def subst[T[_[_]]: Recursive, A](t: LogicalPlan[T[LogicalPlan]], b: G[A]): Option[A] =
         t match {
           case FreeF(symbol) => b.get(symbol)
           case _             => None

--- a/core/src/main/scala/quasar/logicalplan.scala
+++ b/core/src/main/scala/quasar/logicalplan.scala
@@ -221,8 +221,7 @@ object LogicalPlan {
   }
 
   def rename[M[_]: Monad](f: Symbol => M[Symbol])(t: Fix[LogicalPlan]): M[Fix[LogicalPlan]] =
-    Corecursive[Fix].anaM[LogicalPlan, M, (Map[Symbol, Symbol], Fix[LogicalPlan])](
-      (Map(), t))(renameƒ(f))
+    (Map[Symbol, Symbol](), t).anaM(renameƒ(f))
 
   def normalizeTempNames(t: Fix[LogicalPlan]) =
     rename[State[NameGen, ?]](κ(freshName("tmp")))(t).evalZero

--- a/core/src/main/scala/quasar/optimizer.scala
+++ b/core/src/main/scala/quasar/optimizer.scala
@@ -135,7 +135,7 @@ object Optimizer {
   }
 
   def preferProjections(t: Fix[LogicalPlan]): Fix[LogicalPlan] =
-    boundPara(t)(preferProjectionsƒ)._1.transCata(repeatedly(simplifyƒ))
+    t.boundPara(preferProjectionsƒ)._1.transCata(repeatedly(simplifyƒ))
 
   val elideTypeCheckƒ: LogicalPlan[Fix[LogicalPlan]] => Fix[LogicalPlan] = {
     case LetF(n, b, Fix(TypecheckF(Fix(FreeF(nf)), _, cont, _)))
@@ -295,7 +295,7 @@ object Optimizer {
     */
   def optimize(t: Fix[LogicalPlan]): Fix[LogicalPlan] = {
     val t1 = t.transCata(repeatedly(simplifyƒ))
-    val t2 = boundParaS(t1)(rewriteCrossJoinsƒ).evalZero
+    val t2 = t1.boundParaS(rewriteCrossJoinsƒ).evalZero
     val t3 = t2.transCata(repeatedly(simplifyƒ))
     val t4 = (normalizeLets _ >>> normalizeTempNames _)(t3)
     t4

--- a/core/src/main/scala/quasar/optimizer.scala
+++ b/core/src/main/scala/quasar/optimizer.scala
@@ -17,7 +17,8 @@
 package quasar
 
 import quasar.Predef._
-import quasar.recursionschemes._, Recursive.ops._, FunctorT.ops._
+import quasar.namegen._
+import quasar.recursionschemes._, Fix._, Recursive.ops._, FunctorT.ops._, TraverseT.ownOps._
 
 import scalaz._, Scalaz._
 
@@ -57,12 +58,14 @@ object Optimizer {
     case _ => None
   }
 
+  def simplify(t: Fix[LogicalPlan]): Fix[LogicalPlan] = t.transCata(repeatedly(simplifyƒ))
+
   val namesƒ: LogicalPlan[Set[Symbol]] => Set[Symbol] = {
     case FreeF(name) => Set(name)
     case x           => x.fold
   }
 
-  def freshName[F[_]: Functor: Foldable](
+  def uniqueName[F[_]: Functor: Foldable](
     prefix: String, plans: F[Fix[LogicalPlan]]):
       Symbol = {
     val existingNames = plans.map(_.cata(namesƒ)).fold
@@ -98,6 +101,12 @@ object Optimizer {
     case _ => None
   }
 
+  def preserveFree0[A](x: (Fix[LogicalPlan], A))(f: A => Fix[LogicalPlan]):
+      Fix[LogicalPlan] = x._1.unFix match {
+    case FreeF(_) => x._1
+    case _        => f(x._2)
+  }
+
   // TODO: implement `preferDeletions` for other backends that may have more
   //       efficient deletes. Even better, a single function that takes a
   //       function parameter deciding which way each case should be converted.
@@ -106,18 +115,16 @@ object Optimizer {
         Fix[LogicalPlan],
         (Fix[LogicalPlan], Option[List[Fix[LogicalPlan]]]))] =>
   (Fix[LogicalPlan], Option[List[Fix[LogicalPlan]]]) = { node =>
-    def preserveFree(x: (Fix[LogicalPlan], (Fix[LogicalPlan], Option[List[Fix[LogicalPlan]]]))):
-        Fix[LogicalPlan] = x._1.unFix match {
-      case FreeF(_) => x._1
-      case _        => x._2._1
-    }
+
+    def preserveFree(x: (Fix[LogicalPlan], (Fix[LogicalPlan], Option[List[Fix[LogicalPlan]]]))) =
+      preserveFree0(x)(_._1)
 
     (node match {
       case InvokeF(DeleteField, List(src, field)) =>
         src._2._2.fold(
           Invoke(DeleteField, List(preserveFree(src), preserveFree(field)))) {
           fields =>
-            val name = freshName("src", fields)
+            val name = uniqueName("src", fields)
               Let(name, preserveFree(src),
                 Fix(MakeObjectN(fields.filterNot(_ == field._2._1).map(f =>
                   f -> Invoke(ObjectProject, List(Free(name), f))): _*)))
@@ -161,4 +168,136 @@ object Optimizer {
     case x => \/-(Fix(x))
   }
 
+  /** Rewrite joins and subsequent filtering so that:
+    * 1) Filtering that is equivalent to an equi-join is rewritten into the join condition.
+    * 2) Filtering that refers to only side of the join is hoisted prior to the join.
+    * The input plan must have been simplified already so that the structure
+    * is in a canonical form for inspection.
+    */
+  val rewriteCrossJoinsƒ: LogicalPlan[(Fix[LogicalPlan], Fix[LogicalPlan])] => State[NameGen, Fix[LogicalPlan]] = { node =>
+    import quasar.fp._
+
+    def preserveFree(x: (Fix[LogicalPlan], Fix[LogicalPlan])) = preserveFree0(x)(ι)
+
+    def flattenAnd: Fix[LogicalPlan] => List[Fix[LogicalPlan]] = {
+      case Fix(relations.And(ts)) => ts.flatMap(flattenAnd)
+      case t                      => List(t)
+    }
+
+    sealed trait Component[A]
+    // A condition that refers to left and right sources using equality, so may
+    // be rewritten into the join condition:
+    final case class EquiCond[A](run: (Fix[LogicalPlan], Fix[LogicalPlan]) => A) extends Component[A]
+    // A condition which refers only to the left source:
+    final case class LeftCond[A](run: Fix[LogicalPlan] => A) extends Component[A]
+    // A condition which refers only to the right source:
+    final case class RightCond[A](run: Fix[LogicalPlan] => A) extends Component[A]
+    // A condition which refers to both sources but doesn't have the right shape
+    // to become the join condition:
+    final case class OtherCond[A](run: (Fix[LogicalPlan], Fix[LogicalPlan]) => A) extends Component[A]
+    // An expression that doesn't refer to any source.
+    final case class NeitherCond[A](run: A) extends Component[A]
+
+    implicit val ComponentFunctor = new Functor[Component] {
+      def map[A, B](fa: Component[A])(f: A => B) = fa match {
+        case EquiCond(run)    => EquiCond((l, r) => f(run(l, r)))
+        case LeftCond(run)    => LeftCond((l) => f(run(l)))
+        case RightCond(run)   => RightCond((r) => f(run(r)))
+        case OtherCond(run)   => OtherCond((l, r) => f(run(l, r)))
+        case NeitherCond(run) => NeitherCond(f(run))
+      }
+    }
+
+    def toComp(left: Fix[LogicalPlan], right: Fix[LogicalPlan])(c: Fix[LogicalPlan]):
+        Component[Fix[LogicalPlan]] = {
+      c.para[Component[Fix[LogicalPlan]]] {
+        case t if t.map(_._1) ≟ left.unFix  => LeftCond(ι)
+        case t if t.map(_._1) ≟ right.unFix => RightCond(ι)
+
+        case relations.Eq((_, LeftCond(lc)) :: (_, RightCond(rc)) :: Nil) =>
+          EquiCond((l, r) => Fix(relations.Eq(lc(l), rc(r))))
+        case relations.Eq((_, RightCond(rc)) :: (_, LeftCond(lc)) :: Nil) =>
+          EquiCond((l, r) => Fix(relations.Eq(rc(r), lc(l))))
+
+        case InvokeF(func, ts) =>
+          ts.map(_._2).foldRight[Component[List[Fix[LogicalPlan]]]](NeitherCond(Nil)) {
+            case (NeitherCond(h), NeitherCond(cs)) => NeitherCond(h :: cs)
+
+            case (LeftCond(h),    NeitherCond(cs)) => LeftCond(t => h(t) :: cs)
+            case (LeftCond(h),    LeftCond(cs))    => LeftCond(t => h(t) :: cs(t))
+
+            case (RightCond(h),   NeitherCond(cs)) => RightCond(t => h(t) :: cs)
+            case (RightCond(h),   RightCond(cs))   => RightCond(t => h(t) :: cs(t))
+
+            case (LeftCond(h),    RightCond(cs))   => OtherCond((l, r) => h(l) :: cs(r))
+            case (RightCond(h),   LeftCond(cs))    => OtherCond((l, r) => h(r) :: cs(l))
+          }.map(ts => Fix(InvokeF(func, ts)))
+
+        case t => NeitherCond(Fix(t.map(_._1)))
+      }
+    }
+
+    def assembleCond(conds: List[Fix[LogicalPlan]]): Fix[LogicalPlan] =
+      conds.foldLeft(Constant(Data.True))((acc, c) => Fix(relations.And(acc, c)))
+
+    def newJoin(lSrc: Fix[LogicalPlan], rSrc: Fix[LogicalPlan], comps: List[Component[Fix[LogicalPlan]]]):
+        State[NameGen, Fix[LogicalPlan]] = {
+      val equis    = comps.collect { case c @ EquiCond(_) => c }
+      val lefts    = comps.collect { case c @ LeftCond(_) => c }
+      val rights   = comps.collect { case c @ RightCond(_) => c }
+      val others   = comps.collect { case c @ OtherCond(_) => c }
+      val neithers = comps.collect { case c @ NeitherCond(_) => c }
+
+      for {
+        lName  <- freshName("leftSrc")
+        lFName <- freshName("left")
+        rName  <- freshName("rightSrc")
+        rFName <- freshName("right")
+        jName  <- freshName("joined")
+      } yield {
+        // NB: simplifying eagerly to make matching easier up the tree
+        simplify(
+          Let(lName, lSrc,
+            Let(lFName, Fix(Filter(Free(lName), assembleCond(lefts.map(_.run(Free(lName)))))),
+              Let(rName, rSrc,
+                Let(rFName, Fix(Filter(Free(rName), assembleCond(rights.map(_.run(Free(rName)))))),
+                  Let(jName,
+                    Fix(InnerJoin(Free(lFName), Free(rFName),
+                      assembleCond(equis.map(_.run(Free(lFName), Free(rFName)))))),
+                    Fix(Filter(Free(jName), assembleCond(
+                      others.map(_.run(JoinDir.Left.projectFrom(Free(jName)), JoinDir.Right.projectFrom(Free(jName)))) ++
+                      neithers.map(_.run))))))))))
+      }
+    }
+
+
+    node match {
+      case Filter((src, Fix(InnerJoin(joinL :: joinR :: joinCond :: Nil))) :: (cond, _) :: Nil) =>
+        val comps = flattenAnd(joinCond).map(toComp(joinL, joinR)) ++
+                    flattenAnd(cond).map(toComp(JoinDir.Left.projectFrom(src), JoinDir.Right.projectFrom(src)))
+        newJoin(joinL, joinR, comps)
+
+      // TODO: enable this when it can be made to not conflict (see tests pending SD-1190).
+      // Currently, the rewritten join/filter's shape is not matched by the other case,
+      // resulting in un-collapsed Filter steps.
+      // case InnerJoin((srcL, _) :: (srcR, _) :: (_, joinCond) :: Nil) =>
+      //   val comps = flattenAnd(joinCond).map(toComp(srcL, srcR))
+      //   newJoin(srcL, srcR, comps)
+
+      case _ => State.state(Fix(node.map(preserveFree)))
+    }
+  }
+
+  /** Apply universal, type-oblivious transformations intended to
+    * improve the performance of a query regardless of the backend. The
+    * input is expected to come straight from the SQL^2 compiler or
+    * another source of un-optimized queries.
+    */
+  def optimize(t: Fix[LogicalPlan]): Fix[LogicalPlan] = {
+    val t1 = t.transCata(repeatedly(simplifyƒ))
+    val t2 = boundParaS(t1)(rewriteCrossJoinsƒ).evalZero
+    val t3 = t2.transCata(repeatedly(simplifyƒ))
+    val t4 = (normalizeLets _ >>> normalizeTempNames _)(t3)
+    t4
+  }
 }

--- a/core/src/main/scala/quasar/package.scala
+++ b/core/src/main/scala/quasar/package.scala
@@ -1,6 +1,6 @@
 import quasar.Predef.{Long, String, Vector}
 import quasar.fp._
-import quasar.recursionschemes._, Fix._, FunctorT.ops._
+import quasar.recursionschemes._, Fix._
 import quasar.sql._
 
 import scalaz._
@@ -41,8 +41,8 @@ package object quasar {
                         Variables.substVars(ast, vars) leftMap (_.wrapNel))
       annTree     <- phase("Annotated Tree", AllPhases(substAst))
       logical     <- phase("Logical Plan", Compiler.compile(annTree) leftMap (_.wrapNel))
-      simplified  <- phase("Simplified", logical.transCata(repeatedly(Optimizer.simplifyƒ)).right)
-      typechecked <- phase("Typechecked", LogicalPlan.ensureCorrectTypes(simplified).disjunction)
+      optimized   <- phase("Optimized", \/-(Optimizer.optimize(logical)))
+      typechecked <- phase("Typechecked", LogicalPlan.ensureCorrectTypes(optimized).disjunction)
     } yield typechecked
   }
 }

--- a/core/src/main/scala/quasar/physical/mongodb/planner.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/planner.scala
@@ -1086,7 +1086,7 @@ object MongoDbPlanner extends Planner[Crystallized] with JsConversions {
 
     (for {
       cleaned <- log("Logical Plan (reduced typechecks)")(liftError(logical.cataM[PlannerError \/ ?, Fix[LogicalPlan]](Optimizer.assumeReadObjƒ)))
-      align <- log("Logical Plan (aligned joins)")       (liftError(Corecursive[Fix].apo(cleaned)(elideJoinCheckƒ).cataM(alignJoinsƒ ⋘ repeatedly(Optimizer.simplifyƒ))))
+      align <- log("Logical Plan (aligned joins)")       (liftError(cleaned.apo(elideJoinCheckƒ).cataM(alignJoinsƒ ⋘ repeatedly(Optimizer.simplifyƒ))))
       prep <- log("Logical Plan (projections preferred)")(Optimizer.preferProjections(align).point[M])
       wb   <- log("Workflow Builder")                    (swizzle(swapM(lpParaZygoHistoS(prep)(annotateƒ, wfƒ))))
       wf1  <- log("Workflow (raw)")                      (swizzle(build(wb)))

--- a/core/src/main/scala/quasar/physical/mongodb/selector.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/selector.scala
@@ -21,6 +21,8 @@ import quasar.{RenderTree, Terminal, NonTerminal}
 import quasar.fp._
 import quasar.javascript._
 
+import scala.Any
+
 import scalaz._, Scalaz._
 
 sealed trait Selector {
@@ -232,19 +234,41 @@ object Selector {
     def bson = Bson.Doc(ListMap(op -> Bson.Arr(flatten.map(_.bson))))
   }
 
-  final case class And(left: Selector, right: Selector) extends Abstract("$and")
+  final case class And(left: Selector, right: Selector) extends Abstract("$and") {
+    override def equals(that: Any) = that match {
+      case that @ And(_, _) => flatten == that.flatten
+      case _ => false
+    }
+    override def hashCode = flatten.hashCode
+  }
   object And {
     def apply(first: Selector, rest: Selector*): Selector =
       rest.foldLeft(first)(And(_, _))
   }
 
-  final case class Or(left: Selector, right: Selector) extends Abstract("$or")
+  final case class Or(left: Selector, right: Selector) extends Abstract("$or") {
+    override def equals(that: Any) = that match {
+      case that @ Or(_, _) => flatten == that.flatten
+      case _ => false
+    }
+    override def hashCode = flatten.hashCode
+  }
   object Or {
     def apply(first: Selector, rest: Selector*): Selector =
       rest.foldLeft(first)(Or(_, _))
   }
 
-  final case class Nor(left: Selector, right: Selector) extends Abstract("$nor")
+  final case class Nor(left: Selector, right: Selector) extends Abstract("$nor") {
+    override def equals(that: Any) = that match {
+      case that @ Nor(_, _) => flatten == that.flatten
+      case _ => false
+    }
+    override def hashCode = flatten.hashCode
+  }
+  object Nor {
+    def apply(first: Selector, rest: Selector*): Selector =
+      rest.foldLeft(first)(Nor(_, _))
+  }
 
   implicit val SelectorAndSemigroup: Semigroup[Selector] = new Semigroup[Selector] {
     def append(s1: Selector, s2: => Selector): Selector = {

--- a/core/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
@@ -342,7 +342,7 @@ object WorkflowBuilder {
             xs <- inner.map { case (n, x) =>
                     jscore.Select(jscore.Ident(js.param), n.value) -> exprToJs(x)
                   }.sequenceU.toOption
-            expr1 <- Corecursive[Fix].apoM[jscore.JsCoreF, Option, JsCore](js.expr) {
+            expr1 <- js.expr.apoM[jscore.JsCoreF, Option] {
                     case t @ jscore.Access(b, _) if b == jscore.Ident(js.param) =>
                       xs.get(t).map(_(jscore.Ident(js.param)).unFix.map(_.left))
                     case t => t.unFix.map(_.right[JsCore]).some

--- a/core/src/main/scala/quasar/physical/mongodb/workflowop.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/workflowop.scala
@@ -581,7 +581,7 @@ object Workflow {
     }
 
     Crystallized(
-      Corecursive[Fix].ana(promoteKnownShape(finished))(crystallizeƒ).transCata[WorkflowF](coalesce)
+      promoteKnownShape(finished).ana(crystallizeƒ).transCata[WorkflowF](coalesce)
         // TODO: this can coalesce more cases, but hasn’t been done thus far and
         //       requires rewriting many tests in a much less readable way.
         // .cata[Workflow](x => coalesce(uncleanƒ(x).unFix))

--- a/core/src/main/scala/quasar/recursionschemes/Fix.scala
+++ b/core/src/main/scala/quasar/recursionschemes/Fix.scala
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-package quasar
-package recursionschemes
+package quasar.recursionschemes
+
+import quasar.Predef._
+import quasar.RenderTree
 
 import scalaz._
 
@@ -36,7 +38,10 @@ object Fix {
       RenderTree[Fix[F]] =
     new RenderTree[Fix[F]] {
       def render(v: Fix[F]) =
-        RF(fixRenderTree[F]).render(v.unFix).relabel("Fix(" + _ + ")")
+        RF(fixRenderTree[F]).render(v.unFix).retype {
+          case h :: t => ("Fix:" + h) :: t
+          case Nil    => "Fix" :: Nil
+        }
     }
 
   implicit def fixShow[F[_]](implicit F: Show ~> λ[α => Show[F[α]]]):

--- a/core/src/main/scala/quasar/recursionschemes/Recursive.scala
+++ b/core/src/main/scala/quasar/recursionschemes/Recursive.scala
@@ -89,6 +89,41 @@ import simulacrum.typeclass
     h(t)._2
   }
 
+  // Binder
+  def boundCata[F[_]: Functor, A](t: T[F])(f: F[A] => A)(implicit B: Binder[F]): A = {
+    def loop(t: F[T[F]], b: B.G[A]): A = {
+      val newB = B.bindings(t, b)(loop(_, b))(this)
+      B.subst(t, newB)(this).getOrElse(f(t.map(x => loop(project(x), newB))))
+    }
+
+    loop(project(t), B.initial)
+  }
+
+  def boundParaM[M[_]: Monad, F[_]: Traverse, A](t: T[F])(f: F[(T[F], A)] => M[A])(implicit B: Binder[F]): M[A] = {
+    def loop(t: F[T[F]], b: B.G[A]): M[A] = {
+      Applicative[M].sequence(B.bindings[T, M[A]](t, B.G.map(b)(_.point[M]))(s => loop(s, b))(this))(B.G).flatMap { newB =>
+        B.subst(t, newB)(this).cata[M[A]](
+          _.point[M],
+          t.traverse(x => loop(project(x), newB).map((x, _))).flatMap(f))
+      }
+    }
+
+    loop(project(t), B.initial)
+  }
+
+  def boundParaS[F[_]: Traverse, S, A](t: T[F])(f: F[(T[F], A)] => State[S, A])(implicit B: Binder[F]): State[S, A] =
+    boundParaM[State[S, ?], F, A](t)(f)
+
+  def boundPara[F[_]: Functor, A](t: T[F])(f: F[(T[F], A)] => A)(implicit B: Binder[F]): A = {
+    def loop(t: F[T[F]], b: B.G[A]): A = {
+      val newB = B.bindings(t, b)(loop(_, b))(this)
+      B.subst(t, newB)(this).getOrElse(f(t.map(x => (x, loop(project(x), newB)))))
+    }
+
+    loop(project(t), B.initial)
+  }
+
+
   def isLeaf[F[_]: Foldable](t: T[F]): Boolean =
     !Tag.unwrap(project(t).foldMap(κ(true.disjunction)))
 

--- a/core/src/main/scala/quasar/recursionschemes/TraverseT.scala
+++ b/core/src/main/scala/quasar/recursionschemes/TraverseT.scala
@@ -58,6 +58,8 @@ object TraverseT {
 
   /** Import from this object instead of `ops._` to get just ops for the
     * methods of TraverseT, and not those inherited from FunctorT.
+    * Otherwise, importing both leads to ambiguous implicits.
+    * See https://github.com/mpilquist/simulacrum/issues/46.
     */
   object ownOps extends ToTraverseTOps
 }

--- a/core/src/main/scala/quasar/recursionschemes/TraverseT.scala
+++ b/core/src/main/scala/quasar/recursionschemes/TraverseT.scala
@@ -55,4 +55,9 @@ object TraverseT {
       def traverse[M[_]: Applicative, F[_], G[_]](t: T[F])(f: F[T[F]] => M[G[T[G]]]) =
         f(Recursive[T].project(t)).map(Corecursive[T].embed)
     }
+
+  /** Import from this object instead of `ops._` to get just ops for the
+    * methods of TraverseT, and not those inherited from FunctorT.
+    */
+  object ownOps extends ToTraverseTOps
 }

--- a/core/src/main/scala/quasar/recursionschemes/package.scala
+++ b/core/src/main/scala/quasar/recursionschemes/package.scala
@@ -329,4 +329,33 @@ package object recursionschemes extends CofreeInstances with FreeInstances {
     }
     loop(t.unFix, B.initial)._2
   }
+
+  sealed class IdOps[T[_[_]], A](self: A)(implicit T: Corecursive[T]) {
+    def ana[F[_]: Functor](f: A => F[A]): T[F] =
+      T.ana(self)(f)
+    def anaM[F[_]: Traverse, M[_]: Monad](f: A => M[F[A]]): M[T[F]] =
+      T.anaM(self)(f)
+    def gana[F[_]: Functor, M[_]](
+        k: λ[α => M[F[α]]] ~> λ[α => F[M[α]]], f: A => F[M[A]])(
+        implicit M: Monad[M]):
+          T[F] =
+      T.gana(self)(k, f)
+    def apo[F[_]: Functor](f: A => F[T[F] \/ A]): T[F] =
+      T.apo(self)(f)
+    def apoM[F[_]: Traverse, M[_]: Monad](f: A => M[F[T[F] \/ A]]): M[T[F]] =
+      T.apoM(self)(f)
+    def postpro[F[_]: Functor](e: F ~> F, g: A => F[A])(implicit R: Recursive[T]): T[F] =
+      T.postpro(self)(e, g)
+    def gpostpro[F[_]: Functor, M[_]](
+        k: λ[α => M[F[α]]] ~> λ[α => F[M[α]]], e: F ~> F, g: A => F[M[A]])(
+        implicit R: Recursive[T], M: Monad[M]):
+          T[F] =
+      T.gpostpro(self)(k, e, g)
+    def futu[F[_]: Functor](f: A => F[Free[F, A]]): T[F] =
+      T.futu(self)(f)
+    def futuM[F[_]: Traverse, M[_]: Monad](f: A => M[F[Free[F, A]]]):
+        M[T[F]] =
+      T.futuM(self)(f)
+  }
+  implicit def ToFixIdOps[A](a: A): IdOps[Fix, A] = new IdOps[Fix, A](a)
 }

--- a/core/src/test/scala/quasar/compiler.scala
+++ b/core/src/test/scala/quasar/compiler.scala
@@ -83,34 +83,34 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile qualified select * with additional fields" in {
       testLogicalPlanCompile(
         "select foo.*, bar.address from foo, bar",
-        Let('tmp0,
+        Let('__tmp0,
           InnerJoin(read("foo"), read("bar"), Constant(Data.Bool(true))),
           Squash[FLP](
             ObjectConcat[FLP](
-              ObjectProject(Free('tmp0), Constant(Data.Str("left"))),
+              ObjectProject(Free('__tmp0), Constant(Data.Str("left"))),
               makeObj(
                 "address" ->
                   ObjectProject[FLP](
-                    ObjectProject(Free('tmp0), Constant(Data.Str("right"))),
+                    ObjectProject(Free('__tmp0), Constant(Data.Str("right"))),
                     Constant(Data.Str("address"))))))))
     }
 
     "compile deeply-nested qualified select *" in {
       testLogicalPlanCompile(
         "select foo.bar.baz.*, bar.address from foo, bar",
-        Let('tmp0,
+        Let('__tmp0,
           InnerJoin(read("foo"), read("bar"), Constant(Data.Bool(true))),
           Squash[FLP](
             ObjectConcat[FLP](
               ObjectProject[FLP](
                 ObjectProject[FLP](
-                  ObjectProject(Free('tmp0), Constant(Data.Str("left"))),
+                  ObjectProject(Free('__tmp0), Constant(Data.Str("left"))),
                   Constant(Data.Str("bar"))),
                 Constant(Data.Str("baz"))),
               makeObj(
                 "address" ->
                   ObjectProject[FLP](
-                    ObjectProject(Free('tmp0), Constant(Data.Str("right"))),
+                    ObjectProject(Free('__tmp0), Constant(Data.Str("right"))),
                     Constant(Data.Str("address"))))))))
     }
 
@@ -147,13 +147,13 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile two term addition from one table" in {
       testLogicalPlanCompile(
         "select foo + bar from baz",
-        Let('tmp0, read("baz"),
+        Let('__tmp0, read("baz"),
           Squash(
             makeObj(
               "0" ->
                 Add[FLP](
-                  ObjectProject(Free('tmp0), Constant(Data.Str("foo"))),
-                  ObjectProject(Free('tmp0), Constant(Data.Str("bar"))))))))
+                  ObjectProject(Free('__tmp0), Constant(Data.Str("foo"))),
+                  ObjectProject(Free('__tmp0), Constant(Data.Str("bar"))))))))
     }
 
     "compile negate" in {
@@ -168,25 +168,25 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile modulo" in {
       testLogicalPlanCompile(
         "select foo % baz from bar",
-        Let('tmp0, read("bar"),
+        Let('__tmp0, read("bar"),
           Squash(
             makeObj(
               "0" ->
                 Modulo[FLP](
-                  ObjectProject(Free('tmp0), Constant(Data.Str("foo"))),
-                  ObjectProject(Free('tmp0), Constant(Data.Str("baz"))))))))
+                  ObjectProject(Free('__tmp0), Constant(Data.Str("foo"))),
+                  ObjectProject(Free('__tmp0), Constant(Data.Str("baz"))))))))
     }
 
     "compile coalesce" in {
       testLogicalPlanCompile(
         "select coalesce(bar, baz) from foo",
-        Let('tmp0, read("foo"),
+        Let('__tmp0, read("foo"),
           Squash(
             makeObj(
               "0" ->
                 Coalesce[FLP](
-                  ObjectProject(Free('tmp0), Constant(Data.Str("bar"))),
-                  ObjectProject(Free('tmp0), Constant(Data.Str("baz"))))))))
+                  ObjectProject(Free('__tmp0), Constant(Data.Str("bar"))),
+                  ObjectProject(Free('__tmp0), Constant(Data.Str("baz"))))))))
     }
 
     "compile date field extraction" in {
@@ -203,15 +203,15 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile conditional" in {
       testLogicalPlanCompile(
         "select case when pop < 10000 then city else loc end from zips",
-        Let('tmp0, read("zips"),
+        Let('__tmp0, read("zips"),
           Squash(makeObj(
             "0" ->
               Cond[FLP](
                 Lt[FLP](
-                  ObjectProject(Free('tmp0), Constant(Data.Str("pop"))),
+                  ObjectProject(Free('__tmp0), Constant(Data.Str("pop"))),
                   Constant(Data.Int(10000))),
-                ObjectProject(Free('tmp0), Constant(Data.Str("city"))),
-                ObjectProject(Free('tmp0), Constant(Data.Str("loc"))))))))
+                ObjectProject(Free('__tmp0), Constant(Data.Str("city"))),
+                ObjectProject(Free('__tmp0), Constant(Data.Str("loc"))))))))
     }
 
     "compile conditional (match) without else" in {
@@ -252,26 +252,26 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile concat" in {
       testLogicalPlanCompile(
         "select concat(foo, concat(' ', bar)) from baz",
-        Let('tmp0, read("baz"),
+        Let('__tmp0, read("baz"),
           Squash(
             makeObj(
               "0" ->
                 Concat[FLP](
-                  ObjectProject(Free('tmp0), Constant(Data.Str("foo"))),
+                  ObjectProject(Free('__tmp0), Constant(Data.Str("foo"))),
                   Concat[FLP](
                     Constant(Data.Str(" ")),
-                    ObjectProject(Free('tmp0), Constant(Data.Str("bar")))))))))
+                    ObjectProject(Free('__tmp0), Constant(Data.Str("bar")))))))))
     }
 
     "compile between" in {
       testLogicalPlanCompile(
         "select * from foo where bar between 1 and 10",
-        Let('tmp0, read("foo"),
+        Let('__tmp0, read("foo"),
           Squash[FLP](
             Filter[FLP](
-              Free('tmp0),
+              Free('__tmp0),
               Between[FLP](
-                ObjectProject(Free('tmp0), Constant(Data.Str("bar"))),
+                ObjectProject(Free('__tmp0), Constant(Data.Str("bar"))),
                 Constant(Data.Int(1)),
                 Constant(Data.Int(10)))))))
     }
@@ -279,13 +279,13 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile not between" in {
       testLogicalPlanCompile(
         "select * from foo where bar not between 1 and 10",
-        Let('tmp0, read("foo"),
+        Let('__tmp0, read("foo"),
           Squash[FLP](
             Filter[FLP](
-              Free('tmp0),
+              Free('__tmp0),
               Not[FLP](
                 Between[FLP](
-                  ObjectProject(Free('tmp0), Constant(Data.Str("bar"))),
+                  ObjectProject(Free('__tmp0), Constant(Data.Str("bar"))),
                   Constant(Data.Int(1)),
                   Constant(Data.Int(10))))))))
     }
@@ -293,15 +293,15 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile like" in {
       testLogicalPlanCompile(
         "select bar from foo where bar like 'a%'",
-        Let('tmp0, read("foo"),
+        Let('__tmp0, read("foo"),
           Squash(
             makeObj(
               "bar" ->
                 ObjectProject[FLP](
                   Filter[FLP](
-                    Free('tmp0),
+                    Free('__tmp0),
                     Search[FLP](
-                      ObjectProject(Free('tmp0), Constant(Data.Str("bar"))),
+                      ObjectProject(Free('__tmp0), Constant(Data.Str("bar"))),
                       Constant(Data.Str("^a.*$")),
                       Constant(Data.Bool(false)))),
                   Constant(Data.Str("bar")))))))
@@ -310,15 +310,15 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile like with escape char" in {
       testLogicalPlanCompile(
         "select bar from foo where bar like 'a=%' escape '='",
-        Let('tmp0, read("foo"),
+        Let('__tmp0, read("foo"),
           Squash(
             makeObj(
               "bar" ->
                 ObjectProject[FLP](
                   Filter[FLP](
-                    Free('tmp0),
+                    Free('__tmp0),
                     Search[FLP](
-                      ObjectProject(Free('tmp0), Constant(Data.Str("bar"))),
+                      ObjectProject(Free('__tmp0), Constant(Data.Str("bar"))),
                       Constant(Data.Str("^a%$")),
                       Constant(Data.Bool(false)))),
                   Constant(Data.Str("bar")))))))
@@ -327,12 +327,12 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile not like" in {
       testLogicalPlanCompile(
         "select bar from foo where bar not like 'a%'",
-        Let('tmp0, read("foo"),
+        Let('__tmp0, read("foo"),
           Squash(makeObj("bar" -> ObjectProject[FLP](Filter[FLP](
-            Free('tmp0),
+            Free('__tmp0),
             Not[FLP](
               Search[FLP](
-                ObjectProject(Free('tmp0), Constant(Data.Str("bar"))),
+                ObjectProject(Free('__tmp0), Constant(Data.Str("bar"))),
                 Constant(Data.Str("^a.*$")),
                 Constant(Data.Bool(false))))),
             Constant(Data.Str("bar")))))))
@@ -341,15 +341,15 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile ~" in {
       testLogicalPlanCompile(
         "select bar from foo where bar ~ 'a.$'",
-        Let('tmp0, read("foo"),
+        Let('__tmp0, read("foo"),
           Squash(
             makeObj(
               "bar" ->
                 ObjectProject[FLP](
                   Filter[FLP](
-                    Free('tmp0),
+                    Free('__tmp0),
                     Search[FLP](
-                      ObjectProject(Free('tmp0), Constant(Data.Str("bar"))),
+                      ObjectProject(Free('__tmp0), Constant(Data.Str("bar"))),
                       Constant(Data.Str("a.$")),
                       Constant(Data.Bool(false)))),
                   Constant(Data.Str("bar")))))))
@@ -386,28 +386,28 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile cross select *" in {
       testLogicalPlanCompile(
         "select * from person, car",
-        Let('tmp0,
+        Let('__tmp0,
           InnerJoin(read("person"), read("car"), Constant(Data.Bool(true))),
           Squash[FLP](
             ObjectConcat[FLP](
-              ObjectProject(Free('tmp0), Constant(Data.Str("left"))),
-              ObjectProject(Free('tmp0), Constant(Data.Str("right")))))))
+              ObjectProject(Free('__tmp0), Constant(Data.Str("left"))),
+              ObjectProject(Free('__tmp0), Constant(Data.Str("right")))))))
     }
 
     "compile two term multiplication from two tables" in {
       testLogicalPlanCompile(
         "select person.age * car.modelYear from person, car",
-        Let('tmp0,
+        Let('__tmp0,
           InnerJoin(read("person"), read("car"), Constant(Data.Bool(true))),
           Squash(
             makeObj(
               "0" ->
                 Multiply[FLP](
                   ObjectProject[FLP](
-                    ObjectProject(Free('tmp0), Constant(Data.Str("left"))),
+                    ObjectProject(Free('__tmp0), Constant(Data.Str("left"))),
                     Constant(Data.Str("age"))),
                   ObjectProject[FLP](
-                    ObjectProject(Free('tmp0), Constant(Data.Str("right"))),
+                    ObjectProject(Free('__tmp0), Constant(Data.Str("right"))),
                     Constant(Data.Str("modelYear"))))))))
     }
 
@@ -425,15 +425,15 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile simple where" in {
       testLogicalPlanCompile(
         "select name from person where age > 18",
-        Let('tmp0, read("person"),
+        Let('__tmp0, read("person"),
           Squash(
             makeObj(
               "name" ->
                 ObjectProject[FLP](
                   Filter[FLP](
-                    Free('tmp0),
+                    Free('__tmp0),
                     Gt[FLP](
-                      ObjectProject(Free('tmp0), Constant(Data.Str("age"))),
+                      ObjectProject(Free('__tmp0), Constant(Data.Str("age"))),
                       Constant(Data.Int(18)))),
                   Constant(Data.Str("name")))))))
     }
@@ -441,60 +441,60 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile simple group by" in {
       testLogicalPlanCompile(
         "select count(*) from person group by name",
-        Let('tmp0, read("person"),
+        Let('__tmp0, read("person"),
           Squash(
             makeObj(
               "0" ->
                 Count[FLP](
                   GroupBy[FLP](
-                    Free('tmp0),
+                    Free('__tmp0),
                     MakeArrayN[Fix](ObjectProject(
-                      Free('tmp0),
+                      Free('__tmp0),
                       Constant(Data.Str("name"))))))))))
     }
 
     "compile group by with projected keys" in {
       testLogicalPlanCompile(
         "select lower(name), person.gender, avg(age) from person group by lower(person.name), gender",
-        Let('tmp0, read("person"),
-          Let('tmp1,
+        Let('__tmp0, read("person"),
+          Let('__tmp1,
             GroupBy[FLP](
-              Free('tmp0),
+              Free('__tmp0),
               MakeArrayN[Fix](
                 Lower[FLP](
                   ObjectProject(
-                    Free('tmp0),
+                    Free('__tmp0),
                     Constant(Data.Str("name")))),
                 ObjectProject(
-                  Free('tmp0),
+                  Free('__tmp0),
                   Constant(Data.Str("gender"))))),
             Squash(
               makeObj(
                 "0" ->
                   Arbitrary[FLP](
                     Lower[FLP](
-                      ObjectProject(Free('tmp1), Constant(Data.Str("name"))))),
+                      ObjectProject(Free('__tmp1), Constant(Data.Str("name"))))),
                 "gender" ->
                   Arbitrary[FLP](
-                    ObjectProject(Free('tmp1), Constant(Data.Str("gender")))),
+                    ObjectProject(Free('__tmp1), Constant(Data.Str("gender")))),
                 "2" ->
                   Avg[FLP](
-                    ObjectProject(Free('tmp1), Constant(Data.Str("age")))))))))
+                    ObjectProject(Free('__tmp1), Constant(Data.Str("age")))))))))
     }
 
     "compile group by with perverse aggregated expression" in {
       testLogicalPlanCompile(
         "select count(name) from person group by name",
-        Let('tmp0, read("person"),
+        Let('__tmp0, read("person"),
           Squash(
             makeObj(
               "0" ->
                 Count[FLP](
                   ObjectProject[FLP](
                     GroupBy[FLP](
-                      Free('tmp0),
+                      Free('__tmp0),
                       MakeArrayN[Fix](ObjectProject(
-                        Free('tmp0),
+                        Free('__tmp0),
                         Constant(Data.Str("name"))))),
                     Constant(Data.Str("name"))))))))
     }
@@ -511,10 +511,10 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     }
 
     val setA =
-      Let('tmp0, read("zips"),
+      Let('__tmp0, read("zips"),
         Squash(makeObj(
-          "loc" -> ObjectProject(Free('tmp0), Constant(Data.Str("loc"))),
-          "pop" -> ObjectProject(Free('tmp0), Constant(Data.Str("pop"))))))
+          "loc" -> ObjectProject(Free('__tmp0), Constant(Data.Str("loc"))),
+          "pop" -> ObjectProject(Free('__tmp0), Constant(Data.Str("pop"))))))
     val setB =
       Squash(makeObj(
         "city" -> ObjectProject(read("zips"), Constant(Data.Str("city")))))
@@ -666,17 +666,17 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile simple order by" in {
       testLogicalPlanCompile(
         "select name from person order by height",
-        Let('tmp0, read("person"),
-          Let('tmp1,
+        Let('__tmp0, read("person"),
+          Let('__tmp1,
             Squash(
               makeObj(
-                "name" -> ObjectProject(Free('tmp0), Constant(Data.Str("name"))),
-                "__sd__0" -> ObjectProject(Free('tmp0), Constant(Data.Str("height"))))),
+                "name" -> ObjectProject(Free('__tmp0), Constant(Data.Str("name"))),
+                "__sd__0" -> ObjectProject(Free('__tmp0), Constant(Data.Str("height"))))),
             DeleteField[FLP](
               OrderBy[FLP](
-                Free('tmp1),
+                Free('__tmp1),
                 MakeArrayN[Fix](
-                  ObjectProject(Free('tmp1), Constant(Data.Str("__sd__0")))),
+                  ObjectProject(Free('__tmp1), Constant(Data.Str("__sd__0")))),
                 MakeArrayN(
                   Constant(Data.Str("ASC")))),
               Constant(Data.Str("__sd__0"))))))
@@ -685,24 +685,24 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile simple order by with filter" in {
       testLogicalPlanCompile(
         "select name from person where gender = 'male' order by name, height",
-        Let('tmp0, read("person"),
-          Let('tmp1,
+        Let('__tmp0, read("person"),
+          Let('__tmp1,
             Filter[FLP](
-              Free('tmp0),
+              Free('__tmp0),
               Eq[FLP](
-                ObjectProject(Free('tmp0), Constant(Data.Str("gender"))),
+                ObjectProject(Free('__tmp0), Constant(Data.Str("gender"))),
                 Constant(Data.Str("male")))),
-            Let('tmp2,
+            Let('__tmp2,
               Squash(
                 makeObj(
-                  "name"    -> ObjectProject(Free('tmp1), Constant(Data.Str("name"))),
-                  "__sd__0" -> ObjectProject(Free('tmp1), Constant(Data.Str("height"))))),
+                  "name"    -> ObjectProject(Free('__tmp1), Constant(Data.Str("name"))),
+                  "__sd__0" -> ObjectProject(Free('__tmp1), Constant(Data.Str("height"))))),
               DeleteField[FLP](
                 OrderBy[FLP](
-                  Free('tmp2),
+                  Free('__tmp2),
                   MakeArrayN[Fix](
-                    ObjectProject(Free('tmp2), Constant(Data.Str("name"))),
-                    ObjectProject(Free('tmp2), Constant(Data.Str("__sd__0")))),
+                    ObjectProject(Free('__tmp2), Constant(Data.Str("name"))),
+                    ObjectProject(Free('__tmp2), Constant(Data.Str("__sd__0")))),
                   MakeArrayN(
                     Constant(Data.Str("ASC")),
                     Constant(Data.Str("ASC")))),
@@ -712,11 +712,11 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile simple order by with wildcard" in {
       testLogicalPlanCompile(
         "select * from person order by height",
-        Let('tmp1, Squash(read("person")),
+        Let('__tmp0, Squash(read("person")),
           OrderBy[FLP](
-            Free('tmp1),
+            Free('__tmp0),
             MakeArrayN[Fix](
-              ObjectProject(Free('tmp1), Constant(Data.Str("height")))),
+              ObjectProject(Free('__tmp0), Constant(Data.Str("height")))),
             MakeArrayN(
               Constant(Data.Str("ASC"))))))
     }
@@ -724,12 +724,12 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile simple order by with ascending and descending" in {
       testLogicalPlanCompile(
         "select * from person order by height desc, name",
-        Let('tmp1, Squash(read("person")),
+        Let('__tmp0, Squash(read("person")),
           OrderBy[FLP](
-            Free('tmp1),
+            Free('__tmp0),
             MakeArrayN[Fix](
-              ObjectProject(Free('tmp1), Constant(Data.Str("height"))),
-              ObjectProject(Free('tmp1), Constant(Data.Str("name")))),
+              ObjectProject(Free('__tmp0), Constant(Data.Str("height"))),
+              ObjectProject(Free('__tmp0), Constant(Data.Str("name")))),
             MakeArrayN(
               Constant(Data.Str("DESC")),
               Constant(Data.Str("ASC"))))))
@@ -738,20 +738,20 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile simple order by with expression" in {
       testLogicalPlanCompile(
         "select * from person order by height*2.54",
-        Let('tmp0, read("person"),
-          Let('tmp1,
+        Let('__tmp0, read("person"),
+          Let('__tmp1,
             Squash[FLP](
               ObjectConcat(
-                Free('tmp0),
+                Free('__tmp0),
                 makeObj(
                   "__sd__0" -> Multiply[FLP](
-                    ObjectProject(Free('tmp0), Constant(Data.Str("height"))),
+                    ObjectProject(Free('__tmp0), Constant(Data.Str("height"))),
                     Constant(Data.Dec(2.54)))))),
             DeleteField[FLP](
               OrderBy[FLP](
-                Free('tmp1),
+                Free('__tmp1),
                 MakeArrayN[Fix](
-                  ObjectProject(Free('tmp1), Constant(Data.Str("__sd__0")))),
+                  ObjectProject(Free('__tmp1), Constant(Data.Str("__sd__0")))),
                 MakeArrayN(
                   Constant(Data.Str("ASC")))),
               Constant(Data.Str("__sd__0"))))))
@@ -760,33 +760,33 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile order by with alias" in {
       testLogicalPlanCompile(
         "select firstName as name from person order by name",
-        Let('tmp1,
+        Let('__tmp0,
           Squash(
             makeObj(
               "name" -> ObjectProject(read("person"), Constant(Data.Str("firstName"))))),
           OrderBy[FLP](
-            Free('tmp1),
-            MakeArrayN[Fix](ObjectProject(Free('tmp1), Constant(Data.Str("name")))),
+            Free('__tmp0),
+            MakeArrayN[Fix](ObjectProject(Free('__tmp0), Constant(Data.Str("name")))),
             MakeArrayN(Constant(Data.Str("ASC"))))))
     }
 
     "compile simple order by with expression in synthetic field" in {
       testLogicalPlanCompile(
         "select name from person order by height*2.54",
-        Let('tmp0, read("person"),
-          Let('tmp1,
+        Let('__tmp0, read("person"),
+          Let('__tmp1,
             Squash(
               makeObj(
-                "name" -> ObjectProject(Free('tmp0), Constant(Data.Str("name"))),
+                "name" -> ObjectProject(Free('__tmp0), Constant(Data.Str("name"))),
                 "__sd__0" ->
                   Multiply[FLP](
-                    ObjectProject(Free('tmp0), Constant(Data.Str("height"))),
+                    ObjectProject(Free('__tmp0), Constant(Data.Str("height"))),
                     Constant(Data.Dec(2.54))))),
             DeleteField[FLP](
               OrderBy[FLP](
-                Free('tmp1),
+                Free('__tmp1),
                 MakeArrayN[Fix](
-                  ObjectProject(Free('tmp1), Constant(Data.Str("__sd__0")))),
+                  ObjectProject(Free('__tmp1), Constant(Data.Str("__sd__0")))),
                 MakeArrayN(
                   Constant(Data.Str("ASC")))),
               Constant(Data.Str("__sd__0"))))))
@@ -795,24 +795,24 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile order by with nested projection" in {
       testLogicalPlanCompile(
         "select bar from foo order by foo.bar.baz.quux/3",
-        Let('tmp0, read("foo"),
-          Let('tmp1,
+        Let('__tmp0, read("foo"),
+          Let('__tmp1,
             Squash(
               makeObj(
-                "bar" -> ObjectProject(Free('tmp0), Constant(Data.Str("bar"))),
+                "bar" -> ObjectProject(Free('__tmp0), Constant(Data.Str("bar"))),
                 "__sd__0" -> Divide[FLP](
                   ObjectProject[FLP](
                     ObjectProject[FLP](
-                      ObjectProject(Free('tmp0),
+                      ObjectProject(Free('__tmp0),
                         Constant(Data.Str("bar"))),
                       Constant(Data.Str("baz"))),
                     Constant(Data.Str("quux"))),
                   Constant(Data.Int(3))))),
             DeleteField[FLP](
               OrderBy[FLP](
-                Free('tmp1),
+                Free('__tmp1),
                 MakeArrayN[Fix](
-                  ObjectProject(Free('tmp1), Constant(Data.Str("__sd__0")))),
+                  ObjectProject(Free('__tmp1), Constant(Data.Str("__sd__0")))),
                 MakeArrayN(
                   Constant(Data.Str("ASC")))),
               Constant(Data.Str("__sd__0"))))))
@@ -864,20 +864,20 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
           " limit 5",
         Take[FLP](
           Drop(
-            Let('tmp0, read("person"), // from person
-              Let('tmp1,    // where height > 60
+            Let('__tmp0, read("person"), // from person
+              Let('__tmp1,    // where height > 60
                 Filter[FLP](
-                  Free('tmp0),
+                  Free('__tmp0),
                   Gt[FLP](
-                    ObjectProject(Free('tmp0), Constant(Data.Str("height"))),
+                    ObjectProject(Free('__tmp0), Constant(Data.Str("height"))),
                     Constant(Data.Int(60)))),
-                Let('tmp2,    // group by gender, height
+                Let('__tmp2,    // group by gender, height
                   GroupBy[FLP](
-                    Free('tmp1),
+                    Free('__tmp1),
                     MakeArrayN[Fix](
-                      ObjectProject(Free('tmp1), Constant(Data.Str("gender"))),
-                      ObjectProject(Free('tmp1), Constant(Data.Str("height"))))),
-                  Let('tmp4,
+                      ObjectProject(Free('__tmp1), Constant(Data.Str("gender"))),
+                      ObjectProject(Free('__tmp1), Constant(Data.Str("height"))))),
+                  Let('__tmp3,
                     Squash(    // select height*2.54 as cm
                       makeObj(
                         "cm" ->
@@ -885,14 +885,14 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
                             Arbitrary[FLP](
                               ObjectProject[FLP](
                                 Filter[FLP](  // having count(*) > 10
-                                  Free('tmp2),
-                                  Gt[FLP](Count(Free('tmp2)), Constant(Data.Int(10)))),
+                                  Free('__tmp2),
+                                  Gt[FLP](Count(Free('__tmp2)), Constant(Data.Int(10)))),
                                 Constant(Data.Str("height")))),
                             Constant(Data.Dec(2.54))))),
                     OrderBy[FLP](  // order by cm
-                      Free('tmp4),
+                      Free('__tmp3),
                       MakeArrayN[Fix](
-                        ObjectProject(Free('tmp4), Constant(Data.Str("cm")))),
+                        ObjectProject(Free('__tmp3), Constant(Data.Str("cm")))),
                       MakeArrayN(
                         Constant(Data.Str("ASC")))))))),
             Constant(Data.Int(10))), // offset 10
@@ -911,46 +911,111 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile simple inner equi-join" in {
       testLogicalPlanCompile(
         "select foo.name, bar.address from foo join bar on foo.id = bar.foo_id",
-        Let('tmp0,
-          Let('left1, read("foo"),
-            Let('right2, read("bar"),
-              InnerJoin[FLP](Free('left1), Free('right2),
+        Let('__tmp0, read("foo"),
+          Let('__tmp1, read("bar"),
+            Let('__tmp2,
+              InnerJoin[FLP](Free('__tmp0), Free('__tmp1),
                 relations.Eq[FLP](
-                  ObjectProject(Free('left1), Constant(Data.Str("id"))),
-                  ObjectProject(Free('right2), Constant(Data.Str("foo_id"))))))),
-          Squash(
-            makeObj(
-              "name" ->
-                ObjectProject[FLP](
-                  ObjectProject(Free('tmp0), Constant(Data.Str("left"))),
-                  Constant(Data.Str("name"))),
-              "address" ->
-                ObjectProject[FLP](
-                  ObjectProject(Free('tmp0), Constant(Data.Str("right"))),
-                  Constant(Data.Str("address")))))))
+                  ObjectProject(Free('__tmp0), Constant(Data.Str("id"))),
+                  ObjectProject(Free('__tmp1), Constant(Data.Str("foo_id"))))),
+              Squash(
+                makeObj(
+                  "name" ->
+                    ObjectProject[FLP](
+                      ObjectProject(Free('__tmp2), Constant(Data.Str("left"))),
+                      Constant(Data.Str("name"))),
+                  "address" ->
+                    ObjectProject[FLP](
+                      ObjectProject(Free('__tmp2), Constant(Data.Str("right"))),
+                      Constant(Data.Str("address")))))))))
     }
+
+    "compile cross join to the equivalent inner equi-join" in {
+      val query = "select foo.name, bar.address from foo, bar where foo.id = bar.foo_id"
+      val equiv = "select foo.name, bar.address from foo join bar on foo.id = bar.foo_id"
+
+      testLogicalPlanCompile(query, compileExp(equiv))
+    }
+
+    "compile inner join with additional equi-condition to the equivalent inner equi-join" in {
+      val query = "select foo.name, bar.address from foo join bar on foo.id = bar.foo_id where foo.x = bar.y"
+      val equiv = "select foo.name, bar.address from foo join bar on foo.id = bar.foo_id and foo.x = bar.y"
+
+      testLogicalPlanCompile(query, compileExp(equiv))
+    }.pendingUntilFixed("SD-1190")
+
+    "compile inner non-equi join to the equivalent cross join" in {
+      val query = "select foo.name, bar.address from foo join bar on foo.x < bar.y"
+      val equiv = "select foo.name, bar.address from foo, bar where foo.x < bar.y"
+
+      testLogicalPlanCompile(query, compileExp(equiv))
+    }.pendingUntilFixed("SD-1190")
+
+    "compile nested cross join to the equivalent inner equi-join" in {
+      val query = "select a.x, b.y, c.z from a, b, c where a.id = b.a_id and b._id = c.b_id"
+      val equiv = "select a.x, b.y, c.z from (a join b on a.id = b.a_id) join c on b._id = c.b_id"
+
+      testLogicalPlanCompile(query, compileExp(equiv))
+    }.pendingUntilFixed("SD-1190")
+
+    "compile filtered join with one-sided conditions" in {
+      val query = "select foo.name, bar.address from foo, bar where foo.id = bar.foo_id and foo.x < 10 and bar.y = 20"
+
+      // NB: this query produces what we want but currently doesn't match due to spurious SQUASHes
+      // val equiv = "select foo.name, bar.address from (select * from foo where x < 10) foo join (select * from bar where y = 20) bar on foo.id = bar.foo_id"
+
+      testLogicalPlanCompile(query,
+        Let('__tmp0, read("foo"),
+          Let('__tmp1,
+             Fix(Filter(
+               Free('__tmp0),
+               Fix(Lt(
+                 ObjectProject(Free('__tmp0), Constant(Data.Str("x"))),
+                 Constant(Data.Int(10)))))),
+             Let('__tmp2, read("bar"),
+               Let('__tmp3,
+                 Fix(Filter(
+                   Free('__tmp2),
+                   Fix(Eq(
+                     ObjectProject(Free('__tmp2), Constant(Data.Str("y"))),
+                     Constant(Data.Int(20)))))),
+                  Let('__tmp4,
+                    Fix(InnerJoin(Free('__tmp1), Free('__tmp3),
+                      Fix(Eq(
+                        ObjectProject(Free('__tmp1), Constant(Data.Str("id"))),
+                        ObjectProject(Free('__tmp3), Constant(Data.Str("foo_id"))))))),
+                    Fix(Squash(
+                       makeObj(
+                         "name" -> ObjectProject[FLP](
+                           ObjectProject(Free('__tmp4), Constant(Data.Str("left"))),
+                           Constant(Data.Str("name"))),
+                         "address" -> ObjectProject[FLP](
+                           ObjectProject(Free('__tmp4), Constant(Data.Str("right"))),
+                           Constant(Data.Str("address"))))))))))))
+    }
+
 
     "compile simple left ineq-join" in {
       testLogicalPlanCompile(
         "select foo.name, bar.address " +
           "from foo left join bar on foo.id < bar.foo_id",
-        Let('tmp0,
-          Let('left1, read("foo"),
-            Let('right2, read("bar"),
-              LeftOuterJoin[FLP](Free('left1), Free('right2),
+        Let('__tmp0, read("foo"),
+          Let('__tmp1, read("bar"),
+            Let('__tmp2,
+              LeftOuterJoin[FLP](Free('__tmp0), Free('__tmp1),
                 relations.Lt[FLP](
-                  ObjectProject(Free('left1), Constant(Data.Str("id"))),
-                  ObjectProject(Free('right2), Constant(Data.Str("foo_id"))))))),
-          Squash(
-            makeObj(
-              "name" ->
-                ObjectProject[FLP](
-                  ObjectProject(Free('tmp0), Constant(Data.Str("left"))),
-                  Constant(Data.Str("name"))),
-              "address" ->
-                ObjectProject[FLP](
-                  ObjectProject(Free('tmp0), Constant(Data.Str("right"))),
-                  Constant(Data.Str("address")))))))
+                  ObjectProject(Free('__tmp0), Constant(Data.Str("id"))),
+                  ObjectProject(Free('__tmp1), Constant(Data.Str("foo_id"))))),
+              Squash(
+                makeObj(
+                  "name" ->
+                    ObjectProject[FLP](
+                      ObjectProject(Free('__tmp2), Constant(Data.Str("left"))),
+                      Constant(Data.Str("name"))),
+                  "address" ->
+                    ObjectProject[FLP](
+                      ObjectProject(Free('__tmp2), Constant(Data.Str("right"))),
+                      Constant(Data.Str("address")))))))))
     }
 
     "compile complex equi-join" in {
@@ -958,41 +1023,41 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
         "select foo.name, bar.address " +
           "from foo join bar on foo.id = bar.foo_id " +
           "join baz on baz.bar_id = bar.id",
-        Let('tmp0,
-          Let('left1,
-            Let('left3, read("foo"),
-              Let('right4, read("bar"),
-                InnerJoin[FLP](Free('left3), Free('right4),
-                  relations.Eq[FLP](
-                    ObjectProject(
-                      Free('left3),
-                      Constant(Data.Str("id"))),
-                    ObjectProject(
-                      Free('right4),
-                      Constant(Data.Str("foo_id"))))))),
-            Let('right2, read("baz"),
-              InnerJoin[FLP](Free('left1), Free('right2),
+        Let('__tmp0, read("foo"),
+          Let('__tmp1, read("bar"),
+            Let('__tmp2,
+              InnerJoin[FLP](Free('__tmp0), Free('__tmp1),
                 relations.Eq[FLP](
-                  ObjectProject(Free('right2),
-                    Constant(Data.Str("bar_id"))),
-                  ObjectProject[FLP](
-                    ObjectProject(Free('left1),
-                      Constant(Data.Str("right"))),
-                    Constant(Data.Str("id"))))))),
-          Squash(
-            makeObj(
-              "name" ->
-                ObjectProject[FLP](
-                  ObjectProject[FLP](
-                    ObjectProject(Free('tmp0), Constant(Data.Str("left"))),
-                    Constant(Data.Str("left"))),
-                  Constant(Data.Str("name"))),
-              "address" ->
-                ObjectProject[FLP](
-                  ObjectProject[FLP](
-                    ObjectProject(Free('tmp0), Constant(Data.Str("left"))),
-                    Constant(Data.Str("right"))),
-                  Constant(Data.Str("address")))))))
+                  ObjectProject(
+                    Free('__tmp0),
+                    Constant(Data.Str("id"))),
+                  ObjectProject(
+                    Free('__tmp1),
+                    Constant(Data.Str("foo_id"))))),
+              Let('__tmp3, read("baz"),
+                Let('__tmp4,
+                  InnerJoin[FLP](Free('__tmp2), Free('__tmp3),
+                    relations.Eq[FLP](
+                      ObjectProject(Free('__tmp3),
+                        Constant(Data.Str("bar_id"))),
+                      ObjectProject[FLP](
+                        ObjectProject(Free('__tmp2),
+                          Constant(Data.Str("right"))),
+                        Constant(Data.Str("id"))))),
+                  Squash(
+                    makeObj(
+                      "name" ->
+                        ObjectProject[FLP](
+                          ObjectProject[FLP](
+                            ObjectProject(Free('__tmp4), Constant(Data.Str("left"))),
+                            Constant(Data.Str("left"))),
+                          Constant(Data.Str("name"))),
+                      "address" ->
+                        ObjectProject[FLP](
+                          ObjectProject[FLP](
+                            ObjectProject(Free('__tmp4), Constant(Data.Str("left"))),
+                            Constant(Data.Str("right"))),
+                          Constant(Data.Str("address")))))))))))
     }
 
     "compile sub-select in filter" in {
@@ -1004,33 +1069,31 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile simple sub-select" in {
       testLogicalPlanCompile(
         "select temp.name, temp.size from (select zips.city as name, zips.pop as size from zips) temp",
-        Let('tmp0,
-          Let('tmp1,
-            read("zips"),
+        Let('__tmp0, read("zips"),
+          Let('__tmp1,
             Squash(
               makeObj(
-                "name" -> ObjectProject(Free('tmp1), Constant(Data.Str("city"))),
-                "size" -> ObjectProject(Free('tmp1), Constant(Data.Str("pop")))))),
-          Squash(
-            makeObj(
-              "name" -> ObjectProject(Free('tmp0), Constant(Data.Str("name"))),
-              "size" -> ObjectProject(Free('tmp0), Constant(Data.Str("size")))))))
+                "name" -> ObjectProject(Free('__tmp0), Constant(Data.Str("city"))),
+                "size" -> ObjectProject(Free('__tmp0), Constant(Data.Str("pop"))))),
+            Squash(
+              makeObj(
+                "name" -> ObjectProject(Free('__tmp1), Constant(Data.Str("name"))),
+                "size" -> ObjectProject(Free('__tmp1), Constant(Data.Str("size"))))))))
     }
 
     "compile sub-select with same un-qualified names" in {
       testLogicalPlanCompile(
         "select city, pop from (select city, pop from zips) temp",
-        Let('tmp0,
-          Let('tmp1,
-            read("zips"),
+        Let('__tmp0, read("zips"),
+          Let('__tmp1,
             Squash(
               makeObj(
-                "city" -> ObjectProject(Free('tmp1), Constant(Data.Str("city"))),
-                "pop" -> ObjectProject(Free('tmp1), Constant(Data.Str("pop")))))),
-          Squash(
-            makeObj(
-              "city" -> ObjectProject(Free('tmp0), Constant(Data.Str("city"))),
-              "pop" -> ObjectProject(Free('tmp0), Constant(Data.Str("pop")))))))
+                "city" -> ObjectProject(Free('__tmp0), Constant(Data.Str("city"))),
+                "pop" -> ObjectProject(Free('__tmp0), Constant(Data.Str("pop"))))),
+            Squash(
+              makeObj(
+                "city" -> ObjectProject(Free('__tmp1), Constant(Data.Str("city"))),
+                "pop" -> ObjectProject(Free('__tmp1), Constant(Data.Str("pop"))))))))
     }
 
     "compile simple distinct" in {
@@ -1045,16 +1108,16 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile simple distinct ordered" in {
       testLogicalPlanCompile(
         "select distinct city from zips order by city",
-        Let('tmp1,
+        Let('__tmp0,
           Squash(
             makeObj(
               "city" ->
                 ObjectProject(read("zips"), Constant(Data.Str("city"))))),
           Distinct[FLP](
             OrderBy[FLP](
-              Free('tmp1),
+              Free('__tmp0),
               MakeArrayN[Fix](
-                ObjectProject(Free('tmp1), Constant(Data.Str("city")))),
+                ObjectProject(Free('__tmp0), Constant(Data.Str("city")))),
               MakeArrayN(
                 Constant(Data.Str("ASC")))))))
     }
@@ -1062,23 +1125,23 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile distinct with unrelated order by" in {
       testLogicalPlanCompile(
         "select distinct city from zips order by pop desc",
-        Let('tmp0,
+        Let('__tmp0,
           read("zips"),
-          Let('tmp1,
+          Let('__tmp1,
             Squash(
               makeObj(
-                "city" -> ObjectProject(Free('tmp0), Constant(Data.Str("city"))),
-                "__sd__0" -> ObjectProject(Free('tmp0), Constant(Data.Str("pop"))))),
-            Let('tmp2,
+                "city" -> ObjectProject(Free('__tmp0), Constant(Data.Str("city"))),
+                "__sd__0" -> ObjectProject(Free('__tmp0), Constant(Data.Str("pop"))))),
+            Let('__tmp2,
               OrderBy[FLP](
-                Free('tmp1),
+                Free('__tmp1),
                 MakeArrayN[Fix](
-                  ObjectProject(Free('tmp1), Constant(Data.Str("__sd__0")))),
+                  ObjectProject(Free('__tmp1), Constant(Data.Str("__sd__0")))),
                 MakeArrayN(
                   Constant(Data.Str("DESC")))),
               DeleteField[FLP](
-                DistinctBy[FLP](Free('tmp2),
-                  DeleteField(Free('tmp2), Constant(Data.Str("__sd__0")))),
+                DistinctBy[FLP](Free('__tmp2),
+                  DeleteField(Free('__tmp2), Constant(Data.Str("__sd__0")))),
                 Constant(Data.Str("__sd__0")))))))
     }
 
@@ -1093,12 +1156,12 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile simple distinct with two named projections" in {
       testLogicalPlanCompile(
         "select distinct city as CTY, state as ST from zips",
-        Let('tmp0, read("zips"),
+        Let('__tmp0, read("zips"),
           Distinct[FLP](
             Squash(
               makeObj(
-                "CTY" -> ObjectProject(Free('tmp0), Constant(Data.Str("city"))),
-                "ST" -> ObjectProject(Free('tmp0), Constant(Data.Str("state"))))))))
+                "CTY" -> ObjectProject(Free('__tmp0), Constant(Data.Str("city"))),
+                "ST" -> ObjectProject(Free('__tmp0), Constant(Data.Str("state"))))))))
     }
 
     "compile count distinct with two exprs" in {
@@ -1127,15 +1190,15 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
 
     "translate free variable" in {
       testLogicalPlanCompile("select name from zips where age < :age",
-        Let('tmp0, read("zips"),
+        Let('__tmp0, read("zips"),
           Squash(
             makeObj(
               "name" ->
                 ObjectProject[FLP](
                   Filter[FLP](
-                    Free('tmp0),
+                    Free('__tmp0),
                     Lt[FLP](
-                      ObjectProject(Free('tmp0), Constant(Data.Str("age"))),
+                      ObjectProject(Free('__tmp0), Constant(Data.Str("age"))),
                       Free('age))),
                   Constant(Data.Str("name")))))))
     }
@@ -1160,7 +1223,7 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
                 Free('tmp0),
                 MakeArrayN[Fix](ObjectProject(Free('tmp0), Constant(Data.Str("city"))))), Constant(Data.Str("city")))))
 
-      Compiler.reduceGroupKeys(lp) must equalToPlan(exp)
+      reduceGroupKeys(lp) must equalToPlan(exp)
     }
 
     "insert ARBITRARY with intervening filter" in {
@@ -1186,7 +1249,7 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
                   Gt[FLP](Count(Free('tmp1)), Constant(Data.Int(10)))),
                 Constant(Data.Str("city"))))))
 
-      Compiler.reduceGroupKeys(lp) must equalToPlan(exp)
+      reduceGroupKeys(lp) must equalToPlan(exp)
     }
 
     "not insert redundant Reduction" in {
@@ -1199,7 +1262,7 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
                 MakeArrayN[Fix](ObjectProject(Free('tmp0),
                   Constant(Data.Str("city"))))), Constant(Data.Str("city")))))
 
-      Compiler.reduceGroupKeys(lp) must equalToPlan(lp)
+      reduceGroupKeys(lp) must equalToPlan(lp)
     }
 
     "insert ARBITRARY with multiple keys and mixed projections" in {
@@ -1232,7 +1295,7 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
               "loc"  -> ObjectProject(Free('tmp1), Constant(Data.Str("loc"))),
               "2"    -> Sum[FLP](ObjectProject(Free('tmp1), Constant(Data.Str("pop")))))))
 
-      Compiler.reduceGroupKeys(lp) must equalToPlan(exp)
+      reduceGroupKeys(lp) must equalToPlan(exp)
     }
   }
 }

--- a/core/src/test/scala/quasar/helpers.scala
+++ b/core/src/test/scala/quasar/helpers.scala
@@ -1,14 +1,14 @@
 package quasar
 
 import quasar.Predef._
-import quasar.recursionschemes._, FunctorT.ops._
+import quasar.recursionschemes._
 import quasar.sql.{SQLParser, Query}
 import quasar.std._
 import quasar.fs._
 
 import org.specs2.mutable._
 import org.specs2.matcher.{Matcher, Expectable}
-import scalaz._
+import scalaz._, Scalaz._
 
 trait CompilerHelpers extends Specification with TermLogicalPlanMatchers {
   import StdLib._
@@ -24,13 +24,17 @@ trait CompilerHelpers extends Specification with TermLogicalPlanMatchers {
     } yield cld
   }
 
+  // NB: this plan is simplified and normalized, but not optimized. That allows
+  // the expected result to be controlled more precisley. Assuming you know
+  // what plan the compiler produces for a reference query, you can demand that
+  // `optimize` produces the same plan given a query in some more deviant form.
   def compileExp(query: String): Fix[LogicalPlan] =
     compile(query).fold(
       e => throw new RuntimeException("could not compile query for expected value: " + query + "; " + e),
-      _.transCata(repeatedly(Optimizer.simplifyƒ)))
+      lp => (LogicalPlan.normalizeLets _ >>> LogicalPlan.normalizeTempNames _)(Optimizer.simplify(lp)))
 
   def testLogicalPlanCompile(query: String, expected: Fix[LogicalPlan]) = {
-    compile(query).toEither must beRight(equalToPlan(expected))
+    compile(query).map(Optimizer.optimize).toEither must beRight(equalToPlan(expected))
   }
 
   def read(name: String): Fix[LogicalPlan] = LogicalPlan.Read(fs.Path(name))

--- a/core/src/test/scala/quasar/logicalplan.scala
+++ b/core/src/test/scala/quasar/logicalplan.scala
@@ -48,4 +48,73 @@ class LogicalPlanSpecs extends Spec {
   implicit val arbIntLP = arbLogicalPlan(Arbitrary.arbInt)
 
   checkAll(traverse.laws[LogicalPlan])
+
+  import quasar.recursionschemes.Fix
+  import quasar.std.StdLib._, relations._, quasar.std.StdLib.set._, structural._
+
+  "normalizeTempNames" should {
+    "rename simple nested lets" in {
+      LogicalPlan.normalizeTempNames(
+        Let('foo, Read(Path.fileRel("foo")),
+          Let('bar, Read(Path.fileRel("bar")),
+            Fix(MakeObjectN(
+              Constant(Data.Str("x")) -> Fix(ObjectProject(Free('foo), Constant(Data.Str("x")))),
+              Constant(Data.Str("y")) -> Fix(ObjectProject(Free('bar), Constant(Data.Str("y"))))))))) must_==
+        Let('__tmp0, Read(Path.fileRel("foo")),
+          Let('__tmp1, Read(Path.fileRel("bar")),
+            Fix(MakeObjectN(
+              Constant(Data.Str("x")) -> Fix(ObjectProject(Free('__tmp0), Constant(Data.Str("x")))),
+              Constant(Data.Str("y")) -> Fix(ObjectProject(Free('__tmp1), Constant(Data.Str("y"))))))))
+    }
+
+    "rename shadowed name" in {
+      LogicalPlan.normalizeTempNames(
+        Let('x, Read(Path.fileRel("foo")),
+          Let('x, Fix(MakeObjectN(
+              Constant(Data.Str("x")) -> Fix(ObjectProject(Free('x), Constant(Data.Str("x")))))),
+            Free('x)))) must_==
+        Let('__tmp0, Read(Path.fileRel("foo")),
+          Let('__tmp1, Fix(MakeObjectN(
+              Constant(Data.Str("x")) -> Fix(ObjectProject(Free('__tmp0), Constant(Data.Str("x")))))),
+            Free('__tmp1)))
+    }
+  }
+
+  "normalizeLets" should {
+    "re-nest" in {
+      LogicalPlan.normalizeLets(
+        Let('bar,
+          Let('foo,
+            Read(Path.fileRel("foo")),
+            Fix(Filter(Free('foo), Fix(Eq(Fix(ObjectProject(Free('foo), Constant(Data.Str("x"))))))))),
+          Fix(MakeObjectN(
+            Constant(Data.Str("y")) -> Fix(ObjectProject(Free('bar), Constant(Data.Str("y")))))))) must_==
+        Let('foo,
+          Read(Path.fileRel("foo")),
+          Let('bar,
+            Fix(Filter(Free('foo), Fix(Eq(Fix(ObjectProject(Free('foo), Constant(Data.Str("x")))))))),
+            Fix(MakeObjectN(
+              Constant(Data.Str("y")) -> Fix(ObjectProject(Free('bar), Constant(Data.Str("y"))))))))
+    }
+
+    "re-nest deep" in {
+      LogicalPlan.normalizeLets(
+        Let('baz,
+          Let('bar,
+            Let('foo,
+              Read(Path.fileRel("foo")),
+              Fix(Filter(Free('foo), Fix(Eq(Fix(ObjectProject(Free('foo), Constant(Data.Str("x")))), Constant(Data.Int(0))))))),
+            Fix(Filter(Free('bar), Fix(Eq(Fix(ObjectProject(Free('foo), Constant(Data.Str("y")))), Constant(Data.Int(1))))))),
+          Fix(MakeObjectN(
+            Constant(Data.Str("z")) -> Fix(ObjectProject(Free('bar), Constant(Data.Str("z")))))))) must_==
+        Let('foo,
+          Read(Path.fileRel("foo")),
+          Let('bar,
+            Fix(Filter(Free('foo), Fix(Eq(Fix(ObjectProject(Free('foo), Constant(Data.Str("x")))), Constant(Data.Int(0)))))),
+            Let('baz,
+              Fix(Filter(Free('bar), Fix(Eq(Fix(ObjectProject(Free('foo), Constant(Data.Str("y")))), Constant(Data.Int(1)))))),
+              Fix(MakeObjectN(
+                Constant(Data.Str("z")) -> Fix(ObjectProject(Free('bar), Constant(Data.Str("z")))))))))
+    }
+  }
 }

--- a/core/src/test/scala/quasar/recursionschemes/spec.scala
+++ b/core/src/test/scala/quasar/recursionschemes/spec.scala
@@ -505,9 +505,9 @@ class FixplateSpecs extends Specification with ScalaCheck with ScalazMatchers {
     "RenderTree" should {
       "render nodes and leaves" in {
         mul(num(0), num(1)).shows must_==
-          """Mul
-            |├─ Num(Fix(0))
-            |╰─ Num(Fix(1))""".stripMargin
+          """Fix:Mul
+            |├─ Fix:Num(0)
+            |╰─ Fix:Num(1)""".stripMargin
       }
     }
   }

--- a/core/src/test/scala/quasar/recursionschemes/spec.scala
+++ b/core/src/test/scala/quasar/recursionschemes/spec.scala
@@ -289,8 +289,8 @@ class FixplateSpecs extends Specification with ScalaCheck with ScalazMatchers {
 
     "generalizeCoalgebra" should {
       "behave like ana" ! prop { (i: Int) =>
-        Corecursive[Fix].apo(i)(generalizeCoalgebra[Fix[Exp] \/ ?](extractFactors)) must_==
-          Corecursive[Fix].ana(i)(extractFactors)
+        i.apo(generalizeCoalgebra[Fix[Exp] \/ ?](extractFactors)) must_==
+          i.ana(extractFactors)
       }
     }
 
@@ -373,17 +373,17 @@ class FixplateSpecs extends Specification with ScalaCheck with ScalazMatchers {
           else Num(x)
         "apoM" in {
           "should be some" in {
-            Corecursive[Fix].apoM(12)(fM) must beSome(mul(num(2), mul(num(2), num(3))))
+            12.apoM(fM) must beSome(mul(num(2), mul(num(2), num(3))))
           }
           "should be none" in {
-            Corecursive[Fix].apoM(10)(fM) must beNone
+            10.apoM(fM) must beNone
           }
         }
         "apo should be an optimization over apoM and be semantically equivalent" ! prop { i: Int =>
           if (i == 0) ok
           else
-            Corecursive[Fix].apoM[Exp,Id.Id,Int](i.toInt)(f) must_==
-              Corecursive[Fix].apo(i.toInt)(f)
+            i.apoM[Exp, Id](f) must_==
+              i.apo(f)
         }
       }
       "construct factorial" in {
@@ -391,7 +391,7 @@ class FixplateSpecs extends Specification with ScalaCheck with ScalazMatchers {
           if (x > 1) Mul(-\/(num(x)), \/-(x-1))
           else Num(x)
 
-        Corecursive[Fix].apo(4)(fact) must_==
+        4.apo(fact) must_==
           mul(num(4), mul(num(3), mul(num(2), num(1))))
       }
     }
@@ -402,25 +402,25 @@ class FixplateSpecs extends Specification with ScalaCheck with ScalazMatchers {
           def extractFactorsM(x: Int): Option[Exp[Int]] =
             if (x == 5) None else Some(extractFactors(x))
           "pull out factors of two" in {
-            Corecursive[Fix].anaM(12)(extractFactorsM) must beSome(
+            12.anaM(extractFactorsM) must beSome(
               mul(num(2), mul(num(2), num(3)))
             )
           }
           "fail if 5 is present" in {
-            Corecursive[Fix].anaM(10)(extractFactorsM) must beNone
+            10.anaM(extractFactorsM) must beNone
           }
         }
         "ana should be an optimization over anaM and be semantically equivalent" ! prop { i: Int =>
-          Corecursive[Fix].anaM[Exp,Id.Id,Int](i)(extractFactors) must_==
-            Corecursive[Fix].ana(i)(extractFactors)
+          i.anaM[Exp,Id](extractFactors) must_==
+            i.ana(extractFactors)
         }
       }
     }
 
     "distAna" should {
       "behave like ana" ! prop { (i: Int) =>
-        Corecursive[Fix].gana[Exp, Id, Int](i)(distAna, extractFactors) must_==
-          Corecursive[Fix].ana(i)(extractFactors)
+        i.gana[Exp, Id](distAna, extractFactors) must_==
+          i.ana(extractFactors)
       }
     }
 
@@ -483,16 +483,16 @@ class FixplateSpecs extends Specification with ScalaCheck with ScalazMatchers {
 
     "futu" should {
       "factor multiples of two" in {
-        Corecursive[Fix].futu(8)(extract2and3) must_==
+        8.futu(extract2and3) must_==
           mul(num(2), mul(num(2), num(2)))
       }
 
       "factor multiples of three" in {
-        Corecursive[Fix].futu(81)(extract2and3) must_== mul(num(3), num(27))
+        81.futu(extract2and3) must_== mul(num(3), num(27))
       }
 
       "factor 3 within 2" in {
-        Corecursive[Fix].futu(324)(extract2and3) must_==
+        324.futu(extract2and3) must_==
           mul(num(2), mul(num(2), mul(num(3), num(27))))
       }
     }

--- a/it/src/main/resources/tests/crossJoin.test
+++ b/it/src/main/resources/tests/crossJoin.test
@@ -1,0 +1,13 @@
+{
+  "name": "simple join written in 'cross join' form (must be optimized to an inner join or else the join explodes, taking several minutes to complete)",
+  "backends": { "mongodb_read_only": "pending" },
+
+  "data": "largeZips.data",
+
+  "query": "select a.city, b.state from largeZips a, largeZips b where a._id = b._id",
+
+  "predicate": "containsAtLeast",
+  "expected": [
+    { "city": "REDONDO BEACH", "state": "CA" }
+  ]
+}

--- a/it/src/main/resources/tests/crossJoinWithOneSidedConditions.test
+++ b/it/src/main/resources/tests/crossJoinWithOneSidedConditions.test
@@ -1,0 +1,13 @@
+{
+  "name": "cross join with conditions that must be pushed ahead of the join (or else the join explodes, taking several minutes to complete)",
+  "backends": { "mongodb_read_only": "pending" },
+
+  "data": "largeZips.data",
+
+  "query": "select a.city as a, b.city as b, b.pop - a.pop as diff from largeZips a, largeZips b where a._id like '80301' and b._id like '90277'",
+
+  "predicate": "equalsExactly",
+  "expected": [
+    { "a": "BOULDER", "b": "REDONDO BEACH", "diff": 14928 }
+  ]
+}

--- a/web/src/main/scala/quasar/api/server.scala
+++ b/web/src/main/scala/quasar/api/server.scala
@@ -243,7 +243,7 @@ abstract class ServerOps[WC: CodecJson, SC](
       cfgPath        <- opts.config.fold[EnvTask[Option[FsPath[pathy.Path.File, pathy.Path.Sandboxed]]]](
           liftE(Task.now(None)))(
           cfg => FsPath.parseSystemFile(cfg).toRight(InvalidConfig("Invalid path to config file: " + cfg)).map(Some(_)))
-      config         <- configOps.fromFileOrDefaultPaths(cfgPath).orElse(EitherT.right(Task.now(defaultWC)))
+      config         <- configOps.fromFileOrDefaultPaths(cfgPath).fixedOrElse(EitherT.right(Task.now(defaultWC)))
       port           =  opts.port getOrElse wcPort.get(config)
       updCfg         =  wcPort.set(port)(config)
       (proc, useCfg) =  servers(content.toList, Some(redirect), idleTimeout, Backend.test,

--- a/web/src/test/scala/quasar/api/fs.scala
+++ b/web/src/test/scala/quasar/api/fs.scala
@@ -321,8 +321,8 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
     ast        <- (new sql.SQLParser()).parse(sql.Query(q)).toOption
     annotated  <- SemanticAnalysis.AllPhases(ast).toOption
     logical    <- Compiler.compile(annotated).toOption
-    simplified <- logical.transCata(repeatedly(Optimizer.simplifyƒ)).toOption
-    checked    <- LogicalPlan.ensureCorrectTypes(simplified).toOption
+    optimized  <- Optimizer.optimize(logical).toOption
+    checked    <- LogicalPlan.ensureCorrectTypes(optimized).toOption
   } yield checked).getOrElse(scala.sys.error("could not compile: " + q))
 
 


### PR DESCRIPTION
Includes a handful of small fixes, and then the main event:

Rewrite InnerJoin/Filter sequences, putting conditions before, in, or after the join.

The idea is to identify all filtering associated with an inner join in the source plan, breaking down all components into four categories:
- conditions referring to only the left or only the right source, which can be moved ahead of the join (SD-910)
- conditions referring to both sources using `=`, which can be rewritten into the join (SD-1063)
- all others, which have to be done after the join

This is implemented in a new rewriteCrossJoins fold, which uses boundParaM (which is new). Because the new fold introduces new temp names which made it difficult for tests to compare plans, names are now rewritten to a compact sequence starting with `__tmp0` after rewriting cross joins. Nested lets are re-ordered to a consistent sequence. Also, the plan has to be simplified prior to the new fold, so all these steps are now wrapped up in `Optimizer.optimize`, which makes sure to run things in the proper sequence. This replaces the fold with `simplifyƒ` that was being called from several places before.

Added test for two queries which "worked" before but are now massively more efficient. Added an explicit time limit to the regression tests so these will fail definitively if the optimization stops working at some point. These tests (and all the rest) run in a few seconds locally, but the limit is quite high for now (45s) because some take as long as 25s in Travis.