### PR TITLE
Refactor effect interpreters to use MTL classes when available

### DIFF
--- a/core/src/test/scala/quasar/fs/mount/view.scala
+++ b/core/src/test/scala/quasar/fs/mount/view.scala
@@ -39,7 +39,7 @@ class ViewFSSpec extends Specification with ScalaCheck with TreeMatchers {
   def traceViewFs(nodes: Map[ADir, Set[Node]]): ViewFileSystem ~> VST =
     interpretViewFileSystem[VST](
       KeyValueStore.toState[TraceS](_handles),
-      MonotonicSeq.stateMonotonicSeq[Trace](_seq),
+      MonotonicSeq.toState[TraceS](_seq),
       liftMT[Trace, VSF] compose
         interpretFileSystem[Trace](qfTrace(nodes), rfTrace, wfTrace, mfTrace))
 

--- a/it/src/test/scala/quasar/fs/FileSystemTest.scala
+++ b/it/src/test/scala/quasar/fs/FileSystemTest.scala
@@ -120,7 +120,7 @@ object FileSystemTest {
       val memPlus: ViewFileSystem ~> Task =
         interpretViewFileSystem(
           viewState,
-          MonotonicSeq.taskRefMonotonicSeq(seqRef),
+          MonotonicSeq.fromTaskRef(seqRef),
           mem.run)
 
       val fs = foldMapNT(memPlus) compose view.fileSystem[ViewFileSystem](Views(Map.empty))

--- a/it/src/test/scala/quasar/regression/package.scala
+++ b/it/src/test/scala/quasar/regression/package.scala
@@ -30,7 +30,7 @@ package object regression {
 
     def monoSeqTask(ref: TaskRef[Long]): MonotonicSeqF ~> Task =
       Coyoneda.liftTF[MonotonicSeq, Task](
-        MonotonicSeq.taskRefMonotonicSeq(ref))
+        MonotonicSeq.fromTaskRef(ref))
 
     val hfsFailTask: HFSFailureF ~> Task =
       Coyoneda.liftTF[HFSFailure, Task](


### PR DESCRIPTION
Instead of the default interpreters for effects in `quasar.effect` interpreting into specific monads, we can use the "mtl" classes, like `MonadState` and `MonadError`, where possible for more generality.