### PR TITLE
fix ammonite shell

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,8 +77,8 @@ lazy val standardSettings = Defaults.defaultSettings ++ Seq(
   concurrentRestrictions in Global := Seq(
     Tags.exclusive(ExclusiveTest)
   ),
+
   console <<= console in Test, // console alias test:console
-  initialCommands in (Test, console) := """ammonite.repl.Repl.run("prompt.update(\"λ \")")""",
 
   scalazVersion  := "7.1.4",
   slcVersion     := "0.4",


### PR DESCRIPTION
The dependency was missing. Also updated the start command for the
current version.

I'm sure this was working at one point, but I could not find the dependency anywhere in the history. I find it useful occasionally, so here's a fix that also brings it up to the current version.