### PR TITLE
Improve the error message when a file path is supplied to the /query service

### DIFF
--- a/CHANGELOG/4.0.3.md
+++ b/CHANGELOG/4.0.3.md
@@ -1,0 +1,1 @@
+- [SD-1364] produce a more informative error response when a file path is supplied to the /query service

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.0.2"
+version in ThisBuild := "4.0.3"

--- a/web/src/main/scala/quasar/api/services/query/compile.scala
+++ b/web/src/main/scala/quasar/api/services/query/compile.scala
@@ -50,7 +50,7 @@ object compile {
             }))
 
     QHttpService {
-      case req @ GET -> AsDirPath(path) :? QueryParam(query) +& Offset(offset) +& Limit(limit) => respond(
+      case req @ GET -> AsPath(path) :? QueryParam(query) +& Offset(offset) +& Limit(limit) => respond(
         offsetOrInvalid[S](offset).tuple(limitOrInvalid[S](limit))
           .traverse[Free[S, ?], QuasarResponse[S], ParsingError \/ QuasarResponse[S]] { case (offset, limit) =>
             SQLParser.parseInContext(query, QPath.fromAPath(path))

--- a/web/src/main/scala/quasar/api/services/query/execute.scala
+++ b/web/src/main/scala/quasar/api/services/query/execute.scala
@@ -50,7 +50,7 @@ object execute {
     val Q = QueryFile.Ops[S]
 
     QHttpService {
-      case req @ GET -> AsDirPath(path) :? QueryParam(query) +& Offset(offset) +& Limit(limit) => respond(
+      case req @ GET -> AsPath(path) :? QueryParam(query) +& Offset(offset) +& Limit(limit) => respond(
         (offsetOrInvalid[S](offset) |@| limitOrInvalid[S](limit)) { (offset, limit) =>
           SQLParser.parseInContext(query, QPath.fromAPath(path)).map(
             expr => queryPlan(addOffsetLimit(expr, offset, limit), vars(req)).run.value.map(

--- a/web/src/test/scala/quasar/api/PathUtils.scala
+++ b/web/src/test/scala/quasar/api/PathUtils.scala
@@ -18,6 +18,9 @@ package quasar.api
 
 import quasar.Predef._
 
+import quasar.fs.{APath}
+
+import org.http4s.{Uri}
 import pathy.Path, Path._
 import scalaz._, Scalaz._
 
@@ -26,6 +29,8 @@ trait PathUtils {
   // See https://github.com/slamdata/scala-pathy/issues/23.
   def hasDot(p: Path[_, _, _]): Boolean =
     flatten(false, false, false, d => d == "." || d == "..", f => f == "." || f == "..", p).toList.contains(true)
+
+  def pathUri(path: APath): Uri = Uri(path = UriPathCodec.printPath(path))
 }
 
 object PathUtils extends PathUtils

--- a/web/src/test/scala/quasar/api/services/MountServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/MountServiceSpec.scala
@@ -41,8 +41,6 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
 
   val StubFs = FileSystemType("stub")
 
-  def pathUri(path: APath): Uri = Uri(path = UriPathCodec.printPath(path))
-
   def viewConfig(q: String, vars: (String, String)*): (Expr, Variables) =
     ((new quasar.sql.SQLParser).parse(quasar.sql.Query(q)).toOption.get,
       Variables(Map(vars.map { case (n, v) =>

--- a/web/src/test/scala/quasar/api/services/query/QueryFixture.scala
+++ b/web/src/test/scala/quasar/api/services/query/QueryFixture.scala
@@ -28,6 +28,7 @@ import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 
 object queryFixture {
+  import quasar.api.PathUtils.pathUri
 
   type File = pathy.Path[_,pathy.Path.File,Sandboxed]
 
@@ -47,7 +48,7 @@ object queryFixture {
             response: A => MatchResult[scala.Any]) = {
     val offset = query.flatMap(_.offset.map(_.shows))
     val limit = query.flatMap(_.limit.map(_.shows))
-    val baseUri = Uri(path = printPath(path))
+    val baseUri = pathUri(path)
       .+??("q", query.map(_.q))
       .+??("offset", offset)
       .+??("limit", limit)


### PR DESCRIPTION
Fixes SD-1364

Pass file/dir path through to the queryPlanner, which will reject file paths as required, and added a test to verify the resulting error message.

Also moved the `pathUri` utility function that properly escapes paths for use in request URIs to PathUtil where it can be used in any test.