### PR TITLE
Fix handling of `IN` for single-element sets.

### DIFF
--- a/core/src/main/scala/quasar/functions.scala
+++ b/core/src/main/scala/quasar/functions.scala
@@ -70,7 +70,7 @@ trait FuncInstances {
 
 object Func extends FuncInstances {
   trait Simplifier {
-    def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]):
+    def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]):
         Option[LogicalPlan[T[LogicalPlan]]]
   }
   type Typer      = List[Type] => ValidationNel[SemanticError, Type]

--- a/core/src/main/scala/quasar/optimizer.scala
+++ b/core/src/main/scala/quasar/optimizer.scala
@@ -44,7 +44,7 @@ object Optimizer {
       case x => x.map(_._2)
     }
 
-  def simplifyƒ[T[_[_]]: Recursive: FunctorT]:
+  def simplifyƒ[T[_[_]]: Recursive: Corecursive]:
       LogicalPlan[T[LogicalPlan]] => Option[LogicalPlan[T[LogicalPlan]]] = {
     case inv @ InvokeF(func, _) => func.simplify(inv)
     case LetF(ident, form, in) => form.project match {

--- a/core/src/main/scala/quasar/physical/mongodb/planner.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/planner.scala
@@ -189,7 +189,7 @@ object MongoDbPlanner extends Planner[Crystallized] with JsConversions {
         case Not => makeSimpleUnop(jscore.Not)
         case IsNull =>
           Arity1(BinOp(jscore.Eq, _, Literal(Js.Null)))
-        case In  =>
+        case In | Within =>
           Arity2((value, array) =>
             BinOp(jscore.Neq,
               Literal(Js.Num(-1, false)),
@@ -486,7 +486,7 @@ object MongoDbPlanner extends Planner[Crystallized] with JsConversions {
           List(there(0, here))))
         case (IsNull, _) => -\/(UnsupportedPlan(node, None))
 
-        case (In, _)  =>
+        case (In | Within, _)  =>
           relop(
             Selector.In.apply _,
             x => Selector.ElemMatch(\/-(Selector.In(Bson.Arr(List(x))))))

--- a/core/src/main/scala/quasar/std/library.scala
+++ b/core/src/main/scala/quasar/std/library.scala
@@ -25,7 +25,7 @@ import scalaz._, Scalaz._, Validation.{success, failure}
 
 trait Library {
   protected val noSimplification: Func.Simplifier = new Func.Simplifier {
-    def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
+    def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
       None
   }
 

--- a/core/src/main/scala/quasar/std/math.scala
+++ b/core/src/main/scala/quasar/std/math.scala
@@ -83,7 +83,7 @@ trait MathLib extends Library {
   val Add = Mapping("(+)", "Adds two numeric or temporal values",
     MathAbs, MathAbs :: MathRel :: Nil,
     new Func.Simplifier {
-      def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
+      def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
           case IsInvoke(_, List(x, ZeroF())) => x.some
           case IsInvoke(_, List(ZeroF(), x)) => x.some
@@ -112,7 +112,7 @@ trait MathLib extends Library {
   val Multiply = Mapping("(*)", "Multiplies two numeric values or one interval and one numeric value",
     MathRel, MathRel :: Type.Numeric :: Nil,
     new Func.Simplifier {
-      def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
+      def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
           case IsInvoke(_, List(x, OneF())) => x.some
           case IsInvoke(_, List(OneF(), x)) => x.some
@@ -135,7 +135,7 @@ trait MathLib extends Library {
   val Power = Mapping("(^)", "Raises the first argument to the power of the second",
     Type.Numeric, Type.Numeric :: Type.Numeric :: Nil,
     new Func.Simplifier {
-      def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
+      def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
           case IsInvoke(_, List(x, OneF())) => x.some
           case _                            => None
@@ -160,7 +160,7 @@ trait MathLib extends Library {
   val Subtract = Mapping("(-)", "Subtracts two numeric or temporal values",
     MathAbs, MathAbs :: MathAbs :: Nil,
     new Func.Simplifier {
-      def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
+      def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
           case IsInvoke(_, List(x, ZeroF())) => x.some
           case InvokeF(_, List(c, x)) => c.project match {
@@ -194,7 +194,7 @@ trait MathLib extends Library {
   val Divide = Mapping("(/)", "Divides one numeric or interval value by another (non-zero) numeric value",
     MathRel, MathAbs :: MathRel :: Nil,
     new Func.Simplifier {
-      def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
+      def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
           case IsInvoke(_, List(x, OneF())) => x.some
           case _                            => None

--- a/core/src/main/scala/quasar/std/relations.scala
+++ b/core/src/main/scala/quasar/std/relations.scala
@@ -119,7 +119,7 @@ trait RelationsLib extends Library {
   val And = Mapping("(AND)", "Performs a logical AND of two boolean values",
     Type.Bool, Type.Bool :: Type.Bool :: Nil,
     new Func.Simplifier {
-      def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
+      def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
           case IsInvoke(_, List(ConstantF(Data.True), r)) => r.some
           case IsInvoke(_, List(l, ConstantF(Data.True))) => l.some
@@ -139,7 +139,7 @@ trait RelationsLib extends Library {
   val Or = Mapping("(OR)", "Performs a logical OR of two boolean values",
     Type.Bool, Type.Bool :: Type.Bool :: Nil,
     new Func.Simplifier {
-      def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
+      def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
           case IsInvoke(_, List(ConstantF(Data.False), r)) => r.some
           case IsInvoke(_, List(l, ConstantF(Data.False))) => l.some
@@ -168,7 +168,7 @@ trait RelationsLib extends Library {
   val Cond = Mapping("(IF_THEN_ELSE)", "Chooses between one of two cases based on the value of a boolean expression",
     Type.Bottom, Type.Bool :: Type.Top :: Type.Top :: Nil,
     new Func.Simplifier {
-      def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
+      def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
           case IsInvoke(_, List(ConstantF(Data.True),  c, _)) => c.some
           case IsInvoke(_, List(ConstantF(Data.False), _, a)) => a.some
@@ -187,7 +187,7 @@ trait RelationsLib extends Library {
     "Returns the first of its arguments that isn't null.",
     Type.Bottom, Type.Top :: Type.Top :: Nil,
     new Func.Simplifier {
-      def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
+      def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
           case IsInvoke(_, List(ConstantF(Data.Null), second)) => second.some
           case IsInvoke(_, List(first, ConstantF(Data.Null)))  => first.some

--- a/core/src/main/scala/quasar/std/string.scala
+++ b/core/src/main/scala/quasar/std/string.scala
@@ -37,7 +37,7 @@ trait StringLib extends Library {
   val Concat = Mapping("concat", "Concatenates two (or more) string values",
     Type.Str, Type.Str :: Type.Str :: Nil,
     new Func.Simplifier {
-      def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
+      def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
           case IsInvoke(_, List(ConstantF(Data.Str("")), second)) => second.some
           case IsInvoke(_, List(first, ConstantF(Data.Str(""))))  => first.some
@@ -116,7 +116,7 @@ trait StringLib extends Library {
     "Extracts a portion of the string",
     Type.Str, Type.Str :: Type.Int :: Type.Int :: Nil,
     new Func.Simplifier {
-      def apply[T[_[_]]: Recursive: FunctorT](orig: LogicalPlan[T[LogicalPlan]]) =
+      def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
           case InvokeF(f, List(str0, from0, for0)) => (str0.project, from0.project) match {
             case (ConstantF(Data.Str(str)), ConstantF(Data.Int(from))) if 0 < from =>

--- a/core/src/test/scala/quasar/matchers.scala
+++ b/core/src/test/scala/quasar/matchers.scala
@@ -19,7 +19,7 @@ package quasar
 import quasar.Predef._
 import RenderTree.ops._
 import quasar.fp._
-import quasar.recursionschemes._, cofree._, Fix._
+import quasar.recursionschemes._, Fix._, FunctorT.ops._
 
 import scala.reflect.ClassTag
 
@@ -40,13 +40,13 @@ trait TermLogicalPlanMatchers {
   case class equalToPlan(expected: Fix[LogicalPlan])
       extends Matcher[Fix[LogicalPlan]] {
     def apply[S <: Fix[LogicalPlan]](s: Expectable[S]) = {
-      val normed = FunctorT[Cofree[?[_], Fix[LogicalPlan]]].transCata(Recursive[Fix].cata(s.value)(attrSelf))(repeatedly(Optimizer.simplifyƒ[Cofree[?[_], Fix[LogicalPlan]]]))
-      val diff = (Recursive[Cofree[?[_], Fix[LogicalPlan]]].convertTo(normed).render diff expected.render).shows
+      val normed = s.value.transCata(repeatedly(Optimizer.simplifyƒ))
+      val diff = (normed.render diff expected.render).shows
       result(
-        expected ≟ Recursive[Cofree[?[_], Fix[LogicalPlan]]].convertTo(normed),
+        expected ≟ normed,
         "\ntrees are equal:\n" + diff,
         "\ntrees are not equal:\n" + diff +
-          "\noriginal was:\n" + normed.head.render.shows,
+          "\noriginal was:\n" + normed.render.shows,
         s)
     }
   }

--- a/it/src/main/resources/tests/inBareElement.test
+++ b/it/src/main/resources/tests/inBareElement.test
@@ -1,0 +1,9 @@
+{
+    "name": "filter field “in” a bare value",
+    "data": "zips.data",
+    "query": "select * from zips where state in 'ME' and pop < 10",
+    "predicate": "equalsExactly",
+    "expected": [
+        { "city": "BUSTINS ISLAND", "state": "ME",  "pop": 0 ,  "loc": [-70.042247, 43.79602]},
+        { "city": "SQUIRREL ISLAND", "state": "ME", "pop": 3, "loc": [-69.630974, 43.809031] }]
+}

--- a/it/src/main/resources/tests/singleElementSet.test
+++ b/it/src/main/resources/tests/singleElementSet.test
@@ -1,0 +1,8 @@
+{
+    "name": "filter field in single-element set",
+    "data": "zips.data",
+    "query": "select * from zips where state in ('MA') and pop < 10",
+    "predicate": "equalsExactly",
+    "expected": [
+        { "city": "CAMBRIDGE", "state": "MA", "pop": 0, "loc": [-71.141879, 42.364005] }]
+}


### PR DESCRIPTION
SD-1344 #done

In SQL²/MRA,  a value and a single-element set have the same
semantics. This makes that happen for the `IN` operator, which has been
a long-standing problem for the frontend.