### PR TITLE
Allow arbitrary expressions in the REPL.

### DIFF
--- a/core/src/main/scala/quasar/compiler.scala
+++ b/core/src/main/scala/quasar/compiler.scala
@@ -404,6 +404,10 @@ trait Compiler[F[_]] {
       case ArrayLiteralF(exprs) =>
         exprs.traverseU(compile0).map(elems => Fix(MakeArrayN(elems: _*)))
 
+      case MapLiteralF(exprs) =>
+        exprs.traverse(_.bitraverse(compile0, compile0)).map(elems =>
+          Fix(MakeObjectN(elems: _*)))
+
       case SpliceF(expr) =>
         expr.fold(
           CompilerState.fullTable.flatMap(_.map(emit _).getOrElse(fail(GenericError("Not within a table context so could not find table expression for wildcard")))))(

--- a/core/src/main/scala/quasar/semantics.scala
+++ b/core/src/main/scala/quasar/semantics.scala
@@ -323,6 +323,7 @@ trait SemanticAnalysis {
 
     case SetLiteralF(_)  => success(Provenance.Value)
     case ArrayLiteralF(_) => success(Provenance.Value)
+    case MapLiteralF(_) => success(Provenance.Value)
     case SpliceF(expr)       => success(expr.getOrElse(Provenance.Empty))
     case VariF(_)        => success(Provenance.Value)
     case BinopF(left, right, _) => success(left & right)

--- a/core/src/main/scala/quasar/sql/ast.scala
+++ b/core/src/main/scala/quasar/sql/ast.scala
@@ -39,6 +39,8 @@ object ExprF {
   final case class VariF[A](symbol: String) extends ExprF[A]
   final case class SetLiteralF[A](exprs: List[A]) extends ExprF[A]
   final case class ArrayLiteralF[A](exprs: List[A]) extends ExprF[A]
+  /** Can’t be a Map, because we need to arbitrarily transform the key */
+  final case class MapLiteralF[A](exprs: List[(A, A)]) extends ExprF[A]
   final case class SpliceF[A](expr: Option[A]) extends ExprF[A]
   final case class BinopF[A](lhs: A, rhs: A, op: BinaryOperator)
       extends ExprF[A]
@@ -229,6 +231,13 @@ object ArrayLiteralF {
   def unapply[A](obj: ExprF[A]): Option[List[A]] = obj match {
     case ExprF.ArrayLiteralF(exprs) => Some(exprs)
     case _                          => None
+  }
+}
+object MapLiteralF {
+  def apply[A](exprs: List[(A, A)]): ExprF[A] = ExprF.MapLiteralF(exprs)
+  def unapply[A](obj: ExprF[A]): Option[List[(A, A)]] = obj match {
+    case ExprF.MapLiteralF(exprs) => Some(exprs)
+    case _                        => None
   }
 }
 object SpliceF {

--- a/core/src/main/scala/quasar/sql/fixpoint.scala
+++ b/core/src/main/scala/quasar/sql/fixpoint.scala
@@ -62,6 +62,12 @@ object ArrayLiteral {
     ArrayLiteralF.unapply(obj.unFix)
 }
 
+object MapLiteral {
+  def apply(exprs: List[(Expr, Expr)]): Expr = Fix[ExprF](MapLiteralF(exprs))
+  def unapply(obj: Expr): Option[List[(Expr, Expr)]] =
+    MapLiteralF.unapply(obj.unFix)
+}
+
 /** Represents the wildcard in a select projection
   * For instance:
   *  "select foo.* from example" => ...(Splice(Some(Ident("foo"))))...

--- a/core/src/main/scala/quasar/std/set.scala
+++ b/core/src/main/scala/quasar/std/set.scala
@@ -45,6 +45,9 @@ trait SetLib extends Library {
     setTyper(partialTyper {
       case _ :: Type.Const(Data.Int(n)) :: Nil if n == 0 =>
         Type.Const(Data.Set(Nil))
+      case Type.Const(Data.Set(s)) :: Type.Const(Data.Int(n)) :: Nil
+          if n.isValidInt =>
+        Type.Const(Data.Set(s.take(n.intValue)))
       case Type.Set(t) :: _ :: Nil => t
       case t           :: _ :: Nil => t
     }),
@@ -60,6 +63,9 @@ trait SetLib extends Library {
       }
     },
     setTyper(partialTyper {
+      case Type.Const(Data.Set(s)) :: Type.Const(Data.Int(n)) :: Nil
+          if n.isValidInt =>
+        Type.Const(Data.Set(s.drop(n.intValue)))
       case Type.Set(t) :: _ :: Nil => t
       case t           :: _ :: Nil => t
     }),


### PR DESCRIPTION
Previously, the REPL only recognized expressions that began with
`select`, however, the parser has long been able to handle expressions
like `4 + 3`, etc. that don’t use `select`. This gets rid of the
`Unknown` REPL command, and tries to treat anything that doesn’t match
some other pattern as an expression.

This also adds literal map/object syntax to the parser & SQL AST (part
of SD-990), short-circuits Constant LPs before calling the backend
planner, and fixes a few other issues I ran into when testing the REPL:

* `select 4 + 3 offset 1` would parse incorrectly as `select (4 + 3 offset 1)`,
* flattening didn’t constant fold when it could, and
* `Take`/`Drop`/`MakeArray`/`MakeObject` didn’t operate on Data.Set correctly.