### PR TITLE
Remove use of mongolabs in sample config file

### DIFF
--- a/example-quasar-config.json
+++ b/example-quasar-config.json
@@ -2,7 +2,7 @@
     "mountings": {
         "/": {
             "mongodb": {
-                "connectionUri": "mongodb://slamengine:slamengine@ds045089.mongolab.com:45089/slamengine-test-01"
+                "connectionUri": "mongodb://localhost:27018"
             }
         }
     },


### PR DESCRIPTION
- It gets used as part of our test suite that runs on Travis and it is too flaky. Hardcode to localhost instead.