### PR TITLE
Path encoding/escaping issues

### DIFF
--- a/core/src/main/scala/quasar/physical/mongodb/collection.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/collection.scala
@@ -117,18 +117,18 @@ object Collection {
   val DatabaseNameEscapes = List(
     " "  -> "+",
     "."  -> "~",
-    "$"  -> "$$",
-    "+"  -> "$add",
-    "~"  -> "$tilde",
-    "/"  -> "$div",
-    "\\" -> "$esc",
-    "\"" -> "$quot",
-    "*"  -> "$mul",
-    "<"  -> "$lt",
-    ">"  -> "$gt",
-    ":"  -> "$colon",
-    "|"  -> "$bar",
-    "?"  -> "$qmark")
+    "%"  -> "%%",
+    "+"  -> "%add",
+    "~"  -> "%tilde",
+    "/"  -> "%div",
+    "\\" -> "%esc",
+    "\"" -> "%quot",
+    "*"  -> "%mul",
+    "<"  -> "%lt",
+    ">"  -> "%gt",
+    ":"  -> "%colon",
+    "|"  -> "%bar",
+    "?"  -> "%qmark")
 
   private object DatabaseNameParser extends PathParser {
     def name: Parser[String] =

--- a/core/src/test/scala/quasar/physical/mongodb/collection.scala
+++ b/core/src/test/scala/quasar/physical/mongodb/collection.scala
@@ -78,15 +78,15 @@ class CollectionSpec extends Specification with ScalaCheck with DisjunctionMatch
       import quasar.fs._
 
       Collection.fromPath(Path(List(DirNode("db/\\\"")), Some(FileNode("foo")))) must
-        beRightDisjunction(Collection("db$div$esc$quot", "foo"))
+        beRightDisjunction(Collection("db%div%esc%quot", "foo"))
     }
 
     "escape Windows-only MongoDB-reserved chars in db name" in {
-      Collection.fromPath(Path("db*<>:|?/foo")) must beRightDisjunction(Collection("db$mul$lt$gt$colon$bar$qmark", "foo"))
+      Collection.fromPath(Path("db*<>:|?/foo")) must beRightDisjunction(Collection("db%mul%lt%gt%colon%bar%qmark", "foo"))
     }
 
     "escape escape characters in db name" in {
-      Collection.fromPath(Path("db$+~/foo")) must beRightDisjunction(Collection("db$$$add$tilde", "foo"))
+      Collection.fromPath(Path("db%+~/foo")) must beRightDisjunction(Collection("db%%%add%tilde", "foo"))
     }
 
     "fail with sequence of escapes exceeding maximum length" in {
@@ -169,7 +169,7 @@ class CollectionSpec extends Specification with ScalaCheck with DisjunctionMatch
     }
 
     "ignore unrecognized escape in database name" in {
-      Collection("$foo", "bar").asPath must_== Path("$foo/bar")
+      Collection("%foo", "bar").asPath must_== Path("%foo/bar")
     }
 
     "not explode on empty collection name" in {
@@ -255,17 +255,17 @@ class CollectionSpec extends Specification with ScalaCheck with DisjunctionMatch
 
     "escape MongoDB-reserved chars in db name" in {
       Collection.fromPathy(rootDir </> dir("db/\\\"") </> file("foo")) must
-        beRightDisjunction(Collection("db$div$esc$quot", "foo"))
+        beRightDisjunction(Collection("db%div%esc%quot", "foo"))
     }
 
     "escape Windows-only MongoDB-reserved chars in db name" in {
       Collection.fromPathy(rootDir </> dir("db*<>:|?") </> file("foo")) must
-        beRightDisjunction(Collection("db$mul$lt$gt$colon$bar$qmark", "foo"))
+        beRightDisjunction(Collection("db%mul%lt%gt%colon%bar%qmark", "foo"))
     }
 
     "escape escape characters in db name" in {
-      Collection.fromPathy(rootDir </> dir("db$+~") </> file("foo")) must
-        beRightDisjunction(Collection("db$$$add$tilde", "foo"))
+      Collection.fromPathy(rootDir </> dir("db%+~") </> file("foo")) must
+        beRightDisjunction(Collection("db%%%add%tilde", "foo"))
     }
 
     "fail with sequence of escapes exceeding maximum length" in {
@@ -355,8 +355,8 @@ class CollectionSpec extends Specification with ScalaCheck with DisjunctionMatch
     }
 
     "ignore unrecognized escape in database name" in {
-      Collection("$foo", "bar").asFile must_==
-        rootDir </> dir("$foo") </> file("bar")
+      Collection("%foo", "bar").asFile must_==
+        rootDir </> dir("%foo") </> file("bar")
     }
 
     "not explode on empty collection name" in {
@@ -387,6 +387,6 @@ object PathGen {
 
   def genName: Gen[String] = Gen.nonEmptyListOf(
     Gen.oneOf(
-      Gen.oneOf("$./\\_~ *+-".toList),  // NB: boost the frequency of reserved chars
+      Gen.oneOf("%$./\\_~ *+-".toList),  // NB: boost the frequency of reserved chars
       Arbitrary.arbitrary[Char])).map(_.mkString)
 }

--- a/web/src/main/scala/quasar/api/package.scala
+++ b/web/src/main/scala/quasar/api/package.scala
@@ -117,19 +117,23 @@ package object api {
     }
   }
 
-  // TODO: probably need a URL-specific codec here
+  val UriPathCodec = PathCodec('/',
+    UrlCodingUtils.urlEncode(_, toSkip = HPath.pathUnreserved),
+    UrlCodingUtils.urlDecode(_))
+
+  // NB: oddly, every path is prefixed with '/', except "".
+  private def pathString(p: HPath) =
+    if (p.toString === "") "/" else p.toString
+
   object AsDirPath {
     def unapply(p: HPath): Option[ADir] = {
-      val str = "/" + p.toList.mkString("/")
-      posixCodec.parseAbsDir(str) map sandboxAbs
+      UriPathCodec.parseAbsDir(pathString(p)) map sandboxAbs
     }
   }
 
-  // TODO: probably need a URL-specific codec here
   object AsFilePath {
     def unapply(p: HPath): Option[AFile] = {
-      val str = "/" + p.toList.mkString("/")
-      posixCodec.parseAbsFile(str) map sandboxAbs
+      UriPathCodec.parseAbsFile(pathString(p)) map sandboxAbs
     }
   }
 

--- a/web/src/test/scala/quasar/api/AsPathSpec.scala
+++ b/web/src/test/scala/quasar/api/AsPathSpec.scala
@@ -2,24 +2,45 @@ package quasar.api
 
 import quasar.Predef._
 
+import quasar.fs.{ADir, AFile}
+
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
 import pathy.Path._
 import pathy.scalacheck.PathyArbitrary._
-import org.http4s.dsl.{Path => HttpPath}
-import quasar.fs.{ADir, AFile}
+import org.http4s.dsl.{Path => HPath}
 
-class AsPathSpec extends Specification with ScalaCheck {
-  "AsPathPath" should {
+class AsPathSpec extends Specification with ScalaCheck with PathUtils {
+  "AsPath" should {
     "decode any Path we can throw at it" >> {
-      "AbsFile" ! prop { file : AFile =>
-        val httpPath = HttpPath(posixCodec.printPath(file))
-        AsFilePath.unapply(httpPath) must_== Some(file)
+      "AbsFile" ! prop { file: AFile =>
+        !hasDot(file) ==> {
+          val httpPath = HPath(UriPathCodec.printPath(file))
+          AsFilePath.unapply(httpPath) must_== Some(file)
+        }
       }
       "AbsDir" ! prop { dir : ADir =>
-        val httpPath = HttpPath(posixCodec.printPath(dir))
-        AsDirPath.unapply(httpPath) must_== Some(dir)
+        !hasDot(dir) ==> {
+          val httpPath = HPath(UriPathCodec.printPath(dir))
+          AsDirPath.unapply(httpPath) must_== Some(dir)
+        }
       }
+    }
+
+    "decode root" in {
+      val httpPath = HPath("/")
+      AsDirPath.unapply(httpPath) must_== Some(rootDir)
+    }
+
+    "decode escaped /" in {
+      val httpPath = HPath("/foo%2Fbar/baz/")
+      AsDirPath.unapply(httpPath) must beSome(rootDir </> dir("foo/bar") </> dir("baz"))
+    }
+  }
+
+  "UriPathCodec" should {
+    "encode /" in {
+      UriPathCodec.printPath(rootDir </> dir("foo/bar") </> dir("baz")) must_== "/foo%2Fbar/baz/"
     }
   }
 }

--- a/web/src/test/scala/quasar/api/PathUtils.scala
+++ b/web/src/test/scala/quasar/api/PathUtils.scala
@@ -1,0 +1,15 @@
+package quasar.api
+
+import quasar.Predef._
+
+import pathy.Path, Path._
+import scalaz._, Scalaz._
+
+trait PathUtils {
+  // NB: these paths confuse the codec and don't seem important at the moment.
+  // See https://github.com/slamdata/scala-pathy/issues/23.
+  def hasDot(p: Path[_, _, _]): Boolean =
+    flatten(false, false, false, d => d == "." || d == "..", f => f == "." || f == "..", p).toList.contains(true)
+}
+
+object PathUtils extends PathUtils


### PR DESCRIPTION
Really not happy about all the silly filtering this requires in the tests but didn't want to make this wait for a fix in pathy. On the other hand, switching the escape char for DB's has hardly any fallout.

With this in place, I can add folders at the DB-level, through the API, with names like `Untitled Folder.slam` and `foo/bar.slam`:
```
> show databases
...
Untitled+Folder~slam  0.078GB
admin                 0.078GB
foo%divbar~slam       0.078GB
quasar-test           0.453GB
```