### PR TITLE
SD-1181 Hierarchical FileSystem

### DIFF
--- a/core/src/main/scala/quasar/fp/free/lift.scala
+++ b/core/src/main/scala/quasar/fp/free/lift.scala
@@ -14,18 +14,21 @@
  * limitations under the License.
  */
 
-package quasar.effect
-
-import quasar.fp.free
+package quasar.fp.free
 
 import scalaz._
 
-/** Encapsulates boilerplate useful in defining lifted operations on free
-  * monads over effect algebras.
-  */
-abstract class LiftedOps[G[_], S[_]: Functor](implicit S: Coyoneda[G, ?] :<: S) {
-  type F[A] = Free[S, A]
+object lift {
+  final class LifterAux[F[_], A](fa: F[A]) {
+    type CF[A] = Coyoneda[F, A]
 
-  def lift[A](ga: G[A]): F[A] =
-    free.lift(ga).intoC[S]
+    def into[G[_]: Functor](implicit I: F :<: G): Free[G, A] =
+      Free.liftF(I.inj(fa))
+
+    def intoC[G[_]: Functor](implicit I: CF :<: G): Free[G, A] =
+      lift[CF, A](Coyoneda.lift(fa)).into[G]
+  }
+
+  def apply[F[_], A](fa: F[A]): LifterAux[F, A] =
+    new LifterAux(fa)
 }

--- a/core/src/main/scala/quasar/fp/free/package.scala
+++ b/core/src/main/scala/quasar/fp/free/package.scala
@@ -23,6 +23,9 @@ package object free {
   type Coproduct4[F[_], G[_], H[_], I[_], A] = Coproduct[F, Coproduct3[G, H, I, ?], A]
   type Coproduct5[F[_], G[_], H[_], I[_], J[_], A] = Coproduct[F, Coproduct4[G, H, I, J, ?], A]
 
+  /** Given `F[_]` and `G[_]` such that `F :<: G`, lifts a natural transformation
+    * `F ~> F` to `G ~> G`.
+    */
   def injectedNT[F[_], G[_]](f: F ~> F)(implicit G: F :<: G): G ~> G =
     new (G ~> G) {
       def apply[A](ga: G[A]) = G.prj(ga).fold(ga)(fa => G.inj(f(fa)))
@@ -37,6 +40,15 @@ package object free {
     def apply[A](fa: Free[F, A]): G[A] =
       fa.foldMap(f)
   }
+
+  /** Given `F[_]` and `S[_]` such that `F :<: S`, returns a natural
+    * transformation, `S ~> G`, where `f` is used to transform an `F[_]` and `g`
+    * used otherwise.
+    */
+  def transformIn[F[_], S[_], G[_]: Functor](f: F ~> G, g: S ~> G)(implicit S: F :<: S): S ~> G =
+    new (S ~> G) {
+      def apply[A](sa: S[A]) = S.prj(sa).fold(g(sa))(f)
+    }
 
   def interpret2[F[_], G[_], M[_]](f: F ~> M, g: G ~> M): Coproduct[F, G, ?] ~> M =
     new (Coproduct[F, G, ?] ~> M) {

--- a/core/src/main/scala/quasar/fs/FileSystemError.scala
+++ b/core/src/main/scala/quasar/fs/FileSystemError.scala
@@ -14,121 +14,98 @@
  * limitations under the License.
  */
 
-package quasar
-package fs
+package quasar.fs
 
 import quasar.Predef._
+import quasar.{Data, LogicalPlan}
+import quasar.Planner.{PlannerError => PlannerErr}
 import quasar.fp._
 import quasar.recursionschemes._
-import quasar.Planner.{PlannerError => PlannerErr}
 
 import monocle.Prism
 import pathy.Path.posixCodec
 import scalaz._
 import scalaz.syntax.show._
 
-import QueryFile.ResultHandle
-import ReadFile.ReadHandle
-import WriteFile.WriteHandle
-
 sealed trait FileSystemError
 
 object FileSystemError {
-  object Case {
-    final case class PathError(e: PathError2)
-      extends FileSystemError
-    final case class PlannerError(lp: Fix[LogicalPlan], err: PlannerErr)
-      extends FileSystemError
-    final case class UnknownResultHandle(h: ResultHandle)
-      extends FileSystemError
-    final case class UnknownReadHandle(h: ReadHandle)
-      extends FileSystemError
-    final case class UnknownWriteHandle(h: WriteHandle)
-      extends FileSystemError
-    final case class PartialWrite(numFailed: Int)
-      extends FileSystemError
-    final case class WriteFailed(data: Data, reason: String)
-      extends FileSystemError
-  }
+  import QueryFile.ResultHandle
+  import ReadFile.ReadHandle
+  import WriteFile.WriteHandle
 
-  val PathError: PathError2 => FileSystemError =
-    Case.PathError(_)
-
-  val PlannerError: (Fix[LogicalPlan], PlannerErr) => FileSystemError =
-    Case.PlannerError(_, _)
-
-  val UnknownResultHandle: ResultHandle => FileSystemError =
-    Case.UnknownResultHandle(_)
-
-  val UnknownReadHandle: ReadHandle => FileSystemError =
-    Case.UnknownReadHandle(_)
-
-  val UnknownWriteHandle: WriteHandle => FileSystemError =
-    Case.UnknownWriteHandle(_)
-
-  val PartialWrite: Int => FileSystemError =
-    Case.PartialWrite(_)
-
-  val WriteFailed: (Data, String) => FileSystemError =
-    Case.WriteFailed(_, _)
+  final case class PathError private[fs] (e: PathError2)
+    extends FileSystemError
+  final case class PlannerError private[fs] (lp: Fix[LogicalPlan], err: PlannerErr)
+    extends FileSystemError
+  final case class UnknownResultHandle private[fs] (h: ResultHandle)
+    extends FileSystemError
+  final case class UnknownReadHandle private[fs] (h: ReadHandle)
+    extends FileSystemError
+  final case class UnknownWriteHandle private[fs] (h: WriteHandle)
+    extends FileSystemError
+  final case class PartialWrite private[fs] (numFailed: Int)
+    extends FileSystemError
+  final case class WriteFailed private[fs] (data: Data, reason: String)
+    extends FileSystemError
 
   val pathError: Prism[FileSystemError, PathError2] =
     Prism[FileSystemError, PathError2] {
-      case Case.PathError(err) => Some(err)
+      case PathError(err) => Some(err)
       case _ => None
-    } (PathError)
+    } (PathError(_))
 
   val plannerError: Prism[FileSystemError, (Fix[LogicalPlan], PlannerErr)] =
     Prism[FileSystemError, (Fix[LogicalPlan], PlannerErr)] {
-      case Case.PlannerError(lp, e) => Some((lp, e))
+      case PlannerError(lp, e) => Some((lp, e))
       case _ => None
-    } (PlannerError.tupled)
+    } ((PlannerError(_, _)).tupled)
 
   val unknownResultHandle: Prism[FileSystemError, ResultHandle] =
     Prism[FileSystemError, ResultHandle] {
-      case Case.UnknownResultHandle(h) => Some(h)
+      case UnknownResultHandle(h) => Some(h)
       case _ => None
-    } (UnknownResultHandle)
+    } (UnknownResultHandle(_))
 
   val unknownReadHandle: Prism[FileSystemError, ReadHandle] =
     Prism[FileSystemError, ReadHandle] {
-      case Case.UnknownReadHandle(h) => Some(h)
+      case UnknownReadHandle(h) => Some(h)
       case _ => None
-    } (UnknownReadHandle)
+    } (UnknownReadHandle(_))
 
   val unknownWriteHandle: Prism[FileSystemError, WriteHandle] =
     Prism[FileSystemError, WriteHandle] {
-      case Case.UnknownWriteHandle(h) => Some(h)
+      case UnknownWriteHandle(h) => Some(h)
       case _ => None
-    } (UnknownWriteHandle)
+    } (UnknownWriteHandle(_))
 
   val partialWrite: Prism[FileSystemError, Int] =
     Prism[FileSystemError, Int] {
-      case Case.PartialWrite(n) => Some(n)
+      case PartialWrite(n) => Some(n)
       case _ => None
-    } (PartialWrite)
+    } (PartialWrite(_))
 
   val writeFailed: Prism[FileSystemError, (Data, String)] =
     Prism[FileSystemError, (Data, String)] {
-      case Case.WriteFailed(d, r) => Some((d, r))
+      case WriteFailed(d, r) => Some((d, r))
       case _ => None
-    } (WriteFailed.tupled)
+    } ((WriteFailed(_, _)).tupled)
 
   implicit def fileSystemErrorShow: Show[FileSystemError] =
     Show.shows {
-      case Case.PathError(e) =>
+      case PathError(e) =>
         e.shows
-      case Case.PlannerError(_, e) =>
+      case PlannerError(_, e) =>
         e.shows
-      case Case.UnknownResultHandle(h) =>
+      case UnknownResultHandle(h) =>
         s"Attempted to get results from an unknown or closed handle: ${h.run}"
-      case Case.UnknownReadHandle(h) =>
+      case UnknownReadHandle(h) =>
         s"Attempted to read from '${posixCodec.printPath(h.file)}' using an unknown or closed handle: ${h.id}"
-      case Case.UnknownWriteHandle(h) =>
+      case UnknownWriteHandle(h) =>
         s"Attempted to write to '${posixCodec.printPath(h.file)}' using an unknown or closed handle: ${h.id}"
-      case Case.PartialWrite(n) =>
+      case PartialWrite(n) =>
         s"Failed to write $n data."
-      case Case.WriteFailed(d, r) =>
+      case WriteFailed(d, r) =>
         s"Failed to write datum: reason='$r', datum=${d.shows}"
     }
 }

--- a/core/src/main/scala/quasar/fs/InMemory.scala
+++ b/core/src/main/scala/quasar/fs/InMemory.scala
@@ -147,10 +147,11 @@ object InMemory {
       case Delete(path) =>
         refineType(path).fold(deleteDir, deleteFile)
 
-      case TempFile(nearTo) =>
-        nextSeq map (n => nearTo.cata(
-          renameFile(_, κ(FileName(tmpName(n)))),
-          tmpDir </> file(tmpName(n))))
+      case TempFile(path) =>
+        nextSeq map (n => refineType(path).fold(
+          _ </> file(tmpName(n)),
+          renameFile(_, κ(FileName(tmpName(n))))
+        ).right[FileSystemError])
     }
   }
 
@@ -246,7 +247,6 @@ object InMemory {
 
   ////
 
-  private def tmpDir: ADir = rootDir </> dir("__quasar") </> dir("tmp")
   private def tmpName(n: Long) = s"__quasar.gen_$n"
 
   private val seqL: InMemState @> Long =

--- a/core/src/main/scala/quasar/fs/InMemory.scala
+++ b/core/src/main/scala/quasar/fs/InMemory.scala
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package quasar
-package fs
+package quasar.fs
 
 import quasar.Predef._
+import quasar.{Data, PhaseResult, LogicalPlan, PhaseResults}
 import quasar.fp._
 import quasar.recursionschemes.{Fix, Recursive}
 import quasar.Planner.UnsupportedPlan
@@ -107,7 +107,7 @@ object InMemory {
             }
 
           case None =>
-            UnknownReadHandle(h).left.point[InMemoryFs]
+            unknownReadHandle(h).left.point[InMemoryFs]
         }
 
       case ReadFile.Close(h) =>
@@ -131,7 +131,7 @@ object InMemory {
             fileL(f) mods (_ map (_ ++ xs) orElse Some(xs)) as Vector.empty
 
           case None =>
-            Vector(UnknownWriteHandle(h)).point[InMemoryFs]
+            Vector(unknownWriteHandle(h)).point[InMemoryFs]
         }
 
       case WriteFile.Close(h) =>
@@ -177,7 +177,7 @@ object InMemory {
             (resultL(h) := some(Vector())) as xs.right
 
           case None =>
-            UnknownResultHandle(h).left.point[InMemoryFs]
+            unknownResultHandle(h).left.point[InMemoryFs]
         }
 
       case QueryFile.Close(h) =>
@@ -224,7 +224,7 @@ object InMemory {
     }
 
     private def unsupported(lp: Fix[LogicalPlan]) =
-      PlannerError(lp, UnsupportedPlan(
+      plannerError(lp, UnsupportedPlan(
         lp.unFix,
         some("In Memory interpreter does not currently support this plan")))
   }
@@ -295,10 +295,10 @@ object InMemory {
   //----
 
   private def fsPathNotFound[A](f: AFile): InMemoryFs[FileSystemError \/ A] =
-    PathError(PathNotFound(f)).left.point[InMemoryFs]
+    pathError(PathNotFound(f)).left.point[InMemoryFs]
 
   private def fsPathExists[A](f: AFile): InMemoryFs[FileSystemError \/ A] =
-    PathError(PathExists(f)).left.point[InMemoryFs]
+    pathError(PathExists(f)).left.point[InMemoryFs]
 
   private def moveDir(src: ADir, dst: ADir, s: MoveSemantics): InMemoryFs[FileSystemError \/ Unit] =
     for {
@@ -306,7 +306,7 @@ object InMemory {
       sufxs =  m.keys.toStream.map(_ relativeTo src).unite
       files =  sufxs map (src </> _) zip (sufxs map (dst </> _))
       r0    <- files.traverseU { case (sf, df) => EitherT(moveFile(sf, df, s)) }.run
-      r1    =  r0 flatMap (_.nonEmpty either (()) or PathError(PathNotFound(src)))
+      r1    =  r0 flatMap (_.nonEmpty either (()) or pathError(PathNotFound(src)))
     } yield r1
 
   private def moveFile(src: AFile, dst: AFile, s: MoveSemantics): InMemoryFs[FileSystemError \/ Unit] = {
@@ -332,11 +332,11 @@ object InMemory {
       m  <- contentsL.st
       ss =  m.keys.toStream.map(_ relativeTo d).unite
       r0 <- ss.traverseU(f => EitherT(deleteFile(d </> f))).run
-      r1 =  r0 flatMap (_.nonEmpty either (()) or PathError(PathNotFound(d)))
+      r1 =  r0 flatMap (_.nonEmpty either (()) or pathError(PathNotFound(d)))
     } yield r1
 
   private def deleteFile(f: AFile): InMemoryFs[FileSystemError \/ Unit] =
-    (fileL(f) <:= None) map (_.void \/> PathError(PathNotFound(f)))
+    (fileL(f) <:= None) map (_.void \/> pathError(PathNotFound(f)))
 
   //----
 
@@ -350,5 +350,5 @@ object InMemory {
     contentsL.st map (
       _.keys.toList.map(_ relativeTo d).unite.toNel
         .map(_ foldMap (f => Node.fromFirstSegmentOf(f).toSet))
-        .toRightDisjunction(PathError(PathNotFound(d))))
+        .toRightDisjunction(pathError(PathNotFound(d))))
 }

--- a/core/src/main/scala/quasar/fs/InMemory.scala
+++ b/core/src/main/scala/quasar/fs/InMemory.scala
@@ -214,7 +214,7 @@ object InMemory {
         import quasar.std.StdLib.set.{Drop, Take}
         import quasar.std.StdLib.identity.Squash
         Recursive[Fix].para[LogicalPlan, Option[Vector[Data]]](lp) {
-          case ReadF(path) => convertToAFile(path).flatMap(pathyPath => fileL(pathyPath).get(mem))
+          case ReadF(path) => path.asAFile.flatMap(pathyPath => fileL(pathyPath).get(mem))
           case InvokeF(Drop, (_,src) :: (Fix(ConstantF(Data.Int(skip))),_) :: Nil) => src.map(_.drop(skip.toInt))
           case InvokeF(Take, (_,src) :: (Fix(ConstantF(Data.Int(limit))),_) :: Nil) => src.map(_.take(limit.toInt))
           case InvokeF(Squash,(_,src) :: Nil) => src

--- a/core/src/main/scala/quasar/fs/InMemory.scala
+++ b/core/src/main/scala/quasar/fs/InMemory.scala
@@ -214,10 +214,11 @@ object InMemory {
         import quasar.std.StdLib.set.{Drop, Take}
         import quasar.std.StdLib.identity.Squash
         Recursive[Fix].para[LogicalPlan, Option[Vector[Data]]](lp) {
-          case ReadF(path) => convertToAFile(path).flatMap{ pathyPath => fileL(pathyPath).get(mem)}
+          case ReadF(path) => convertToAFile(path).flatMap(pathyPath => fileL(pathyPath).get(mem))
           case InvokeF(Drop, (_,src) :: (Fix(ConstantF(Data.Int(skip))),_) :: Nil) => src.map(_.drop(skip.toInt))
           case InvokeF(Take, (_,src) :: (Fix(ConstantF(Data.Int(limit))),_) :: Nil) => src.map(_.take(limit.toInt))
           case InvokeF(Squash,(_,src) :: Nil) => src
+          case ConstantF(data) => Some(Vector(data))
           case other => queryResponsesL.get(mem).get(Fix(other.map(_._1)))
         }
       })

--- a/core/src/main/scala/quasar/fs/ManageFile.scala
+++ b/core/src/main/scala/quasar/fs/ManageFile.scala
@@ -181,7 +181,7 @@ object ManageFile {
             (from, to) => List(from.render, to.render),
             (from, to) => List(from.render, to.render)))
         case Delete(path) => NonTerminal(List("Delete"), None, List(path.render))
-        case TempFile(nearTo) => NonTerminal(List("TempFile"), None, nearTo.map(_.render).toList)
+        case TempFile(nearTo) => NonTerminal(List("TempFile"), None, List(nearTo.render))
       }
     }
 }

--- a/core/src/main/scala/quasar/fs/ManageFile.scala
+++ b/core/src/main/scala/quasar/fs/ManageFile.scala
@@ -126,8 +126,8 @@ object ManageFile {
   final case class Delete(path: APath)
     extends ManageFile[FileSystemError \/ Unit]
 
-  final case class TempFile(nearTo: Option[AFile])
-    extends ManageFile[AFile]
+  final case class TempFile(near: APath)
+    extends ManageFile[FileSystemError \/ AFile]
 
   // TODO{scalaz}: Refactor, dropping Coyoneda and Functor constraint once we
   //               update to scalaz-7.2
@@ -161,22 +161,11 @@ object ManageFile {
     def delete(path: APath): M[Unit] =
       EitherT(lift(Delete(path)))
 
-    /** Returns the path to a new temporary file. When `nearTo` is specified,
-      * an attempt is made to return a tmp path that is as physically close to
-      * the given file as possible.
-      */
-    def tempFile(nearTo: Option[AFile]): F[AFile] =
-      lift(TempFile(nearTo))
-
-    /** Returns the path to a new temporary file. */
-    def anyTempFile: F[AFile] =
-      tempFile(None)
-
     /** Returns the path to a new temporary file as physically close to the
-      * specified file as possible.
+      * supplied path as possible.
       */
-    def tempFileNear(file: AFile): F[AFile] =
-      tempFile(Some(file))
+    def tempFile(near: APath): M[AFile] =
+      EitherT(lift(TempFile(near)))
   }
 
   object Ops {

--- a/core/src/main/scala/quasar/fs/ReadFile.scala
+++ b/core/src/main/scala/quasar/fs/ReadFile.scala
@@ -22,7 +22,12 @@ import quasar._, RenderTree.ops._
 import quasar.effect.LiftedOps
 import quasar.fp._
 
-import scalaz._, Scalaz._
+import monocle.Iso
+import scalaz._
+import scalaz.std.anyVal._
+import scalaz.std.tuple._
+import scalaz.syntax.monad._
+import scalaz.syntax.std.option._
 import scalaz.stream._
 
 sealed trait ReadFile[A]
@@ -31,12 +36,15 @@ object ReadFile {
   final case class ReadHandle(file: AFile, id: Long)
 
   object ReadHandle {
+    val tupleIso: Iso[ReadHandle, (AFile, Long)] =
+      Iso((h: ReadHandle) => (h.file, h.id))((ReadHandle(_, _)).tupled)
+
     implicit val readHandleShow: Show[ReadHandle] =
       Show.showFromToString
 
     // TODO: Switch to order once Order[Path[B,T,S]] exists
     implicit val readHandleEqual: Equal[ReadHandle] =
-      Equal.equalBy(h => (h.file, h.id))
+      Equal.equalBy(tupleIso.get)
   }
 
   final case class Open(file: AFile, offset: Natural, limit: Option[Positive])

--- a/core/src/main/scala/quasar/fs/Views.scala
+++ b/core/src/main/scala/quasar/fs/Views.scala
@@ -61,10 +61,10 @@ final case class Views(map: Map[AFile, Fix[LogicalPlan]]) {
   def rewrite(lp: Fix[LogicalPlan]): Fix[LogicalPlan] = rewrite0(lp, Set())
 
   private def rewrite0(lp: Fix[LogicalPlan], expanded: Set[AFile]): Fix[LogicalPlan] = {
-    val expandedP = expanded.map(convert)
+    val expandedP = expanded.map(Path.fromAPath)
     lp.transCata(once {
       case LogicalPlan.ReadF(p) if !(expandedP contains p) =>
-        convertToAFile(p).flatMap(f => map.get(f).map { lp =>
+        p.asAFile.flatMap(f => map.get(f).map { lp =>
           val q = absolutize(lp, fileParent(f))
           rewrite0(q, expanded + f).unFix
         })
@@ -76,7 +76,7 @@ final case class Views(map: Map[AFile, Fix[LogicalPlan]]) {
   private def absolutize(lp: Fix[LogicalPlan], dir: ADir): Fix[LogicalPlan] =
     lp.transCata {
       case read @ LogicalPlan.ReadF(p) =>
-        p.from(convert(dir)).fold(
+        p.from(Path.fromAPath(dir)).fold(
           κ(read),
           LogicalPlan.ReadF(_))
       case t => t

--- a/core/src/main/scala/quasar/fs/WriteFile.scala
+++ b/core/src/main/scala/quasar/fs/WriteFile.scala
@@ -178,7 +178,7 @@ object WriteFile {
           if (fsPathNotFound.getOption(e) exists (_ == tmp)) ().point[M]
           else MonadError[G, FileSystemError].raiseError(e))
 
-      MF.tempFileNear(dst).liftM[FileSystemErrT].liftM[Process] flatMap { tmp =>
+      MF.tempFile(dst).liftM[Process] flatMap { tmp =>
         appendChunked(tmp, src).terminated.take(1)
           .flatMap(_.cata(
             werr => MF.delete(tmp).as(werr).liftM[Process],

--- a/core/src/main/scala/quasar/fs/WriteFile.scala
+++ b/core/src/main/scala/quasar/fs/WriteFile.scala
@@ -21,6 +21,7 @@ import quasar._, RenderTree.ops._
 import quasar.effect.LiftedOps
 import quasar.fp._
 
+import monocle.Iso
 import scalaz._, Scalaz._
 import scalaz.stream._
 
@@ -30,12 +31,15 @@ object WriteFile {
   final case class WriteHandle(file: AFile, id: Long)
 
   object WriteHandle {
+    val tupleIso: Iso[WriteHandle, (AFile, Long)] =
+      Iso((h: WriteHandle) => (h.file, h.id))((WriteHandle(_, _)).tupled)
+
     implicit val writeHandleShow: Show[WriteHandle] =
       Show.showFromToString
 
     // TODO: Switch to order once Order[Path[B,T,S]] exists
     implicit val writeHandleEqual: Equal[WriteHandle] =
-      Equal.equalBy(h => (h.file, h.id))
+      Equal.equalBy(tupleIso.get)
   }
 
   final case class Open(file: AFile)

--- a/core/src/main/scala/quasar/fs/chroot.scala
+++ b/core/src/main/scala/quasar/fs/chroot.scala
@@ -103,9 +103,9 @@ object chroot {
           Coyoneda.lift(Delete(rebase(p, prefix)))
             .map(_ leftMap stripPathError(prefix))
 
-        case TempFile(nt) =>
-          Coyoneda.lift(TempFile(nt map (rebase(_, prefix))))
-            .map(stripPrefix(prefix))
+        case TempFile(p) =>
+          Coyoneda.lift(TempFile(rebase(p, prefix)))
+            .map(_ bimap (stripPathError(prefix), stripPrefix(prefix)))
       }
     }
 

--- a/core/src/main/scala/quasar/fs/chroot.scala
+++ b/core/src/main/scala/quasar/fs/chroot.scala
@@ -16,190 +16,38 @@
 
 package quasar.fs
 
-import quasar.LogicalPlan, LogicalPlan.ReadF
-import quasar.fp.free._
-import quasar.recursionschemes._, FunctorT.ops._
-
-import monocle.Optional
-import monocle.function.Field1
-import monocle.std.tuple2._
-import pathy.{Path => PPath}, PPath._
-import scalaz._
-import scalaz.std.tuple._
-import scalaz.syntax.functor._
+import scalaz._, NaturalTransformation.refl
 
 object chroot {
 
   /** Rebases all paths in `ReadFile` operations onto the given prefix. */
-  def readFile[S[_]: Functor](prefix: ADir)
-                             (implicit S: ReadFileF :<: S)
-                             : S ~> S = {
-    import ReadFile._
-
-    val g = new (ReadFile ~> ReadFileF) {
-      def apply[A](rf: ReadFile[A]) = rf match {
-        case Open(src, off, lim) =>
-          Coyoneda.lift(Open(rebaseA(src, prefix), off, lim))
-            .map(_ leftMap stripPathError(prefix))
-
-        case Read(h) =>
-          Coyoneda.lift(Read(h))
-            .map(_ leftMap stripPathError(prefix))
-
-        case Close(h) =>
-          Coyoneda.lift(Close(h))
-      }
-    }
-
-    injectedNT[ReadFileF, S](Coyoneda.liftTF(g))
-  }
+  def readFile[S[_]: Functor](prefix: ADir)(implicit S: ReadFileF :<: S): S ~> S =
+    transformPaths.readFile[S](rebaseA(prefix), stripPrefixA(prefix))
 
   /** Rebases all paths in `WriteFile` operations onto the given prefix. */
-  def writeFile[S[_]: Functor](prefix: ADir)
-                              (implicit S: WriteFileF :<: S)
-                              : S ~> S = {
-    import WriteFile._
-
-    val g = new (WriteFile ~> WriteFileF) {
-      def apply[A](wf: WriteFile[A]) = wf match {
-        case Open(dst) =>
-          Coyoneda.lift(Open(rebaseA(dst, prefix)))
-            .map(_ leftMap stripPathError(prefix))
-
-        case Write(h, d) =>
-          Coyoneda.lift(Write(h, d))
-            .map(_ map stripPathError(prefix))
-
-        case Close(h) =>
-          Coyoneda.lift(Close(h))
-      }
-    }
-
-    injectedNT[WriteFileF, S](Coyoneda.liftTF(g))
-  }
+  def writeFile[S[_]: Functor](prefix: ADir)(implicit S: WriteFileF :<: S): S ~> S =
+    transformPaths.writeFile[S](rebaseA(prefix), stripPrefixA(prefix))
 
   /** Rebases all paths in `ManageFile` operations onto the given prefix. */
-  def manageFile[S[_]: Functor](prefix: ADir)
-                               (implicit S: ManageFileF :<: S)
-                               : S ~> S = {
-    import ManageFile._, MoveScenario._
-
-    val g = new (ManageFile ~> ManageFileF) {
-      def apply[A](mf: ManageFile[A]) = mf match {
-        case Move(scn, sem) =>
-          Coyoneda.lift(Move(
-            scn.fold(
-              (src, dst) => DirToDir(rebaseA(src, prefix), rebaseA(dst, prefix)),
-              (src, dst) => FileToFile(rebaseA(src, prefix), rebaseA(dst, prefix))),
-            sem))
-            .map(_ leftMap stripPathError(prefix))
-
-        case Delete(p) =>
-          Coyoneda.lift(Delete(rebaseA(p, prefix)))
-            .map(_ leftMap stripPathError(prefix))
-
-        case TempFile(p) =>
-          Coyoneda.lift(TempFile(rebaseA(p, prefix)))
-            .map(_ bimap (stripPathError(prefix), stripPrefixA(prefix)))
-      }
-    }
-
-    injectedNT[ManageFileF, S](Coyoneda.liftTF(g))
-  }
+  def manageFile[S[_]: Functor](prefix: ADir)(implicit S: ManageFileF :<: S): S ~> S =
+    transformPaths.manageFile[S](rebaseA(prefix), stripPrefixA(prefix))
 
   /** Rebases paths in `QueryFile` onto the given prefix. */
-  def queryFile[S[_]: Functor](prefix: ADir)
-                              (implicit S: QueryFileF :<: S)
-                              : S ~> S = {
-    import QueryFile._
-
-    val base = Path(posixCodec.printPath(prefix))
-
-    val rebasePlan: LogicalPlan ~> LogicalPlan =
-      new (LogicalPlan ~> LogicalPlan) {
-        def apply[A](lp: LogicalPlan[A]) = lp match {
-          case ReadF(p) => ReadF(base ++ p)
-          case _        => lp
-        }
-      }
-
-    val g = new (QueryFile ~> QueryFileF) {
-      def apply[A](qf: QueryFile[A]) = qf match {
-        case ExecutePlan(lp, out) =>
-          Coyoneda.lift(ExecutePlan(lp.translate(rebasePlan), rebaseA(out, prefix)))
-            .map(_.map(_.bimap(stripPathError(prefix), stripPrefixA(prefix))))
-
-        case EvaluatePlan(lp) =>
-          Coyoneda.lift(EvaluatePlan(lp.translate(rebasePlan)))
-            .map(_.map(_ leftMap stripPathError(prefix)))
-
-        case More(h) =>
-          Coyoneda.lift(More(h))
-            .map(_ leftMap stripPathError(prefix))
-
-        case Close(h) =>
-          Coyoneda.lift(Close(h))
-
-        case Explain(lp) =>
-          Coyoneda.lift(Explain(lp.translate(rebasePlan)))
-            .map(_.map(_ leftMap stripPathError(prefix)))
-
-        case ListContents(d) =>
-          Coyoneda.lift(ListContents(rebaseA(d, prefix)))
-            .map(_.bimap(stripPathError(prefix), _ map stripNodePrefix(prefix)))
-
-        case FileExists(f) =>
-          Coyoneda.lift(FileExists(rebaseA(f, prefix)))
-            .map(_ leftMap stripPathError(prefix))
-      }
-    }
-
-    injectedNT[QueryFileF, S](Coyoneda.liftTF(g))
-  }
+  def queryFile[S[_]: Functor](prefix: ADir)(implicit S: QueryFileF :<: S): S ~> S =
+    transformPaths.queryFile[S](rebaseA(prefix), stripPrefixA(prefix), refl)
 
   /** Rebases all paths in `FileSystem` operations onto the given prefix. */
-  def fileSystem[S[_]: Functor](prefix: ADir)
-                               (implicit S0: ReadFileF :<: S,
-                                         S1: WriteFileF :<: S,
-                                         S2: ManageFileF :<: S,
-                                         S3: QueryFileF :<: S)
-                               : S ~> S = {
-
+  def fileSystem[S[_]: Functor](
+    prefix: ADir
+  )(implicit
+    S0: ReadFileF :<: S,
+    S1: WriteFileF :<: S,
+    S2: ManageFileF :<: S,
+    S3: QueryFileF :<: S
+  ): S ~> S = {
     readFile[S](prefix)   compose
     writeFile[S](prefix)  compose
     manageFile[S](prefix) compose
     queryFile[S](prefix)
   }
-
-  ////
-
-  private val fsPathError: Optional[FileSystemError, APath] =
-    FileSystemError.pathError composeLens PathError2.errorPath
-
-  private val fsPlannerError: Optional[FileSystemError, Fix[LogicalPlan]] =
-    FileSystemError.plannerError composeLens Field1.first
-
-  private def stripPathError(prefix: ADir): FileSystemError => FileSystemError = {
-    val base = Path(posixCodec.printPath(prefix))
-
-    val stripRead: LogicalPlan ~> LogicalPlan =
-      new (LogicalPlan ~> LogicalPlan) {
-        def apply[A](lp: LogicalPlan[A]) = lp match {
-          case ReadF(p) => ReadF(p.rebase(base).map(_.asAbsolute) | p)
-          case _        => lp
-        }
-      }
-
-    val stripPlan: Fix[LogicalPlan] => Fix[LogicalPlan] =
-      _ translate stripRead
-
-    fsPathError.modify(stripAPathPrefix(prefix)) compose
-      fsPlannerError.modify(stripPlan)
-  }
-
-  private def stripNodePrefix(prefix: ADir): Node => Node =
-    _.fold(
-      Node.Mount compose stripPrefixR(prefix),
-      Node.Plain compose stripRPathPrefix(prefix),
-      Node.View  compose stripPrefixR(prefix))
 }

--- a/core/src/main/scala/quasar/fs/hierarchical.scala
+++ b/core/src/main/scala/quasar/fs/hierarchical.scala
@@ -1,0 +1,470 @@
+/*
+ * Copyright 2014 - 2015 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.fs
+
+import quasar.Predef._
+import quasar.{Data, LogicalPlan, PhaseResult, PhaseResults}
+import quasar.effect._
+import quasar.fp._
+import quasar.recursionschemes.{free => _, _}, Recursive.ops._
+import quasar.mount.Mounts
+
+import monocle.{Iso, Prism}
+import monocle.syntax.fields._
+import monocle.std.tuple2._
+import pathy.Path._
+import scalaz.{Failure => _, _}, Scalaz._
+
+object hierarchical {
+  import QueryFile.ResultHandle
+  import ReadFile.ReadHandle
+  import WriteFile.WriteHandle
+  import FileSystemError._, PathError2._
+
+  type HFSFailure[A]      = Failure[HierarchicalFileSystemError, A]
+  type HFSFailureF[A]     = Coyoneda[HFSFailure, A]
+
+  type MountedResultH[A]  = KeyValueStore[ResultHandle, (ADir, ResultHandle), A]
+  type MountedResultHF[A] = Coyoneda[MountedResultH, A]
+
+  type HFSErrT[F[_], A] = EitherT[F, HierarchicalFileSystemError, A]
+
+  sealed trait HierarchicalFileSystemError
+
+  object HierarchicalFileSystemError {
+    final case class MultipleMountsApply private[fs] (mounts: Set[ADir], lp: Fix[LogicalPlan])
+      extends HierarchicalFileSystemError
+
+    val multipleMountsApply: Prism[HierarchicalFileSystemError, (Set[ADir], Fix[LogicalPlan])] =
+      Prism[HierarchicalFileSystemError, (Set[ADir], Fix[LogicalPlan])] {
+        case MultipleMountsApply(mnts, lp) => Some((mnts, lp))
+        case _ => None
+      } ((MultipleMountsApply(_, _)).tupled)
+
+    implicit val hierarchicalFSErrorShow: Show[HierarchicalFileSystemError] =
+      Show.shows {
+        case MultipleMountsApply(mnts, lp) =>
+          s"Multiple mounted filesystems can handle the plan: mounts=${mnts.shows}, plan=${lp.shows}"
+      }
+  }
+
+  /** Returns a `ReadFileF` interpreter that selects one of the configured
+    * child interpreters based on the path of the incoming request.
+    *
+    * @param mountSep used to separate the mount from the original file in handles
+    * @param rfs `ReadFileF` interpreters indexed by mount
+    */
+  def readFile[F[_], S[_]](
+    mountSep: DirName,
+    rfs: Mounts[ReadFileF ~> F]
+  )(implicit
+    S0: Functor[S],
+    S1: F :<: S
+  ): ReadFileF ~> Free[S, ?] = {
+    import ReadFile._
+
+    type M[A] = Free[S, A]
+
+    lazy val mountedRfs = rfs mapWithDir { case (d, f) =>
+      f compose mounted.readFile[ReadFileF](d)
+    }
+
+    def evalRead[A](g: ReadFileF ~> F, ra: ReadFile[A]): M[A] =
+      free.lift(g(Coyoneda.lift(ra))).into[S]
+
+    val f = new (ReadFile ~> M) {
+      def apply[A](rf: ReadFile[A]) = rf match {
+        case Open(loc, off, lim) =>
+          lookupMounted(mountedRfs, loc)
+            .fold(pathError(pathNotFound(loc)).left[ReadHandle].point[M]) {
+              case (mnt, g) =>
+                evalRead(g, Open(loc, off, lim))
+                  .map(_ map prefixH(mountSep, ReadHandle.tupleIso, mnt))
+            }
+
+        case Read(h) =>
+          mntH(mountSep, ReadHandle.tupleIso, h).flatMap { case (mnt, origH) =>
+            mountedRfs.lookup(mnt) map (evalRead(_, Read(origH)))
+          } getOrElse unknownReadHandle(h).left.point[M]
+
+        case Close(h) =>
+          mntH(mountSep, ReadHandle.tupleIso, h).flatMap { case (mnt, origH) =>
+            mountedRfs.lookup(mnt) map (evalRead(_, Close(origH)))
+          } getOrElse ().point[M]
+      }
+    }
+
+    Coyoneda.liftTF(f)
+  }
+
+  /** Returns a `WriteFileF` interpreter that selects one of the configured
+    * child interpreters based on the path of the incoming request.
+    *
+    * @param mountSep used to separate the mount from the original file in handles
+    * @param wfs `WriteFileF` interpreters indexed by mount
+    */
+  def writeFile[F[_], S[_]](
+    mountSep: DirName,
+    wfs: Mounts[WriteFileF ~> F]
+  )(implicit
+    S0: Functor[S],
+    S1: F :<: S
+  ): WriteFileF ~> Free[S, ?] = {
+    import WriteFile._
+
+    type M[A] = Free[S, A]
+
+    lazy val mountedWfs = wfs mapWithDir { case (d, f) =>
+      f compose mounted.writeFile[WriteFileF](d)
+    }
+
+    def evalWrite[A](g: WriteFileF ~> F, wa: WriteFile[A]): M[A] =
+      free.lift(g(Coyoneda.lift(wa))).into[S]
+
+    val f = new (WriteFile ~> M) {
+      def apply[A](wf: WriteFile[A]) = wf match {
+        case Open(loc) =>
+          lookupMounted(mountedWfs, loc)
+            .fold(pathError(pathNotFound(loc)).left[WriteHandle].point[M]) {
+              case (mnt, g) =>
+                evalWrite(g, Open(loc))
+                  .map(_ map prefixH(mountSep, WriteHandle.tupleIso, mnt))
+            }
+
+        case Write(h, chunk) =>
+          mntH(mountSep, WriteHandle.tupleIso, h).flatMap { case (mnt, origH) =>
+            mountedWfs.lookup(mnt) map (evalWrite(_, Write(origH, chunk)))
+          } getOrElse Vector(unknownWriteHandle(h)).point[M]
+
+        case Close(h) =>
+          mntH(mountSep, WriteHandle.tupleIso, h).flatMap { case (mnt, origH) =>
+            mountedWfs.lookup(mnt) map (evalWrite(_, Close(origH)))
+          } getOrElse ().point[M]
+      }
+    }
+
+    Coyoneda.liftTF(f)
+  }
+
+  /** Returns a `ManageFileF` interpreter that selects one of the configured
+    * child interpreters based on the path of the incoming request.
+    */
+  def manageFile[F[_], S[_]](
+    mfs: Mounts[ManageFileF ~> F]
+  )(implicit
+    S0: Functor[S],
+    S1: F :<: S
+  ): ManageFileF ~> Free[S, ?] = {
+    import ManageFile._
+
+    type M[A] = Free[S, A]
+    type ME[A, B] = EitherT[M, A, B]
+
+    val mountedMfs = mfs mapWithDir { case (d, f) =>
+      f compose mounted.manageFile[ManageFileF](d)
+    }
+
+    def evalManage[A](g: ManageFileF ~> F, ma: ManageFile[A]): M[A] =
+      free.lift(g(Coyoneda.lift(ma))).into[S]
+
+    val lookup = lookupMounted(mountedMfs, _: APath)
+
+    def noMountError(path: APath) =
+      pathError(invalidPath(path, "does not refer to a mounted filesystem"))
+
+    val f = new (ManageFile ~> M) {
+      def apply[A](mf: ManageFile[A]) = mf match {
+        case Move(scn, sem) =>
+          val src = lookup(scn.src).toRightDisjunction(
+            pathError(pathNotFound(scn.src)))
+
+          val dst = lookup(scn.dst).toRightDisjunction(
+            noMountError(scn.dst))
+
+          EitherT.fromDisjunction[M](src tuple dst).flatMap {
+            case ((srcMnt, g), (dstMnt, _)) if srcMnt == dstMnt =>
+              EitherT(evalManage(g, Move(scn, sem)))
+
+            case _ =>
+              pathError(invalidPath(
+                scn.dst,
+                s"must refer to the same filesystem as '${posixCodec.printPath(scn.src)}'"
+              )).raiseError[ME, Unit]
+          }.run
+
+        case Delete(path) =>
+          refineType(path).fold(deleteDir, deleteFile)
+
+        case TempFile(near) =>
+          EitherT.fromDisjunction[M](
+            lookup(near) toRightDisjunction noMountError(near)
+          ).flatMapF { case (_, g) =>
+            evalManage(g, TempFile(near))
+          }.run
+      }
+
+      def deleteDir(d: ADir) =
+        lookup(d) cata (
+          { case (_, g) => evalManage(g, Delete(d)) },
+          mountedMfs.toMap.filterKeys(_.relativeTo(d).isDefined)
+            .toList
+            .traverse { case (mnt, g) => evalManage(g, Delete(mnt)) }
+            .map(_.traverseU_(x => x))) // NB: sequenceU_ doesn't exist =(
+
+      def deleteFile(f: AFile) =
+        EitherT.fromDisjunction[M](
+          lookup(f) toRightDisjunction pathError(pathNotFound(f))
+        ).flatMapF { case (_, g) =>
+          evalManage(g, Delete(f))
+        }.run
+    }
+
+    Coyoneda.liftTF(f)
+  }
+
+  /** Returns a `QueryFileF` interpreter that selects one of the configured
+    * child interpreters based on the path of the incoming request.
+    */
+  def queryFile[F[_], S[_]](qfs: Mounts[QueryFileF ~> F])
+                           (implicit S0: Functor[S],
+                                     S1: F :<: S,
+                                     S2: HFSFailureF :<: S,
+                                     S3: MonotonicSeqF :<: S,
+                                     S4: MountedResultHF :<: S)
+                           : QueryFileF ~> Free[S, ?] = {
+    import QueryFile._
+
+    type M[A] = Free[S, A]
+
+    val failure = Failure.Ops[HierarchicalFileSystemError, S]
+    val seq     = MonotonicSeq.Ops[S]
+    val handles = KeyValueStore.Ops[ResultHandle, (ADir, ResultHandle), S]
+    val transforms = Transforms[M]
+    import transforms._
+
+    lazy val mountedQfs = qfs mapWithDir { case (d, f) =>
+      f compose mounted.queryFile[QueryFileF](d)
+    }
+
+    def evalQuery[A](g: QueryFileF ~> F, qa: QueryFile[A]): M[A] =
+      free.lift(g(Coyoneda.lift(qa))).into[S]
+
+    val f = new (QueryFile ~> M) {
+      def apply[A](qf: QueryFile[A]) = qf match {
+        case ExecutePlan(lp, out) =>
+          resultForPlan(lp, some(out), ExecutePlan(lp, out))
+            .map(_._2).run.run
+
+        case EvaluatePlan(lp) =>
+          (for {
+            r    <- resultForPlan(lp, none, EvaluatePlan(lp))
+            newH <- toExec(seq.next.map(ResultHandle(_)))
+            _    <- toExec(handles.put(newH, r))
+          } yield newH).run.run
+
+        case More(h) =>
+          getMounted[S](h, mountedQfs)
+            .toRight(unknownResultHandle(h))
+            .flatMapF { case (qh, g) => evalQuery(g, More(qh)) }
+            .run
+
+        case Close(h) =>
+          getMounted[S](h, mountedQfs)
+            .flatMapF(handles.delete(h).as(_))
+            .flatMapF { case (qh, g) => evalQuery(g, Close(qh)) }
+            .getOrElse(())
+
+        case Explain(lp) =>
+          resultForPlan(lp, none, Explain(lp))
+            .map(_._2).run.run
+
+        case ListContents(d) =>
+          lookupMounted(mountedQfs, d)
+            .map { case (_, g) => evalQuery(g, ListContents(d)) }
+            .orElse(
+              lsMounts(mountedQfs.toMap.keySet, d)
+                .map(_.right[FileSystemError].point[M]))
+            .getOrElse(pathError(pathNotFound(d)).left.point[M])
+
+        case FileExists(f) =>
+          lookupMounted(mountedQfs, f)
+            .map { case (_, g) => evalQuery(g, FileExists(f)) }
+            .getOrElse(pathError(pathNotFound(f)).left.point[M])
+      }
+
+      def resultForPlan[A](
+        lp: Fix[LogicalPlan],
+        out: Option[AFile],
+        qf: QueryFile[(PhaseResults, FileSystemError \/ A)]
+      ): ExecM[(ADir, A)] =
+        mountForPlan(mountedQfs, lp, out) match {
+          case -\/(-\/(hfsErr)) =>
+            toExec(failure.fail[(ADir, A)](hfsErr))
+
+          case -\/(\/-(pErr)) =>
+            EitherT.leftU[(ADir, A)](pathError(pErr).point[G])
+
+          case \/-((mnt, g)) =>
+            EitherT(WriterT(evalQuery(g, qf)): G[FileSystemError \/ A])
+              .strengthL(mnt)
+        }
+    }
+
+    Coyoneda.liftTF(f)
+  }
+
+  def fileSystem[F[_], S[_]](
+    mountSep: DirName,
+    mounts: Mounts[FileSystem ~> F]
+  )(implicit
+    S0: Functor[S],
+    S1: F :<: S,
+    S2: MountedResultHF :<: S,
+    S3: MonotonicSeqF :<: S,
+    S4: HFSFailureF :<: S
+  ): FileSystem ~> Free[S, ?] = {
+    type M[A] = Free[S, A]
+    type FS[A] = FileSystem[A]
+
+    def injFS[G[_]](implicit I: G :<: FS): G ~> FS = injectNT[G, FS]
+
+    val qf: QueryFileF ~> M  = queryFile[F, S](mounts map (_ compose injFS[QueryFileF]))
+    val rf: ReadFileF ~> M   = readFile[F, S](mountSep, mounts map (_ compose injFS[ReadFileF]))
+    val wf: WriteFileF ~> M  = writeFile[F, S](mountSep, mounts map (_ compose injFS[WriteFileF]))
+    val mf: ManageFileF ~> M = manageFile[F, S](mounts map (_ compose injFS[ManageFileF]))
+
+    free.interpret4(qf, rf, wf, mf)
+  }
+
+  ////
+
+  private def lookupMounted[A](mounts: Mounts[A], path: APath): Option[(ADir, A)] =
+    mounts.toMap find { case (d, a) => path.relativeTo(d).isDefined }
+
+  private def mountForPlan[A](
+    mounts: Mounts[A],
+    lp: Fix[LogicalPlan],
+    out: Option[AFile]
+  ): (HierarchicalFileSystemError \/ PathError2) \/ (ADir, A) = {
+    import LogicalPlan._
+    import HierarchicalFileSystemError._
+
+    type MntA = (ADir, A)
+    type F[A] = State[Option[MntA], A]
+    type M[A] = EitherT[F, PathError2, A]
+
+    val F = MonadState[State, Option[MntA]]
+
+    def lookupMnt(p: APath): PathError2 \/ MntA =
+      lookupMounted(mounts, p) toRightDisjunction PathNotFound(p)
+
+    def compareToExisting(mnt: ADir): M[Unit] = {
+      def errMsg(exMnt: ADir): PathError2 =
+        InvalidPath(mnt, s"refers to a different filesystem than '${posixCodec.printPath(exMnt)}'")
+
+      EitherT[F, PathError2, Unit](F.gets(exMnt =>
+        exMnt map (_._1) filter (_ != mnt) map errMsg toLeftDisjunction (())
+      ))
+    }
+
+    def mountFor(p: APath): M[Unit] = for {
+      mntA     <- EitherT.fromDisjunction[F](lookupMnt(p))
+      (mnt, a) =  mntA
+      _        <- compareToExisting(mnt)
+      _        <- F.put(some(mntA)).liftM[PathErr2T]
+    } yield ()
+
+    out.cata(d => lookupMnt(d) bimap (_.right, some), none.right) flatMap (initMnt =>
+      lp.cataM[M, Unit] {
+        case ReadF(p) => mountFor(p.asAPath)
+        case _        => ().point[M]
+      }.run.run(initMnt) match {
+        // TODO: If mnt is empty, then there were no `ReadF`, so we should
+        //       be able to get a result without needing an actual filesystem
+        //       Though, if that is the case, the plan shouldn't even be handed
+        //       to a filesystem in the first place.
+        case (mntA, r) =>
+          r.leftMap(_.right[HierarchicalFileSystemError]) *>
+            mntA.toRightDisjunction(multipleMountsApply(mounts.toMap.keySet, lp).left)
+      })
+  }
+
+  private def lsMounts(mounts: Set[ADir], ls: ADir): Option[Set[Node]] = {
+    def mkNode(rdir: RDir): Option[Node] =
+      flatten(none, none, none, n => dir(n).some, κ(none), rdir).toList.unite match {
+        case d :: Nil => Node.Mount(d).some
+        case d :: _   => Node.Plain(d).some
+        case Nil      => none
+      }
+
+    mounts.toList.map(_ relativeTo ls flatMap mkNode).unite match {
+      case Nil => none
+      case xs  => xs.toSet.some
+    }
+  }
+
+  /** Returns the extracted mount from the given handle and a new handle with
+    * the mount prefix and separator removed.
+    */
+  private def mntH[H](sep: DirName, iso: Iso[H, (AFile, Long)], h: H): Option[(ADir, H)] = {
+    import IList.{single, empty}
+    type F[A] = Option[(ADir, A)]
+
+    def splitAtSep(f: AFile): Option[(ADir, AFile)] = {
+      val segs = {
+        val ss = flatten[IList[String]](empty, empty, empty, single, single, f)
+        (ss.head :: ss.tail).join
+      }
+      val mntSegs = segs.takeWhile(_ != sep.value)
+      val fileSegs = segs.drop(mntSegs.length + 1)
+
+      val mnt = mntSegs.foldLeft(rootDir[Sandboxed])(_ </> dir(_))
+      val origF = fileSegs.toNel.map(_.reverse).map { nel =>
+        nel.tail.foldRight(rootDir[Sandboxed])((s, d) => d </> dir(s)) </> file(nel.head)
+      }
+
+      origF strengthL mnt
+    }
+
+    iso.composeLens(_1)
+      .modifyF[F](splitAtSep)(h)(Functor[Option].compose[(ADir, ?)])
+  }
+
+  /** Returns a function that adds a mount-specific prefix to a handle,
+    * separated by `sep`.
+    */
+  private def prefixH[H](sep: DirName, iso: Iso[H, (AFile, Long)], mnt: ADir): H => H =
+    iso.composeLens(_1) modify { f =>
+      f.relativeTo(rootDir).fold(f)(rf => mnt </> dir1(sep) </> rf)
+    }
+
+  private object getMounted {
+    final class Aux[S[_]] {
+      type F[A] = Free[S, A]
+
+      def apply[A, B](a: A, mnts: Mounts[B])
+                     (implicit S: Functor[S], I: KeyValueStoreF[A, (ADir, A), ?] :<: S)
+                     : OptionT[F, (A, B)] = {
+        KeyValueStore.Ops[A, (ADir, A), S].get(a) flatMap { case (d, a1) =>
+          OptionT(mnts.lookup(d).strengthL(a1).point[F])
+        }
+      }
+    }
+
+    def apply[S[_]]: Aux[S] = new Aux[S]
+  }
+}

--- a/core/src/main/scala/quasar/fs/mounted.scala
+++ b/core/src/main/scala/quasar/fs/mounted.scala
@@ -16,194 +16,45 @@
 
 package quasar.fs
 
-import quasar.LogicalPlan, LogicalPlan.ReadF
-import quasar.fp.free.injectedNT
-import quasar.recursionschemes._, FunctorT.ops._
-
-import monocle.Optional
-import monocle.function.Field1
-import monocle.std.tuple2._
-import pathy.{Path => PPath}, PPath._
-import scalaz._
-import scalaz.std.tuple._
-import scalaz.syntax.functor._
+import scalaz._, NaturalTransformation.refl
 
 object mounted {
 
   /** Strips the `mountPoint` off of all input paths in `ReadFile` operations
     * and restores it on output paths.
     */
-   def readFile[S[_]: Functor](mountPoint: ADir)
-                              (implicit S: ReadFileF :<: S)
-                              : S ~> S = {
-    import ReadFile._
-
-    val g = new (ReadFile ~> ReadFileF) {
-      def apply[A](rf: ReadFile[A]) = rf match {
-        case Open(src, off, lim) =>
-          Coyoneda.lift(Open(stripPrefixA(mountPoint)(src), off, lim))
-            .map(_ leftMap rebasePathError(mountPoint))
-
-        case Read(h) =>
-          Coyoneda.lift(Read(h))
-            .map(_ leftMap rebasePathError(mountPoint))
-
-        case Close(h) =>
-          Coyoneda.lift(Close(h))
-      }
-    }
-
-    injectedNT[ReadFileF, S](Coyoneda.liftTF(g))
-  }
+   def readFile[S[_]: Functor](mountPoint: ADir)(implicit S: ReadFileF :<: S): S ~> S =
+     transformPaths.readFile[S](stripPrefixA(mountPoint), rebaseA(mountPoint))
 
   /** Strips the `mountPoint` off of all input paths in `WriteFile` operations
     * and restores it on output paths.
     */
-  def writeFile[S[_]: Functor](mountPoint: ADir)
-                              (implicit S: WriteFileF :<: S)
-                              : S ~> S = {
-    import WriteFile._
-
-    val g = new (WriteFile ~> WriteFileF) {
-      def apply[A](wf: WriteFile[A]) = wf match {
-        case Open(dst) =>
-          Coyoneda.lift(Open(stripPrefixA(mountPoint)(dst)))
-            .map(_ leftMap rebasePathError(mountPoint))
-
-        case Write(h, d) =>
-          Coyoneda.lift(Write(h, d))
-            .map(_ map rebasePathError(mountPoint))
-
-        case Close(h) =>
-          Coyoneda.lift(Close(h))
-      }
-    }
-
-    injectedNT[WriteFileF, S](Coyoneda.liftTF(g))
-  }
+  def writeFile[S[_]: Functor](mountPoint: ADir)(implicit S: WriteFileF :<: S): S ~> S =
+    transformPaths.writeFile[S](stripPrefixA(mountPoint), rebaseA(mountPoint))
 
   /** Strips the `mountPoint` off of all input paths in `ManageFile` operations
     * and restores it on output paths.
     */
-  def manageFile[S[_]: Functor](mountPoint: ADir)
-                               (implicit S: ManageFileF :<: S)
-                               : S ~> S = {
-    import ManageFile._, MoveScenario._
-
-    val g = new (ManageFile ~> ManageFileF) {
-      def apply[A](mf: ManageFile[A]) = mf match {
-        case Move(scn, sem) =>
-          Coyoneda.lift(Move(
-            scn.fold(
-              (src, dst) => DirToDir(
-                stripPrefixA(mountPoint)(src),
-                stripPrefixA(mountPoint)(dst)),
-              (src, dst) => FileToFile(
-                stripPrefixA(mountPoint)(src),
-                stripPrefixA(mountPoint)(dst))),
-            sem))
-            .map(_ leftMap rebasePathError(mountPoint))
-
-        case Delete(p) =>
-          Coyoneda.lift(Delete(stripPrefixA(mountPoint)(p)))
-            .map(_ leftMap rebasePathError(mountPoint))
-
-        case TempFile(p) =>
-          Coyoneda.lift(TempFile(stripPrefixA(mountPoint)(p)))
-            .map(_ bimap (rebasePathError(mountPoint), rebaseA(_, mountPoint)))
-      }
-    }
-
-    injectedNT[ManageFileF, S](Coyoneda.liftTF(g))
-  }
+  def manageFile[S[_]: Functor](mountPoint: ADir)(implicit S: ManageFileF :<: S): S ~> S =
+    transformPaths.manageFile[S](stripPrefixA(mountPoint), rebaseA(mountPoint))
 
   /** Strips the `mountPoint` off of all input paths in `QueryFile` operations
     * and restores it on output paths.
     */
-  def queryFile[S[_]: Functor](mountPoint: ADir)
-                              (implicit S: QueryFileF :<: S)
-                              : S ~> S = {
-    import QueryFile._
+  def queryFile[S[_]: Functor](mountPoint: ADir)(implicit S: QueryFileF :<: S): S ~> S =
+    transformPaths.queryFile[S](stripPrefixA(mountPoint), rebaseA(mountPoint), refl)
 
-    val base = Path(posixCodec.printPath(mountPoint))
-
-    val stripPlan: LogicalPlan ~> LogicalPlan =
-      new (LogicalPlan ~> LogicalPlan) {
-        def apply[A](lp: LogicalPlan[A]) = lp match {
-          case ReadF(p) => ReadF(p.rebase(base).map(_.asAbsolute) | p)
-          case _        => lp
-        }
-      }
-
-    val g = new (QueryFile ~> QueryFileF) {
-      def apply[A](qf: QueryFile[A]) = qf match {
-        case ExecutePlan(lp, out) =>
-          Coyoneda.lift(ExecutePlan(lp.translate(stripPlan), stripPrefixA(mountPoint)(out)))
-            .map(_.map(_.bimap(rebasePathError(mountPoint), rebaseA(_, mountPoint))))
-
-        case EvaluatePlan(lp) =>
-          Coyoneda.lift(EvaluatePlan(lp.translate(stripPlan)))
-            .map(_.map(_ leftMap rebasePathError(mountPoint)))
-
-        case More(h) =>
-          Coyoneda.lift(More(h))
-            .map(_ leftMap rebasePathError(mountPoint))
-
-        case Close(h) =>
-          Coyoneda.lift(Close(h))
-
-        case Explain(lp) =>
-          Coyoneda.lift(Explain(lp.translate(stripPlan)))
-            .map(_.map(_.leftMap(rebasePathError(mountPoint))))
-
-        case ListContents(d) =>
-          Coyoneda.lift(ListContents(stripPrefixA(mountPoint)(d)))
-            .map(_.leftMap(rebasePathError(mountPoint)))
-
-        case FileExists(f) =>
-          Coyoneda.lift(FileExists(stripPrefixA(mountPoint)(f)))
-            .map(_.leftMap(rebasePathError(mountPoint)))
-      }
-    }
-
-    injectedNT[QueryFileF, S](Coyoneda.liftTF(g))
-  }
-
-  def fileSystem[S[_]: Functor](mountPoint: ADir)
-                               (implicit S0: ReadFileF :<: S,
-                                         S1: WriteFileF :<: S,
-                                         S2: ManageFileF :<: S,
-                                         S3: QueryFileF :<: S)
-                               : S ~> S = {
-
+  def fileSystem[S[_]: Functor](
+    mountPoint: ADir
+  )(implicit
+    S0: ReadFileF :<: S,
+    S1: WriteFileF :<: S,
+    S2: ManageFileF :<: S,
+    S3: QueryFileF :<: S
+  ): S ~> S = {
     readFile[S](mountPoint)   compose
     writeFile[S](mountPoint)  compose
     manageFile[S](mountPoint) compose
     queryFile[S](mountPoint)
-  }
-
-  ////
-
-  private val fsPathError: Optional[FileSystemError, APath] =
-    FileSystemError.pathError composeLens PathError2.errorPath
-
-  private val fsPlannerError: Optional[FileSystemError, Fix[LogicalPlan]] =
-    FileSystemError.plannerError composeLens Field1.first
-
-  private def rebasePathError(onto: ADir): FileSystemError => FileSystemError = {
-    val base = Path(posixCodec.printPath(onto))
-
-    val rebaseRead: LogicalPlan ~> LogicalPlan =
-      new (LogicalPlan ~> LogicalPlan) {
-        def apply[A](lp: LogicalPlan[A]) = lp match {
-          case ReadF(p) => ReadF(base ++ p)
-          case _        => lp
-        }
-      }
-
-    val rebasePlan: Fix[LogicalPlan] => Fix[LogicalPlan] =
-      _ translate rebaseRead
-
-    fsPathError.modify(rebaseA(_, onto)) compose fsPlannerError.modify(rebasePlan)
   }
 }

--- a/core/src/main/scala/quasar/fs/path.scala
+++ b/core/src/main/scala/quasar/fs/path.scala
@@ -18,6 +18,7 @@ package quasar.fs
 
 import quasar.Predef._
 
+import pathy.{Path => PPath}
 import scalaz._, Scalaz._
 
 // TODO: Should probably make this an ADT
@@ -59,6 +60,17 @@ final case class Path(dir: List[DirNode], file: Option[FileNode]) {
   def asDir: Path = file match {
     case Some(fileNode) => Path(dir :+ DirNode(fileNode.value), None)
     case None => this
+  }
+
+  /** Interpret as an absolute Pathy path, treating relative paths as relative
+    * to the root directory.
+    */
+  def asAPath: APath = {
+    import PPath._
+    val abs = asAbsolute
+    val absDir = abs.dir.foldLeft(PPath.rootDir[Sandboxed])(
+      (d, n) => d </> PPath.dir(n.value))
+    abs.file.map(n => absDir </> PPath.file(n.value)) getOrElse absDir
   }
 
   def relative = dir.headOption == Some(DirNode.Current)

--- a/core/src/main/scala/quasar/fs/path.scala
+++ b/core/src/main/scala/quasar/fs/path.scala
@@ -73,6 +73,12 @@ final case class Path(dir: List[DirNode], file: Option[FileNode]) {
     abs.file.map(n => absDir </> PPath.file(n.value)) getOrElse absDir
   }
 
+  def asADir: Option[ADir] =
+    PPath.maybeDir(asAPath)
+
+  def asAFile: Option[AFile] =
+    PPath.maybeFile(asAPath)
+
   def relative = dir.headOption == Some(DirNode.Current)
 
   def absolute = !relative
@@ -146,6 +152,9 @@ object Path {
   def fileRel(file0: String) = file("." :: Nil, file0)
 
   def canonicalize(value: String): String = Path(value).pathname
+
+  def fromAPath(apath: APath): Path =
+    Path(PPath.posixCodec.printPath(apath))
 
   type PathErrT[F[_], A] = EitherT[F, PathError, A]
 

--- a/core/src/main/scala/quasar/fs/transformPaths.scala
+++ b/core/src/main/scala/quasar/fs/transformPaths.scala
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2014 - 2015 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.fs
+
+import quasar.LogicalPlan, LogicalPlan.ReadF
+import quasar.fp.free.injectedNT
+import quasar.recursionschemes.{FunctorT, Fix}, FunctorT.ops._
+
+import monocle.Optional
+import monocle.syntax.fields._
+import monocle.std.tuple2._
+import scalaz.{Optional => _, _}
+import scalaz.std.tuple._
+import scalaz.syntax.functor._
+
+object transformPaths {
+
+  /** Returns a natural transformation that transforms all paths in `ReadFile`
+    * operations using the given transformations.
+    *
+    * @param inPath transforms input paths
+    * @param outPath transforms output paths (including those in errors)
+    */
+  def readFile[S[_]: Functor](
+    inPath: AbsPath ~> AbsPath,
+    outPath: AbsPath ~> AbsPath
+  )(implicit
+    S: ReadFileF :<: S
+  ): S ~> S = {
+    import ReadFile._
+
+    val g = new (ReadFile ~> ReadFileF) {
+      def apply[A](rf: ReadFile[A]) = rf match {
+        case Open(src, off, lim) =>
+          Coyoneda.lift(Open(inPath(src), off, lim))
+            .map(_ leftMap transformErrorPath(outPath))
+
+        case Read(h) =>
+          Coyoneda.lift(Read(h))
+            .map(_ leftMap transformErrorPath(outPath))
+
+        case Close(h) =>
+          Coyoneda.lift(Close(h))
+      }
+    }
+
+    injectedNT[ReadFileF, S](Coyoneda.liftTF(g))
+  }
+
+  /** Returns a natural transformation that transforms all paths in `WriteFile`
+    * operations using the given functions.
+    *
+    * @param inPath transforms input paths
+    * @param outPath transforms output paths (including those in errors)
+    */
+  def writeFile[S[_]: Functor](
+    inPath: AbsPath ~> AbsPath,
+    outPath: AbsPath ~> AbsPath
+  )(implicit
+    S: WriteFileF :<: S
+  ): S ~> S = {
+    import WriteFile._
+
+    val g = new (WriteFile ~> WriteFileF) {
+      def apply[A](wf: WriteFile[A]) = wf match {
+        case Open(dst) =>
+          Coyoneda.lift(Open(inPath(dst)))
+            .map(_ leftMap transformErrorPath(outPath))
+
+        case Write(h, d) =>
+          Coyoneda.lift(Write(h, d))
+            .map(_ map transformErrorPath(outPath))
+
+        case Close(h) =>
+          Coyoneda.lift(Close(h))
+      }
+    }
+
+    injectedNT[WriteFileF, S](Coyoneda.liftTF(g))
+  }
+
+  /** Returns a natural transformation that transforms all paths in `ManageFile`
+    * operations using the given functions.
+    *
+    * @param inPath transforms input paths
+    * @param outPath transforms output paths (including those in errors)
+    */
+  def manageFile[S[_]: Functor](
+    inPath: AbsPath ~> AbsPath,
+    outPath: AbsPath ~> AbsPath
+  )(implicit S:
+    ManageFileF :<: S
+  ): S ~> S = {
+    import ManageFile._, MoveScenario._
+
+    val g = new (ManageFile ~> ManageFileF) {
+      def apply[A](mf: ManageFile[A]) = mf match {
+        case Move(scn, sem) =>
+          Coyoneda.lift(Move(
+            scn.fold(
+              (src, dst) => DirToDir(inPath(src), inPath(dst)),
+              (src, dst) => FileToFile(inPath(src), inPath(dst))),
+            sem))
+            .map(_ leftMap transformErrorPath(outPath))
+
+        case Delete(p) =>
+          Coyoneda.lift(Delete(inPath(p)))
+            .map(_ leftMap transformErrorPath(outPath))
+
+        case TempFile(p) =>
+          Coyoneda.lift(TempFile(inPath(p)))
+            .map(_ bimap (transformErrorPath(outPath), outPath(_)))
+      }
+    }
+
+    injectedNT[ManageFileF, S](Coyoneda.liftTF(g))
+  }
+
+  /** Returns a natural transformation that transforms all paths in `QueryFile`
+    * operations using the given functions.
+    *
+    * @param inPath transforms input paths
+    * @param outPath transforms output paths (including those in errors)
+    * @param outPathR transforms relative output paths
+    */
+  def queryFile[S[_]: Functor](
+    inPath: AbsPath ~> AbsPath,
+    outPath: AbsPath ~> AbsPath,
+    outPathR: RelPath ~> RelPath
+  )(implicit
+    S: QueryFileF :<: S
+  ): S ~> S = {
+    import QueryFile._
+
+    val g = new (QueryFile ~> QueryFileF) {
+      def apply[A](qf: QueryFile[A]) = qf match {
+        case ExecutePlan(lp, out) =>
+          Coyoneda.lift(ExecutePlan(lp.translate(transformLPPaths(inPath)), inPath(out)))
+            .map(_.map(_.bimap(transformErrorPath(outPath), outPath(_))))
+
+        case EvaluatePlan(lp) =>
+          Coyoneda.lift(EvaluatePlan(lp.translate(transformLPPaths(inPath))))
+            .map(_.map(_ leftMap transformErrorPath(outPath)))
+
+        case More(h) =>
+          Coyoneda.lift(More(h))
+            .map(_ leftMap transformErrorPath(outPath))
+
+        case Close(h) =>
+          Coyoneda.lift(Close(h))
+
+        case Explain(lp) =>
+          Coyoneda.lift(Explain(lp.translate(transformLPPaths(inPath))))
+            .map(_.map(_ leftMap transformErrorPath(outPath)))
+
+        case ListContents(d) =>
+          Coyoneda.lift(ListContents(inPath(d)))
+            .map(_.bimap(transformErrorPath(outPath), _ map transformNodePath(outPathR)))
+
+        case FileExists(f) =>
+          Coyoneda.lift(FileExists(inPath(f)))
+            .map(_ leftMap transformErrorPath(outPath))
+      }
+    }
+
+    injectedNT[QueryFileF, S](Coyoneda.liftTF(g))
+  }
+
+  /** Returns a natural transformation that transforms all paths in `FileSystem`
+    * operations using the given functions.
+    *
+    * @param inPath transforms input paths
+    * @param outPath transforms output paths (including those in errors)
+    * @param outPathR transforms relative output paths
+    */
+  def fileSystem[S[_]: Functor](
+    inPath: AbsPath ~> AbsPath,
+    outPath: AbsPath ~> AbsPath,
+    outPathR: RelPath ~> RelPath
+  )(implicit
+    S0: ReadFileF :<: S,
+    S1: WriteFileF :<: S,
+    S2: ManageFileF :<: S,
+    S3: QueryFileF :<: S
+  ): S ~> S = {
+    readFile[S](inPath, outPath)   compose
+    writeFile[S](inPath, outPath)  compose
+    manageFile[S](inPath, outPath) compose
+    queryFile[S](inPath, outPath, outPathR)
+  }
+
+  ////
+
+  private val fsPathError: Optional[FileSystemError, APath] =
+    FileSystemError.pathError composeLens PathError2.errorPath
+
+  private val fsPlannerError: Optional[FileSystemError, Fix[LogicalPlan]] =
+    FileSystemError.plannerError composeLens _1
+
+  private def transformErrorPath(
+    f: AbsPath ~> AbsPath
+  ): FileSystemError => FileSystemError =
+    fsPathError.modify(f(_)) compose
+      fsPlannerError.modify(_ translate transformLPPaths(f))
+
+  private def transformLPPaths(f: AbsPath ~> AbsPath): LogicalPlan ~> LogicalPlan =
+    new (LogicalPlan ~> LogicalPlan) {
+      def apply[A](lp: LogicalPlan[A]) = lp match {
+        case ReadF(p) => ReadF(Path.fromAPath(f(p.asAPath)))
+        case _        => lp
+      }
+    }
+
+  private def transformNodePath(f: RelPath ~> RelPath): Node => Node =
+    _.fold(
+      Node.Mount compose (f(_)),
+      Node.Plain compose (f(_)),
+      Node.View  compose (f(_)))
+}

--- a/core/src/main/scala/quasar/mount/MapMounter.scala
+++ b/core/src/main/scala/quasar/mount/MapMounter.scala
@@ -29,14 +29,14 @@ object MapMounter {
   type VCfg                 = (Expr, Variables)
   type FsCfg                = (FileSystemType, ConnectionUri)
   type ViewMounts           = Map[AFile, VCfg]
-  type FsMounts             = Map[ADir, FsCfg]
-  type MapMounterT[F[_], A] = StateT[F, Mounts, A]
+  type FsMounts             = Mounts[FsCfg]
+  type MapMounterT[F[_], A] = StateT[F, Mountings, A]
   type MountR               = Either3[String, EnvironmentError2, Unit]
 
-  final case class Mounts(view: ViewMounts, fs: FsMounts)
+  final case class Mountings(view: ViewMounts, fs: FsMounts)
 
-  object Mounts {
-    val empty: Mounts = Mounts(Map.empty, Map.empty)
+  object Mountings {
+    val empty: Mountings = Mountings(Map.empty, Mounts.empty)
   }
 
   /** `Mounting` interpreter using in-memory maps to maintain state.
@@ -63,9 +63,7 @@ private final class MapMounter[F[_]: Monad](
 
   def apply[A](m: Mounting[A]) = m match {
     case Lookup(path) =>
-      refineType(path)
-        .fold(fsMntL, viewMntL)
-        .st.lift[F]
+      refineType(path).fold(lookupFsMnt, f => viewMntL(f).st.lift[F])
 
     case MountView(loc, query, vars) =>
       OptionT[Mnt, VCfg](viewL(loc).st.lift[F])
@@ -75,53 +73,61 @@ private final class MapMounter[F[_]: Monad](
         .run
 
     case MountFileSystem(loc, typ, uri) =>
-      OptionT[Mnt, FsCfg](fsL(loc).st.lift[F])
+      OptionT[Mnt, FsCfg](lookupFsCfg(loc))
         .as(pathExists(loc))
         .toLeft(())
         .flatMap(κ(mountFileSystem(loc, typ, uri)))
         .run
 
     case Unmount(path) =>
-      refineType(path)
-        .fold(fsMntL, viewMntL)
-        .assigno(None)
-        .map(_.void \/> pathNotFound(path))
-        .lift[F]
+      refineType(path).fold(
+        d => OptionT(lookupFsMnt(d))
+               .toRight(pathNotFound(path))
+               .flatMap(κ(liftPure(fssL.mods_(_ - d))))
+               .run,
+        f => viewMntL(f)
+               .assigno(None)
+               .map(_.void \/> pathNotFound(path))
+               .lift[F])
   }
 
   val pathNotFound = MountingError.pathError composePrism PathError2.pathNotFound
   val pathExists = MountingError.pathError composePrism PathError2.pathExists
   val invalidPath = MountingError.pathError composePrism PathError2.invalidPath
 
-  val viewsL: Mounts @> ViewMounts =
+  val viewsL: Mountings @> ViewMounts =
     Lens.lensu((m, vs) => m.copy(view = vs), _.view)
 
-  def viewL(f: AFile): Mounts @> Option[VCfg] =
+  def viewL(f: AFile): Mountings @> Option[VCfg] =
     Lens.mapVLens(f) <=< viewsL
 
-  def viewMntL(f: AFile): Mounts @> Option[MountConfig2] =
+  def viewMntL(f: AFile): Mountings @> Option[MountConfig2] =
     viewL(f).xmapB(_ map (viewConfig(_)))(_ flatMap viewConfig.getOption)
 
-  val fssL: Mounts @> FsMounts =
+  val fssL: Mountings @> FsMounts =
     Lens.lensu((m, f) => m.copy(fs = f), _.fs)
 
-  def fsL(d: ADir): Mounts @> Option[FsCfg] =
-    Lens.mapVLens(d) <=< fssL
+  def lookupFsCfg(d: ADir): Mnt[Option[FsCfg]] =
+    fssL.st.map(_ lookup d).lift[F]
 
-  def fsMntL(d: ADir): Mounts @> Option[MountConfig2] =
-    fsL(d).xmapB(_ map (fileSystemConfig(_)))(_ flatMap fileSystemConfig.getOption)
+  def lookupFsMnt(d: ADir): Mnt[Option[MountConfig2]] =
+    lookupFsCfg(d) map (_ map (fileSystemConfig(_)))
 
   def mountView(loc: AFile, query: Expr, vars: Variables): MntE[Unit] =
     mount(viewConfig(query, vars)) *>
       liftPure(viewL(loc).assign((query, vars).some).void)
 
   def mountFileSystem(loc: ADir, typ: FileSystemType, uri: ConnectionUri): MntE[Unit] = {
-    val checkOverlaps: MntE[Unit] =
-      EitherT(ensureNoOverlaps(loc).lift[F]: Mnt[MountingError \/ Unit])
+    def addMountTo(mnts: FsMounts): MntE[FsMounts] =
+      EitherT.fromDisjunction[Mnt](
+        mnts.add(loc, (typ, uri)).leftMap(invalidPath(loc, _)))
 
-    checkOverlaps                         *>
-    mount(fileSystemConfig(typ, uri))     <*
-    liftPure(fsL(loc) := (typ, uri).some)
+    for {
+      prevMnts <- liftPure(fssL.st)
+      newMnts  <- addMountTo(prevMnts)
+      _        <- mount(fileSystemConfig(typ, uri))
+      _        <- liftPure(fssL := newMnts)
+    } yield ()
   }
 
   def mount(cfg: MountConfig2): MntE[Unit] =
@@ -131,18 +137,6 @@ private final class MapMounter[F[_]: Monad](
         e => MountingError.environmentError(e).left,
         _ => ().right)).liftM[MapMounterT])
 
-  def liftPure[A](a: State[Mounts, A]): MntE[A] =
+  def liftPure[A](a: State[Mountings, A]): MntE[A] =
     (a.lift[F]: Mnt[A]).liftM[MntErrT]
-
-  def ensureNoOverlaps(d0: ADir): State[Mounts, MountingError \/ Unit] =
-    fssL.st map { fss =>
-      fss.keys.toList.traverseU_(d1 =>
-        d1.relativeTo(d0)
-          .as("existing mount below: " + posixCodec.printPath(d1))
-          .toLeftDisjunction(()) *>
-        d0.relativeTo(d1)
-          .as("existing mount above: " + posixCodec.printPath(d1))
-          .toLeftDisjunction(())
-      ) leftMap (invalidPath(d0, _))
-    }
 }

--- a/core/src/main/scala/quasar/mount/Mounts.scala
+++ b/core/src/main/scala/quasar/mount/Mounts.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2014 - 2015 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.mount
+
+import quasar.Predef._
+import quasar.fs.ADir
+
+import pathy.Path._
+import scalaz._, Scalaz._
+
+/** A mapping of values to directory paths, maintains the invariant that no
+  * path is a prefix of any other path.
+  *
+  * The current implementation is linear in the number of mounts, might be able
+  * to do better using a bintree given an `Order` on `ADir`.
+  */
+final class Mounts[A] private (val toMap: Map[ADir, A]) {
+  def add(at: ADir, a: A): String \/ Mounts[A] = {
+    def added: Mounts[A] =
+      new Mounts(toMap + (at -> a))
+
+    if (toMap contains at)
+      added.right
+    else
+      toMap.keys.toStream.traverseU_ { mnt =>
+        mnt.relativeTo(at)
+          .as("existing mount below: " + posixCodec.printPath(mnt))
+          .toLeftDisjunction(()) *>
+        at.relativeTo(mnt)
+          .as("existing mount above: " + posixCodec.printPath(mnt))
+          .toLeftDisjunction(())
+      } as added
+  }
+
+  def + (mount: (ADir, A)): String \/ Mounts[A] =
+    add(mount._1, mount._2)
+
+  def remove(at: ADir): Mounts[A] =
+    new Mounts(toMap - at)
+
+  def - (at: ADir): Mounts[A] =
+    remove(at)
+
+  def lookup(at: ADir): Option[A] =
+    toMap.get(at)
+
+  def mapWithDir[B](f: (ADir, A) => B): Mounts[B] =
+    new Mounts(toMap map { case (d, a) => (d, f(d, a)) })
+
+  def map[B](f: A => B): Mounts[B] =
+    mapWithDir((_, a) => f(a))
+
+  /** Right-biased union of two `Mounts`. */
+  def union(other: Mounts[A]): String \/ Mounts[A] =
+    other.toMap.toList.foldLeftM[String \/ ?, Mounts[A]](this)(_ + _)
+}
+
+object Mounts {
+  def empty[A] = _empty.asInstanceOf[Mounts[A]]
+
+  def singleton[A](dir: ADir, a: A): Mounts[A] =
+    new Mounts(Map(dir -> a))
+
+  def fromFoldable[F[_]: Foldable, A](entries: F[(ADir, A)]): String \/ Mounts[A] =
+    entries.foldLeftM[String \/ ?, Mounts[A]](empty[A])(_ + _)
+
+  implicit val mountsFunctor: Functor[Mounts] =
+    new Functor[Mounts] {
+      def map[A, B](fa: Mounts[A])(f: A => B) = fa map f
+    }
+
+  ////
+
+  private val _empty = new Mounts(Map())
+}

--- a/core/src/main/scala/quasar/physical/mongodb/fs/queryfile.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/fs/queryfile.scala
@@ -91,7 +91,7 @@ private final class QueryFileInterpreter[C](
         (for {
           _      <- checkPathsExist(lp)
           dst    <- EitherT(Collection.fromPathy(out)
-                              .leftMap(PathError)
+                              .leftMap(pathError(_))
                               .point[MongoLogWF])
           wf     <- convertPlanR(lp)(MongoDbPlanner plan lp)
           prefix <- liftMQ(genPrefix)
@@ -113,7 +113,7 @@ private final class QueryFileInterpreter[C](
 
     case More(h) =>
       moreResults(h)
-        .toRight(UnknownResultHandle(h))
+        .toRight(unknownResultHandle(h))
         .run
 
     case Close(h) =>
@@ -213,7 +213,7 @@ private final class QueryFileInterpreter[C](
   private def convertPlanR(lp: Fix[LogicalPlan]): PlanR ~> MongoLogWFR =
     new (PlanR ~> MongoLogWFR) {
       def apply[A](pa: PlanR[A]) = {
-        val r = pa.leftMap(PlannerError(lp, _)).run
+        val r = pa.leftMap(plannerError(lp, _)).run
         val f: MongoLogWF[FileSystemError \/ A] = WriterT(r.point[MQ])
         EitherT(f)
       }
@@ -254,9 +254,9 @@ private final class QueryFileInterpreter[C](
   private def checkPathsExist(lp: Fix[LogicalPlan]): MongoLogWFR[Unit] = {
     def checkPathExists(p: QPath): MongoFsM[Unit] = for {
       coll <- EitherT.fromDisjunction[MongoDbIO](Collection.fromPath(p))
-                .leftMap(e => PathError(InvalidPath(qPathToPathy(p), e.message)))
+                .leftMap(e => pathError(InvalidPath(qPathToPathy(p), e.message)))
       _    <- EitherT(MongoDbIO.collectionExists(coll)
-                .map(_ either (()) or PathError(PathNotFound(qPathToPathy(p)))))
+                .map(_ either (()) or pathError(PathNotFound(qPathToPathy(p)))))
     } yield ()
 
     EitherT[MongoLogWF, FileSystemError, Unit](

--- a/core/src/main/scala/quasar/physical/mongodb/fs/queryfile.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/fs/queryfile.scala
@@ -254,9 +254,9 @@ private final class QueryFileInterpreter[C](
   private def checkPathsExist(lp: Fix[LogicalPlan]): MongoLogWFR[Unit] = {
     def checkPathExists(p: QPath): MongoFsM[Unit] = for {
       coll <- EitherT.fromDisjunction[MongoDbIO](Collection.fromPath(p))
-                .leftMap(e => pathError(InvalidPath(qPathToPathy(p), e.message)))
+                .leftMap(e => pathError(InvalidPath(p.asAPath, e.message)))
       _    <- EitherT(MongoDbIO.collectionExists(coll)
-                .map(_ either (()) or pathError(PathNotFound(qPathToPathy(p)))))
+                .map(_ either (()) or pathError(PathNotFound(p.asAPath))))
     } yield ()
 
     EitherT[MongoLogWF, FileSystemError, Unit](
@@ -271,14 +271,6 @@ private final class QueryFileInterpreter[C](
       case ReadF(p) => Set(p)
       case other    => other.fold
     })
-
-  // TODO: This is a hack, but is only used to create a Pathy.Path for error
-  //       messages and will go away once LogicalPlan is converted to Pathy.
-  private def qPathToPathy(p: QPath): APath = {
-    val abs = p.asAbsolute
-    val absDir = abs.dir.foldLeft(rootDir[Sandboxed])((d, n) => d </> dir(n.value))
-    abs.file.map(n => absDir </> file(n.value)) getOrElse absDir
-  }
 
   private def moreResults(h: ResultHandle): OptionT[MQ, Vector[Data]] = {
     def pureNextChunk(bsons: List[Bson]) =

--- a/core/src/main/scala/quasar/physical/mongodb/fs/readfile.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/fs/readfile.scala
@@ -17,7 +17,9 @@
 package quasar.physical.mongodb.fs
 
 import quasar.Predef._
+import quasar.Data
 import quasar.fp.TaskRef
+import quasar.fp.prism._
 import quasar.fs._
 import quasar.physical.mongodb._
 import quasar.physical.mongodb.fs.bsoncursor._
@@ -44,7 +46,7 @@ object readfile {
       case Read(h) =>
         lookupCursor(h)
           .flatMapF(c => DC.nextChunk(c).liftM[ReadStateT])
-          .toRight(UnknownReadHandle(h))
+          .toRight(unknownReadHandle(h))
           .run
 
       case Close(h) =>
@@ -106,9 +108,9 @@ object readfile {
       } yield h
 
     Collection.fromPathy(f).fold(
-      err  => PathError(err).left.point[MongoRead],
+      err  => pathError(err).left.point[MongoRead],
       coll => collectionExists(coll).liftM[ReadStateT].ifM(
                 openCursor0(coll) map (_.right[FileSystemError]),
-                PathError(PathNotFound(f)).left.point[MongoRead]))
+                pathError(pathNotFound(f)).left.point[MongoRead]))
   }
 }

--- a/core/src/test/scala/quasar/fs/HierarchicalFileSystemSpec.scala
+++ b/core/src/test/scala/quasar/fs/HierarchicalFileSystemSpec.scala
@@ -1,0 +1,249 @@
+package quasar.fs
+
+import quasar.Predef._
+import quasar.{Data, LogicalPlan}
+import quasar.effect._
+import quasar.fp.{hoistFree, liftMT, free, zoomNT}
+import quasar.mount.Mounts
+import quasar.recursionschemes.Fix
+import quasar.std.IdentityLib.Squash
+import quasar.std.SetLib.Take
+
+import monocle.Lens
+import org.specs2.mutable.Specification
+import pathy.Path._
+import scalaz.{Lens => _, Failure => _, _}, Id.Id
+import scalaz.syntax.either._
+import scalaz.std.list._
+
+class HierarchicalFileSystemSpec extends Specification with FileSystemFixture {
+  import InMemory.InMemState, FileSystemError._, PathError2._
+  import hierarchical.{HFSErrT, HierarchicalFileSystemError, HFSFailure, HFSFailureF, MountedResultH, MountedResultHF}
+  import ManageFile.MoveSemantics, QueryFile.ResultHandle, LogicalPlan._
+
+  val transforms = QueryFile.Transforms[F]
+  val unsafeq = QueryFile.Unsafe[FileSystem]
+
+  type ExecM[A] = transforms.ExecM[A]
+  type MountedFs[A] = State[MountedState, A]
+  type HFSM[A] = HFSErrT[MountedFs, A]
+
+  type HEff0[A] = Coproduct[HFSFailureF, MountedFs, A]
+  type HEff1[A] = Coproduct[MountedResultHF, HEff0, A]
+  type HEff[A]  = Coproduct[MonotonicSeqF, HEff1, A]
+  type HEffM[A] = Free[HEff, A]
+
+  type RHandles = Map[ResultHandle, (ADir, ResultHandle)]
+
+  case class MountedState(
+    n: Long,
+    h: RHandles,
+    a: InMemState,
+    b: InMemState,
+    c: InMemState)
+
+  def emptyMS: MountedState =
+    MountedState(0, Map.empty, InMemState.empty, InMemState.empty, InMemState.empty)
+
+  val mntA: ADir = rootDir </> dir("bar") </> dir("mntA")
+  val mntB: ADir = rootDir </> dir("bar") </> dir("mntB")
+  val mntC: ADir = rootDir </> dir("foo") </> dir("mntC")
+
+  val seq: Lens[MountedState, Long]         = Lens((_: MountedState).n)(x => ms => ms.copy(n = x))
+  val handles: Lens[MountedState, RHandles] = Lens((_: MountedState).h)(m => ms => ms.copy(h = m))
+  val aMem: Lens[MountedState, InMemState]  = Lens((_: MountedState).a)(s => ms => ms.copy(a = s))
+  val bMem: Lens[MountedState, InMemState]  = Lens((_: MountedState).b)(s => ms => ms.copy(b = s))
+  val cMem: Lens[MountedState, InMemState]  = Lens((_: MountedState).c)(s => ms => ms.copy(c = s))
+
+  val interpretH: FileSystem ~> HEffM =
+    hierarchical.fileSystem[MountedFs, HEff](DirName(":"), Mounts.fromFoldable(List(
+      (mntA, zoomNT[Id](aMem) compose Mem.interpretTerm),
+      (mntB, zoomNT[Id](bMem) compose Mem.interpretTerm),
+      (mntC, zoomNT[Id](cMem) compose Mem.interpretTerm)
+    )).toOption.get)
+
+  def runH: F ~> HFSM = {
+    val seqNT: MonotonicSeqF ~> HFSM =
+      liftMT[MountedFs, HFSErrT].compose[MonotonicSeqF](
+        Coyoneda.liftTF[MonotonicSeq, MountedFs](MonotonicSeq.stateMonotonicSeq[Id](seq)))
+
+    val failNT: HFSFailureF ~> HFSM =
+      Coyoneda.liftTF[HFSFailure, HFSM](
+        Failure.toEitherT[MountedFs, HierarchicalFileSystemError])
+
+    val handlesNT: MountedResultHF ~> HFSM =
+      liftMT[MountedFs, HFSErrT].compose[MountedResultHF](
+        Coyoneda.liftTF[MountedResultH, MountedFs](KeyValueStore.stateKeyValueStore[Id](handles)))
+
+    val runEff: HEff ~> HFSM =
+      free.interpret4(seqNT, handlesNT, failNT, liftMT[MountedFs, HFSErrT]: (MountedFs ~> HFSM))
+
+    hoistFree(hoistFree(runEff).compose[FileSystem](interpretH))
+  }
+
+  // NB: Defining these here for a reuse, but also because using `beLike`
+  //     inline triggers a scalac bug that results in malformed class files
+  def succeedH[A] =
+    beLike[HierarchicalFileSystemError \/ (FileSystemError \/ A)] {
+      case \/-(\/-(_)) => ok
+    }
+
+  def failDueToInvalidPath[A](p: APath) =
+    beLike[HierarchicalFileSystemError \/ (FileSystemError \/ A)] {
+      case \/-(-\/(PathError(Case.InvalidPath(p0, _)))) => p0 must_== p
+    }
+
+  def failDueToMultipleMnts[A] =
+    beLike[HierarchicalFileSystemError \/ (FileSystemError \/ A)] {
+      case -\/(HierarchicalFileSystemError.MultipleMountsApply(_, _)) => ok
+    }
+
+  def failsForDifferentFs[A](f: (Fix[LogicalPlan], AFile) => ExecM[A]) =
+    "should fail if any plan paths refer to different filesystems" >> {
+      import quasar.{queryPlan, Variables}
+      import quasar.sql._
+
+      val joinQry =
+        "select f.x, q.y from \"/bar/mntA/foo\" as f inner join \"/foo/mntC/quux\" as q on f.id = q.id"
+
+      val lp = new SQLParser().parse(Query(joinQry)).toOption
+        .flatMap(expr => queryPlan(expr, Variables(Map())).run.value.toOption)
+        .get
+
+      runH(f(lp, mntA </> file("out0")).run.value)
+        .run.eval(emptyMS) must failDueToInvalidPath(mntC)
+    }
+
+  def failsWhenNoPaths[A](f: Fix[LogicalPlan] => ExecM[A]) =
+    "containing no paths fails with HFS error" >> {
+      runH(f(Constant(Data.Obj(Map("0" -> Data.Int(5))))).run.value)
+        .run.eval(emptyMS) must failDueToMultipleMnts
+    }
+
+  def succeedsForMountedPath[A](f: Fix[LogicalPlan] => ExecM[A]) =
+    "containing a mounted path succeeds" >> {
+      val local = dir("d1") </> file("f1")
+      val mnted = mntB </> local
+
+      val lp = Invoke(Take, List(
+        Invoke(Squash, List(Read(Path(posixCodec.printPath(mnted))))),
+        Constant(Data.Int(5))))
+
+      val fss = bMem.set(
+        InMemState.fromFiles(Map((rootDir </> local) -> Vector(Data.Int(1)))))(
+        emptyMS)
+
+      runH(f(lp).run.value).run.eval(fss) must succeedH
+    }
+
+  "Mounted filesystems" should {
+    "QueryFile" >> {
+      "executing a plan" >> {
+        failsForDifferentFs((lp, out) => query.execute(lp, out))
+
+        "should fail when output path and plan paths refer to different filesystems" >> {
+          val rd = mntB </> file("f1")
+          val out = mntC </> file("outf")
+
+          val lp = Invoke(Take, List(
+            Invoke(Squash, List(Read(Path(posixCodec.printPath(rd))))),
+            Constant(Data.Int(5))))
+
+          val fss = bMem.set(InMemState.fromFiles(Map(rd -> Vector(Data.Int(1)))))(emptyMS)
+
+          runH(query.execute(lp, out).run.value)
+            .run.eval(fss) must failDueToInvalidPath(mntB)
+        }
+
+        "containing no paths succeeds" >> {
+          val out = mntC </> file("outfile")
+          runH(query.execute(Constant(Data.Obj(Map("0" -> Data.Int(3)))), out).run.value)
+            .run.eval(emptyMS) must_== out.right.right
+        }
+      }
+
+      "evaluating a plan" >> {
+        failsForDifferentFs((lp, _) => unsafeq.eval(lp))
+
+        failsWhenNoPaths(unsafeq.eval)
+
+        succeedsForMountedPath(unsafeq.eval)
+      }
+
+      "explaining a plan" >> {
+        failsForDifferentFs((lp, _) => query.explain(lp))
+
+        failsWhenNoPaths(query.explain)
+
+        succeedsForMountedPath(query.explain)
+      }
+
+      "listing children" >> {
+        "of mount ancestor dir should return dir nodes" >> {
+          val dirs = Set(Node.Plain(dir("bar")), Node.Plain(dir("foo")))
+          runH(query.ls(rootDir).run).run.eval(emptyMS) must_== dirs.right.right
+        }
+
+        "of mount parent dir should return mounts nodes" >> {
+          val mnts = Set(Node.Mount(dir("mntA")), Node.Mount(dir("mntB")))
+          runH(query.ls(rootDir </> dir("bar")).run)
+            .run.eval(emptyMS) must_== mnts.right.right
+        }
+      }
+    }
+
+    "ManageFile" >> {
+      "move dir should fail when dst not in same filesystem" >> {
+        val src = mntA </> dir("srcdir")
+        val dst = mntC </> dir("dstdir")
+        val fss = emptyMS.copy(a = InMemState.fromFiles(Map(
+          (src </> file("f1")) -> Vector(Data.Str("contents")))))
+
+        runH(manage.moveDir(src, dst, MoveSemantics.Overwrite).run)
+          .run.eval(fss) must failDueToInvalidPath(dst)
+      }
+
+      "move file should fail when dst not in same filesystem" >> {
+        val src = mntA </> dir("srcdir") </> file("f1")
+        val dst = mntC </> dir("dstdir") </> file("f2")
+        val fss = emptyMS.copy(a = InMemState.fromFiles(Map(
+          src -> Vector(Data.Str("contents")))))
+
+        runH(manage.moveFile(src, dst, MoveSemantics.Overwrite).run)
+          .run.eval(fss) must failDueToInvalidPath(dst)
+      }
+
+      "deleting a mount point should delete all data in mounted filesystem" >> {
+        val f1 = mntB </> dir("d1") </> file("f1")
+        val f2 = mntB </> file("f2")
+
+        val fss = emptyMS.copy(b = InMemState.fromFiles(Map(
+          f1 -> Vector(Data.Str("conts1")),
+          f2 -> Vector(Data.Int(42)))))
+
+        runH(manage.delete(mntB).run)
+          .run.exec(fss) must_== emptyMS
+      }
+
+      "deleting the ancestor of one or more mount points should delete all data in their filesystems" >> {
+        val f1 = mntB </> dir("d1") </> file("f1")
+        val f2 = mntB </> dir("d1") </> file("f2")
+        val f3 = mntA </> dir("d2") </> file("f3")
+        val f4 = mntA </> dir("d2") </> file("f4")
+
+        val fss = emptyMS.copy(
+          b = InMemState.fromFiles(Map(
+            f1 -> Vector(Data.Str("file1")),
+            f2 -> Vector(Data.Str("file2")))),
+          a = InMemState.fromFiles(Map(
+            f3 -> Vector(Data.Str("file3")),
+            f4 -> Vector(Data.Str("file4")))))
+
+        runH(manage.delete(rootDir </> dir("bar")).run)
+          .run.exec(fss) must_== emptyMS
+      }
+    }
+  }
+
+}
+

--- a/core/src/test/scala/quasar/fs/ManageFileSpec.scala
+++ b/core/src/test/scala/quasar/fs/ManageFileSpec.scala
@@ -1,7 +1,7 @@
-package quasar
-package fs
+package quasar.fs
 
 import quasar.Predef._
+import quasar.{Data, DataGen}
 import quasar.fp._
 
 import org.specs2.mutable.Specification

--- a/core/src/test/scala/quasar/fs/QueryFileSpec.scala
+++ b/core/src/test/scala/quasar/fs/QueryFileSpec.scala
@@ -1,7 +1,7 @@
-package quasar
-package fs
+package quasar.fs
 
 import quasar.Predef._
+import quasar.{Data, DataGen, LogicalPlan, PhaseResults}
 import quasar.fp._
 import quasar.scalacheck._
 
@@ -32,7 +32,8 @@ class QueryFileSpec extends Specification with ScalaCheck with FileSystemFixture
         .set(workers = java.lang.Runtime.getRuntime.availableProcessors)
 
       "returns not found when dir does not exist" ! prop { d: ADir =>
-        Mem.interpret(query.descendantFiles(d)).eval(emptyMem).toEither must beLeft(PathError(PathNotFound(d)))
+        Mem.interpret(query.descendantFiles(d)).eval(emptyMem)
+          .toEither must beLeft(pathError(PathNotFound(d)))
       }
     }
 

--- a/core/src/test/scala/quasar/fs/QueryFileSpec.scala
+++ b/core/src/test/scala/quasar/fs/QueryFileSpec.scala
@@ -60,7 +60,7 @@ class QueryFileSpec extends Specification with ScalaCheck with FileSystemFixture
 
     "evaluate" >> {
       "streams the results of evaluating the logical plan" ! prop { s: SingleFileMemState =>
-        val query = LogicalPlan.Read(convert(s.file))
+        val query = LogicalPlan.Read(Path.fromAPath(s.file))
         val state = s.state.copy(queryResps = Map(query -> s.contents))
         val result = MemTask.runLog[FileSystemError, PhaseResults, Data](evaluate(query)).run.run.eval(state)
         result.run._2.toEither must beRight(s.contents)

--- a/core/src/test/scala/quasar/fs/ReadFileSpec.scala
+++ b/core/src/test/scala/quasar/fs/ReadFileSpec.scala
@@ -1,7 +1,7 @@
-package quasar
-package fs
+package quasar.fs
 
 import quasar.Predef._
+import quasar.{Data, DataGen}
 import quasar.fp._
 
 import org.specs2.mutable.Specification
@@ -33,12 +33,12 @@ class ReadFileSpec extends Specification with ScalaCheck with FileSystemFixture 
 
     "scan should automatically close the read handle on failure" ! prop {
       (f: AFile, xs: Vector[Data]) => xs.nonEmpty ==> {
-        val reads = List(xs.right, PathError(PathNotFound(f)).left)
+        val reads = List(xs.right, pathError(PathNotFound(f)).left)
 
         MemFixTask.runLogWithReads(reads, read.scanAll(f)).run
           .leftMap(_.rm)
           .run(emptyMem)
-          .run must_== ((Map.empty, \/.left(PathError(PathNotFound(f)))))
+          .run must_== ((Map.empty, \/.left(pathError(PathNotFound(f)))))
       }
     }
   }

--- a/core/src/test/scala/quasar/fs/TraceFS.scala
+++ b/core/src/test/scala/quasar/fs/TraceFS.scala
@@ -1,10 +1,8 @@
 package quasar.fs
 
 import quasar.Predef._
-
 import quasar._, RenderTree.ops._
 import quasar.fp._
-import quasar.fp.free.{Interpreter}
 
 import pathy.{Path => PPath}, PPath._
 import scalaz._, Scalaz._
@@ -68,8 +66,8 @@ object TraceFS {
         mf match {
           case Move(scenario, semantics) => \/-(())
           case Delete(path)              => \/-(())
-          case TempFile(maybeNear) =>
-            maybeNear.fold[ADir](rootDir)(fileParent(_)) </> file("tmp")
+          case TempFile(near) =>
+            \/-(refineType(near).fold(ι, fileParent) </> file("tmp"))
         }))
   }
 
@@ -77,6 +75,6 @@ object TraceFS {
     interpretFileSystem[Trace](qfTrace(nodes), rfTrace, wfTrace, mfTrace)
 
   def traceInterp[A](t: Free[FileSystem, A], nodes: Map[ADir, Set[Node]]): (Vector[RenderedTree], A) = {
-    new Interpreter(traceFs(nodes)).interpret(t).run
+    new free.Interpreter(traceFs(nodes)).interpret(t).run
   }
 }

--- a/core/src/test/scala/quasar/fs/ViewsSpec.scala
+++ b/core/src/test/scala/quasar/fs/ViewsSpec.scala
@@ -110,7 +110,7 @@ class ViewsSpec extends Specification with ScalaCheck with TreeMatchers {
       // to act like a filter or decorator for an existing collection.
 
       val p = rootDir </> dir("foo") </> file("bar")
-      val q = Fix(Take(Read(convert(p)), Constant(Data.Int(10))))
+      val q = Fix(Take(Read(Path.fromAPath(p)), Constant(Data.Int(10))))
       val vs = Views(Map(p -> q))
 
       vs.lookup(p) must beSome(q)

--- a/core/src/test/scala/quasar/fs/view.scala
+++ b/core/src/test/scala/quasar/fs/view.scala
@@ -26,7 +26,7 @@ class ViewFSSpec extends Specification with ScalaCheck with TreeMatchers {
   val write  = WriteFile.Ops[FileSystem]
   val manage = ManageFile.Ops[FileSystem]
 
-  case class VS(seq: Long, handles: Map[ReadFile.ReadHandle, ReadFile.ReadHandle \/ QueryFile.ResultHandle])
+  case class VS(seq: Long, handles: ViewHandles)
   val _seq = GenLens[VS](_.seq)
   val _handles = GenLens[VS](_.handles)
 
@@ -37,8 +37,8 @@ class ViewFSSpec extends Specification with ScalaCheck with TreeMatchers {
 
   def traceViewFs(nodes: Map[ADir, Set[Node]]): ViewFileSystem ~> VST =
     interpretViewFileSystem[VST](
-      KeyValueStore.stateKeyValueStore[Trace, ReadFile.ReadHandle, ReadFile.ReadHandle \/ QueryFile.ResultHandle, VS](_handles),
-      MonotonicSeq.stateMonotonicSeq[Trace, VS](_seq),
+      KeyValueStore.stateKeyValueStore[Trace](_handles),
+      MonotonicSeq.stateMonotonicSeq[Trace](_seq),
       liftMT[Trace, VSF] compose
         interpretFileSystem[Trace](qfTrace(nodes), rfTrace, wfTrace, mfTrace))
 

--- a/core/src/test/scala/quasar/mount/MapMounterSpec.scala
+++ b/core/src/test/scala/quasar/mount/MapMounterSpec.scala
@@ -9,7 +9,7 @@ import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 
 class MapMounterSpec extends MountingSpec[MountingF] {
-  import MapMounter.{Mounts, MountR}, MountConfig2._
+  import MapMounter.{Mountings, MountR}, MountConfig2._
 
   val invalidUri = ConnectionUri(uriA.value + "INVALID")
   val unsuppUri  = ConnectionUri(uriB.value + "VERSION")
@@ -25,7 +25,7 @@ class MapMounterSpec extends MountingSpec[MountingF] {
 
   def interpret = {
     val mm = MapMounter[Id](doMount)
-    val ref = TaskRef(Mounts.empty).run
+    val ref = TaskRef(Mountings.empty).run
 
     val interp0: Mounting ~> Task = new (Mounting ~> Task) {
       def apply[A](m: Mounting[A]) = ref.modifyS(mm(m).run)

--- a/core/src/test/scala/quasar/mount/MountsArbitrary.scala
+++ b/core/src/test/scala/quasar/mount/MountsArbitrary.scala
@@ -1,0 +1,24 @@
+package quasar.mount
+
+import org.scalacheck._
+import pathy.Path._
+import pathy.scalacheck.PathyArbitrary._
+import scalaz.std.list._
+import scalaz.syntax.std.option._
+
+object MountsArbitrary {
+  import Arbitrary.arbitrary
+
+  implicit def mountsArbitrary[A: Arbitrary]: Arbitrary[Mounts[A]] =
+    Arbitrary(for {
+      n    <- Gen.size
+      x    <- Gen.choose(0, n)
+      dirs <- Gen.listOfN(x, arbitrary[RelDir[Sandboxed]])
+      uniq =  dirs.zipWithIndex map { case (d, i) =>
+                rootDir </> dir(i.toString) </> d
+              }
+      as   <- Gen.listOfN(x, arbitrary[A])
+      mres =  Mounts.fromFoldable(uniq zip as)
+      mnts <- mres.toOption.cata(Gen.const, Gen.fail)
+    } yield mnts)
+}

--- a/core/src/test/scala/quasar/mount/MountsSpec.scala
+++ b/core/src/test/scala/quasar/mount/MountsSpec.scala
@@ -1,0 +1,38 @@
+package quasar.mount
+
+import quasar.Predef.List
+
+import org.specs2.mutable
+import org.specs2.ScalaCheck
+import org.specs2.scalaz.DisjunctionMatchers
+import pathy.Path._
+import pathy.scalacheck.PathyArbitrary._
+import scalaz.std.list._
+
+class MountsSpec extends mutable.Specification with ScalaCheck with DisjunctionMatchers {
+  "Mounts" should {
+    "adding entries" >> {
+      "fails when dir is a prefix of existing" ! prop { mnt: AbsDir[Sandboxed] =>
+        Mounts.singleton(mnt </> dir("c1"), 1).add(mnt, 2) must beLeftDisjunction
+      }
+
+      "fails when dir is prefixed by existing" ! prop { mnt: AbsDir[Sandboxed] =>
+        Mounts.singleton(mnt, 1).add(mnt </> dir("c2"), 2) must beLeftDisjunction
+      }
+
+      "succeeds when dir not a prefix of existing" >> {
+        val mnt1: AbsDir[Sandboxed] = rootDir </> dir("one")
+        val mnt2: AbsDir[Sandboxed] = rootDir </> dir("two")
+
+        Mounts.fromFoldable(List((mnt1, 1), (mnt2, 2))) must beRightDisjunction
+      }
+
+      "succeeds when replacing value at existing" ! prop { mnt: AbsDir[Sandboxed] =>
+        Mounts.singleton(mnt, 1)
+          .add(mnt, 2)
+          .toOption
+          .flatMap(_.toMap.get(mnt)) must beSome(2)
+      }
+    }
+  }
+}

--- a/it/src/test/scala/quasar/ResultFileQueryRegressionSpec.scala
+++ b/it/src/test/scala/quasar/ResultFileQueryRegressionSpec.scala
@@ -5,7 +5,6 @@ import quasar.fs._
 import quasar.regression._
 import quasar.sql._
 
-import pathy.Path._
 import scalaz.{~>, Hoist}
 import scalaz.stream.Process
 import scalaz.std.vector._
@@ -23,14 +22,11 @@ class ResultFileQueryRegressionSpec
 
     type M[A] = FileSystemErrT[F, A]
 
-    val tmpPath =
-      DataDir </> file("out")
-
     val hoistM: M ~> CompExecM =
       execToCompExec compose[M] Hoist[FileSystemErrT].hoist[F, G](liftMT[F, PhaseResultT])
 
     for {
-      tmpFile <- toCompExec(manage.tempFileNear(tmpPath)).liftM[Process]
+      tmpFile <- hoistM(manage.tempFile(DataDir)).liftM[Process]
       outFile <- query.executeQuery(expr, vars, tmpFile).liftM[Process]
       cleanup =  hoistM(manage.delete(tmpFile))
       data    <- read.scanAll(outFile)

--- a/it/src/test/scala/quasar/fs/FileSystemUT.scala
+++ b/it/src/test/scala/quasar/fs/FileSystemUT.scala
@@ -1,5 +1,6 @@
-package quasar
-package fs
+package quasar.fs
+
+import quasar.BackendName
 
 import scalaz._
 import scalaz.concurrent.Task

--- a/it/src/test/scala/quasar/fs/ManageFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/ManageFilesSpec.scala
@@ -1,7 +1,7 @@
-package quasar
-package fs
+package quasar.fs
 
 import quasar.Predef._
+import quasar.Data
 import quasar.fp._
 
 import pathy.Path._
@@ -51,7 +51,7 @@ class ManageFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT)
                 write.save(f2, oneDoc.toProcess).drain ++
                 manage.moveFile(f1, f2, MoveSemantics.FailIfExists).liftM[Process]
 
-        (execT(run, p).runOption must beSome(PathError(PathExists(f2)))) and
+        (execT(run, p).runOption must beSome(pathError(PathExists(f2)))) and
         (runT(run)(ls).runEither must beRight(containTheSameElementsAs(expectedFiles)))
       }
 
@@ -81,7 +81,7 @@ class ManageFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT)
                 manage.moveFile(f1, f2, MoveSemantics.Overwrite)
                   .liftM[Process]
 
-        (execT(run, p).runOption must beSome(PathError(PathNotFound(f1)))) and
+        (execT(run, p).runOption must beSome(pathError(PathNotFound(f1)))) and
         (runT(run)(ls).runEither must beRight(containTheSameElementsAs(expectedFiles)))
       }
 
@@ -91,7 +91,7 @@ class ManageFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT)
         val f2 = d </> file("f2")
 
         runT(run)(manage.moveFile(f1, f2, MoveSemantics.Overwrite))
-          .runOption must beSome(PathError(PathNotFound(f1)))
+          .runOption must beSome(pathError(PathNotFound(f1)))
       }
 
       "moving a file to itself with FailIfExists semantics should fail with PathExists" >> {
@@ -99,7 +99,7 @@ class ManageFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT)
         val p  = write.save(f1, oneDoc.toProcess).drain ++
                  manage.moveFile(f1, f1, MoveSemantics.FailIfExists).liftM[Process]
 
-        execT(run, p).runOption must beSome(PathError(PathExists(f1)))
+        execT(run, p).runOption must beSome(pathError(PathExists(f1)))
       }
 
       "moving a file to a nonexistent path when using FailIfMissing sematics should fail with dst NotFound" >> {
@@ -110,7 +110,7 @@ class ManageFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT)
         val p  = write.save(f1, oneDoc.toProcess).drain ++
                  manage.moveFile(f1, f2, MoveSemantics.FailIfMissing).liftM[Process]
 
-        (execT(run, p).runOption must beSome(PathError(PathNotFound(f2)))) and
+        (execT(run, p).runOption must beSome(pathError(PathNotFound(f2)))) and
         (runT(run)(query.ls(d)).runEither must beRight(containTheSameElementsAs(expectedFiles)))
       }
 
@@ -129,7 +129,7 @@ class ManageFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT)
 
         (execT(run, p).runOption must beNone) and
         (runT(run)(query.ls(d2)).runEither must beRight(containTheSameElementsAs(expectedFiles))) and
-        (runT(run)(query.ls(d1)).runEither must beLeft(PathError(PathNotFound(d1))))
+        (runT(run)(query.ls(d1)).runEither must beLeft(pathError(PathNotFound(d1))))
       }
 
       "moving a nonexistent dir to another nonexistent dir fails with src NotFound" >> {
@@ -137,12 +137,12 @@ class ManageFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT)
         val d2 = managePrefix </> dir("dirdnetodirdne") </> dir("d2")
 
         runT(run)(manage.moveDir(d1, d2, MoveSemantics.FailIfExists))
-          .runOption must beSome(PathError(PathNotFound(d1)))
+          .runOption must beSome(pathError(PathNotFound(d1)))
       }
 
       "deleting a nonexistent file returns PathNotFound" >> {
         val f = managePrefix </> file("delfilenotfound")
-        runT(run)(manage.delete(f)).runEither must beLeft(PathError(PathNotFound(f)))
+        runT(run)(manage.delete(f)).runEither must beLeft(pathError(PathNotFound(f)))
       }
 
       "deleting a file makes it no longer accessible" >> {
@@ -150,7 +150,7 @@ class ManageFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT)
         val p  = write.save(f1, oneDoc.toProcess).drain ++ manage.delete(f1).liftM[Process]
 
         (execT(run, p).runOption must beNone) and
-        (runLogT(run, read.scanAll(f1)).runEither must beLeft(PathError(PathNotFound(f1))))
+        (runLogT(run, read.scanAll(f1)).runEither must beLeft(pathError(PathNotFound(f1))))
       }
 
       "deleting a file with siblings in directory leaves siblings untouched" >> {
@@ -163,7 +163,7 @@ class ManageFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT)
                 manage.delete(f1).liftM[Process]
 
         (execT(run, p).runOption must beNone) and
-        (runLogT(run, read.scanAll(f1)).runEither must beLeft(PathError(PathNotFound(f1)))) and
+        (runLogT(run, read.scanAll(f1)).runEither must beLeft(pathError(PathNotFound(f1)))) and
         (runLogT(run, read.scanAll(f2)).runEither must beRight(anotherDoc))
       }
 
@@ -177,14 +177,14 @@ class ManageFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT)
                 manage.delete(d).liftM[Process]
 
         (execT(run, p).runOption must beNone) and
-        (runLogT(run, read.scanAll(f1)).runEither must beLeft(PathError(PathNotFound(f1)))) and
-        (runLogT(run, read.scanAll(f2)).runEither must beLeft(PathError(PathNotFound(f2)))) and
-        (runT(run)(query.ls(d)).runEither must beLeft(PathError(PathNotFound(d))))
+        (runLogT(run, read.scanAll(f1)).runEither must beLeft(pathError(PathNotFound(f1)))) and
+        (runLogT(run, read.scanAll(f2)).runEither must beLeft(pathError(PathNotFound(f2)))) and
+        (runT(run)(query.ls(d)).runEither must beLeft(pathError(PathNotFound(d))))
       }
 
       "deleting a nonexistent directory returns PathNotFound" >> {
         val d = managePrefix </> dir("deldirnotfound")
-        runT(run)(manage.delete(d)).runEither must beLeft(PathError(PathNotFound(d)))
+        runT(run)(manage.delete(d)).runEither must beLeft(pathError(PathNotFound(d)))
       }
 
       "write/read from temp dir near existing" >> {

--- a/it/src/test/scala/quasar/fs/QueryFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/QueryFilesSpec.scala
@@ -1,5 +1,4 @@
-package quasar
-package fs
+package quasar.fs
 
 import quasar.Predef._
 import quasar.fp._
@@ -43,7 +42,7 @@ class QueryFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT) 
 
       "listing nonexistent directory returns dir NotFound" >> {
         val d = queryPrefix </> dir("lsdne")
-        runT(run)(query.ls(d)).runEither must beLeft(PathError(PathNotFound(d)))
+        runT(run)(query.ls(d)).runEither must beLeft(pathError(PathNotFound(d)))
       }
 
       "listing results should not contain deleted files" >> {

--- a/it/src/test/scala/quasar/fs/ReadFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/ReadFilesSpec.scala
@@ -1,17 +1,14 @@
-package quasar
-package fs
+package quasar.fs
 
 import quasar.Predef._
+import quasar.{Data, DataGen}
 import quasar.fp._
 
 import java.lang.RuntimeException
-
-import monocle.std.{disjunction => D}
-
-import pathy.Path._
-
 import scala.annotation.tailrec
 
+import monocle.std.{disjunction => D}
+import pathy.Path._
 import scalaz.{EphemeralStream => EStream, _}, Scalaz._
 import scalaz.concurrent.Task
 import scalaz.stream._
@@ -51,14 +48,14 @@ class ReadFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT) {
       "open returns PathNotFound when file DNE" >>* {
         val dne = rootDir </> dir("doesnt") </> file("exist")
         read.unsafe.open(dne, Natural._0, None).run map { r =>
-          r.toEither must beLeft(PathError(PathNotFound(dne)))
+          r.toEither must beLeft(pathError(PathNotFound(dne)))
         }
       }
 
       "read unopened file handle returns UnknownReadHandle" >>* {
         val h = ReadHandle(rootDir </> file("f1"), 42)
         read.unsafe.read(h).run map { r =>
-          r.toEither must beLeft(UnknownReadHandle(h))
+          r.toEither must beLeft(unknownReadHandle(h))
         }
       }
 

--- a/it/src/test/scala/quasar/fs/WriteFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/WriteFilesSpec.scala
@@ -1,5 +1,4 @@
-package quasar
-package fs
+package quasar.fs
 
 import quasar.Predef._
 import quasar.fp._
@@ -43,7 +42,7 @@ class WriteFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT) 
       "write to unknown handle returns UnknownWriteHandle" >>* {
         val h = WriteHandle(rootDir </> file("f1"), 42)
         write.unsafe.write(h, Vector()) map { r =>
-          r must_== Vector(UnknownWriteHandle(h))
+          r must_== Vector(unknownWriteHandle(h))
         }
       }
 

--- a/it/src/test/scala/quasar/physical/mongodb/filesystems.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/filesystems.scala
@@ -1,19 +1,14 @@
-package quasar
-package physical
-package mongodb
+package quasar.physical.mongodb
 
-import quasar.Predef._
-import quasar.regression._
+import quasar.{EnvironmentError2, rethrow}
 import quasar.fp.free._
 import quasar.fs._
 import quasar.physical.mongodb.fs._
+import quasar.regression._
 
 import com.mongodb.ConnectionString
-import com.mongodb.async.client.{MongoClient, MongoClients}
-import pathy.Path._
+import com.mongodb.async.client.MongoClients
 import scalaz._
-import scalaz.syntax.applicative._
-import scalaz.syntax.std.option._
 import scalaz.concurrent.Task
 
 object filesystems {
@@ -21,10 +16,9 @@ object filesystems {
     cs: ConnectionString,
     prefix: ADir
   ): Task[FileSystem ~> Task] = for {
-    defDb    <- defaultDb(cs, prefix)
     client   <- Task.delay(MongoClients create cs)
     mongofs0 <- rethrow[Task, EnvironmentError2]
-                  .apply(mongoDbFileSystem(client, defDb))
+                  .apply(mongoDbFileSystem(client, DefaultDb fromPath prefix))
     mongofs  =  rethrow[Task, WorkflowExecutionError] compose mongofs0
   } yield mongofs
 
@@ -34,14 +28,4 @@ object filesystems {
   ): Task[FileSystemIO ~> Task] =
     testFileSystem(cs, prefix)
       .map(interpret2(NaturalTransformation.refl[Task], _))
-
-  ////
-
-  private def defaultDb(cs: ConnectionString, prefix: ADir): Task[DefaultDb] = {
-    def noDefaultDbError = new RuntimeException(
-      s"Unable to determine a default database for `${cs.toString}` from `${posixCodec.printPath(prefix)}`."
-    )
-
-    DefaultDb fromPath prefix cata (_.point[Task], Task.fail(noDefaultDbError))
-  }
 }

--- a/it/src/test/scala/quasar/regression/package.scala
+++ b/it/src/test/scala/quasar/regression/package.scala
@@ -1,10 +1,40 @@
 package quasar
 
-import quasar.fs.FileSystem
+import quasar.Predef.Map
+import quasar.fs.{QueryFile, FileSystem, ADir}
+import quasar.fp.free
+import quasar.effect._
 
-import scalaz._
+import scalaz.{Failure => _, _}
+import scalaz.syntax.apply._
 import scalaz.concurrent._
 
 package object regression {
+  import quasar.fs.hierarchical.{HFSFailureF, MountedResultHF}
+
   type FileSystemIO[A] = Coproduct[Task, FileSystem, A]
+
+  type HfsIO0[A] = Coproduct[MountedResultHF, Task, A]
+  type HfsIO1[A] = Coproduct[HFSFailureF, HfsIO0, A]
+  type HfsIO[A]  = Coproduct[MonotonicSeqF, HfsIO1, A]
+
+  val interpretHfsIO: Task[HfsIO ~> Task] = {
+    import QueryFile.ResultHandle
+    import quasar.fs.hierarchical._
+
+    val handlesTask: Task[MountedResultHF ~> Task] =
+      KeyValueStore.taskRefKeyValueStore[ResultHandle, (ADir, ResultHandle)](Map())
+        .map(Coyoneda.liftTF[MountedResultH, Task](_))
+
+    val monoSeqTask: Task[MonotonicSeqF ~> Task] =
+      MonotonicSeq.taskRefMonotonicSeq(0)
+        .map(Coyoneda.liftTF[MonotonicSeq, Task](_))
+
+    val hfsFailTask: HFSFailureF ~> Task =
+      Coyoneda.liftTF[HFSFailure, Task](
+        Failure.toTaskFailure[HierarchicalFileSystemError])
+
+    (handlesTask |@| monoSeqTask)((hndl, monos) =>
+      free.interpret4(monos, hfsFailTask, hndl, NaturalTransformation.refl))
+  }
 }


### PR DESCRIPTION
Adds a filesystem interpreter that, given a set of mounts, routes filesystem requests to underlying interpreters based on the paths in the requests.