### PR TITLE
Update scalaz to 7.1.7

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import scala.collection.Seq
 import sbt._, Keys._
 
 object Dependencies {
-  private val scalazVersion  = "7.1.4"
+  private val scalazVersion  = "7.1.7"
   private val slcVersion     = "0.4"
   private val monocleVersion = "1.1.1"
   private val pathyVersion   = "0.0.3"


### PR DESCRIPTION
Other than staying current, the main reason for upgrading is the
potential performance benefits for `Free`, given the `fastFlatMap`
optimization backported in 7.1.7.

See https://github.com/scalaz/scalaz/pull/1085