### PR TITLE
Implement streaming distinct() on MongoDB.

### DIFF
--- a/core/src/main/scala/quasar/physical/mongodb/MongoDbIO.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/MongoDbIO.scala
@@ -5,18 +5,18 @@ package mongodb
 import quasar.Predef._
 import quasar.fp._
 
-import scala.collection.JavaConverters._
 import java.lang.{Boolean => JBoolean}
 import java.util.LinkedList
 import java.util.concurrent.TimeUnit
+import scala.Predef.classOf
+import scala.collection.JavaConverters._
 
 import com.mongodb.{MongoClient => _, _}
 import com.mongodb.bulk.BulkWriteResult
 import com.mongodb.client.model._
 import com.mongodb.async._
 import com.mongodb.async.client._
-import org.bson.Document
-import org.bson.conversions.{Bson => ToBson}
+import org.bson.BsonDocument
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 import scalaz.stream._
@@ -48,9 +48,9 @@ object MongoDbIO {
     */
   def aggregate(
     src: Collection,
-    pipeline: List[ToBson],
+    pipeline: List[Bson.Doc],
     allowDiskUse: Boolean
-  ): Process[MongoDbIO, Document] =
+  ): Process[MongoDbIO, BsonDocument] =
     collection(src).liftM[Process] flatMap (c => iterableToProcess(
       c.aggregate(pipeline.asJava)
         .allowDiskUse(new JBoolean(allowDiskUse))
@@ -62,7 +62,7 @@ object MongoDbIO {
     */
   def aggregate_(
     src: Collection,
-    pipeline: List[ToBson],
+    pipeline: List[Bson.Doc],
     allowDiskUse: Boolean
   ): MongoDbIO[Unit] =
     collection(src).flatMap(c => async[java.lang.Void](
@@ -123,10 +123,10 @@ object MongoDbIO {
   def firstWritableDb(collName: String): OptionT[MongoDbIO, String] = {
     type M[A] = OptionT[MongoDbIO, A]
 
-    val testDoc = Bson.Doc(ListMap("a" -> Bson.Int32(1))).repr
+    val testDoc = Bson.Doc(ListMap("a" -> Bson.Int32(1)))
 
     def canWriteToCol(coll: Collection): M[String] =
-      insertAny[Id](coll, testDoc)
+      insertAny[Id](coll, testDoc.repr)
         .filter(_ == 1)
         .as(coll.databaseName)
         .attempt
@@ -140,8 +140,8 @@ object MongoDbIO {
   }
 
   /** Inserts the given documents into the collection. */
-  def insert[F[_]: Foldable](coll: Collection, docs: F[Document]): MongoDbIO[Unit] = {
-    val docList = new LinkedList[Document]
+  def insert[F[_]: Foldable](coll: Collection, docs: F[BsonDocument]): MongoDbIO[Unit] = {
+    val docList = new LinkedList[BsonDocument]
     val insertOpts = (new InsertManyOptions()).ordered(false)
 
     Foldable[F].traverse_(docs)(d => docList.add(d): Id[Boolean])
@@ -158,8 +158,8 @@ object MongoDbIO {
     * possible. The number of documents inserted is returned, if possible, and
     * may be smaller than the original amount if any documents failed to insert.
     */
-  def insertAny[F[_]: Foldable](coll: Collection, docs: F[Document]): OptionT[MongoDbIO, Int] = {
-    val docList = new LinkedList[WriteModel[Document]]
+  def insertAny[F[_]: Foldable](coll: Collection, docs: F[BsonDocument]): OptionT[MongoDbIO, Int] = {
+    val docList = new LinkedList[WriteModel[BsonDocument]]
     val writeOpts = (new BulkWriteOptions()).ordered(false)
 
     Foldable[F].traverse_(docs)(d => docList.add(new InsertOneModel(d)): Id[Boolean])
@@ -175,7 +175,7 @@ object MongoDbIO {
   /** Returns the results of executing the map-reduce job described by `cfg`
     * on the documents from `src`.
     */
-  def mapReduce(src: Collection, cfg: MapReduce): Process[MongoDbIO, Document] =
+  def mapReduce(src: Collection, cfg: MapReduce): Process[MongoDbIO, BsonDocument] =
     configuredMapReduceIterable(src, cfg)
       .liftM[Process]
       .flatMap(iterableToProcess)
@@ -190,8 +190,8 @@ object MongoDbIO {
   ): MongoDbIO[Unit] = {
     import MapReduce._, Action._
 
-    type F[A] = State[MapReduceIterable[Document], A]
-    val ms = MonadState[State, MapReduceIterable[Document]]
+    type F[A] = State[MapReduceIterable[BsonDocument], A]
+    val ms = MonadState[State, MapReduceIterable[BsonDocument]]
 
     def withAction(actOut: ActionedOutput): F[Unit] =
       actOut.databaseName.traverse_[F](n => ms.modify(_.databaseName(n)))     *>
@@ -240,7 +240,7 @@ object MongoDbIO {
       runCommand(dbName, cmd).attemptMongo.run map (_ flatMap (doc =>
         Option(doc getString "version")
           .toRightDisjunction(new MongoException("Unable to determine server version, buildInfo response is missing the 'version' field"))
-          .map(_.split('.').toList.map(_.toInt))))
+          .map(_.getValue.split('.').toList.map(_.toInt))))
     }
 
     val finalize: ((Vector[MongoException], Vector[List[Int]])) => MongoDbIO[List[Int]] = {
@@ -271,7 +271,7 @@ object MongoDbIO {
       def apply[A](t: Task[A]) = lift(_ => t)
     }
 
-  private[mongodb] def find(c: Collection): MongoDbIO[FindIterable[Document]] =
+  private[mongodb] def find(c: Collection): MongoDbIO[FindIterable[BsonDocument]] =
     collection(c) map (_.find)
 
   private[mongodb] def async[A](f: SingleResultCallback[A] => Unit): MongoDbIO[A] =
@@ -301,18 +301,18 @@ object MongoDbIO {
   private val credentials: MongoDbIO[List[MongoCredential]] =
     MongoDbIO(_.getSettings.getCredentialList.asScala.toList)
 
-  private def collection(c: Collection): MongoDbIO[MongoCollection[Document]] =
-    database(c.databaseName) map (_ getCollection c.collectionName)
+  private def collection(c: Collection): MongoDbIO[MongoCollection[BsonDocument]] =
+    database(c.databaseName).map(_.getCollection(c.collectionName, classOf[BsonDocument]))
 
   private def database(named: String): MongoDbIO[MongoDatabase] =
     MongoDbIO(_ getDatabase named)
 
-  private def runCommand(dbName: String, cmd: Bson.Doc): MongoDbIO[Document] =
-    database(dbName) flatMap (db => async[Document](db.runCommand(cmd.repr, _)))
+  private def runCommand(dbName: String, cmd: Bson.Doc): MongoDbIO[BsonDocument] =
+    database(dbName) flatMap (db => async[BsonDocument](db.runCommand(cmd, classOf[BsonDocument], _)))
 
   private def configuredMapReduceIterable(src: Collection, cfg: MapReduce)
-                                         : MongoDbIO[MapReduceIterable[Document]] = {
-    type IT   = MapReduceIterable[Document]
+                                         : MongoDbIO[MapReduceIterable[BsonDocument]] = {
+    type IT   = MapReduceIterable[BsonDocument]
     type F[A] = State[IT, A]
     val ms = MonadState[State, IT]
 
@@ -325,15 +325,14 @@ object MongoDbIO {
     val sortRepr =
       cfg.inputSort map (ts =>
         Bson.Doc(ListMap(
-          ts.list.map(_.bimap(_.asText, _.bson)): _*
-        )).repr)
+          ts.list.map(_.bimap(_.asText, _.bson)): _*)))
 
     val configuredIt =
-      foldIt(cfg.selection)((i, s) => i.filter(s.bson.repr))           *>
+      foldIt(cfg.selection)((i, s) => i.filter(s.bson))                *>
       foldIt(sortRepr)(_ sort _)                                       *>
       foldIt(cfg.limit)(_ limit _.toInt)                               *>
       foldIt(cfg.finalizer)((i, f) => i.finalizeFunction(f.pprint(0))) *>
-      foldIt(nonEmptyScope)((i, s) => i.scope(Bson.Doc(s).repr))       *>
+      foldIt(nonEmptyScope)((i, s) => i.scope(Bson.Doc(s)))            *>
       foldIt(cfg.jsMode)(_ jsMode _)                                   *>
       foldIt(cfg.verbose)(_ verbose _)
 

--- a/core/src/main/scala/quasar/physical/mongodb/MongoDbIOWorkflowExecutor.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/MongoDbIOWorkflowExecutor.scala
@@ -19,13 +19,13 @@ private[mongodb] final class MongoDbWorkflowExecutor
   import MapReduce._
 
   def aggregate(src: Collection, pipeline: Pipeline) =
-    MongoDbIO.aggregate_(src, pipeline map (_.bson.repr), true)
+    MongoDbIO.aggregate_(src, pipeline map(_.bson), true)
 
   def drop(c: Collection) =
     MongoDbIO.dropCollection(c)
 
   def insert(dst: Collection, values: List[Bson.Doc]) =
-    MongoDbIO.insert(dst, values map (_.repr))
+    MongoDbIO.insert(dst, values.map(_.repr))
 
   def mapReduce(src: Collection, dst: OutputCollection, mr: MapReduce) =
     MongoDbIO.mapReduce_(src, dst, mr)

--- a/core/src/main/scala/quasar/physical/mongodb/evaluator.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/evaluator.scala
@@ -26,7 +26,10 @@ import quasar.physical.mongodb.accumulator._
 import quasar.physical.mongodb.expression._
 import Workflow._
 
+import scala.Predef.classOf
+
 import com.mongodb._
+import org.bson.{BsonDocument, BsonValue}
 import scalaz.{Free => FreeM, _}, Scalaz._
 import scalaz.concurrent._
 import scalaz.stream._
@@ -51,6 +54,7 @@ trait Executor[F[_], C] {
 
   def pureCursor(values: List[Bson]): F[C]
   def wrappedCount(field: BsonField.Name, source: Col, count: Count): F[C]
+  def wrappedDistinct(field: BsonField.Name, source: Col, distinct: Distinct): F[C]
   def find(source: Col, find: Find): F[C]
   def aggregateCursor(source: Col, pipeline: workflowtask.Pipeline): F[C]
   def mapReduceCursor(source: Col, mr: MapReduce): F[C]
@@ -81,6 +85,10 @@ final case class Count(
   query:      Option[Selector],
   skip:       Option[Long],
   limit:      Option[Long])
+
+final case class Distinct(
+  field:      BsonField.Name,
+  query:      Option[Selector])
 
 class MongoDbEvaluator(impl: MongoDbEvaluatorImpl[
     StateT[EvaluationTask, SequenceNameGenerator.EvalState, ?],
@@ -122,17 +130,17 @@ object MongoDbEvaluator {
 
   def apply(client0: MongoClient): EnvTask[Evaluator[Crystallized]] = {
     val nameGen = SequenceNameGenerator.Gen
-    val testDoc = Bson.Doc(ListMap("a" -> Bson.Int32(1))).repr
+    val testDoc = Bson.Doc(ListMap("a" -> Bson.Int32(1)))
 
     /** Returns the name of the database if a write succeeds. */
     def canWriteToCol(col: Collection): OptionT[Task, String] = {
       val mongoCol = Task.delay(
         client0.getDatabase(col.databaseName)
-          getCollection(col.collectionName))
+          getCollection(col.collectionName, classOf[BsonDocument]))
 
       val inserted = for {
         c <- mongoCol
-        _ <- Task.delay(c.insertOne(testDoc))
+        _ <- Task.delay(c.insertOne(testDoc.repr))
         _ <- Task.delay(c.drop())
       } yield col.databaseName
 
@@ -319,6 +327,26 @@ trait MongoDbEvaluatorImpl[F[_], C] {
     }
   }
 
+  private object Distinctable {
+    def unapply(pipeline: workflowtask.Pipeline): Option[(BsonField.Name, BsonField.Name)] =
+      pipeline match {
+        case List($Group((), Grouped(map), by), $Project((), Reshape(fields), IdHandling.IgnoreId | IdHandling.ExcludeId))
+            if map.isEmpty && fields.size ≟ 1 =>
+          fields.headOption.fold[Option[(BsonField.Name, BsonField.Name)]] (None)(field =>
+            (by, field) match {
+              case (\/-($var(DocField(origField @ BsonField.Name(_)))), (newField, \/-($var(DocField(IdName))))) =>
+                (origField, newField).some
+              case (-\/(Reshape(map)), (newField, \/-($var(DocField(BsonField.Path(NonEmptyList(IdName, x))))))) if map.size ≟ 1 =>
+                map.get(x).flatMap {
+                  case \/-($var(DocField(origField @ BsonField.Name(_)))) => (origField, newField).some
+                  case _ => None
+                }
+              case _ => None
+            })
+        case _ => None
+      }
+  }
+
   private def extractRange(pipeline: workflowtask.Pipeline):
       ((workflowtask.Pipeline, workflowtask.Pipeline),
         (Option[Long], Option[Long])) =
@@ -367,8 +395,11 @@ trait MongoDbEvaluatorImpl[F[_], C] {
         executor.wrappedCount(field, source, Count(sel.some, None, None))
       case (List($Match((), sel)), List(Countable(field))) =>
         executor.wrappedCount(field, source, Count(sel.some, skip, limit))
-      case _ => executor.aggregateCursor(source, pipeline)
-    }
+      case (Distinctable(origField, newField), Nil) if skip ≟ None && limit ≟ None =>
+        executor.wrappedDistinct(newField, source, Distinct(origField, None))
+      case ($Match((), sel) :: Distinctable(origField, newField), Nil) if skip ≟ None && limit ≟ None =>
+        executor.wrappedDistinct(newField, source, Distinct(origField, sel.some))
+      case _ => executor.aggregateCursor(source, pipeline)}
   }
 
   def evaluate(physical: Crystallized): F[C] = {
@@ -474,7 +505,7 @@ class MongoDbExecutor[S](client: MongoClient,
     nameGen.generateTempName(dbName).mapK(_.point[EvaluationTask])
 
   def insert(dst: Collection, value: Bson.Doc): M[Unit] =
-    liftMongo(mongoCol(dst).insertOne(value.repr))
+    liftTask(mongoCol(dst).map(_.insertOne(value.repr)))
 
   def aggregate(source: Collection, pipeline: workflowtask.Pipeline): M[Unit] =
     runMongoCommand(
@@ -499,33 +530,40 @@ class MongoDbExecutor[S](client: MongoClient,
       case other => other
     }: EvaluationTask[(S, Unit)])
 
-  def drop(coll: Collection) = liftMongo(mongoCol(coll).drop())
+  def drop(coll: Collection) = liftTask(mongoCol(coll).map(_.drop()))
 
   def pureCursor(values: List[Bson]) =
     liftTask(Task.now(Process.emitAll(values.map(BsonCodec.toData))))
 
   def count0(source: Col, count: Count) =
-    Process.emit(
-      mongoCol(source.collection).count(
-        count.query.fold(Bson.Doc(ListMap()).repr)(_.bson.repr),
-        new com.mongodb.client.model.CountOptions()
-          .app(count.skip)((c, count) => c.skip(count.toInt))
-          .app(count.limit)((c, count) => c.limit(count.toInt))))
+    liftTask(
+      mongoCol(source.collection).map(col =>
+        Process.emit(col.count(
+          count.query.fold(Bson.Doc(ListMap()))(_.bson),
+          new com.mongodb.client.model.CountOptions()
+            .app(count.skip)((c, count) => c.skip(count.toInt))
+            .app(count.limit)((c, count) => c.limit(count.toInt))))))
 
   def wrappedCount(field: BsonField.Name, source: Col, count: Count) =
-    liftTask(
-      Task.delay(count0(source, count).map(n =>
-        Data.Obj(ListMap(field.asText -> Data.Int(n))))))
+    count0(source, count).map(_.map(n =>
+      Data.Obj(ListMap(field.asText -> Data.Int(n)))))
+
+  def wrappedDistinct(field: BsonField.Name, source: Col, distinct: Distinct) =
+    fromCursor(
+      mongoCol(source.collection).map(
+        _.distinct(distinct.field.asText, classOf[BsonValue])
+          .app(distinct.query)((c, sel) => c.filter(sel.bson))),
+      source).map(_.map(elem => Data.Obj(ListMap(field.asText -> elem))))
 
   def find(source: Col, find: Find) =
-    fromCursor(Task.delay(
-      mongoCol(source.collection)
-        .find()
-        .app(find.query)((c, sel) => c.filter(sel.bson.repr))
-        .app(find.projection)((c, proj) => c.projection(proj.repr))
-        .app(find.sort)((c, sort) => c.sort($Sort.keyBson(sort).repr))
-        .app(find.skip)((c, count) => c.skip(count.toInt))
-        .app(find.limit)((c, count) => c.limit(count.toInt))),
+    fromCursor(
+      mongoCol(source.collection).map(
+        _.find()
+          .app(find.query)((c, sel) => c.filter(sel.bson))
+          .app(find.projection)((c, proj) => c.projection(proj))
+          .app(find.sort)((c, sort) => c.sort($Sort.keyBson(sort)))
+          .app(find.skip)((c, count) => c.skip(count.toInt))
+          .app(find.limit)((c, count) => c.limit(count.toInt))),
       source)
 
   def aggregateCursor(source: Col, pipeline: workflowtask.Pipeline) = {
@@ -533,51 +571,50 @@ class MongoDbExecutor[S](client: MongoClient,
     import scala.Predef.boolean2Boolean
 
     fromCursor(
-      Task.delay(
-        mongoCol(source.collection)
-          .aggregate(pipeline.map(_.bson.repr).asJava)
+      mongoCol(source.collection).map(
+        _.aggregate(pipeline.map(_.bson).asJava)
           .allowDiskUse(true)),
       source)
   }
 
   def mapReduceCursor(source: Col, mr: MapReduce) = {
-    fromCursor(Task.delay {
-      mongoCol(source.collection)
-        .mapReduce(mr.map.pprint(0), mr.reduce.pprint(0))
-        .app(mr.selection)((c, q) => c.filter(q.bson.repr))
-        .app(mr.limit)((c, l) => c.limit(l.toInt))
-        .app(mr.finalizer)((c, f) => c.finalizeFunction(f.pprint(0)))
-        .scope(Bson.Doc(mr.scope).repr)
-        .app(mr.verbose)((c, v) => c.verbose(v))
-    }, source)
+    fromCursor(
+      mongoCol(source.collection).map(
+        _.mapReduce(mr.map.pprint(0), mr.reduce.pprint(0))
+          .app(mr.selection)((c, q) => c.filter(q.bson))
+          .app(mr.limit)((c, l) => c.limit(l.toInt))
+          .app(mr.finalizer)((c, f) => c.finalizeFunction(f.pprint(0)))
+          .scope(Bson.Doc(mr.scope))
+          .app(mr.verbose)((c, v) => c.verbose(v))),
+      source)
   }
 
-  private def fromCursor(cursor: Task[com.mongodb.client.MongoIterable[org.bson.Document]], source: Col): M[Process[EvaluationTask, Data]] = {
+  private def fromCursor[A <: BsonValue](cursor: Task[com.mongodb.client.MongoIterable[A]], source: Col):
+      M[Process[EvaluationTask, Data]] = {
     val t = new (ETask[Backend.ResultError, ?] ~> EvaluationTask) {
       def apply[A](t: ETask[Backend.ResultError, A]) =
         t.leftMap(EvalResultError(_))
     }
     val cleanup: EvaluationTask[Unit] = source match {
-      case Col.Tmp(coll) => MongoWrapper.liftTask(Task.delay { mongoCol(coll).drop() })
-      case Col.User(_) => liftE(Task.now(()))
+      case Col.Tmp(coll) => MongoWrapper.liftTask(mongoCol(coll).map(_.drop()))
+      case Col.User(_)   => liftE(Task.now(()))
     }
     liftMongo(
       MongoWrapper(client).readCursor(cursor)
-          .translate[EvaluationTask](t)
-          .onComplete(Process.eval_(cleanup)))
+        .translate[EvaluationTask](t)
+        .onComplete(Process.eval_(cleanup)))
   }
 
   def fail[A](e: EvaluationError): M[A] =
     MonadError[ETask, EvaluationError].raiseError[A](e).liftM[MT]
 
-  @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.NoNeedForMonad"))
   def version: M[List[Int]] = {
     def lookupVersion(dbName: String): EvaluationTask[List[Int]] = {
-      val cmd = Bson.Doc(ListMap("buildinfo" -> Bson.Int32(1))).repr
-      MongoWrapper.delay(client.getDatabase(dbName).runCommand(cmd)) flatMapF { r =>
+      val cmd = Bson.Doc(ListMap("buildinfo" -> Bson.Int32(1)))
+      MongoWrapper.delay(client.getDatabase(dbName).runCommand(cmd, classOf[BsonDocument])) flatMapF { r =>
         Option(r getString "version")
           .toRightDisjunction(CommandFailed("buildInfo: response missing 'version' field"))
-          .map(_.split('.').toList.map(_.toInt))
+          .map(_.getValue.split('.').toList.map(_.toInt))
           .point[Task]
       }
     }
@@ -599,7 +636,10 @@ class MongoDbExecutor[S](client: MongoClient,
   }
 
   private def mongoCol(col: Collection) =
-    client.getDatabase(col.databaseName).getCollection(col.collectionName)
+    Task.delay(
+      client
+        .getDatabase(col.databaseName)
+        .getCollection(col.collectionName, classOf[BsonDocument]))
 
   private def liftTask[A](a: Task[A]): M[A] =
     MongoWrapper.liftTask(a).liftM[MT]
@@ -608,7 +648,7 @@ class MongoDbExecutor[S](client: MongoClient,
     MongoWrapper.delay(a).liftM[MT]
 
   private def runMongoCommand(db: String, cmd: Bson.Doc): M[Unit] =
-    liftMongo(client.getDatabase(db).runCommand(cmd.repr)).void
+    liftMongo(client.getDatabase(db).runCommand(cmd)).void
 }
 
 // Convenient partially-applied type: LoggerT[X]#Rec
@@ -653,6 +693,15 @@ class JSExecutor[F[_]: Monad](nameGen: NameGenerator[F])
 
   def wrappedCount(field: BsonField.Name, source: Col, count: Count) =
     write(AnonElem(List(AnonObjDecl(List(field.asText -> count0(source, count))))))
+
+  def distinct0(source: Col, distinct: Distinct) =
+      Call(Select(toJsRef(source.collection), "distinct"), List(Js.Str(distinct.field.asText)))
+        .app(distinct.query)((c, sel) => Call(Select(c, "filter"), List(sel.bson.toJs)))
+
+  def wrappedDistinct(field: BsonField.Name, source: Col, distinct: Distinct) =
+    write(
+      Call(Select(distinct0(source, distinct), "map"), List(
+        AnonFunDecl(List("elem"), List(Return(AnonObjDecl(List(field.asText -> Ident("elem")))))))))
 
   def find(source: Col, find: Find) =
     write(

--- a/core/src/main/scala/quasar/physical/mongodb/optimize/optimize.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/optimize/optimize.scala
@@ -100,10 +100,10 @@ package object optimize {
                   })
 
               id.fold(
-                re => maybeSimplify(re.find(v.copoint).map(f => DocField(BsonField.Name("_id") \ f))),
+                re => maybeSimplify(re.find(v.copoint).map(f => DocField(IdName \ f))),
                 expr =>
                   maybeSimplify(
-                    if (v.copoint == expr) DocField(BsonField.Name("_id")).some
+                    if (v.copoint == expr) DocField(IdName).some
                     else None))
           }
 

--- a/core/src/main/scala/quasar/physical/mongodb/selector.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/selector.scala
@@ -78,7 +78,7 @@ object Selector {
         case and: And     => NonTerminal("And" :: SelectorNodeType, None, and.flatten.map(render))
         case or: Or       => NonTerminal("Or" :: SelectorNodeType, None, or.flatten.map(render))
         case nor: Nor     => NonTerminal("Nor" :: SelectorNodeType, None, nor.flatten.map(render))
-        case where: Where => Terminal("Where" :: SelectorNodeType, Some(where.bson.repr.toString))
+        case where: Where => Terminal("Where" :: SelectorNodeType, Some(where.bson.toJs.pprint(0)))
         case Doc(pairs)   => {
           val children = pairs.map {
             case (field, Expr(expr)) =>

--- a/core/src/main/scala/quasar/physical/mongodb/workflowop.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/workflowop.scala
@@ -451,7 +451,7 @@ object Workflow {
     case $Pure(Bson.Doc(value))          =>
       value.keys.toList.map(BsonField.Name).some
     case $Project(_, Reshape(value), id) =>
-      (if (id == IncludeId) BsonField.Name("_id") :: value.keys.toList
+      (if (id == IncludeId) IdName :: value.keys.toList
       else value.keys.toList).some
     case sm @ $SimpleMap(_, _, _)        =>
       def loop(expr: JsCore): Option[List[jscore.Name]] =
@@ -461,8 +461,7 @@ object Workflow {
           case _ => None
         }
       loop(sm.simpleExpr.expr).map(_.map(n => BsonField.Name(n.value)))
-    case $Group(_, Grouped(value), _)    =>
-      (BsonField.Name("_id") :: value.keys.toList).some
+    case $Group(_, Grouped(value), _)    => (IdName :: value.keys.toList).some
     case $Unwind(src, _)                 => simpleShape(src)
     case sp: ShapePreservingF[_]         => simpleShape(sp.src)
     case _                               => None

--- a/core/src/test/scala/quasar/physical/mongodb/bson.scala
+++ b/core/src/test/scala/quasar/physical/mongodb/bson.scala
@@ -6,8 +6,6 @@ import quasar._
 import quasar.javascript._
 import quasar.jscore
 
-import scala.collection.JavaConverters._
-
 import org.specs2.mutable._
 import org.specs2.ScalaCheck
 import org.threeten.bp._
@@ -31,15 +29,6 @@ class BsonSpecs extends Specification with ScalaCheck {
       val b = Doc(ListMap("a" -> Undefined))
 
       fromRepr(b.repr) must_== b
-    }
-
-    "handle completely unexpected object" in {
-      // Simulating a type MongoDB uses that we know nothing about:
-      class Foo
-
-      val native = new org.bson.Document(Map[String, java.lang.Object]("a" -> new Foo()).asJava)
-
-      Bson.fromRepr(native) must_== Doc(ListMap("a" -> Undefined))
     }
 
     import BsonGen._

--- a/core/src/test/scala/quasar/physical/mongodb/expression/spec.scala
+++ b/core/src/test/scala/quasar/physical/mongodb/expression/spec.scala
@@ -55,7 +55,7 @@ class ExpressionSpec extends Specification with DisjunctionMatchers {
     }
 
     "render $$ROOT" in {
-      DocVar.ROOT().bson.repr must_== "$$ROOT"
+      DocVar.ROOT().bson must_== Bson.Text("$$ROOT")
     }
 
     "treat DocField as alias for DocVar.ROOT()" in {
@@ -63,11 +63,11 @@ class ExpressionSpec extends Specification with DisjunctionMatchers {
     }
 
     "render $foo under $$ROOT" in {
-      DocVar.ROOT(BsonField.Name("foo")).bson.repr must_== "$foo"
+      DocVar.ROOT(BsonField.Name("foo")).bson must_== Bson.Text("$foo")
     }
 
     "render $foo.bar under $$CURRENT" in {
-      DocVar.CURRENT(BsonField.Name("foo") \ BsonField.Name("bar")).bson.repr must_== "$$CURRENT.foo.bar"
+      DocVar.CURRENT(BsonField.Name("foo") \ BsonField.Name("bar")).bson must_== Bson.Text("$$CURRENT.foo.bar")
     }
   }
 

--- a/core/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/core/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -2323,21 +2323,16 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
       beWorkflow(
         chain(
           $read(Collection("db", "zips")),
-          $project(
-            reshape(
-              "city"  -> $field("city"),
-              "state" -> $field("state")),
-            IgnoreId),
           $group(
-            grouped("__tmp0" -> $first($$ROOT)),
+            grouped(),
             -\/(reshape(
               "0" -> $field("city"),
               "1" -> $field("state")))),
           $project(
             reshape(
-              "city"  -> $field("__tmp0", "city"),
-              "state" -> $field("__tmp0", "state")),
-            ExcludeId)))
+              "city"  -> $field("_id", "0"),
+              "state" -> $field("_id", "1")),
+            IgnoreId)))
     }
 
     "plan distinct as expression" in {
@@ -2420,13 +2415,12 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               IgnoreId),
             $sort(NonEmptyList(BsonField.Name("city") -> Ascending)),
             $group(
-              grouped("__tmp1" -> $first($$ROOT)),
+              grouped(),
               -\/(reshape("0" -> $field("city")))),
-            $sort(NonEmptyList(
-              BsonField.Name("__tmp1") \ BsonField.Name("city") -> Ascending)),
             $project(
-              reshape("city" -> $field("__tmp1", "city")),
-              ExcludeId)))
+              reshape("city" -> $field("_id", "0")),
+              IgnoreId),
+            $sort(NonEmptyList(BsonField.Name("city") -> Ascending))))
     }
 
     "plan distinct with unrelated order by" in {
@@ -2493,19 +2487,18 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               "state"    -> $include()),
             IgnoreId),
           $unwind(DocField("state")),
-
           $group(
-            grouped("__tmp7" -> $first($$ROOT)),
+            grouped(),
             -\/(reshape(
               "0" -> $field("totalPop"),
               "1" -> $field("city"),
               "2" -> $field("state")))),
           $project(
             reshape(
-              "totalPop" -> $field("__tmp7", "totalPop"),
-              "city"     -> $field("__tmp7", "city"),
-              "state"    -> $field("__tmp7", "state")),
-            ExcludeId)))
+              "totalPop" -> $field("_id", "0"),
+              "city"     -> $field("_id", "1"),
+              "state"    -> $field("_id", "2")),
+            IgnoreId)))
     }
 
     "plan distinct with sum, group, and orderBy" in {
@@ -2534,19 +2527,18 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             $unwind(DocField("state")),
             $sort(NonEmptyList(BsonField.Name("totalPop") -> Descending)),
             $group(
-              grouped("__tmp8" -> $first($$ROOT)),
+              grouped(),
               -\/(reshape(
                 "0" -> $field("totalPop"),
                 "1" -> $field("city"),
                 "2" -> $field("state")))),
-            $sort(NonEmptyList(
-              BsonField.Name("__tmp8") \ BsonField.Name("totalPop") -> Descending)),
             $project(
               reshape(
-                "totalPop" -> $field("__tmp8", "totalPop"),
-                "city"     -> $field("__tmp8", "city"),
-                "state"    -> $field("__tmp8", "state")),
-              ExcludeId)))
+                "totalPop" -> $field("_id", "0"),
+                "city"     -> $field("_id", "1"),
+                "state"    -> $field("_id", "2")),
+              IgnoreId),
+            $sort(NonEmptyList(BsonField.Name("totalPop") -> Descending))))
 
     }
 

--- a/core/src/test/scala/quasar/physical/mongodb/workflowbuilder.scala
+++ b/core/src/test/scala/quasar/physical/mongodb/workflowbuilder.scala
@@ -239,11 +239,8 @@ class WorkflowBuilderSpec
             IgnoreId),
           $group(
             Grouped(ListMap(
-              BsonField.Name("__tmp0") -> $first($$ROOT))),
-            -\/(Reshape(ListMap(BsonField.Name("0") -> \/-($field("city")))))),
-          $project(Reshape(ListMap(
-            BsonField.Name("city") -> \/-($field("__tmp0", "city")))),
-            ExcludeId)))
+              BsonField.Name("city") -> $first($field("city")))),
+            -\/(Reshape(ListMap(BsonField.Name("0") -> \/-($field("city"))))))))
     }
 
     "distinct after group" in {
@@ -269,14 +266,12 @@ class WorkflowBuilderSpec
           -\/(Reshape(ListMap(BsonField.Name("0") -> \/-($field("city")))))),
         $unwind(DocField(BsonField.Name("city"))),
         $group(
-          Grouped(ListMap(BsonField.Name("__tmp0") -> $first($$ROOT))),
+          Grouped(ListMap(
+            BsonField.Name("total") -> $first($field("total")),
+            BsonField.Name("city")  -> $first($field("city")))),
           -\/(Reshape(ListMap(
             BsonField.Name("0") -> \/-($field("total")),
-            BsonField.Name("1")  -> \/-($field("city")))))),
-        $project(Reshape(ListMap(
-          BsonField.Name("total") -> \/-($field("__tmp0", "total")),
-          BsonField.Name("city")  -> \/-($field("__tmp0", "city")))),
-          ExcludeId)))
+            BsonField.Name("1")  -> \/-($field("city"))))))))
     }
 
     "distinct and sort with intervening op" in {
@@ -308,17 +303,14 @@ class WorkflowBuilderSpec
         $limit(10),
         $group(
           Grouped(ListMap(
-            BsonField.Name("__tmp1") -> $first($$ROOT))),
+            BsonField.Name("city") -> $first($field("city")),
+            BsonField.Name("state") -> $first($field("state")))),
           -\/(Reshape(ListMap(
             BsonField.Name("0") -> \/-($field("city")),
             BsonField.Name("1") -> \/-($field("state")))))),
         $sort(NonEmptyList(
-          BsonField.Name("__tmp1") \ BsonField.Name("city")  -> Ascending,
-          BsonField.Name("__tmp1") \ BsonField.Name("state") -> Ascending)),
-        $project(Reshape(ListMap(
-          BsonField.Name("city")  -> \/-($field("__tmp1", "city")),
-          BsonField.Name("state") -> \/-($field("__tmp1", "state")))),
-          ExcludeId)))
+          BsonField.Name("city")  -> Ascending,
+          BsonField.Name("state") -> Ascending))))
     }
 
     "group in proj" in {

--- a/core/src/test/scala/quasar/physical/mongodb/workflowop.scala
+++ b/core/src/test/scala/quasar/physical/mongodb/workflowop.scala
@@ -799,9 +799,9 @@ class WorkflowSpec extends Specification with TreeMatchers {
   "$redact" should {
 
     "render result variables" in {
-      $Redact.DESCEND.bson.repr must_== "$$DESCEND"
-      $Redact.PRUNE.bson.repr   must_== "$$PRUNE"
-      $Redact.KEEP.bson.repr    must_== "$$KEEP"
+      $Redact.DESCEND.bson must_== Bson.Text("$$DESCEND")
+      $Redact.PRUNE.bson   must_== Bson.Text("$$PRUNE")
+      $Redact.KEEP.bson    must_== Bson.Text("$$KEEP")
     }
   }
 

--- a/it/src/main/resources/tests/filteredDistinct.test
+++ b/it/src/main/resources/tests/filteredDistinct.test
@@ -1,0 +1,9 @@
+{
+  "name": "filtered distinct of one field",
+  "data": "olympics.data",
+  "query": "select distinct discipline from olympics where event like '%pursuit'",
+  "predicate": "containsExactly",
+  "expected": [{ "discipline": "Speed skating"   },
+               { "discipline": "Biathlon"        },
+               { "discipline": "Cross Country S" }]
+}

--- a/it/src/main/resources/tests/singleFieldDistinct.test
+++ b/it/src/main/resources/tests/singleFieldDistinct.test
@@ -1,0 +1,21 @@
+{
+  "name": "distinct of one field",
+  "data": "olympics.data",
+  "query": "select distinct discipline as d from olympics",
+  "predicate": "containsExactly",
+  "expected": [{ "d": "Figure skating"  },
+               { "d": "Bobsleigh"       },
+               { "d": "Ice Hockey"      },
+               { "d": "Biathlon"        },
+               { "d": "Speed skating"   },
+               { "d": "Cross Country S" },
+               { "d": "Curling"         },
+               { "d": "Nordic Combined" },
+               { "d": "Ski Jumping"     },
+               { "d": "Skeleton"        },
+               { "d": "Alpine Skiing"   },
+               { "d": "Luge"            },
+               { "d": "Short Track S."  },
+               { "d": "Freestyle Ski."  },
+               { "d": "Snowboard"       }]
+}


### PR DESCRIPTION
SD-956 #done

A few other changes done to support this:

* Replaced the `java.lang.Object` BSON representation with the new
  `BsonValue` one added in the 3.0 driver. This is a bit more principled
  and gets rid of a few places where we had to suppress WartRemover
  warnings.
* Implemented `org.bson.conversions.Bson` for our Bson type, which
  eliminates some cases where we previously had to explicitly convert to
  BsonDocument.
* Modified `Workflow.distinct` to distinct in a way that can be
  optimized by `simplifyGroupƒ`, which also makes it easier to match in
  the evaluator.

Otherwise, this follows the same form as the `find()` and `count()`
implementations.