### PR TITLE
[SD-1367] Fix issue where certain error conditions would respond with 200 and then drop connection

### DIFF
--- a/CHANGELOG/4.0.2.md
+++ b/CHANGELOG/4.0.2.md
@@ -1,0 +1,1 @@
+- [SD-1367] Fix issue where certain error conditions would respond with 200 and then drop connection

--- a/core/src/main/scala/quasar/fp/process.scala
+++ b/core/src/main/scala/quasar/fp/process.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.fp
+
+import quasar.Predef._
+
+import scala.collection.{Seq => SSeq}
+
+import scalaz._, Scalaz._
+import scalaz.concurrent.Task
+import scalaz.stream._
+
+trait ProcessOps {
+  implicit class PrOps[F[_], O](self: Process[F, O]) {
+    def cleanUpWith(t: F[Unit]): Process[F, O] =
+      self.onComplete(Process.eval(t).drain)
+
+    // NB: backported from scalaz-stream master
+    import Process._
+    import Cause._
+    final def unconsOption[F2[x] >: F[x], O2 >: O](implicit F: Monad[F2], C: Catchable[F2]): F2[Option[(O2, Process[F2, O2])]] = {
+      def evaluate[F2[x] >: F[x], O2 >: O, A](await: Await[F2, A, O2])(implicit F: Monad[F2], C: Catchable[F2]): F2[Process[F2,O2]] =
+        C.attempt(await.req).map { e =>
+          await.rcv(EarlyCause.fromTaskResult(e)).run
+        }
+
+      self.step match {
+        case Step(head, next) => head match {
+          case Emit(as) => as.headOption.map(x => F.point[Option[(O2, Process[F2, O2])]](Some((x, Process.emitAll[O2](as drop 1) +: next)))) getOrElse
+              new PrOps(next.continue).unconsOption
+          case await: Await[F2, _, O2] => evaluate(await).flatMap(p => new PrOps(p +: next).unconsOption(F,C))
+        }
+        case Halt(cause) => cause match {
+          case End | Kill => F.point(None)
+          case _ : EarlyCause => C.fail(cause.asThrowable)
+        }
+      }
+    }
+
+    final def evalScan1(f: (O, O) => F[O])(implicit monad: Monad[F]): Process[F, O] = {
+      self.zipWithPrevious.evalMap {
+        case (None, next) => monad.point(next)
+        case (Some(prev), next) => f(prev, next)
+      }
+    }
+
+    /** Exposes the effect from the first `Await` encountered, the inner process
+      * emits the same values, in the same order as this process.
+      */
+    final def firstStep[F2[x] >: F[x], O2 >: O](implicit F: Monad[F2], C: Catchable[F2]): F2[Process[F2, O2]] = {
+      val (hd, tl) = self.unemit
+      tl.unconsOption[F2, O2] map {
+        case Some((x, xs)) => Process.emitAll(hd :+ x) ++ xs
+        case None          => Process.emitAll(hd)
+      }
+    }
+
+    /** Step through `Await`s in this `Process`, combining effects via `Bind`,
+      * until the predicate returns true or the stream ends. The returned inner
+      * `Process` emits the same values, in the same order as this process.
+      */
+    final def stepUntil[F2[x] >: F[x], O2 >: O](p: SSeq[O2] => Boolean)(implicit F: Monad[F2], C: Catchable[F2]): F2[Process[F2, O2]] =
+      firstStep[F2, O2] flatMap { next =>
+        val (hd, tl) = next.unemit
+
+        if (hd.isEmpty || p(hd))
+          (Process.emitAll(hd) ++ tl).point[F2]
+        else
+          tl.stepUntil(p).map(Process.emitAll(hd) ++ _)
+      }
+  }
+
+  implicit class ProcessOfTaskOps[O](self: Process[Task,O]) {
+    // Is there a better way to implement this?
+    def onHaltWithLastElement(f: (Option[O], Cause) => Process[Task,O]): Process[Task,O] = {
+      val lastA: TaskRef[Option[O]] = TaskRef[Option[O]](None).run
+      self.observe(Process.constant((a:O) => lastA.write(Some(a)))).onHalt{ cause =>
+        Process.await(lastA.read)( a => f(a,cause))
+      }
+    }
+    def cleanUpWithA(f: Option[O] => Task[Unit]): Process[Task,O] = {
+      self.onHaltWithLastElement((a, cause) => Process.eval_(f(a)).causedBy(cause))
+    }
+  }
+
+  implicit class TaskOps[A](t: Task[A]) {
+    def onSuccess(f: A => Task[Unit]): Task[A] = {
+      t.flatMap(a => f(a).as(a))
+    }
+  }
+}
+
+object ProcessOps extends ProcessOps

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.0.1"
+version in ThisBuild := "4.0.2"

--- a/web/src/test/scala/quasar/api/QuasarResponseSpec.scala
+++ b/web/src/test/scala/quasar/api/QuasarResponseSpec.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api
+
+import quasar.Predef._
+import quasar.fp._
+
+import org.http4s.dsl._
+import org.http4s.headers.Host
+import org.specs2.mutable
+import scalaz._
+import scalaz.std.anyVal._
+import scalaz.syntax.applicative._
+import scalaz.syntax.order._
+import scalaz.concurrent.Task
+import scalaz.stream.Process
+import scodec.bits.ByteVector
+
+class QuasarResponseSpec extends mutable.Specification {
+  import QuasarResponse.{PROCESS_EFFECT_THRESHOLD_BYTES, HttpResponseStreamFailureException}
+  import QuasarResponseSpec._
+
+  type StrIO[A]  = Coproduct[Str, Task, A]
+  type StrIOM[A] = Free[StrIO, A]
+
+  def str(s: String): StrIOM[String] =
+    Free.liftF(Inject[Str, StrIO].inj(Str(s, ι)))
+
+  def strs(ss: String*): Process[StrIOM, String] =
+    Process.emitAll(ss).map(str).eval
+
+  val errHost: Host = Host("example.com", 443)
+
+  def evalStr(errs: String*): StrIO ~> ResponseOr = {
+    val f = new (Str ~> ResponseOr) {
+      def apply[A](a: Str[A]) =
+        if (errs.toSet contains a.s)
+          EitherT.left(BadRequest(a.s).putHeaders(errHost).withBody("FAIL"))
+        else
+          a.k(a.s).point[ResponseOr]
+    }
+
+    free.interpret2[Str, Task, ResponseOr](f, liftMT[Task, ResponseT])
+  }
+
+  "toHttpResponse" should {
+    "sucessful evaluation" >> {
+      "has same status" >> {
+        val res = QuasarResponse.empty[StrIO].toHttpResponse(evalStr())
+        res.run.status must_== NoContent
+      }
+
+      "has same headers" >> {
+        val qr = QuasarResponse.json[String, StrIO](Ok, "foo")
+        val res = qr.toHttpResponse(evalStr())
+        res.run.headers.toList must_== qr.headers.toList
+      }
+
+      "has body of interpreted values" >> {
+        val qr = QuasarResponse.streaming[StrIO, String](
+          strs("a", "b", "c", "d", "e"))
+        val res = qr.toHttpResponse(evalStr())
+        res.as[String].run must_== "abcde"
+      }
+    }
+
+    "failed evaluation" >> {
+      val failStream =
+        QuasarResponse.streaming[StrIO, String](strs("one", "two", "three"))
+
+      "has alternate response status" >> {
+        failStream.toHttpResponse(evalStr("one"))
+          .run.status must_== BadRequest
+      }
+
+      "has alternate response headers" >> {
+        failStream.toHttpResponse(evalStr("one"))
+          .run.headers.get(Host) must beSome(errHost)
+      }
+
+      "has alternate response body" >> {
+        failStream.toHttpResponse(evalStr("one"))
+          .as[String].run must_== "FAIL"
+      }
+
+      "responds with alternate response when a small amount of data before first effect" >> {
+        val pad = Process.emit(ByteVector.low(0 max (PROCESS_EFFECT_THRESHOLD_BYTES - 1)))
+        val padStream = failStream.copy(body = pad.append[StrIOM, ByteVector](failStream.body))
+        padStream.toHttpResponse(evalStr("one")).as[String].run must_== "FAIL"
+      }
+
+      "responds with alternate response when other internal effects before first effect" >> {
+        val hi  = ByteVector.high(1)
+        val pad = Process.emit(ByteVector.low(0 max (PROCESS_EFFECT_THRESHOLD_BYTES / 2)))
+        val stm = pad.append[StrIOM, ByteVector](failStream.body intersperse hi)
+
+        failStream.copy(body = stm).toHttpResponse(evalStr("one"))
+          .as[String].run must_== "FAIL"
+      }
+
+      "results in response stream failure exception when fails in middle of stream" >> {
+        val pad = Process.emit(ByteVector.low(PROCESS_EFFECT_THRESHOLD_BYTES))
+        failStream.copy(body = pad.append[StrIOM, ByteVector](failStream.body))
+          .toHttpResponse(evalStr("two"))
+          .as[String].run must throwA[HttpResponseStreamFailureException]
+      }
+    }
+  }
+}
+
+object QuasarResponseSpec {
+  final case class Str[A](s: String, k: String => A)
+
+  object Str {
+    implicit val functor: Functor[Str] =
+      new Functor[Str] {
+        def map[A, B](str: Str[A])(f: A => B) =
+          Str(str.s, f compose str.k)
+      }
+  }
+}


### PR DESCRIPTION
Fixes an issue where when a `QuasarResponse` body `Process` emits some output before the first effect and/or has other `Await` cases before the first "real" effect (like those introduced by many process1 combinators) _and_ the first `F` effect fails, the resulting response becomes a `200 OK` and then drops the connection.

More concretely, this manifested when retrieving a view-backed file via the `/data/fs` endpoint in `application/json` format where the view query resulted in an error. In this case, a `[\n` is prepended to the output stream which also has process1 "effects" due to `intersperse`-ing characters between the values in the response.

Kudos to @mossprescott who actually figured out the problem and authored the solution with me.

This is related to SD-1367, but I'm not sure if it fixes the issue as the defect fixed here was preventing the actual error encountered from surfacing to the client. So even if SD-1367 isn't fixed by this, it should allow us to now see the root cause of the issue and fix it.