### PR TITLE
Readable TraceFS logs

### DIFF
--- a/core/src/main/scala/quasar/fs/ManageFile.scala
+++ b/core/src/main/scala/quasar/fs/ManageFile.scala
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package quasar
-package fs
+package quasar.fs
 
 import quasar.Predef._
+import quasar._, RenderTree.ops._
 import quasar.effect.LiftedOps
 import quasar.fp._
 
@@ -183,4 +183,16 @@ object ManageFile {
     implicit def apply[S[_]](implicit S0: Functor[S], S1: ManageFileF :<: S): Ops[S] =
       new Ops[S]
   }
+
+  implicit def RenderManageFile[A] =
+    new RenderTree[ManageFile[A]] {
+      def render(mf: ManageFile[A]) = mf match {
+        case Move(scenario, semantics) => NonTerminal(List("Move"), semantics.toString.some,
+          scenario.fold(
+            (from, to) => List(from.render, to.render),
+            (from, to) => List(from.render, to.render)))
+        case Delete(path) => NonTerminal(List("Delete"), None, List(path.render))
+        case TempFile(nearTo) => NonTerminal(List("TempFile"), None, nearTo.map(_.render).toList)
+      }
+    }
 }

--- a/core/src/main/scala/quasar/fs/Views.scala
+++ b/core/src/main/scala/quasar/fs/Views.scala
@@ -82,3 +82,7 @@ final case class Views(map: Map[AFile, Fix[LogicalPlan]]) {
       case t => t
     }
 }
+
+object Views {
+  def empty: Views = Views(Map.empty)
+}

--- a/core/src/main/scala/quasar/fs/WriteFile.scala
+++ b/core/src/main/scala/quasar/fs/WriteFile.scala
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package quasar
-package fs
+package quasar.fs
 
 import quasar.Predef._
+import quasar._, RenderTree.ops._
 import quasar.effect.LiftedOps
 import quasar.fp._
 
@@ -229,4 +229,15 @@ object WriteFile {
     implicit def apply[S[_]](implicit S0: Functor[S], S1: WriteFileF :<: S): Unsafe[S] =
       new Unsafe[S]
   }
+
+  implicit def RenderWriteFile[A] =
+    new RenderTree[WriteFile[A]] {
+      def render(wf: WriteFile[A]) = wf match {
+        case Open(file)           => NonTerminal(List("Open"), None, List(file.render))
+        case Write(handle, chunk) =>
+          NonTerminal(List("Read"), handle.toString.some,
+            chunk.map(d => Terminal(List("Data"), d.toString.some)).toList)
+        case Close(handle)        => Terminal(List("Close"), handle.toString.some)
+      }
+    }
 }

--- a/core/src/main/scala/quasar/fs/view.scala
+++ b/core/src/main/scala/quasar/fs/view.scala
@@ -183,6 +183,9 @@ object view {
         case ListContents(dir) =>
           val viewNodes = views.ls(dir).map(_.fold(Node.Plain(_), Node.View(_)))
           query.ls(dir).map(ns => overlay(ns, viewNodes)).run
+
+        case FileExists(file) =>
+           query.fileExists(file).map(_ || views.contains(file)).run
       }
     }
   }

--- a/core/src/test/scala/quasar/fs/TraceFS.scala
+++ b/core/src/test/scala/quasar/fs/TraceFS.scala
@@ -2,6 +2,8 @@ package quasar.fs
 
 import quasar.Predef._
 
+import quasar._, RenderTree.ops._
+import quasar.fp._
 import quasar.fp.free.{Interpreter}
 
 import pathy.{Path => PPath}, PPath._
@@ -11,19 +13,15 @@ import scalaz._, Scalaz._
 object TraceFS {
   val FsType = FileSystemType("trace")
 
-  type __FSAction0[A] = Coproduct[WriteFile, ReadFile, A]
-  type __FSAction1[A] = Coproduct[ManageFile, __FSAction0, A]
-  type FSAction[A] = Coproduct[QueryFile, __FSAction1, A]
+  type Trace[A] = Writer[Vector[RenderedTree], A]
 
-  type Trace[A] = Writer[Vector[FSAction[_]], A]
-
-  def qfTrace(nodes: Map[ADir, Set[Node]]) = new (QueryFile ~> Writer[Vector[QueryFile[_]], ?]) {
+  def qfTrace(nodes: Map[ADir, Set[Node]]) = new (QueryFile ~> Trace) {
     import QueryFile._
 
     def ls(dir: ADir) = nodes.getOrElse(dir, Set())
 
-    def apply[A](qf: QueryFile[A]): Writer[Vector[QueryFile[_]], A] =
-      WriterT.writer((Vector(qf),
+    def apply[A](qf: QueryFile[A]): Trace[A] =
+      WriterT.writer((Vector(qf.render),
         qf match {
           case ExecutePlan(lp, out) => (Vector.empty, \/-(out))
           case EvaluatePlan(lp)     => (Vector.empty, \/-(ResultHandle(0)))
@@ -38,11 +36,11 @@ object TraceFS {
         }))
   }
 
-  def rfTrace = new (ReadFile ~> Writer[Vector[ReadFile[_]], ?]) {
+  def rfTrace = new (ReadFile ~> Trace) {
     import ReadFile._
 
-    def apply[A](rf: ReadFile[A]): Writer[Vector[ReadFile[_]], A] =
-      WriterT.writer((Vector(rf),
+    def apply[A](rf: ReadFile[A]): Trace[A] =
+      WriterT.writer((Vector(rf.render),
         rf match {
           case Open(file, off, lim) => \/-(ReadHandle(file, 0))
           case Read(handle)         => \/-(Vector.empty)
@@ -50,11 +48,11 @@ object TraceFS {
         }))
   }
 
-  def wfTrace = new (WriteFile ~> Writer[Vector[WriteFile[_]], ?]) {
+  def wfTrace = new (WriteFile ~> Trace) {
     import WriteFile._
 
-    def apply[A](wf: WriteFile[A]): Writer[Vector[WriteFile[_]], A] =
-      WriterT.writer((Vector(wf),
+    def apply[A](wf: WriteFile[A]): Trace[A] =
+      WriterT.writer((Vector(wf.render),
         wf match {
           case Open(file)           => \/-(WriteHandle(file, 0))
           case Write(handle, chunk) => Vector.empty
@@ -62,11 +60,11 @@ object TraceFS {
         }))
   }
 
-  def mfTrace = new (ManageFile ~> Writer[Vector[ManageFile[_]], ?]) {
+  def mfTrace = new (ManageFile ~> Trace) {
     import ManageFile._
 
-    def apply[A](mf: ManageFile[A]): Writer[Vector[ManageFile[_]], A] =
-      WriterT.writer((Vector(mf),
+    def apply[A](mf: ManageFile[A]): Trace[A] =
+      WriterT.writer((Vector(mf.render),
         mf match {
           case Move(scenario, semantics) => \/-(())
           case Delete(path)              => \/-(())
@@ -80,19 +78,9 @@ object TraceFS {
     Node.Plain(currentDir </> dir("adir"))))
 
   def traceFs: FileSystem ~> Trace =
-    interpretFileSystem[Writer[Vector[FSAction[_]], ?]](
-      inj[QueryFile] compose qfTrace(DefaultNodes),
-      inj[ReadFile] compose rfTrace,
-      inj[WriteFile] compose wfTrace,
-      inj[ManageFile] compose mfTrace)
+    interpretFileSystem[Trace](qfTrace(DefaultNodes), rfTrace, wfTrace, mfTrace)
 
-  def inj[F[_]](implicit I: F :<: FSAction) =
-    new (Writer[Vector[F[_]], ?] ~> Writer[Vector[FSAction[_]], ?]) {
-      def apply[A](w: Writer[Vector[F[_]], A]): Writer[Vector[FSAction[_]], A] =
-        w.mapWritten(_.map(I.inj(_)))
-      }
-
-  def traceInterp[A](t: Free[FileSystem, A]): (Vector[FSAction[_]], A) = {
+  def traceInterp[A](t: Free[FileSystem, A]): (Vector[RenderedTree], A) = {
     new Interpreter(traceFs).interpret(t).run
   }
 }

--- a/core/src/test/scala/quasar/fs/TraceFS.scala
+++ b/core/src/test/scala/quasar/fs/TraceFS.scala
@@ -73,14 +73,10 @@ object TraceFS {
         }))
   }
 
-  val DefaultNodes = Map[ADir, Set[Node]](rootDir -> Set(
-    Node.Plain(currentDir </> file("afile")),
-    Node.Plain(currentDir </> dir("adir"))))
+  def traceFs(nodes: Map[ADir, Set[Node]]): FileSystem ~> Trace =
+    interpretFileSystem[Trace](qfTrace(nodes), rfTrace, wfTrace, mfTrace)
 
-  def traceFs: FileSystem ~> Trace =
-    interpretFileSystem[Trace](qfTrace(DefaultNodes), rfTrace, wfTrace, mfTrace)
-
-  def traceInterp[A](t: Free[FileSystem, A]): (Vector[RenderedTree], A) = {
-    new Interpreter(traceFs).interpret(t).run
+  def traceInterp[A](t: Free[FileSystem, A], nodes: Map[ADir, Set[Node]]): (Vector[RenderedTree], A) = {
+    new Interpreter(traceFs(nodes)).interpret(t).run
   }
 }


### PR DESCRIPTION
Note: this is based on @jedesah's PR to fix the build. Will rebase on master as soon as that's merged, just to be safe.

After burning a bunch of time trying to get RenderTree to work with the quantified type we were using for `Trace`, I realized it gets a lot simpler if we just render *before* accumulating the values in Writer, so here's an implementation of that, plus some slight improvements to the view tests following on JR's addition.