### PR TITLE
Improve reliability of arbitrary generation of refined values

### DIFF
--- a/CHANGELOG/4.1.1.md
+++ b/CHANGELOG/4.1.1.md
@@ -1,0 +1,1 @@
+- [Internal refactoring] Use custom generators for refined values that rely less on filtering thus reducing the occurrence of spurious test failures due to scalacheck/specs2 being unable to generate sufficient values for some of our property based tests.

--- a/core/src/test/scala/quasar/fp/numeric/NumericArbitrary.scala
+++ b/core/src/test/scala/quasar/fp/numeric/NumericArbitrary.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.fp.numeric
+
+import quasar.Predef._
+
+import scala.math.Numeric
+
+import eu.timepit.refined.api.{ RefType, Validate }
+import eu.timepit.refined.numeric._
+import eu.timepit.refined.scalacheck.arbitraryRefType
+import eu.timepit.refined.scalacheck.numeric.Bounded
+import org.scalacheck.{ Arbitrary, Gen }
+import org.scalacheck.Gen.Choose
+import shapeless.{ Nat, Witness }
+import shapeless.ops.nat.ToInt
+
+/**
+  * Functions defined in this trait are largely identical to the ones defined in eu.timepit.refined.scalacheck.numeric.
+  * These versions are specific to discrete numerical values as opposed to any numerical value. This allows us to avoid
+  * using filter which leads to discarded generation attempts and ultimately often to failed proprety validation
+  * attempts.
+  */
+trait NumericArbitrary {
+
+  trait Discrete[A]
+
+  object Discrete {
+    implicit val int: Discrete[Int] = new Discrete[Int] {}
+    implicit val long: Discrete[Long] = new Discrete[Long] {}
+    implicit val short: Discrete[Short] = new Discrete[Short] {}
+    implicit val byte: Discrete[Byte] = new Discrete[Byte] {}
+    implicit val safeIntForVector: Discrete[SafeIntForVector] = new Discrete[SafeIntForVector] {}
+  }
+
+  implicit def lessArbitraryWitDiscrete[F[_, _]: RefType, T: Numeric: Choose: Discrete, N <: T](
+     implicit
+     bounded: Bounded[T],
+     wn: Witness.Aux[N]
+   ): Arbitrary[F[T, Less[N]]] =
+    rangeClosedOpenArbitrary(bounded.minValue, wn.value)
+
+  implicit def lessArbitraryNatDiscrete[F[_, _]: RefType, T: Choose: Discrete, N <: Nat](
+    implicit
+    bounded: Bounded[T],
+    nt: Numeric[T],
+    tn: ToInt[N]
+  ): Arbitrary[F[T, Less[N]]] =
+    rangeClosedOpenArbitrary(bounded.minValue, nt.fromInt(tn()))
+
+  implicit def greaterArbitraryWitDiscrete[F[_, _]: RefType, T: Numeric: Choose: Discrete, N <: T](
+    implicit
+    bounded: Bounded[T],
+    wn: Witness.Aux[N]
+  ): Arbitrary[F[T, Greater[N]]] =
+    rangeOpenClosedArbitrary(wn.value, bounded.maxValue)
+
+  implicit def greaterArbitraryNatDiscrete[F[_, _]: RefType, T: Choose: Discrete, N <: Nat](
+     implicit
+     bounded: Bounded[T],
+     nt: Numeric[T],
+     tn: ToInt[N]
+   ): Arbitrary[F[T, Greater[N]]] =
+    rangeOpenClosedArbitrary(nt.fromInt(tn()), bounded.maxValue)
+
+  implicit def intervalOpenArbitraryDiscrete[F[_, _]: RefType, T: Numeric: Choose : Discrete, L <: T, H <: T](
+    implicit
+    wl: Witness.Aux[L],
+    wh: Witness.Aux[H]
+  ): Arbitrary[F[T, Interval.Open[L, H]]] =
+    rangeOpenArbitrary(wl.value, wh.value)
+
+  implicit def intervalOpenClosedArbitraryDiscrete[F[_, _]: RefType, T: Numeric: Choose : Discrete, L <: T, H <: T](
+    implicit
+    wl: Witness.Aux[L],
+    wh: Witness.Aux[H]
+  ): Arbitrary[F[T, Interval.OpenClosed[L, H]]] =
+    rangeOpenClosedArbitrary(wl.value, wh.value)
+
+  implicit def intervalClosedOpenArbitraryDiscrete[F[_, _]: RefType, T: Numeric: Choose : Discrete, L <: T, H <: T](
+    implicit
+    wl: Witness.Aux[L],
+    wh: Witness.Aux[H]
+  ): Arbitrary[F[T, Interval.ClosedOpen[L, H]]] =
+    rangeClosedOpenArbitrary(wl.value, wh.value)
+
+  ///
+
+  private def rangeOpenArbitrary[F[_, _]: RefType, T: Choose: Discrete, P](min: T, max: T)(
+    implicit
+    nt: Numeric[T]
+  ): Arbitrary[F[T, P]] = {
+    import nt.mkOrderingOps
+    arbitraryRefType(Gen.chooseNum(nt.plus(min,nt.fromInt(1)), nt.minus(max, nt.fromInt(1))))
+  }
+
+  private def rangeOpenClosedArbitrary[F[_, _]: RefType, T: Choose: Discrete, P](min: T, max: T)(
+    implicit
+    nt: Numeric[T]
+  ): Arbitrary[F[T, P]] = {
+    import nt.mkOrderingOps
+    arbitraryRefType(Gen.chooseNum(nt.plus(min,nt.fromInt(1)), max))
+  }
+
+  private def rangeClosedOpenArbitrary[F[_, _]: RefType, T: Choose: Discrete, P](min: T, max: T)(
+    implicit
+    nt: Numeric[T]
+  ): Arbitrary[F[T, P]] = {
+    import nt.mkOrderingOps
+    arbitraryRefType(Gen.chooseNum(min, nt.minus(max, nt.fromInt(1))))
+  }
+}
+
+object NumericArbitrary extends NumericArbitrary

--- a/core/src/test/scala/quasar/fp/numeric/SafeIntForVectorArbitrary.scala
+++ b/core/src/test/scala/quasar/fp/numeric/SafeIntForVectorArbitrary.scala
@@ -16,8 +16,6 @@
 
 package quasar.fp.numeric
 
-import quasar.Predef._
-
 import eu.timepit.refined.scalacheck.numeric.Bounded
 import org.scalacheck.Gen
 import org.scalacheck.Gen.Choose
@@ -25,7 +23,7 @@ import org.scalacheck.Gen.Choose
 object SafeIntForVectorArbitrary {
   implicit val chooseSafeIntForVector: Choose[SafeIntForVector] = new Choose[SafeIntForVector] {
     def choose(low: SafeIntForVector, high: SafeIntForVector) =
-      Gen.choose(Int.MinValue, SafeIntForVector.maxValue).map(SafeIntForVector.unsafe)
+      Gen.choose(low.value, high.value).map(SafeIntForVector.unsafe)
   }
 
   implicit val SafeIntForVectorBounded: Bounded[SafeIntForVector] =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   private val pathyVersion   = "0.0.3"
   private val http4sVersion  = "0.10.1"
   private val mongoVersion   = "3.2.1"
-  private val refinedVersion = "0.3.4"
+  private val refinedVersion = "0.3.6"
 
   val core = Seq(
     // NB: This version is forced because there seems to be some difference

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.1.0"
+version in ThisBuild := "4.1.1"

--- a/web/src/test/scala/quasar/api/services/DataServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/DataServiceSpec.scala
@@ -29,6 +29,7 @@ import quasar.fs.{Path => _, _}
 import quasar.fp.{evalNT, free, liftMT}
 import quasar.fp.numeric._
 import quasar.fp.numeric.SafeIntForVectorArbitrary._
+import quasar.fp.numeric.NumericArbitrary._
 import quasar.fp.prism._
 
 import argonaut.Json
@@ -56,7 +57,7 @@ import org.scalacheck.{Arbitrary, Gen}
 
 import eu.timepit.refined.numeric.{NonNegative, Negative, Positive => RPositive}
 import eu.timepit.refined.auto._
-import eu.timepit.refined.scalacheck.numeric._
+import eu.timepit.refined.scalacheck.numeric.greaterEqualArbitraryNat
 import shapeless.tag.@@
 
 class DataServiceSpec extends Specification with ScalaCheck with FileSystemFixture with Http4s {


### PR DESCRIPTION
- Fix bug in `Choose` instance of `SafeIntForVector`
- Add custom generators for discrete refined numerical values
- fix error in specification of "scan with offset k and limit j takes j data, starting from k" in ReadFilesSpec
- use custom generators in specs