### PR TITLE
Additional effect algebras

### DIFF
--- a/core/src/main/scala/quasar/effect/Failure.scala
+++ b/core/src/main/scala/quasar/effect/Failure.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2014 - 2015 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.effect
+
+import quasar.Predef._
+
+import scalaz._
+import scalaz.syntax.monad._
+
+/** Provides the ability to indicate a computation has failed.
+  *
+  * @tparam E the reason/error describing why the computation failed
+  */
+sealed trait Failure[E, A]
+
+object Failure {
+  final case class Fail[E, A](e: E) extends Failure[E, A]
+
+  @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.NonUnitStatements"))
+  final class Ops[E, S[_]: Functor](implicit S: FailureF[E, ?] :<: S)
+    extends LiftedOps[Failure[E, ?], S] {
+
+    def attempt[A](fa: F[A]): F[E \/ A] =
+      fa.foldMap(attempt0).run
+
+    def fail[A](e: E): F[A] =
+      lift(Fail(e))
+
+    def onFinish[A](fa: F[A], f: Option[E] => F[Unit]): F[A] =
+      attempt(fa).flatMap(_.fold(
+        e => f(Some(e)) *> fail(e),
+        a => f(None)    as a))
+
+    def recover[A](fa: F[A], f: E => F[A]): F[A] =
+      attempt(fa).flatMap(_.fold(f, _.point[F]))
+
+    def unattempt[A](fa: F[E \/ A]): F[A] =
+      fa.flatMap(_.fold(fail, _.point[F]))
+
+    ////
+
+    private type Err[A]      = Failure[E, A]
+    private type ErrF[A]     = FailureF[E, A]
+    private type G[A]        = EitherT[F, E, A]
+    private type GT[X[_], A] = EitherT[X, E, A]
+    private type GE[A, B]    = EitherT[F, A, B]
+
+    private val attemptE: ErrF ~> G = {
+      val g: Err ~> G = new (Err ~> G) {
+        val err = MonadError[GE, E]
+        def apply[A](ea: Err[A]) = ea match {
+          case Fail(e) => err.raiseError[A](e)
+        }
+      }
+      Coyoneda.liftTF(g)
+    }
+
+    private val attempt0: S ~> G = new (S ~> G) {
+      def apply[A](sa: S[A]) =
+        S.prj(sa) match {
+          case Some(errF) => attemptE(errF)
+          case None       => Free.liftF(sa).liftM[GT]
+        }
+    }
+  }
+
+  object Ops {
+    def apply[E, S[_]: Functor](implicit S: FailureF[E, ?] :<: S): Ops[E, S] =
+      new Ops[E, S]
+  }
+}

--- a/core/src/main/scala/quasar/effect/KeyValueStore.scala
+++ b/core/src/main/scala/quasar/effect/KeyValueStore.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014 - 2015 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.effect
+
+import quasar.Predef._
+
+import scalaz._
+
+/** Provides the ability to read, write and delete from a store of values
+  * indexed by keys.
+  *
+  * @tparam K the type of keys used to index values
+  * @tparam V the type of values in the store
+  */
+sealed trait KeyValueStore[K, V, A]
+
+object KeyValueStore {
+  final case class Get[K, V](k: K)
+    extends KeyValueStore[K, V, Option[V]]
+
+  final case class Put[K, V](k: K, v: V)
+    extends KeyValueStore[K, V, Unit]
+
+  final case class Delete[K, V](k: K)
+    extends KeyValueStore[K, V, Unit]
+
+  @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.NonUnitStatements"))
+  final class Ops[K, V, S[_]: Functor](implicit S: KeyValueStoreF[K, V, ?] :<: S)
+    extends LiftedOps[KeyValueStore[K, V, ?], S] {
+
+    def get(k: K): OptionT[F, V] =
+      OptionT(lift(Get[K, V](k)))
+
+    def put(k: K, v: V): F[Unit] =
+      lift(Put(k, v))
+
+    def delete(k: K): F[Unit] =
+      lift(Delete(k))
+
+    def modify(k: K, f: V => V): F[Unit] =
+      get(k) flatMapF (v => put(k, f(v))) getOrElse (())
+  }
+
+  object Ops {
+    def apply[K, V, S[_]: Functor](implicit S: KeyValueStoreF[K, V, ?] :<: S): Ops[K, V, S] =
+      new Ops[K, V, S]
+  }
+}

--- a/core/src/main/scala/quasar/effect/LiftedOps.scala
+++ b/core/src/main/scala/quasar/effect/LiftedOps.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014 - 2015 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.effect
+
+import scalaz._
+
+/** Encapsulates boilerplate useful in defining lifted operations on free
+  * monads over effect algebras.
+  */
+abstract class LiftedOps[G[_], S[_]: Functor](implicit S: Coyoneda[G, ?] :<: S) {
+  type F[A] = Free[S, A]
+
+  def lift[A](ga: G[A]): F[A] =
+    Free.liftF(S.inj(Coyoneda.lift(ga)))
+}

--- a/core/src/main/scala/quasar/effect/MonotonicSeq.scala
+++ b/core/src/main/scala/quasar/effect/MonotonicSeq.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014 - 2015 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.effect
+
+import quasar.Predef._
+
+import scalaz._
+
+/** Provides the ability to request the next element of a monotonically
+  * increasing numeric sequence.
+  *
+  * That is,
+  *
+  *   for {
+  *     a <- next
+  *     b <- next
+  *   } yield a < b
+  *
+  * must always be true.
+  */
+sealed trait MonotonicSeq[A]
+
+object MonotonicSeq {
+  case object Next extends MonotonicSeq[Long]
+
+  @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.NonUnitStatements"))
+  final class Ops[S[_]: Functor](implicit S: MonotonicSeqF :<: S)
+    extends LiftedOps[MonotonicSeq, S] {
+
+    def next: F[Long] =
+      lift(Next)
+  }
+
+  object Ops {
+    def apply[S[_]: Functor](implicit S: MonotonicSeqF :<: S): Ops[S] =
+      new Ops[S]
+  }
+}

--- a/core/src/main/scala/quasar/effect/package.scala
+++ b/core/src/main/scala/quasar/effect/package.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2014 - 2015 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar
+
+import scalaz.Coyoneda
+
+package object effect {
+  type FailureF[E, A] = Coyoneda[Failure[E, ?], A]
+  type KeyValueStoreF[K, V, A] = Coyoneda[KeyValueStore[K, V, ?], A]
+  type MonotonicSeqF[A] = Coyoneda[MonotonicSeq, A]
+}

--- a/core/src/main/scala/quasar/fs/ManageFile.scala
+++ b/core/src/main/scala/quasar/fs/ManageFile.scala
@@ -18,6 +18,7 @@ package quasar
 package fs
 
 import quasar.Predef._
+import quasar.effect.LiftedOps
 import quasar.fp._
 
 import scala.Ordering
@@ -130,8 +131,10 @@ object ManageFile {
 
   // TODO{scalaz}: Refactor, dropping Coyoneda and Functor constraint once we
   //               update to scalaz-7.2
-  final class Ops[S[_]](implicit S0: Functor[S], S1: ManageFileF :<: S) {
-    type F[A] = Free[S, A]
+  @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.NonUnitStatements"))
+  final class Ops[S[_]](implicit S0: Functor[S], S1: ManageFileF :<: S)
+    extends LiftedOps[ManageFile, S] {
+
     type M[A] = FileSystemErrT[F, A]
 
     /** Request the given move scenario be applied to the file system, using the
@@ -174,11 +177,6 @@ object ManageFile {
       */
     def tempFileNear(file: AFile): F[AFile] =
       tempFile(Some(file))
-
-    ////
-
-    def lift[A](fs: ManageFile[A]): F[A] =
-      Free.liftF(S1.inj(Coyoneda.lift(fs)))
   }
 
   object Ops {

--- a/core/src/main/scala/quasar/fs/ReadFile.scala
+++ b/core/src/main/scala/quasar/fs/ReadFile.scala
@@ -18,6 +18,7 @@ package quasar
 package fs
 
 import quasar.Predef._
+import quasar.effect.LiftedOps
 
 import scalaz._
 import scalaz.std.anyVal._
@@ -94,8 +95,10 @@ object ReadFile {
   /** Low-level, unsafe operations. Clients are responsible for resource-safety
     * when using these.
     */
-  final class Unsafe[S[_]](implicit S0: Functor[S], S1: ReadFileF :<: S) {
-    type F[A] = Free[S, A]
+  @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.NonUnitStatements"))
+  final class Unsafe[S[_]](implicit S0: Functor[S], S1: ReadFileF :<: S)
+    extends LiftedOps[ReadFile, S] {
+
     type M[A] = FileSystemErrT[F, A]
 
     /** Returns a read handle for the given file, positioned at the given
@@ -119,11 +122,6 @@ object ReadFile {
     /** Closes the given read handle, freeing any resources it was using. */
     def close(rh: ReadHandle): F[Unit] =
       lift(Close(rh))
-
-    ////
-
-    def lift[A](rf: ReadFile[A]): F[A] =
-      Free.liftF(S1.inj(Coyoneda.lift(rf)))
   }
 
   object Unsafe {

--- a/core/src/main/scala/quasar/fs/WriteFile.scala
+++ b/core/src/main/scala/quasar/fs/WriteFile.scala
@@ -18,6 +18,7 @@ package quasar
 package fs
 
 import quasar.Predef._
+import quasar.effect.LiftedOps
 import quasar.fp._
 
 import scalaz._, Scalaz._
@@ -201,8 +202,10 @@ object WriteFile {
   /** Low-level, unsafe operations. Clients are responsible for resource-safety
     * when using these.
     */
-  final class Unsafe[S[_]](implicit S0: Functor[S], S1: WriteFileF :<: S) {
-    type F[A] = Free[S, A]
+  @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.NonUnitStatements"))
+  final class Unsafe[S[_]](implicit S0: Functor[S], S1: WriteFileF :<: S)
+    extends LiftedOps[WriteFile, S] {
+
     type M[A] = FileSystemErrT[F, A]
 
     /** Returns a write handle for the specified file which may be used to
@@ -226,11 +229,6 @@ object WriteFile {
     /** Close the write handle, freeing any resources it was using. */
     def close(h: WriteHandle): F[Unit] =
       lift(Close(h))
-
-    ////
-
-    def lift[A](wf: WriteFile[A]): F[A] =
-      Free.liftF(S1.inj(Coyoneda.lift(wf)))
   }
 
   object Unsafe {

--- a/core/src/main/scala/quasar/mount/Mounting.scala
+++ b/core/src/main/scala/quasar/mount/Mounting.scala
@@ -18,6 +18,7 @@ package quasar.mount
 
 import quasar.Predef._
 import quasar.Variables
+import quasar.effect.LiftedOps
 import quasar.fp._
 import quasar.fs.{Path => _, _}
 import quasar.sql._
@@ -45,10 +46,12 @@ object Mounting {
   final case class Unmount(path: APath)
     extends Mounting[MountingError \/ Unit]
 
-  final class Ops[S[_]](implicit S0: Functor[S], S1: MountingF :<: S) {
+  @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.NonUnitStatements"))
+  final class Ops[S[_]](implicit S0: Functor[S], S1: MountingF :<: S)
+    extends LiftedOps[Mounting, S] {
+
     import MountConfig2._
 
-    type F[A] = Free[S, A]
     type M[A] = EitherT[F, MountingError, A]
 
     /** Returns the mount configuration for the given mount path or nothing
@@ -127,9 +130,6 @@ object Mounting {
                }
       } yield ()
     }
-
-    private def lift[A](m: Mounting[A]): F[A] =
-      Free.liftF(S1.inj(Coyoneda.lift(m)))
   }
 
   object Ops {


### PR DESCRIPTION
Adds algebras for three new, generic, effects: monotonic numeric sequence source, key-value store and failure, mostly extracted from @mossprescott's work in #1040. This is just to make the new algebras available to others and avoid blocking on that PR.