### PR TITLE
fix inlining of $project ops

### DIFF
--- a/CHANGELOG/4.0.6.md
+++ b/CHANGELOG/4.0.6.md
@@ -1,0 +1,1 @@
+- [SD-1403] fixed a bug that affected queries against views that involved array flattening (e.g. SlamData-generated "search" queries)

--- a/core/src/main/scala/quasar/PhaseResult.scala
+++ b/core/src/main/scala/quasar/PhaseResult.scala
@@ -33,6 +33,13 @@ object PhaseResult {
     override def toString = name + "\n" + value
   }
 
+  implicit def phaseResultRenderTree: RenderTree[PhaseResult] = new RenderTree[PhaseResult] {
+    def render(v: PhaseResult) = v match {
+      case Tree(name, value)   => NonTerminal(List("PhaseResult"), Some(name), List(value))
+      case Detail(name, value) => NonTerminal(List("PhaseResult"), Some(name), List(Terminal(List("Detail"), Some(value))))
+    }
+  }
+
   implicit def phaseResultEncodeJson: EncodeJson[PhaseResult] = EncodeJson {
     case Tree(name, value)   => Json.obj("name" := name, "tree" := value)
     case Detail(name, value) => Json.obj("name" := name, "detail" := value)

--- a/core/src/main/scala/quasar/physical/mongodb/workflowop.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/workflowop.scala
@@ -179,7 +179,7 @@ object Workflow {
     }
     case p @ $Project(src, shape, id) => src.unFix match {
       case $Project(src0, shape0, id0) =>
-        $Project(src0, inlineProject(p, List(shape0)), id0 |+| id).some
+        inlineProject(p, List(shape0)).map($Project(src0, _, id0 |+| id))
       // Would like to inline a $project into a preceding $simpleMap, but
       // This is not safe, because sometimes a $project is inserted after
       // $simpleMap specifically to pull fields out of `value`, and those

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.0.5"
+version in ThisBuild := "4.0.6"


### PR DESCRIPTION
Fixes SD-1403

Two cases were being silently dropped:

1. "dangling" references, where a project op referred to a name that was simply missing from the previous shape.
2. references where the referenced expresion was not a trival name _and_ the reference reached down into the named object. In particular, the case we were hitting is when the first projection does a type check on `$$ROOT` (i.e. `"__tmp0": $cond(..., $$ROOT, undefined)`) and then the second reaches in with something like `"__tmp3": "$__tmp0.city"`.

Both cases are now treated as non-inlinable and the two projections are left as is. That makes the dangling reference easier to spot and debug (and it will be caught in property-based tests). In the second case, it seems prudent to preserve the two projections because attempting to inline it would mean expanding the first expression more than once in the second (three times, in the case of a type-check).

Includes tests at three levels: optimizer, WorkflowBuilder, and planner, because the effect is pretty subtle.