### PR TITLE
Implement the /mount API given a `Mounting ~> Task`

### DIFF
--- a/core/src/main/scala/quasar/fs/InMemory.scala
+++ b/core/src/main/scala/quasar/fs/InMemory.scala
@@ -246,6 +246,9 @@ object InMemory {
       (trans, ref.read)
     }
 
+  def runFs(initial: InMemState): Task[FileSystem ~> Task] =
+    runStatefully(initial).map(_ compose fileSystem)
+
   ////
 
   private def tmpName(n: Long) = s"__quasar.gen_$n"

--- a/core/src/main/scala/quasar/fs/mount/Mounting.scala
+++ b/core/src/main/scala/quasar/fs/mount/Mounting.scala
@@ -26,10 +26,7 @@ import quasar.sql._
 import monocle.Prism
 import monocle.std.{disjunction => D}
 import pathy._, Path._
-import scalaz._
-import scalaz.syntax.std.option._
-import scalaz.syntax.apply._
-import scalaz.syntax.monadError._
+import scalaz._, Scalaz._
 
 sealed trait Mounting[A]
 
@@ -45,6 +42,11 @@ object Mounting {
 
   final case class Unmount(path: APath)
     extends Mounting[MountingError \/ Unit]
+
+  /** Indicates the wrong type of path (file vs. dir) was supplied to the `mount`
+    * convenience function.
+    */
+  final case class PathTypeMismatch(path: APath)
 
   @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.NonUnitStatements"))
   final class Ops[S[_]](implicit S0: Functor[S], S1: MountingF :<: S)
@@ -71,31 +73,29 @@ object Mounting {
     /** Attempt to create a mount described by the given configuration at the
       * given location.
       */
-    def mount(loc: APath, config: MountConfig2): M[Unit] =
+    def mount(loc: APath, config: MountConfig2): M[PathTypeMismatch \/ Unit] =
       config match {
         case ViewConfig(query, vars) =>
-          D.right.getOption(refineType(loc)) cata (file =>
-              mountView(file, query, vars),
-              invalidPath(loc, "view mount location must be a file")
-                .raiseError[E, Unit])
+          D.right.getOption(refineType(loc)) cata (
+            file => mountView(file, query, vars).map(_.right),
+            PathTypeMismatch(loc).left.point[M])
 
         case FileSystemConfig(typ, uri) =>
-          D.left.getOption(refineType(loc)) cata (dir =>
-            mountFileSystem(dir, typ, uri),
-            invalidPath(loc, "filesytem mount location must be a directory")
-              .raiseError[E, Unit])
+          D.left.getOption(refineType(loc)) cata (
+            dir => mountFileSystem(dir, typ, uri).map(_.right),
+            PathTypeMismatch(loc).left.point[M])
       }
 
     /** Remount `src` at `dst`, results in an error if there is no mount at
       * `src`.
       */
     def remount[T](src: Path[Abs,T,Sandboxed], dst: Path[Abs,T,Sandboxed]): M[Unit] =
-      modify(src, dst, ι)
+      modify(src, dst, ι).void
 
     /** Replace the mount at the given path with one described by the
       * provided config.
       */
-    def replace(loc: APath, config: MountConfig2): M[Unit] =
+    def replace(loc: APath, config: MountConfig2): M[PathTypeMismatch \/ Unit] =
       modify(loc, loc, κ(config))
 
     /** Remove the mount at the given path. */
@@ -104,10 +104,16 @@ object Mounting {
 
     ////
 
-    private type E[A, B] = EitherT[F, A, B]
+    private type ErrF[A, B] = EitherT[F, A, B]
 
-    private val mErr: MonadError[E, MountingError] =
-      MonadError[E, MountingError]
+    def bifold[G[_]: Functor, E, A, EE, AA](v: EitherT[G,E,A])(e: E => EE \/ AA, a: A => EE \/ AA): EitherT[G, EE, AA] =
+      EitherT[G,EE,AA](v.run.map(_.fold(e, a)))
+
+    def toLeft[G[_]: Functor, E1, E2, A](v: EitherT[G, E1, E2 \/ A]): EitherT[G, E1 \/ E2, A] =
+      bifold(v)(_.left.left, _.fold(_.right.left, _.right))
+
+    def toRight[G[_]: Functor, E1, E2, A](v: EitherT[G, E1 \/ E2, A]): EitherT[G, E1, E2 \/ A] =
+      bifold(v)(_.fold(_.left, _.left.right), _.right.right)
 
     private val notFound: Prism[MountingError, APath] =
       MountingError.pathError composePrism PathError2.pathNotFound
@@ -119,16 +125,17 @@ object Mounting {
       src: Path[Abs,T,Sandboxed],
       dst: Path[Abs,T,Sandboxed],
       f: MountConfig2 => MountConfig2
-    ): M[Unit] = {
+    ): M[PathTypeMismatch \/ Unit] = {
+      val mErr = MonadError[ErrF, MountingError \/ PathTypeMismatch]
       import mErr._
 
       for {
         cfg <- lookup(src) toRight notFound(src)
         _   <- unmount(src)
-        _   <- handleError(mount(dst, f(cfg))) { err =>
-                 mount(src, cfg) *> raiseError(err)
-               }
-      } yield ()
+        rez <- toRight(handleError(toLeft(mount(dst, f(cfg)))) { err =>
+                 toLeft(mount(src, cfg)) *> raiseError(err)
+               })
+      } yield rez
     }
   }
 

--- a/core/src/main/scala/quasar/fs/mount/Mounting.scala
+++ b/core/src/main/scala/quasar/fs/mount/Mounting.scala
@@ -46,7 +46,7 @@ object Mounting {
   /** Indicates the wrong type of path (file vs. dir) was supplied to the `mount`
     * convenience function.
     */
-  final case class PathTypeMismatch(path: APath)
+  final case class PathTypeMismatch(path: APath) extends scala.AnyVal
 
   @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.NonUnitStatements"))
   final class Ops[S[_]](implicit S0: Functor[S], S1: MountingF :<: S)
@@ -106,13 +106,13 @@ object Mounting {
 
     private type ErrF[A, B] = EitherT[F, A, B]
 
-    def bifold[G[_]: Functor, E, A, EE, AA](v: EitherT[G,E,A])(e: E => EE \/ AA, a: A => EE \/ AA): EitherT[G, EE, AA] =
+    private def bifold[G[_]: Functor, E, A, EE, AA](v: EitherT[G,E,A])(e: E => EE \/ AA, a: A => EE \/ AA): EitherT[G, EE, AA] =
       EitherT[G,EE,AA](v.run.map(_.fold(e, a)))
 
-    def toLeft[G[_]: Functor, E1, E2, A](v: EitherT[G, E1, E2 \/ A]): EitherT[G, E1 \/ E2, A] =
+    private def toLeft[G[_]: Functor, E1, E2, A](v: EitherT[G, E1, E2 \/ A]): EitherT[G, E1 \/ E2, A] =
       bifold(v)(_.left.left, _.fold(_.right.left, _.right))
 
-    def toRight[G[_]: Functor, E1, E2, A](v: EitherT[G, E1 \/ E2, A]): EitherT[G, E1, E2 \/ A] =
+    private def toRight[G[_]: Functor, E1, E2, A](v: EitherT[G, E1 \/ E2, A]): EitherT[G, E1, E2 \/ A] =
       bifold(v)(_.fold(_.left, _.left.right), _.right.right)
 
     private val notFound: Prism[MountingError, APath] =

--- a/core/src/main/scala/quasar/fs/mount/MountingError.scala
+++ b/core/src/main/scala/quasar/fs/mount/MountingError.scala
@@ -22,6 +22,7 @@ import quasar.fs._
 
 import monocle.Prism
 import scalaz.NonEmptyList
+import scalaz._, Scalaz._
 
 sealed trait MountingError
 
@@ -52,4 +53,14 @@ object MountingError {
       case InvalidConfig(cfg, reasons) => Some((cfg, reasons))
       case _ => None
     } ((InvalidConfig(_, _)).tupled)
+
+  implicit def mountingErrorShow: Show[MountingError] =
+    Show.shows {
+      case PathError(e) =>
+        e.shows
+      case EnvironmentError(e) =>
+        e.shows
+      case InvalidConfig(cfg, rsns) =>
+        "Invalid config: " + cfg.shows + "; " + rsns.list.mkString("; ")
+    }
 }

--- a/core/src/main/scala/quasar/fs/mount/package.scala
+++ b/core/src/main/scala/quasar/fs/mount/package.scala
@@ -31,6 +31,14 @@ package object mount {
   type MountConfigs[A]  = KeyValueStore[APath, MountConfig2, A]
   type MountConfigsF[A] = Coyoneda[MountConfigs, A]
 
+  type MountingFileSystem[A] = Coproduct[MountingF, FileSystem, A]
+
+  def interpretMountingFileSystem[M[_]: Functor](
+      m: Mounting ~> M,
+      fs: FileSystem ~> M
+    ): MountingFileSystem ~> M =
+  free.interpret2[MountingF, FileSystem, M](Coyoneda.liftTF(m), fs)
+
   //-- Views --
 
   type ViewHandles = Map[

--- a/core/src/main/scala/quasar/fs/mount/package.scala
+++ b/core/src/main/scala/quasar/fs/mount/package.scala
@@ -34,10 +34,10 @@ package object mount {
   type MountingFileSystem[A] = Coproduct[MountingF, FileSystem, A]
 
   def interpretMountingFileSystem[M[_]: Functor](
-      m: Mounting ~> M,
-      fs: FileSystem ~> M
-    ): MountingFileSystem ~> M =
-  free.interpret2[MountingF, FileSystem, M](Coyoneda.liftTF(m), fs)
+    m: Mounting ~> M,
+    fs: FileSystem ~> M
+  ): MountingFileSystem ~> M =
+    free.interpret2[MountingF, FileSystem, M](Coyoneda.liftTF(m), fs)
 
   //-- Views --
 

--- a/core/src/test/scala/quasar/fs/mount/MountingSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/MountingSpec.scala
@@ -239,13 +239,14 @@ abstract class MountingSpec[S[_]](implicit S0: Functor[S], S1: MountingF :<: S)
       }
 
       "fails when using a dir for a view" >>* {
-        mnt.mount(rootDir, viewCfgA)
-          .run map (dj => maybeInvalid(dj) must beSome(rootDir[Sandboxed]))
+        mnt.mount(rootDir, viewCfgA) .run map (_ must_==
+          \/-(-\/(Mounting.PathTypeMismatch(rootDir))))
       }
 
       "fails when using a file for a filesystem" >>* {
         val f = rootDir </> file("foo")
-        mnt.mount(f, fsCfgA).run map (dj => maybeInvalid(dj) must beSome(f))
+        mnt.mount(f, fsCfgA) .run map (_ must_==
+          \/-(-\/(Mounting.PathTypeMismatch(f))))
       }
     }
 
@@ -313,8 +314,8 @@ abstract class MountingSpec[S[_]](implicit S0: Functor[S], S1: MountingF :<: S)
         val f = rootDir </> file("f1")
         val r = mountViewNoVars(f, exprA) *> replace(f, fsCfgB)
 
-        r.run.tuple(lookup(f).run) map { case (dj, cfg) =>
-          maybeInvalid(dj).tuple(cfg) must beSome((f, viewCfgA))
+        r.run.tuple(lookup(f).run) map { _ must_==(
+          (\/-(-\/(Mounting.PathTypeMismatch(f))), Some(viewCfgA)))
         }
       }
     }

--- a/web/src/main/scala/quasar/api/services/RestApi.scala
+++ b/web/src/main/scala/quasar/api/services/RestApi.scala
@@ -24,6 +24,7 @@ import quasar.Predef._
 import quasar.api.ServerOps.StaticContent
 import quasar.api.{Destination, HeaderParam}
 import quasar.fs.{ReadFile, WriteFile, ManageFile, QueryFile}
+import quasar.fs.mount.{Mounting}
 
 import scala.collection.immutable.ListMap
 import scalaz.concurrent.Task
@@ -56,12 +57,14 @@ final case class RestApi(staticContent: List[StaticContent],
         R: ReadFile.Ops[S],
         W: WriteFile.Ops[S],
         M: ManageFile.Ops[S],
-        Q: QueryFile.Ops[S]
-      ): ListMap[String,HttpService] = {
+        Q: QueryFile.Ops[S],
+        Mnt: Mounting.Ops[S]
+      ): ListMap[String, HttpService] = {
     val apiServices = ListMap(
       "/compile/fs"   -> query.compileService(f),
       "/data/fs"      -> data.service(f),
       "/metadata/fs"  -> metadata.service(f),
+      "/mount/fs"     -> mount.service(f),
       "/query/fs"     -> query.service(f),
       "/server"       -> server.service(defaultPort, restart),
       "/welcome"      -> welcome.service

--- a/web/src/main/scala/quasar/api/services/mount.scala
+++ b/web/src/main/scala/quasar/api/services/mount.scala
@@ -72,7 +72,7 @@ object mount {
         M.lookup(path).fold(
           cfg => Ok(EncodeJson.of[MountConfig2].encode(cfg)),
           errorResponse(NotFound, "There is no mount point at " + posixCodec.printPath(path)))
-        .foldMap(f).run
+        .foldMap(f).join
 
       case req @ MOVE -> AsPath(src) =>
         def move[T](src: Path[Abs, T, Sandboxed], dstStr: String, parse: String => Option[Path[Abs, T, Unsandboxed]], typeStr: String)

--- a/web/src/main/scala/quasar/api/services/mount.scala
+++ b/web/src/main/scala/quasar/api/services/mount.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2014 - 2015 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api.services
+
+import quasar.Predef._
+import quasar.api._
+import quasar.fp._
+import quasar.fs.{APath, PathError2}
+import quasar.fs.mount._
+
+import argonaut._
+import org.http4s._, Method.MOVE
+import org.http4s.headers.Accept
+import org.http4s.dsl.{Path => HPath, _}
+import org.http4s.server._
+import org.http4s.argonaut._
+import pathy.Path, Path._
+import scalaz._, Scalaz._
+import scalaz.concurrent.Task
+
+object mount {
+  def mountingErrorResponse(err: MountingError): Task[Response] =
+    err match {
+      case MountingError.PathError(e @ PathError2.Case.InvalidPath(path, reason))
+                                                    => errorResponse(Conflict, s"cannot mount at ${posixCodec.printPath(path)} because $reason")
+      case MountingError.PathError(e)               => pathErrorResponse(e)
+      case MountingError.EnvironmentError(e)        => errorResponse(InternalServerError, e.shows)
+      case MountingError.InvalidConfig(cfg, reasons) => errorResponse(BadRequest, reasons.list.mkString("; "))
+    }
+
+  def pathTypeMismatchResponse(err: Mounting.PathTypeMismatch): Task[Response] = {
+    val expectedType = refineType(err.path).fold(κ("file"), κ("directory"))
+    errorResponse(BadRequest, s"wrong path type for mount: ${posixCodec.printPath(err.path)}; $expectedType path required")
+  }
+
+  def service[S[_]: Functor]
+      (f: S ~> Task)
+      (implicit
+        M: Mounting.Ops[S]
+      ): HttpService = {
+
+    def addPath(path: APath, req: Request, replacing: Boolean): EitherT[Task, Task[Response], Boolean] =
+      for {
+        body  <- EitherT.right(EntityDecoder.decodeString(req))
+        bConf <- EitherT(Task.now(Parse.decodeWith[Task[Response] \/ MountConfig2, MountConfig2](body,
+                    \/.right,
+                    parseErrorMsg => errorResponse(BadRequest, s"input error: $parseErrorMsg").left,
+                    { case (msg, _) => errorResponse(BadRequest, msg).left })))
+        exists <- EitherT.right(M.lookup(path).isDefined.foldMap(f))
+        mnt    =  if (replacing && exists) M.replace(path, bConf) else M.mount(path, bConf)
+        _      <- EitherT(mnt.run.foldMap(f).map(_.fold(
+                    mountingErrorResponse(_).left,
+                    _.leftMap(pathTypeMismatchResponse))))
+      } yield exists
+
+    HttpService {
+      case GET -> AsPath(path) =>
+        M.lookup(path).fold(
+          cfg => Ok(EncodeJson.of[MountConfig2].encode(cfg)),
+          errorResponse(NotFound, "There is no mount point at " + posixCodec.printPath(path)))
+        .foldMap(f).run
+
+      case req @ MOVE -> AsPath(src) =>
+        def move[T](src: Path[Abs, T, Sandboxed], dstStr: String, parse: String => Option[Path[Abs, T, Unsandboxed]], typeStr: String)
+            : EitherT[M.F, Task[Response], Unit] =
+          parse(dstStr).flatMap(resandbox).cata(
+            dst => M.remount[T](src, dst).leftMap(mountingErrorResponse),
+            EitherT.left(errorResponse(BadRequest, s"Not an absolute $typeStr path: $dstStr").point[M.F]))
+        (for {
+          dst  <- EitherT(Task.now(requiredHeader(Destination, req)))
+          _    <- EitherT(refineType(src).fold[EitherT[M.F, Task[Response], Unit]](
+            srcDir => move(srcDir, dst, posixCodec.parseAbsDir, "directory"),
+            srcFile => move(srcFile, dst, posixCodec.parseAbsFile, "file")).run.foldMap(f))
+          resp <- EitherT.right(Ok(s"moved ${posixCodec.printPath(src)} to $dst"))
+        } yield resp).run.map(_.map(Task.now).merge).join
+
+      case req @ POST -> AsDirPath(parent) => (for {
+        f   <- EitherT(Task.now(
+                requiredHeader(XFileName, req)))
+        dst <- EitherT(Task.now(
+                (posixCodec.parseRelDir(f) orElse posixCodec.parseRelFile(f))
+                  .flatMap(sandbox(currentDir, _)).map(parent </> _) \/>
+                  errorResponse(BadRequest, "Not a relative path: " + f)))
+        _   <- addPath(dst, req, false)
+      } yield Ok("added " + posixCodec.printPath(dst))).merge.join
+
+      case req @ PUT -> AsPath(path) => (for {
+        upd <- addPath(path, req, true)
+      } yield Ok((if (upd) "updated" else "added") + " " + posixCodec.printPath(path))).merge.join
+
+      case DELETE -> AsPath(p) =>
+        M.unmount(p).run.foldMap(f).map(_.fold(
+          mountingErrorResponse,
+          κ(Ok(s"deleted ${posixCodec.printPath(p)}")))).join
+    }
+  }
+}

--- a/web/src/test/scala/quasar/api/services/MountServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/MountServiceSpec.scala
@@ -1,0 +1,588 @@
+package quasar.api.services
+
+import quasar.Predef._
+import quasar.{Variables}
+import quasar.api._
+import quasar.sql.{Expr}
+import quasar.effect.{KeyValueStore}
+import quasar.fp._
+import quasar.fs.{Path => QPath, _}
+import quasar.fs.mount._
+
+import argonaut._, Argonaut._
+import org.http4s._
+import org.http4s.argonaut._
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+import scalaz._, Scalaz._
+import scalaz.concurrent.Task
+import pathy.Path, Path._
+import pathy.scalacheck._
+import pathy.scalacheck.PathyArbitrary._
+
+class MountServiceSpec extends Specification with ScalaCheck with Http4s {
+  import posixCodec.printPath
+
+  val StubFs = FileSystemType("stub")
+
+  def pathUri(path: APath): Uri = Uri(path = printPath(path))
+
+  def viewConfig(q: String, vars: (String, String)*): (Expr, Variables) =
+    ((new quasar.sql.SQLParser).parse(quasar.sql.Query(q)).toOption.get,
+      Variables(Map(vars.map { case (n, v) =>
+        quasar.VarName(n) -> quasar.VarValue(v) }: _*)))
+
+  type Eff[A] = Coproduct[Task, MountingF, A]
+
+  val M = Mounting.Ops[Eff]
+
+  type HttpSvc = Request => M.F[Response]
+
+  def runTest[R: org.specs2.execute.AsResult](f: HttpSvc => M.F[R]): R = {
+    type MEff[A] = Coproduct[Task, MountConfigsF, A]
+
+    TaskRef(Map[APath, MountConfig2]()).map { ref =>
+
+      val mounter: Mounting ~> Free[MEff, ?] = Mounter[Task, MEff](
+        {
+          case MountRequest.MountView(_, expr, Variables(vars)) if (vars.isEmpty) =>
+            Task.now(MountingError.invalidConfig(MountConfig2.viewConfig(expr, Variables(vars)),
+              "unbound variable (simulated)".wrapNel).left)
+          case MountRequest.MountFileSystem(_, typ, uri @ ConnectionUri("invalid")) =>
+            Task.now(MountingError.invalidConfig(MountConfig2.fileSystemConfig(typ, uri),
+              "invalid connectionUri (simulated)".wrapNel).left)
+          case _ =>
+            Task.now(().right)
+        },
+        κ(Task.now(())))
+
+      val store: MountConfigs ~> Task = KeyValueStore.fromTaskRef(ref)
+
+      val mt: MEff ~> Task = free.interpret2[Task, MountConfigsF, Task](NaturalTransformation.refl, Coyoneda.liftTF(store))
+
+      val tf: MountingF ~> Task = Coyoneda.liftTF(hoistFree(mt) compose mounter)
+
+      val service = mount.service[MountingF](tf)
+
+      f(service.run andThen (free.lift(_).into[Eff]))
+        .foldMap(free.interpret2[Task, MountingF, Task](NaturalTransformation.refl, tf))
+    }.run.run
+  }
+
+  def orFail[A](v: MountingError \/ A): Task[A] =
+    Task.fromDisjunction(v.leftMap(e => new RuntimeException(e.shows)))
+  def orFailF[A](v: MountingError \/ A): M.F[A] =
+    free.lift(orFail(v)).into[Eff]
+
+  "Mount Service" should {
+    "GET" should {
+      "succeed with correct filesystem path" ! prop { d: ADir =>
+        runTest { service =>
+          for {
+            _    <- M.mountFileSystem(d, StubFs, ConnectionUri("foo")).run.flatMap(orFailF)
+
+            resp <- service(Request(uri = pathUri(d)))
+          } yield {
+            resp.as[Json].run must_== Json("stub" -> Json("connectionUri" := "foo"))
+            resp.status must_== Status.Ok
+          }
+        }
+      }
+
+      "succeed with correct view path" ! prop { f: AFile =>
+        runTest { service =>
+          val cfg = viewConfig("select * from zips where pop > :cutoff", "cutoff" -> "1000")
+          val cfgStr = EncodeJson.of[MountConfig2].encode(MountConfig2.viewConfig(cfg))
+
+          for {
+            _    <- M.mountView(f, cfg._1, cfg._2).run.flatMap(orFailF)
+
+            resp <- service(Request(uri = pathUri(f)))
+          } yield {
+            resp.as[Json].run must_== cfgStr
+            resp.status must_== Status.Ok
+          }
+        }
+      }
+
+      // FIXME: use APath (see PathGen)
+      // TODO: escaped paths do not survive being embedded in error messges
+      "be 404 with missing mount (dir)" ! prop { d: AbsDirOf[AlphaCharacters] =>
+        runTest { service =>
+          for {
+            resp <- service(Request(uri = pathUri(d.path)))
+          } yield {
+            resp.as[Json].run must_== Json("error" := s"There is no mount point at ${printPath(d.path)}")
+            resp.status must_== Status.NotFound
+          }
+        }
+      }
+
+      // TODO: escaped paths do not survive being embedded in error messges
+      "be 404 with path type mismatch" ! prop { fp: AbsFileOf[AlphaCharacters] =>
+        runTest { service =>
+          val dp = fileParent(fp.path) </> dir(fileName(fp.path).value)
+
+          for {
+            _    <- M.mountFileSystem(dp, StubFs, ConnectionUri("foo")).run.flatMap(orFailF)
+
+            resp <- service(Request(uri = pathUri(fp.path)))
+          } yield {
+            resp.as[Json].run must_== Json("error" := s"There is no mount point at ${printPath(fp.path)}")
+            resp.status must_== Status.NotFound
+          }
+        }
+      }
+    }
+
+    "MOVE" should {
+      import org.http4s.Method.MOVE
+
+      def destination(p: pathy.Path[_, _, Sandboxed]) = Header(Destination.name.value, printPath(p))
+
+      "succeed with filesystem mount" ! prop { (srcHead: String, srcTail: RDir, dstHead: String, dstTail: RDir) =>
+        // NB: distinct first segments means no possible conflict, but doesn't
+        // hit every possible scenario.
+        (srcHead != "" && dstHead != "" && srcHead != dstHead) ==> {
+          runTest { service =>
+            val src = rootDir </> dir(srcHead) </> srcTail
+            val dst = rootDir </> dir(dstHead) </> dstTail
+
+            for {
+              _    <- M.mountFileSystem(src, StubFs, ConnectionUri("foo")).run.flatMap(orFailF)
+
+              resp <- service(Request(
+                method = MOVE,
+                uri = pathUri(src),
+                headers = Headers(destination(dst))))
+
+              srcAfter <- M.lookup(src).run
+              dstAfter <- M.lookup(dst).run
+            } yield {
+              resp.as[String].run must_== s"moved ${printPath(src)} to ${printPath(dst)}"
+              resp.status must_== Status.Ok
+
+              srcAfter must beNone
+              dstAfter must beSome(MountConfig2.fileSystemConfig(StubFs, ConnectionUri("foo")))
+            }
+          }
+        }
+      }
+
+      // TODO: escaped paths do not survive being embedded in error messges
+      "be 404 with missing source" ! prop { (src: AbsDirOf[AlphaCharacters], dst: ADir) =>
+        runTest { service =>
+          for {
+            resp <- service(Request(
+              method = MOVE,
+              uri = pathUri(src.path),
+              headers = Headers(destination(dst))))
+          } yield {
+            resp.as[Json].run must_== Json("error" := s"${printPath(src.path)} doesn't exist")
+            resp.status must_== Status.NotFound
+          }
+        }
+      }
+
+      "be 400 with no specified Destination" ! prop { (src: ADir) =>
+        runTest { service =>
+          for {
+            _    <- M.mountFileSystem(src, StubFs, ConnectionUri("foo")).run.flatMap(orFailF)
+
+            resp <- service(Request(
+              method = MOVE,
+              uri = pathUri(src)))
+          } yield {
+            resp.as[Json].run must_== Json("error" := s"The 'Destination' header must be specified")
+            resp.status must_== Status.BadRequest
+          }
+        }
+      }
+
+      // TODO: escaped paths do not survive being embedded in error messages
+      "be 400 with relative path destination" ! prop { (src: ADir, dst: RelDirOf[AlphaCharacters]) =>
+        runTest { service =>
+          for {
+            _    <- M.mountFileSystem(src, StubFs, ConnectionUri("foo")).run.flatMap(orFailF)
+
+            resp <- service(Request(
+              method = MOVE,
+              uri = pathUri(src),
+              headers = Headers(destination(dst.path))))
+          } yield {
+            resp.as[Json].run must_== Json("error" := s"Not an absolute directory path: ${printPath(dst.path)}")
+            resp.status must_== Status.BadRequest
+          }
+        }
+      }
+
+      // TODO: escaped paths do not survive being embedded in error messages
+      "be 400 with non-directory path destination" ! prop { (src: ADir, dst: AbsFileOf[AlphaCharacters]) =>
+        runTest { service =>
+          for {
+            _    <- M.mountFileSystem(src, StubFs, ConnectionUri("foo")).run.flatMap(orFailF)
+
+            resp <- service(Request(
+              method = MOVE,
+              uri = pathUri(src),
+              headers = Headers(destination(dst.path))))
+          } yield {
+            resp.as[Json].run must_== Json("error" := s"Not an absolute directory path: ${printPath(dst.path)}")
+            resp.status must_== Status.BadRequest
+          }
+        }
+      }
+    }
+
+    def xFileName(p: pathy.Path[_, _, Sandboxed]) = Header(XFileName.name.value, printPath(p))
+
+    "Common" >> {
+      import org.http4s.Method.POST
+      import org.http4s.Method.PUT
+
+      trait RequestBuilder {
+        def apply[B](parent: ADir, mount: RPath, body: B)(implicit B: EntityEncoder[B]): Request
+      }
+
+      def testBoth(test: RequestBuilder => Unit) = {
+        "POST" should {
+          test(new RequestBuilder {
+            def apply[B](parent: ADir, mount: RPath, body: B)(implicit B: EntityEncoder[B]) =
+              Request(
+                method = POST,
+                uri = pathUri(parent),
+                headers = Headers(xFileName(mount)))
+              .withBody(body).run
+            })
+        }
+
+        "PUT" should {
+          test(new RequestBuilder {
+            def apply[B](parent: ADir, mount: RPath, body: B)(implicit B: EntityEncoder[B]) =
+              Request(
+                method = PUT,
+                uri = pathUri(parent </> mount))
+              .withBody(body).run
+          })
+        }
+      }
+
+      testBoth { reqBuilder =>
+        "succeed with filesystem path" ! prop { (parent: ADir, fsDir: RDir) =>
+          runTest { service =>
+            for {
+              resp  <- service(reqBuilder(parent, fsDir, """{"stub": { "connectionUri": "foo" } }"""))
+
+              after <- M.lookup(parent </> fsDir).run
+            } yield {
+              resp.as[String].run must_== s"added ${printPath(parent </> fsDir)}"
+              resp.status must_== Status.Ok
+
+              after must beSome(MountConfig2.fileSystemConfig(StubFs, ConnectionUri("foo")))
+            }
+          }
+        }
+
+        "succeed with view path" ! prop { (parent: ADir, f: RFile) =>
+          runTest { service =>
+            val cfg = viewConfig("select * from zips where pop < :cutoff", "cutoff" -> "1000")
+            val cfgStr = EncodeJson.of[MountConfig2].encode(MountConfig2.viewConfig(cfg))
+
+            for {
+              resp  <- service(reqBuilder(parent, f, cfgStr))
+
+              after <- M.lookup(parent </> f).run
+            } yield {
+              resp.as[String].run must_== s"added ${printPath(parent </> f)}"
+              resp.status must_== Status.Ok
+
+              after must beSome(MountConfig2.viewConfig(cfg))
+            }
+          }
+        }
+
+        "succeed with view under existing fs path" ! prop { (fs: ADir, viewSuffix: RFile) =>
+          runTest { service =>
+            val cfg = viewConfig("select * from zips where pop < :cutoff", "cutoff" -> "1000")
+            val cfgStr = EncodeJson.of[MountConfig2].encode(MountConfig2.viewConfig(cfg))
+
+            val view = fs </> viewSuffix
+
+            for {
+              _         <- M.mountFileSystem(fs, StubFs, ConnectionUri("foo")).run.flatMap(orFailF)
+
+              resp      <- service(reqBuilder(fs, viewSuffix, cfgStr))
+
+              afterFs   <- M.lookup(fs).run
+              afterView <- M.lookup(view).run
+            } yield {
+              resp.as[String].run must_== s"added ${printPath(view)}"
+              resp.status must_== Status.Ok
+
+              afterFs must beSome
+              afterView must beSome(MountConfig2.viewConfig(cfg))
+            }
+          }
+        }
+
+        // TODO: escaped paths do not survive being embedded in error messages
+        "succeed with view 'above' existing fs path" ! prop { (d: AbsDirOf[AlphaCharacters], view: RFile, fsSuffix: RDir) =>
+          runTest { service =>
+            val fsCfg = ()
+
+            val cfg = viewConfig("select * from zips where pop < :cutoff", "cutoff" -> "1000")
+            val cfgStr = EncodeJson.of[MountConfig2].encode(MountConfig2.viewConfig(cfg))
+
+            val fs = d.path </> posixCodec.parseRelDir(printPath(view) + "/").flatMap(sandbox(currentDir, _)).get </> fsSuffix
+
+            for {
+              _     <- M.mountFileSystem(fs,StubFs, ConnectionUri("foo")).run.flatMap(orFailF)
+
+              resp  <- service(reqBuilder(d.path, view, cfgStr))
+
+              after <- M.lookup(d.path </> view).run
+            } yield {
+              resp.as[String].run must_== s"added ${printPath(d.path </> view)}"
+              resp.status must_== Status.Ok
+
+              after must beSome(MountConfig2.viewConfig(cfg))
+            }
+          }
+        }
+
+        // TODO: escaped paths do not survive being embedded in error messages
+        "be 409 with fs above existing fs path" ! prop { (d: AbsDirOf[AlphaCharacters], fs: RelDirOf[AlphaCharacters], fsSuffix: RelDirOf[AlphaCharacters]) =>
+          (!identicalPath(fsSuffix.path, currentDir)) ==> {
+            runTest { service =>
+              val cfg = (StubFs, ConnectionUri("foo"))
+
+              val cfgStr = EncodeJson.of[MountConfig2].encode(MountConfig2.fileSystemConfig(cfg))
+
+              val fs1 = d.path </> fs.path </> fsSuffix.path
+
+              for {
+                _     <- M.mountFileSystem(fs1, cfg._1, cfg._2).run.flatMap(orFailF)
+
+                resp  <- service(reqBuilder(d.path, fs.path, cfgStr))
+
+                after <- M.lookup(d.path </> fs.path).run
+              } yield {
+                resp.as[Json].run must_== Json("error" := s"cannot mount at ${printPath(d.path </> fs.path)} because existing mount below: ${printPath(fs1)}")
+                resp.status must_== Status.Conflict
+
+                after must beNone
+              }
+            }
+          }
+        }.pendingUntilFixed("test harness does not yet detect conflicts")
+
+        // TODO: escaped paths do not survive being embedded in error messages
+        "be 400 with fs config and file path in X-File-Name header" ! prop { (parent: AbsDirOf[AlphaCharacters], fsFile: RelFileOf[AlphaCharacters]) =>
+          runTest { service =>
+            val cfg = (StubFs, ConnectionUri("foo"))
+
+            for {
+              resp <- service(reqBuilder(parent.path, fsFile.path, """{ "stub": { "connectionUri": "foo" } }"""))
+            } yield {
+              resp.as[Json].run must_== Json("error" := s"wrong path type for mount: ${printPath(parent.path </> fsFile.path)}; directory path required")
+              resp.status must_== Status.BadRequest
+            }
+          }
+        }
+
+        // TODO: escaped paths do not survive being embedded in error messages
+        "be 400 with view config and dir path in X-File-Name header" ! prop { (parent: AbsDirOf[AlphaCharacters], viewDir: RelDirOf[AlphaCharacters]) =>
+          runTest { service =>
+            val cfg = viewConfig("select * from zips where pop < :cutoff", "cutoff" -> "1000")
+            val cfgStr = EncodeJson.of[MountConfig2].encode(MountConfig2.viewConfig(cfg))
+
+            for {
+              resp <- service(reqBuilder(parent.path, viewDir.path, cfgStr))
+            } yield {
+              resp.as[Json].run must_== Json("error" := s"wrong path type for mount: ${printPath(parent.path </> viewDir.path)}; file path required")
+              resp.status must_== Status.BadRequest
+            }
+          }
+        }
+
+        "be 400 with unbound variable in view" ! prop { (parent: ADir, f: RFile) =>
+          runTest { service =>
+            val cfg = viewConfig("select * from zips where pop < :cutoff")
+            val cfgStr = EncodeJson.of[MountConfig2].encode(MountConfig2.viewConfig(cfg))
+
+            for {
+              resp <- service(reqBuilder(parent, f, cfgStr))
+            } yield {
+              resp.as[Json].run must_== Json("error" := s"unbound variable (simulated)")
+              resp.status must_== Status.BadRequest
+            }
+          }
+        }
+
+        "be 400 with invalid JSON" ! prop { (parent: ADir, f: RFile) =>
+          runTest { service =>
+            for {
+              resp <- service(reqBuilder(parent, f, "{"))
+            } yield {
+              resp.as[Json].run must_== Json("error" := "input error: JSON terminates unexpectedly.")
+              resp.status must_== Status.BadRequest
+            }
+          }
+        }
+
+        "be 400 with invalid connection uri" ! prop { (parent: ADir, d: RDir) =>
+          runTest { service =>
+            for {
+              resp <- service(reqBuilder(parent, d, """{ "stub": { "connectionUri": "invalid" } }"""))
+            } yield {
+              resp.as[Json].run must_== Json("error" := "invalid connectionUri (simulated)")
+              resp.status must_== Status.BadRequest
+            }
+          }
+        }
+
+        "be 400 with invalid view URI" ! prop { (parent: ADir, f: RFile) =>
+          runTest { service =>
+            for {
+              resp <- service(reqBuilder(parent, f, """{ "view": { "connectionUri": "foo://bar" } }"""))
+            } yield {
+              resp.as[Json].run must_== Json("error" := "unrecognized scheme: foo")
+              resp.status must_== Status.BadRequest
+            }
+          }
+        }
+
+        () // TODO: Remove after upgrading to specs2 3.x
+      }
+    }
+
+
+    "POST" should {
+      import org.http4s.Method.POST
+
+      // TODO: escaped paths do not survive being embedded in error messages
+      "be 409 with existing filesystem path" ! prop { (parent: AbsDirOf[AlphaCharacters], fsDir: RelDirOf[AlphaCharacters]) =>
+        runTest { service =>
+          val previousCfg = (StubFs, ConnectionUri("bar"))
+
+          for {
+            _    <- M.mountFileSystem(parent.path </> fsDir.path, previousCfg._1, previousCfg._2).run.flatMap(orFailF)
+
+            resp <- service(Request(
+                      method = POST,
+                      uri = pathUri(parent.path),
+                      headers = Headers(xFileName(fsDir.path)))
+                    .withBody("""{ "stub": { "connectionUri": "foo" } }""").run)
+
+            after <- M.lookup(parent.path </> fsDir.path).run
+          } yield {
+            resp.as[Json].run must_== Json("error" := s"${printPath(parent.path </> fsDir.path)} already exists")
+            resp.status must_== Status.Conflict
+
+            after must beSome(MountConfig2.fileSystemConfig(previousCfg))
+          }
+        }
+      }
+
+      "be 400 with missing X-File-Name header" ! prop { (parent: ADir, fsDir: RDir) =>
+        runTest { service =>
+          for {
+            resp <- service(Request(
+                      method = POST,
+                      uri = pathUri(parent))
+                    .withBody("""{ "stub": { "connectionUri": "foo" } }""").run)
+          } yield {
+            resp.as[Json].run must_== Json("error" := "The 'X-File-Name' header must be specified")
+            resp.status must_== Status.BadRequest
+          }
+        }
+      }
+    }
+
+    "PUT" should {
+      import org.http4s.Method.PUT
+
+      "succeed with overwritten filesystem" ! prop { (fsDir: ADir) =>
+        runTest { service =>
+          val previousCfg = (StubFs, ConnectionUri("bar"))
+          val cfg = (StubFs, ConnectionUri("foo"))
+
+          for {
+            _    <- M.mountFileSystem(fsDir, StubFs, ConnectionUri("foo")).run.flatMap(orFailF)
+
+            resp <- service(Request(
+                      method = PUT,
+                      uri = pathUri(fsDir))
+                    .withBody("""{ "stub": { "connectionUri": "foo" } }""").run)
+
+            after <- M.lookup(fsDir).run
+          } yield {
+            resp.as[String].run must_== s"updated ${printPath(fsDir)}"
+            resp.status must_== Status.Ok
+
+            after must beSome(MountConfig2.fileSystemConfig(cfg))
+          }
+        }
+      }
+    }
+
+    "DELETE" should {
+      import org.http4s.Method.DELETE
+
+      "succeed with filesystem path" ! prop { (d: ADir) =>
+        runTest { service =>
+          for {
+            _     <- M.mountFileSystem(d, StubFs, ConnectionUri("foo")).run.flatMap(orFailF)
+
+            resp  <- service(Request(
+                      method = DELETE,
+                      uri = pathUri(d)))
+
+            after <- M.lookup(d).run
+          } yield {
+            resp.as[String].run must_== s"deleted ${printPath(d)}"
+            resp.status must_== Status.Ok
+
+            after must beNone
+          }
+        }
+      }
+
+      "succeed with view path" ! prop { (f: AFile) =>
+        runTest { service =>
+          val cfg = viewConfig("select * from zips where pop > :cutoff", "cutoff" -> "1000")
+
+          for {
+            _     <- M.mountView(f, cfg._1, cfg._2).run.flatMap(orFailF)
+
+            resp  <- service(Request(
+                      method = DELETE,
+                      uri = pathUri(f)))
+
+            after <- M.lookup(f).run
+          } yield {
+            resp.status must_== Status.Ok
+            resp.as[String].run must_== s"deleted ${printPath(f)}"
+
+            after must beNone
+          }
+        }
+      }
+
+      // FIXME: need Arbitrary[APath]
+      // TODO: escaped paths do not survive being embedded in error messages
+      "be 404 with missing path" ! prop { (p: AbsDirOf[AlphaCharacters]) =>
+        runTest { service =>
+          for {
+            resp <- service(Request(
+                      method = DELETE,
+                      uri = pathUri(p.path)))
+          } yield {
+            resp.as[Json].run must_== Json("error" := s"${printPath(p.path)} doesn't exist")
+            resp.status must_== Status.NotFound
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
See SD-1142

In `Mounting.Ops.mount`, return errors that result from the ambiguity in that method's argument in a separate error type (PathTypeMismatch), so that MountingErrors will only represent errors from actually interpreting the algebra.

New common stuff:
- `errorResponse()` to format simple error messages in the expected JSON syntax.
- Use that in generating responses for FileSystemError and PathError2.
- `requiredHeader()` to extract headers in a convenient EitherT.
- `resandbox()` for the previously duplicated code to fix up the type of `Abs` paths parsed by the services.

Renamed FileName to XFileName to hopefully reduce confusion and to avoid collisions.