### PR TITLE
Refactor how "finalization" of qservices is done

### DIFF
--- a/web/src/test/scala/quasar/api/services/DataServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/DataServiceSpec.scala
@@ -412,8 +412,8 @@ class DataServiceSpec extends Specification with ScalaCheck with FileSystemFixtu
               def apply[A](a: FileSystem[A]): Task[Nothing] = Task.fail(new RuntimeException(failureMsg))
             }
             def service: HttpService = data.service[Eff].toHttpService(effRespOr(failInter))
-            val serverBlueprint = Http4sUtils.ServerBlueprint(port, scala.concurrent.duration.Duration.Inf,ListMap("" -> service))
-            val (server, _) = Http4sUtils.startServerFromBlueprint(serverBlueprint,true).run
+            val serverBlueprint = Http4sUtils.ServerBlueprint(port, scala.concurrent.duration.Duration.Inf, service)
+            val (server, _) = Http4sUtils.startServer(serverBlueprint, true).run
             val client = org.http4s.client.blaze.defaultClient
             val response = client(request).onFinish(_ => server.shutdown.void).run
             response.status must_== Status.InternalServerError

--- a/web/src/test/scala/quasar/api/services/ServerServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/ServerServiceSpec.scala
@@ -40,7 +40,7 @@ class ServerServiceSpec extends Specification {
                                       (causeRestart: Uri => Task[Unit])(afterRestart: Task[B]): B = {
     val uri = Uri(authority = Some(Authority(port = Some(initialPort))))
 
-    val servers = Http4sUtils.startServers(initialPort, reload => ListMap("" -> server.service(defaultPort,reload)))
+    val servers = Http4sUtils.startServers(initialPort, reload => server.service(defaultPort, reload))
 
     (for {
       result <- servers


### PR DESCRIPTION
By "finalization" I mean the collapsing of the various individual api services into a single service that routes requests via the path and adds our standard middleware, feel free to suggest a better name for this.

* Separates choice of what to finalize from finalization itself
* Move api mounting out of the server, update ServerBlueprint
* Take advantage of composition to construct default middleware

Most of these changes are to make existing "server" functionality easier to reuse in quasar-advanced.

I think there is more we could do to this end, but I didn't want to risk disrupting too much before the 2.5 release. For example, I'm not sure we need the `Prefix` middleware we're currently using and could instead use `org.http4s.server.Router`, but wasn't sure if we had anything that depended on the way `Prefix` mangles paths.