### PR TITLE
Fix bug where failure effects were being handled via Task.fail

### DIFF
--- a/CHANGELOG/4.0.1.md
+++ b/CHANGELOG/4.0.1.md
@@ -1,0 +1,1 @@
+- Properly convert Failure effects into responses rather than shunting into Task.fail

--- a/core/src/main/scala/quasar/physical/mongodb/WorkflowExecutionError.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/WorkflowExecutionError.scala
@@ -58,7 +58,7 @@ object WorkflowExecutionError {
         case InsertFailed(b, r) =>
           s"Failed to insert BSON, `$b`, $r"
         case NoDatabase =>
-          "No database"
+          "Unable to determine a database in which to store temporary collections"
       }
 
       s"Error executing workflow: $msg"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.0.0"
+version in ThisBuild := "4.0.1"

--- a/web/src/main/scala/quasar/api/ServerOps.scala
+++ b/web/src/main/scala/quasar/api/ServerOps.scala
@@ -122,59 +122,74 @@ object Server {
     }
   }
 
-  // Task \/ MonotonicSeqF \/ ViewStateF \/ MountedResultHF \/ HFSFailureF
+  /** Effect for FileSystemDefs */
+  type FsDefEff[A]  = Coproduct[WorkflowExecErrF, Task, A]
+  type FsDefEffM[A] = Free[FsDefEff, A]
+
+  // FsDefEffM \/ MonotonicSeqF \/ ViewStateF \/ MountedResultHF \/ HFSFailureF
   type FsEff0[A] = Coproduct[MountedResultHF, HFSFailureF, A]
   type FsEff1[A] = Coproduct[ViewStateF, FsEff0, A]
   type FsEff2[A] = Coproduct[MonotonicSeqF, FsEff1, A]
-  type FsEff[A]  = Coproduct[Task, FsEff2, A]
+  type FsEff[A]  = Coproduct[FsDefEffM, FsEff2, A]
   type FsEffM[A] = Free[FsEff, A]
+
+  // HFSFailureF \/ WorkflowExecErrF \/ Task
+  type FsErrsIO0[A] = Coproduct[WorkflowExecErrF, Task, A]
+  type FsErrsIO[A]  = Coproduct[HFSFailureF, FsErrsIO0, A]
+  type FsErrsIOM[A] = Free[FsErrsIO, A]
 
   // NB: Will eventually be the lcd of all physical filesystems, or we limit
   //     to a fixed set of effects that filesystems must interpret into.
-  val mongoDbFs: FileSystemDef[Task] = {
-    type MongoEff[A] = Coproduct[Task, WorkflowExecErrF, A]
+  val mongoDbFs: FileSystemDef[FsDefEffM] =
+    mongoDbFileSystemDef[FsDefEff]
 
-    mongoDbFileSystemDef[MongoEff].translate(free.foldMapNT[MongoEff, Task](
-      free.interpret2[Task, WorkflowExecErrF, Task](
-        NaturalTransformation.refl,
-        Coyoneda.liftTF[WorkflowExecErr, Task](Failure.toTaskFailure[WorkflowExecutionError]))))
-  }
+  val evalFsDefEff: FsDefEff ~> FsErrsIOM =
+    free.interpret2[WorkflowExecErrF, Task, FsErrsIOM](
+      injectFT[WorkflowExecErrF, FsErrsIO],
+      injectFT[Task, FsErrsIO])
 
-  // TODO: Interpret HFSFailureF into `ResponseOr`
-  def fsEffToTask(
+  def fsEffToFsErrsIOM(
     seqRef: TaskRef[Long],
     viewHandlesRef: TaskRef[ViewHandles],
     mntResRef: TaskRef[Map[ResultHandle, (ADir, ResultHandle)]]
-  ): FsEff ~> Task =
-    free.interpret5[Task, MonotonicSeqF, ViewStateF, MountedResultHF, HFSFailureF, Task](
-      NaturalTransformation.refl[Task],
-      Coyoneda.liftTF[MonotonicSeq, Task](MonotonicSeq.fromTaskRef(seqRef)),
-      Coyoneda.liftTF[ViewState, Task](KeyValueStore.fromTaskRef(viewHandlesRef)),
-      Coyoneda.liftTF[MountedResultH, Task](KeyValueStore.fromTaskRef(mntResRef)),
-      Coyoneda.liftTF[HFSFailure, Task](Failure.toTaskFailure[HierarchicalFileSystemError]))
+  ): FsEff ~> FsErrsIOM = {
+    def injTask[E[_]](f: E ~> Task): E ~> FsErrsIOM =
+      injectFT[Task, FsErrsIO].compose[E](f)
 
-  val evalMounter = EvaluatorMounter[Task, FsEff](mongoDbFs)
+    free.interpret5[FsDefEffM, MonotonicSeqF, ViewStateF, MountedResultHF, HFSFailureF, FsErrsIOM](
+      hoistFree(evalFsDefEff),
+      injTask[MonotonicSeqF](Coyoneda.liftTF(MonotonicSeq.fromTaskRef(seqRef))),
+      injTask[ViewStateF](Coyoneda.liftTF[ViewState, Task](KeyValueStore.fromTaskRef(viewHandlesRef))),
+      injTask[MountedResultHF](Coyoneda.liftTF[MountedResultH, Task](KeyValueStore.fromTaskRef(mntResRef))),
+      injectFT[HFSFailureF, FsErrsIO])
+  }
+
+  val evalMounter = EvaluatorMounter[FsDefEffM, FsEff](mongoDbFs)
   import evalMounter.{EvalFSRef, EvalFSRefF}
 
-  type MountedFs[A]  = AtomicRef[Mounts[DefinitionResult[Task]], A]
+  type MountedFs[A]  = AtomicRef[Mounts[DefinitionResult[FsDefEffM]], A]
   type MountedFsF[A] = Coyoneda[MountedFs, A]
 
-  // EvalFSRefF \/ Task \/ MountedFsF \/ MountedViewsF
+  // EvalFSRefF \/ FsDefEffM \/ MountedFsF \/ MountedViewsF
   type EvalEff0[A] = Coproduct[MountedFsF, MountedViewsF, A]
-  type EvalEff1[A] = Coproduct[Task, EvalEff0, A]
+  type EvalEff1[A] = Coproduct[FsDefEffM, EvalEff0, A]
   type EvalEff[A]  = Coproduct[EvalFSRefF, EvalEff1, A]
   type EvalEffM[A] = Free[EvalEff, A]
 
-  def evalEffToTask(
+  def evalEffToFsErrsIOM(
     evalRef: TaskRef[FileSystem ~> FsEffM],
-    mntsRef: TaskRef[Mounts[DefinitionResult[Task]]],
+    mntsRef: TaskRef[Mounts[DefinitionResult[FsDefEffM]]],
     viewsRef: TaskRef[Views]
-  ): EvalEff ~> Task =
-    free.interpret4[EvalFSRefF, Task, MountedFsF, MountedViewsF, Task](
-      Coyoneda.liftTF[EvalFSRef, Task](AtomicRef.fromTaskRef(evalRef)),
-      NaturalTransformation.refl[Task],
-      Coyoneda.liftTF[MountedFs, Task](AtomicRef.fromTaskRef(mntsRef)),
-      Coyoneda.liftTF[MountedViews, Task](AtomicRef.fromTaskRef(viewsRef)))
+  ): EvalEff ~> FsErrsIOM = {
+    def injTask[E[_]](f: E ~> Task): E ~> FsErrsIOM =
+      injectFT[Task, FsErrsIO].compose[E](f)
+
+    free.interpret4[EvalFSRefF, FsDefEffM, MountedFsF, MountedViewsF, FsErrsIOM](
+      injTask[EvalFSRefF](Coyoneda.liftTF[EvalFSRef, Task](AtomicRef.fromTaskRef(evalRef))),
+      hoistFree(evalFsDefEff),
+      injTask[MountedFsF](Coyoneda.liftTF[MountedFs, Task](AtomicRef.fromTaskRef(mntsRef))),
+      injTask[MountedViewsF](Coyoneda.liftTF[MountedViews, Task](AtomicRef.fromTaskRef(viewsRef))))
+  }
 
   type MntEff[A]  = Coproduct[EvalEffM, MountConfigsF, A]
   type MntEffM[A] = Free[MntEff, A]
@@ -189,11 +204,17 @@ object Server {
       evalMounter.mount[EvalEff](_),
       evalMounter.unmount[EvalEff](_))
 
-  def evalFromRef(ref: TaskRef[FileSystem ~> FsEffM], f: FsEff ~> Task): FileSystem ~> Task =
-    new (FileSystem ~> Task) {
+  def evalFromRef[S[_]: Functor](
+    ref: TaskRef[FileSystem ~> FsEffM],
+    f: FsEff ~> Free[S, ?]
+  )(implicit S: Task :<: S): FileSystem ~> Free[S, ?] = {
+    type F[A] = Free[S, A]
+    new (FileSystem ~> F) {
       def apply[A](fs: FileSystem[A]) =
-        ref.read.map(free.foldMapNT(f) compose _).flatMap(_.apply(fs))
+        injectFT[Task, S].apply(ref.read.map(free.foldMapNT[FsEff, F](f) compose _))
+          .flatMap(_.apply(fs))
     }
+  }
 
   final case class QuasarConfig(staticContent: List[StaticContent],
                                 redirect: Option[String],
@@ -204,69 +225,101 @@ object Server {
   type ApiEff0[A] = Coproduct[MountingF, FileSystem, A]
   type ApiEff1[A] = Coproduct[FileSystemFailureF, ApiEff0, A]
   type ApiEff[A]  = Coproduct[Task, ApiEff1, A]
-
   type ApiEffM[A] = Free[ApiEff, A]
 
-  type TaskAndConfigs[A] = Coproduct[Task, MountConfigsF, A]
-  type TaskAndConfigsM[A] = Free[TaskAndConfigs, A]
+  type ConfigsIO[A]  = Coproduct[MountConfigsF, Task, A]
+  type ConfigsIOM[A] = Free[ConfigsIO, A]
+
+  // FileSystemFailureF \/ WorkflowExecErrF \/ HFSFailureF \/ ConfigsIO
+  type CfgsErrsIO0[A] = Coproduct[HFSFailureF, ConfigsIO, A]
+  type CfgsErrsIO1[A] = Coproduct[WorkflowExecErrF, CfgsErrsIO0, A]
+  type CfgsErrsIO[A]  = Coproduct[FileSystemFailureF, CfgsErrsIO1, A]
+  type CfgsErrsIOM[A] = Free[CfgsErrsIO, A]
 
   // TODO: Include failure effects in output coproduct
-  val evalApi: Task[ApiEff ~> Free[TaskAndConfigs, ?]] =
+  val evalApi: Task[ApiEff ~> CfgsErrsIOM] =
     for {
       startSeq   <- Task.delay(scala.util.Random.nextInt.toLong)
       seqRef     <- TaskRef(startSeq)
       viewHRef   <- TaskRef[ViewHandles](Map())
       mntedRHRef <- TaskRef(Map[ResultHandle, (ADir, ResultHandle)]())
       evalFsRef  <- TaskRef(Empty.fileSystem[FsEffM])
-      mntsRef    <- TaskRef(Mounts.empty[DefinitionResult[Task]])
+      mntsRef    <- TaskRef(Mounts.empty[DefinitionResult[FsDefEffM]])
       viewsRef   <- TaskRef(Views.empty)
     } yield {
-      val f: FsEff ~> Task = fsEffToTask(seqRef, viewHRef, mntedRHRef)
-      val g: EvalEff ~> Task = evalEffToTask(evalFsRef, mntsRef, viewsRef)
+      val f: FsEff ~> FsErrsIOM = fsEffToFsErrsIOM(seqRef, viewHRef, mntedRHRef)
+      val g: EvalEff ~> FsErrsIOM = evalEffToFsErrsIOM(evalFsRef, mntsRef, viewsRef)
 
-      val liftTask: Task ~> TaskAndConfigsM =
-        injectFT[Task, TaskAndConfigs]
+      val translateFsErrs: FsErrsIOM ~> CfgsErrsIOM =
+        free.foldMapNT[FsErrsIO, CfgsErrsIOM](free.interpret3[HFSFailureF, WorkflowExecErrF, Task, CfgsErrsIOM](
+          injectFT[HFSFailureF, CfgsErrsIO],
+          injectFT[WorkflowExecErrF, CfgsErrsIO],
+          injectFT[Task, CfgsErrsIO]))
 
-      val mnt: MntEff ~> TaskAndConfigsM =
-        free.interpret2[EvalEffM, MountConfigsF, TaskAndConfigsM](
-          liftTask.compose[EvalEffM](free.foldMapNT(g)),
-          liftFT[TaskAndConfigs] compose injectNT[MountConfigsF, TaskAndConfigs])
+      val liftTask: Task ~> CfgsErrsIOM =
+        injectFT[Task, CfgsErrsIO]
 
-      val mounting: MountingF ~> TaskAndConfigsM =
-        Coyoneda.liftTF[Mounting, TaskAndConfigsM](free.foldMapNT(mnt) compose mounter)
+      val mnt: MntEff ~> CfgsErrsIOM =
+        free.interpret2[EvalEffM, MountConfigsF, CfgsErrsIOM](
+          translateFsErrs.compose[EvalEffM](free.foldMapNT(g)),
+          injectFT[MountConfigsF, CfgsErrsIO])
 
-      val throwFailure: FileSystemFailureF ~> Task =
-        Coyoneda.liftTF[FileSystemFailure, Task](
-          Failure.toTaskFailure[FileSystemError])
+      val mounting: MountingF ~> CfgsErrsIOM =
+        Coyoneda.liftTF[Mounting, CfgsErrsIOM](free.foldMapNT(mnt) compose mounter)
 
-      free.interpret4[Task, FileSystemFailureF, MountingF, FileSystem, TaskAndConfigsM](
+      free.interpret4[Task, FileSystemFailureF, MountingF, FileSystem, CfgsErrsIOM](
         liftTask,
-        injectFT[Task, TaskAndConfigs] compose throwFailure,
+        injectFT[FileSystemFailureF, CfgsErrsIO],
         mounting,
-        liftTask compose evalFromRef(evalFsRef, f))
+        translateFsErrs compose evalFromRef(evalFsRef, f))
     }
 
-  def configsAsState: TaskAndConfigsM ~> Task = {
+  def configsAsState: ConfigsIO ~> Task = {
     type ST[A] = StateT[Task, Map[APath, MountConfig2], A]
 
     val toState: MountConfigs ~> ST =
       KeyValueStore.toState[StateT[Task, ?, ?]](Lens.id[Map[APath, MountConfig2]])
 
-    val interpret: TaskAndConfigsM ~> ST =
-      free.foldMapNT[TaskAndConfigs, ST](
-        free.interpret2[Task, MountConfigsF, ST](
-          liftMT[Task, StateT[?[_], Map[APath, MountConfig2], ?]],
-          Coyoneda.liftTF(toState)))
+    val interpret: ConfigsIO ~> ST =
+      free.interpret2[MountConfigsF, Task, ST](
+        Coyoneda.liftTF(toState),
+        liftMT[Task, StateT[?[_], Map[APath, MountConfig2], ?]])
 
     evalNT[Task, Map[APath, MountConfig2]](Map()) compose interpret
   }
 
-  def configsWithPersistence[C:EncodeJson](ref: TaskRef[C], loc: Option[FsFile])(implicit configOps: ConfigOps[C])
-      : TaskAndConfigsM ~> Task =
-    free.foldMapNT[TaskAndConfigs, Task](
-      free.interpret2[Task, MountConfigsF, Task](
-        NaturalTransformation.refl,
-        Coyoneda.liftTF[MountConfigs, Task](writeConfig(configOps)(ref, loc))))
+  def configsWithPersistence[C: EncodeJson](
+    ref: TaskRef[C],
+    loc: Option[FsFile]
+  )(implicit configOps: ConfigOps[C]): ConfigsIO ~> Task =
+    free.interpret2[MountConfigsF, Task, Task](
+      Coyoneda.liftTF[MountConfigs, Task](writeConfig(configOps)(ref, loc)),
+      NaturalTransformation.refl)
+
+  def cfgsErrsIOToMainTask(evalCfgsIO: ConfigsIO ~> Task): CfgsErrsIOM ~> MainTask = {
+    val f = free.interpret4[FileSystemFailureF, WorkflowExecErrF, HFSFailureF, ConfigsIO, Task](
+      Coyoneda.liftTF[FileSystemFailure, Task](Failure.toTaskFailure[FileSystemError]),
+      Coyoneda.liftTF[WorkflowExecErr, Task](Failure.toTaskFailure[WorkflowExecutionError]),
+      Coyoneda.liftTF[HFSFailure, Task](Failure.toTaskFailure[HierarchicalFileSystemError]),
+      evalCfgsIO)
+
+    val g = new (CfgsErrsIO ~> MainTask) {
+      def apply[A](a: CfgsErrsIO[A]) =
+        EitherT(f(a).attempt).leftMap(_.getMessage)
+    }
+
+    hoistFree(g)
+  }
+
+  def cfgsErrsIOToResponseOr(evalCfgsIO: ConfigsIO ~> Task): CfgsErrsIOM ~> ResponseOr = {
+    val f = free.interpret4[FileSystemFailureF, WorkflowExecErrF, HFSFailureF, ConfigsIO, ResponseOr](
+      Coyoneda.liftTF[FileSystemFailure, ResponseOr](failureResponseOr[FileSystemError]),
+      Coyoneda.liftTF[WorkflowExecErr, ResponseOr](failureResponseOr[WorkflowExecutionError]),
+      Coyoneda.liftTF[HFSFailure, ResponseOr](failureResponseOr[HierarchicalFileSystemError]),
+      liftMT[Task, ResponseT] compose evalCfgsIO)
+
+    hoistFree(f: CfgsErrsIO ~> ResponseOr)
+  }
 
   def mountAll(mc: MountingsConfig2): Free[ApiEff, String \/ Unit] = {
     val mnt = Mounting.Ops[ApiEff]
@@ -329,15 +382,16 @@ object Server {
                     // TODO: Find better way to do this
       updConfig   = config.copy(server = config.server.copy(qConfig.port.getOrElse(config.server.port)))
       api         <- evalApi.liftM[MainErrT]
+      stateApi    =  cfgsErrsIOToMainTask(configsAsState) compose api
+      _           <- mountAll(config.mountings) foldMap stateApi
       cfgRef      <- TaskRef(config).liftM[MainErrT]
-      apiWithPersistence = configsWithPersistence(cfgRef, qConfig.configPath) compose api
-      _           <- EitherT(mountAll(config.mountings) foldMap (configsAsState compose api))
+      durableApi  =  cfgsErrsIOToResponseOr(configsWithPersistence(cfgRef, qConfig.configPath)) compose api
       _           <- startWebServer(
                        updConfig.server.port,
                        qConfig.staticContent,
                        qConfig.redirect,
                        qConfig.openClient,
-                       liftMT[Task, ResponseT] compose apiWithPersistence
+                       durableApi
                      ).liftM[MainErrT]
     } yield ()
 


### PR DESCRIPTION
As part of the translation to the free architecture, we handled some `Failure` effects via `Task.fail`, this caused a few classes of errors to always result in 500 responses.

This fixes the problem by properly interpreting these errors into `QuasarResponse`s.

Unfortunately this happens when constructing the final interpreters in `main` and thus there is no test coverage currently. We'll need tests for the server process itself to check that the effects are being evaluated as expected.

Authored with @mossprescott 