### PR TITLE
Don’t inherit “standard” lexers.

### DIFF
--- a/core/src/main/scala/quasar/sql/parser.scala
+++ b/core/src/main/scala/quasar/sql/parser.scala
@@ -57,11 +57,22 @@ class SQLParser extends StandardTokenParsers {
       override def toString = ":" + chars
     }
 
-    override def token: Parser[Token] = variParser | numLitParser | charLitParser | stringLitParser | quotedIdentParser | super.token
+    override def token: Parser[Token] =
+      variParser |
+      numLitParser |
+      charLitParser |
+      stringLitParser |
+      quotedIdentParser |
+      identifierString ^^ processIdent |
+      EofCh ^^^ EOF |
+      '\'' ~> failure("unclosed character literal") |
+      '"'  ~> failure("unclosed string literal") |
+      '`'  ~> failure("unclosed quoted identifier") |
+      delim
 
     def identifierString: Parser[String] =
       ((letter | elem('_')) ~ rep(digit | letter | elem('_'))) ^^ {
-        case x ~ xs => x.toString + xs.mkString
+        case x ~ xs => (x :: xs).mkString
       }
 
     def variParser: Parser[Token] = ':' ~> identifierString ^^ (Variable(_))

--- a/core/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/core/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -724,7 +724,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     }
 
     "filter field in single-element set" in {
-      plan("select * from zips where state in ('NV')") must
+      plan("""select * from zips where state in ("NV")""") must
         beWorkflow(chain(
           $read(Collection("db", "zips")),
           $match(Selector.Doc(BsonField.Name("state") ->
@@ -732,7 +732,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     }
 
     "filter field “in” a bare value" in {
-      plan("select * from zips where state in 'PA'") must
+      plan("""select * from zips where state in "PA"""") must
         beWorkflow(chain(
           $read(Collection("db", "zips")),
           $match(Selector.Doc(BsonField.Name("state") ->
@@ -3845,7 +3845,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     }
 
     "include correct phases with planner error" in {
-      planLog("select date_part('foo', bar) from zips").map(_.map(_.name)) must
+      planLog("""select date_part("foo", bar) from zips""").map(_.map(_.name)) must
         beRightDisjunction(Vector(
           "SQL AST", "Variables Substituted", "Annotated Tree",
           "Logical Plan", "Optimized", "Typechecked",

--- a/core/src/test/scala/quasar/sql/SqlParserSpec.scala
+++ b/core/src/test/scala/quasar/sql/SqlParserSpec.scala
@@ -187,6 +187,10 @@ class SQLParserSpec extends Specification with ScalaCheck with DisjunctionMatche
       parser.parse("""select * from foo where bar = "that\"s it!"""").toOption should beSome
     }
 
+    "don’t parse multi-character char literal" in {
+      parser.parse("""select * from foo where bar = 'it!'""").toOption should beNone
+    }
+
     "parse literal that’s too big for an Int" in {
       parser.parse("select * from users where add_date > 1425460451000") should
         beRightDisjOrDiff(

--- a/core/src/test/scala/quasar/sql/SqlQueries.scala
+++ b/core/src/test/scala/quasar/sql/SqlQueries.scala
@@ -32,7 +32,7 @@ select
 from
   lineitem
 where
-  l_shipdate <= date('1998-12-01') - interval('5 day')
+  l_shipdate <= date("1998-12-01") - interval("5 day")
 group by
   l_returnflag,
   l_linestatus
@@ -60,10 +60,10 @@ where
   p_partkey = ps_partkey
   and s_suppkey = ps_suppkey
   and p_size = 10
-  and p_type like '%foo'
+  and p_type like "%foo"
   and s_nationkey = n_nationkey
   and n_regionkey = r_regionkey
-  and r_name = 'somename'
+  and r_name = "somename"
   and ps_supplycost = (
     select
       min(ps_supplycost)
@@ -77,7 +77,7 @@ where
       and s_suppkey = ps_suppkey
       and s_nationkey = n_nationkey
       and n_regionkey = r_regionkey
-      and r_name = 'somename'
+      and r_name = "somename"
   )
 order by
   s_acctbal desc,
@@ -98,11 +98,11 @@ from
   orders,
   lineitem
 where
-  c_mktsegment = 'somesegment'
+  c_mktsegment = "somesegment"
   and c_custkey = o_custkey
   and l_orderkey = o_orderkey
-  and o_orderdate < date('1999-01-01')
-  and l_shipdate > date('1999-01-01')
+  and o_orderdate < date("1999-01-01")
+  and l_shipdate > date("1999-01-01")
 group by
   l_orderkey,
   o_orderdate,
@@ -120,8 +120,8 @@ select
 from
   orders
 where
-  o_orderdate >= date('1999-01-01')
-  and o_orderdate < date('1999-01-01') + interval('3 month')
+  o_orderdate >= date("1999-01-01")
+  and o_orderdate < date("1999-01-01") + interval("3 month")
   and exists (
     select
       *
@@ -155,9 +155,9 @@ where
   and c_nationkey = s_nationkey
   and s_nationkey = n_nationkey
   and n_regionkey = r_regionkey
-  and r_name = 'foo'
-  and o_orderdate >= date('1999-01-01')
-  and o_orderdate < date('1999-01-01') + interval('1 day')
+  and r_name = "foo"
+  and o_orderdate >= date("1999-01-01")
+  and o_orderdate < date("1999-01-01") + interval("1 day")
 group by
   n_name
 order by
@@ -170,8 +170,8 @@ select
 from
   lineitem
 where
-  l_shipdate >= date('1999-01-01')
-  and l_shipdate < date('1999-01-01') + interval('1 day')
+  l_shipdate >= date("1999-01-01")
+  and l_shipdate < date("1999-01-01") + interval("1 day")
   and l_discount between 2 - 0.01 and 2 + 0.01
   and l_quantity < 3;
 """
@@ -187,7 +187,7 @@ from
     select
       n1.n_name as supp_nation,
       n2.n_name as cust_nation,
-      date_part('year', l_shipdate) as l_year,
+      date_part("year", l_shipdate) as l_year,
       l_extendedprice * (1 - l_discount) as volume
     from
       supplier,
@@ -203,10 +203,10 @@ from
       and s_nationkey = n1.n_nationkey
       and c_nationkey = n2.n_nationkey
       and (
-        (n1.n_name = 'a' and n2.n_name = 'b')
-        or (n1.n_name = 'b' and n2.n_name = 'a')
+        (n1.n_name = "a" and n2.n_name = "b")
+        or (n1.n_name = "b" and n2.n_name = "a")
       )
-      and l_shipdate between date('1995-01-01') and date('1996-12-31')
+      and l_shipdate between date("1995-01-01") and date("1996-12-31")
   ) as shipping
 group by
   supp_nation,
@@ -222,13 +222,13 @@ order by
 select
   o_year,
   sum(case
-    when nation = 'nation' then volume
+    when nation = "nation" then volume
     else 0
   end) / sum(volume) as mkt_share
 from
   (
     select
-      date_part('year', o_orderdate) as o_year,
+      date_part("year", o_orderdate) as o_year,
       l_extendedprice * (1 - l_discount) as volume,
       n2.n_name as nation
     from
@@ -247,10 +247,10 @@ from
       and o_custkey = c_custkey
       and c_nationkey = n1.n_nationkey
       and n1.n_regionkey = r_regionkey
-      and r_name = 'rname'
+      and r_name = "rname"
       and s_nationkey = n2.n_nationkey
-      and o_orderdate between date('1995-01-01') and date('1996-12-31')
-      and p_type = 'ptype'
+      and o_orderdate between date("1995-01-01") and date("1996-12-31")
+      and p_type = "ptype"
   ) as all_nations
 group by
   o_year
@@ -267,7 +267,7 @@ from
   (
     select
       n_name as nation,
-      date_part('year', o_orderdate) as o_year,
+      date_part("year", o_orderdate) as o_year,
       l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
     from
       part,
@@ -283,7 +283,7 @@ from
       and p_partkey = l_partkey
       and o_orderkey = l_orderkey
       and s_nationkey = n_nationkey
-      and p_name like '%sky%'
+      and p_name like "%sky%"
   ) as profit
 group by
   nation,
@@ -311,9 +311,9 @@ from
 where
   c_custkey = o_custkey
   and l_orderkey = o_orderkey
-  and o_orderdate >= date('1999-01-01')
-  and o_orderdate < date('1999-01-01') + interval('3 month')
-  and l_returnflag = 'R'
+  and o_orderdate >= date("1999-01-01")
+  and o_orderdate < date("1999-01-01") + interval("3 month")
+  and l_returnflag = "R"
   and c_nationkey = n_nationkey
 group by
   c_custkey,
@@ -338,7 +338,7 @@ from
 where
   ps_suppkey = s_suppkey
   and s_nationkey = n_nationkey
-  and n_name = 'nnation'
+  and n_name = "nnation"
 group by
   ps_partkey having
     sum(ps_supplycost * ps_availqty) > (
@@ -351,7 +351,7 @@ group by
       where
         ps_suppkey = s_suppkey
         and s_nationkey = n_nationkey
-        and n_name = 'name'
+        and n_name = "name"
     )
 order by
   value desc;
@@ -361,14 +361,14 @@ order by
 select
   l_shipmode,
   sum(case
-    when o_orderpriority = '1-URGENT'
-      or o_orderpriority = '2-HIGH'
+    when o_orderpriority = "1-URGENT"
+      or o_orderpriority = "2-HIGH"
       then 1
     else 0
   end) as high_line_count,
   sum(case
-    when o_orderpriority <> '1-URGENT'
-      and o_orderpriority <> '2-HIGH'
+    when o_orderpriority <> "1-URGENT"
+      and o_orderpriority <> "2-HIGH"
       then 1
     else 0
   end) as low_line_count
@@ -377,11 +377,11 @@ from
   lineitem
 where
   o_orderkey = l_orderkey
-  and l_shipmode in ('mode0', 'mode1')
+  and l_shipmode in ("mode0", "mode1")
   and l_commitdate < l_receiptdate
   and l_shipdate < l_commitdate
-  and l_receiptdate >= date('1998-01-01')
-  and l_receiptdate < date('1998-01-01') + interval('1 year')
+  and l_receiptdate >= date("1998-01-01")
+  and l_receiptdate < date("1998-01-01") + interval("1 year")
 group by
   l_shipmode
 order by
@@ -400,7 +400,7 @@ from
     from
       customer left outer join orders on
         c_custkey = o_custkey
-        and o_comment not like '%:1%:2%'
+        and o_comment not like "%:1%:2%"
     group by
       c_custkey
   ) as c_orders
@@ -414,7 +414,7 @@ order by
   val q14 = """
 select
   100.00 * sum(case
-    when p_type like 'PROMO%'
+    when p_type like "PROMO%"
       then l_extendedprice * (1 - l_discount)
     else 0
   end) / sum(l_extendedprice * (1 - l_discount)) as promo_revenue
@@ -423,8 +423,8 @@ from
   part
 where
   l_partkey = p_partkey
-  and l_shipdate >= date('1999-01-01')
-  and l_shipdate < date('1999-01-01') + interval('1 month');
+  and l_shipdate >= date("1999-01-01")
+  and l_shipdate < date("1999-01-01") + interval("1 month");
 """
 
   val q16 = """
@@ -438,8 +438,8 @@ from
   part
 where
   p_partkey = ps_partkey
-  and p_brand <> 'foo'
-  and p_type not like 'bar%'
+  and p_brand <> "foo"
+  and p_type not like "bar%"
   and p_size in (3, 4, 5, 6, 7, 8, 9, 10)
   and ps_suppkey not in (
     select
@@ -447,7 +447,7 @@ where
     from
       supplier
     where
-      s_comment like '%Customer%Complaints%'
+      s_comment like "%Customer%Complaints%"
   )
 group by
   p_brand,
@@ -468,8 +468,8 @@ from
   part
 where
   p_partkey = l_partkey
-  and p_brand = 'a'
-  and p_container = 'b'
+  and p_brand = "a"
+  and p_container = "b"
   and l_quantity < (
     select
       0.2 * avg(l_quantity)
@@ -525,32 +525,32 @@ from
 where
   (
     p_partkey = l_partkey
-    and p_brand = 'foo'
-    and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+    and p_brand = "foo"
+    and p_container in ("SM CASE", "SM BOX", "SM PACK", "SM PKG")
     and l_quantity >= 4 and l_quantity <= 4 + 10
     and p_size between 1 and 5
-    and l_shipmode in ('AIR', 'AIR REG')
-    and l_shipinstruct = 'DELIVER IN PERSON'
+    and l_shipmode in ("AIR", "AIR REG")
+    and l_shipinstruct = "DELIVER IN PERSON"
   )
   or
   (
     p_partkey = l_partkey
-    and p_brand = 'bar'
-    and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+    and p_brand = "bar"
+    and p_container in ("MED BAG", "MED BOX", "MED PKG", "MED PACK")
     and l_quantity >= 5 and l_quantity <= 5 + 10
     and p_size between 1 and 10
-    and l_shipmode in ('AIR', 'AIR REG')
-    and l_shipinstruct = 'DELIVER IN PERSON'
+    and l_shipmode in ("AIR", "AIR REG")
+    and l_shipinstruct = "DELIVER IN PERSON"
   )
   or
   (
     p_partkey = l_partkey
-    and p_brand = 'baz'
-    and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+    and p_brand = "baz"
+    and p_container in ("LG CASE", "LG BOX", "LG PACK", "LG PKG")
     and l_quantity >= 6 and l_quantity <= 6 + 10
     and p_size between 1 and 15
-    and l_shipmode in ('AIR', 'AIR REG')
-    and l_shipinstruct = 'DELIVER IN PERSON'
+    and l_shipmode in ("AIR", "AIR REG")
+    and l_shipinstruct = "DELIVER IN PERSON"
   );
 """
 
@@ -574,7 +574,7 @@ where
         from
           part
         where
-          p_name like 'foo%'
+          p_name like "foo%"
       )
       and ps_availqty > (
         select
@@ -584,12 +584,12 @@ where
         where
           l_partkey = ps_partkey
           and l_suppkey = ps_suppkey
-          and l_shipdate >= date('1999-01-01')
-          and l_shipdate < date('1999-01-01') + interval('1 year')
+          and l_shipdate >= date("1999-01-01")
+          and l_shipdate < date("1999-01-01") + interval("1 year")
       )
   )
   and s_nationkey = n_nationkey
-  and n_name = 'foo'
+  and n_name = "foo"
 order by
   s_name;
 """
@@ -606,7 +606,7 @@ from
 where
   s_suppkey = l1.l_suppkey
   and o_orderkey = l1.l_orderkey
-  and o_orderstatus = 'F'
+  and o_orderstatus = "F"
   and l1.l_receiptdate > l1.l_commitdate
   and exists (
     select
@@ -628,7 +628,7 @@ where
       and l3.l_receiptdate > l3.l_commitdate
   )
   and s_nationkey = n_nationkey
-  and n_name = 'foo'
+  and n_name = "foo"
 group by
   s_name
 order by
@@ -651,7 +651,7 @@ from
       customer
     where
       substring(c_phone, 1, 2) in
-        ('11', '22', '33', '44', '55', '66', '77')
+        ("11", "22", "33", "44", "55", "66", "77")
       and c_acctbal > (
         select
           avg(c_acctbal)
@@ -660,7 +660,7 @@ from
         where
           c_acctbal > 0.00
           and substring(c_phone, 1, 2) in
-            ('11', '22', '33', '44', '55', '66', '77')
+            ("11", "22", "33", "44", "55", "66", "77")
       )
       and not exists (
         select

--- a/it/src/main/resources/tests/boulderLikePop.test
+++ b/it/src/main/resources/tests/boulderLikePop.test
@@ -3,7 +3,7 @@
 
   "data": "zips.data",
 
-  "query": "select city, state, sum(pop) as totalPop from zips where city like 'BOULDER%' group by city, state",
+  "query": "select city, state, sum(pop) as totalPop from zips where city like \"BOULDER%\" group by city, state",
 
   "predicate": "containsExactly",
 

--- a/it/src/main/resources/tests/boulderPop.test
+++ b/it/src/main/resources/tests/boulderPop.test
@@ -1,7 +1,7 @@
 {
     "name": "population of Boulder",
     "data": "zips.data",
-    "query": "select sum(pop) as Population from zips where city='BOULDER' and state='CO'",
+    "query": "select sum(pop) as Population from zips where city=\"BOULDER\" and state=\"CO\"",
     "predicate": "containsExactly",
     "expected": [{ "Population": 108968 }]
 }

--- a/it/src/main/resources/tests/caseVariations.test
+++ b/it/src/main/resources/tests/caseVariations.test
@@ -5,20 +5,20 @@
 
     "query": "select distinct
                 case pop
-                  when 0 then 'nobody'
-                  when 1 then 'one'
-                  when 2 then 'a couple'
-                  when 3 then 'a few'
-                  else 'more'
+                  when 0 then \"nobody\"
+                  when 1 then \"one\"
+                  when 2 then \"a couple\"
+                  when 3 then \"a few\"
+                  else \"more\"
                 end as cardinal,
                 case pop
                   when 1 then 0
                   when 10 then 1
                 end as power,
                 case
-                  when pop % 2 = 0 then 'even'
-                  when pop = 1 or pop = 9 then 'odd'
-                  else 'prime'
+                  when pop % 2 = 0 then \"even\"
+                  when pop = 1 or pop = 9 then \"odd\"
+                  else \"prime\"
                 end as parity,
                 case
                   when pop > 5 then pop - 5

--- a/it/src/main/resources/tests/caseWithGroup.test
+++ b/it/src/main/resources/tests/caseWithGroup.test
@@ -7,10 +7,10 @@
                 state as abbr,
                 count(pop) as quantity,
                 case
-                  when state = 'CO' then 1
-                  when state = 'WA' then 2
-                  when state = 'PA' then 3
-                  when state = 'VA' then 4
+                  when state = \"CO\" then 1
+                  when state = \"WA\" then 2
+                  when state = \"PA\" then 3
+                  when state = \"VA\" then 4
                   else 100
                 end as funnel
                 from zips

--- a/it/src/main/resources/tests/constantAndGrouped.test
+++ b/it/src/main/resources/tests/constantAndGrouped.test
@@ -4,7 +4,7 @@
   "data": "zips.data",
 
   "variables": {
-    "state": "'CO'"
+    "state": "\"CO\""
   },
 
   "query": "select :state as state, count(*) as `count` from zips where state = :state",

--- a/it/src/main/resources/tests/crossJoinWithOneSidedConditions.test
+++ b/it/src/main/resources/tests/crossJoinWithOneSidedConditions.test
@@ -4,7 +4,7 @@
 
   "data": "largeZips.data",
 
-  "query": "select a.city as a, b.city as b, b.pop - a.pop as diff from largeZips as a, largeZips as b where a._id like '80301' and b._id like '90277'",
+  "query": "select a.city as a, b.city as b, b.pop - a.pop as diff from largeZips as a, largeZips as b where a._id like \"80301\" and b._id like \"90277\"",
 
   "predicate": "equalsExactly",
   "expected": [

--- a/it/src/main/resources/tests/distinctStar.test
+++ b/it/src/main/resources/tests/distinctStar.test
@@ -2,7 +2,7 @@
     "name": "distinct *",
     "backends": { "mongodb_read_only": "pending" },
     "data": "cities.data",
-    "query": "select distinct * from cities where city = 'BOSTON'",
+    "query": "select distinct * from cities where city = \"BOSTON\"",
     "predicate": "equalsExactly",
     "expected": [{ "value": { "city": "BOSTON" } }]
 }

--- a/it/src/main/resources/tests/filterComplement.test
+++ b/it/src/main/resources/tests/filterComplement.test
@@ -1,7 +1,7 @@
 {
     "name": "filter on list complement",
     "data": "zips.data",
-    "query": "select count(*) from zips where state not in ('AZ', 'CO')",
+    "query": "select count(*) from zips where state not in (\"AZ\", \"CO\")",
     "predicate": "equalsExactly",
     "expected": [{"0": 28669}]
 }

--- a/it/src/main/resources/tests/filterMembership.test
+++ b/it/src/main/resources/tests/filterMembership.test
@@ -1,7 +1,7 @@
 {
     "name": "filter on list membership",
     "data": "zips.data",
-    "query": "select count(*) from zips where state in ('AZ', 'CO')",
+    "query": "select count(*) from zips where state in (\"AZ\", \"CO\")",
     "predicate": "equalsExactly",
     "expected": [{"0": 684}]
 }

--- a/it/src/main/resources/tests/filterSkipLimitCount.test
+++ b/it/src/main/resources/tests/filterSkipLimitCount.test
@@ -3,7 +3,7 @@
 
     "data": "zips.data",
 
-    "query": "select count(*) from (select * from zips where city like 'BOU%' offset 15 limit 10) as x",
+    "query": "select count(*) from (select * from zips where city like \"BOU%\" offset 15 limit 10) as x",
 
     "predicate": "equalsExactly",
     "expected": [{ "0": 5 }]

--- a/it/src/main/resources/tests/filterSortLimit.test
+++ b/it/src/main/resources/tests/filterSortLimit.test
@@ -3,7 +3,7 @@
 
     "data": "zips.data",
 
-    "query": "select * from zips where city like 'BOU%' order by pop limit 10",
+    "query": "select * from zips where city like \"BOU%\" order by pop limit 10",
 
     "predicate": "equalsExactly",
     "expected": [

--- a/it/src/main/resources/tests/filterWithComplexNot.test
+++ b/it/src/main/resources/tests/filterWithComplexNot.test
@@ -3,7 +3,7 @@
     "backends": { "mongodb_read_only": "pending" },
 
     "query": "select _id as zip from largeZips
-              where not (city not like 'BOULD%' or state != 'CO' or (pop between 20000 and 40000 and loc[1] != 40.017235))",
+              where not (city not like \"BOULD%\" or state != \"CO\" or (pop between 20000 and 40000 and loc[1] != 40.017235))",
 
     "predicate": "containsExactly",
     "expected": [{ "zip": "80301" },

--- a/it/src/main/resources/tests/filterWithNot.test
+++ b/it/src/main/resources/tests/filterWithNot.test
@@ -1,7 +1,7 @@
 {
   "name": "filter with negated regex selector",
 
-  "query": "select city, state from zips where city not like 'BOULD%' and pop = 18174",
+  "query": "select city, state from zips where city not like \"BOULD%\" and pop = 18174",
 
   "predicate": "containsExactly",
   "expected": [

--- a/it/src/main/resources/tests/filteredDistinct.test
+++ b/it/src/main/resources/tests/filteredDistinct.test
@@ -1,7 +1,7 @@
 {
   "name": "filtered distinct of one field",
   "data": "olympics.data",
-  "query": "select distinct discipline from olympics where event like '%pursuit'",
+  "query": "select distinct discipline from olympics where event like \"%pursuit\"",
   "predicate": "containsExactly",
   "expected": [{ "discipline": "Speed skating"   },
                { "discipline": "Biathlon"        },

--- a/it/src/main/resources/tests/flattenGroupedObject.test
+++ b/it/src/main/resources/tests/flattenGroupedObject.test
@@ -2,7 +2,7 @@
     "name": "flatten a grouped object with filter",
     "backends": { "mongodb_read_only": "pending" },
     "data": "slamengine_commits.data",
-    "query": "select distinct commit{*}, count(*) from slamengine_commits where commit{*} like 'http%' group by committer.login",
+    "query": "select distinct commit{*}, count(*) from slamengine_commits where commit{*} like \"http%\" group by committer.login",
     "predicate": "containsAtLeast",
     "expected": [
         { "commit": "https://api.github.com/repos/slamdata/slamengine/git/commits/859f02befb7774aae6f7526a5a7d0a083697e4ea", "1": 9 },

--- a/it/src/main/resources/tests/groupAndWildcard.test
+++ b/it/src/main/resources/tests/groupAndWildcard.test
@@ -1,7 +1,7 @@
 {
   "name": "select wildcard with group by",
 
-  "query": "select * from zips where _id like '8030%' group by city",
+  "query": "select * from zips where _id like \"8030%\" group by city",
 
   "predicate": "containsExactly",
 

--- a/it/src/main/resources/tests/guardedExpression.test
+++ b/it/src/main/resources/tests/guardedExpression.test
@@ -2,7 +2,7 @@
   "name": "regex on non-string field",
   "backends": { "mongodb_read_only": "pending" },
   "data": "zips.data",
-  "query": "select distinct * from zips where pop ~* 'foo'",
+  "query": "select distinct * from zips where pop ~* \"foo\"",
   "predicate": "equalsExactly",
   "expected": []
 }

--- a/it/src/main/resources/tests/idAliased.test
+++ b/it/src/main/resources/tests/idAliased.test
@@ -3,7 +3,7 @@
 
   "data": "zips.data",
 
-  "query": "select _id as zip from zips where city = 'BOULDER' and state = 'CO'",
+  "query": "select _id as zip from zips where city = \"BOULDER\" and state = \"CO\"",
 
   "predicate": "containsExactly",
 

--- a/it/src/main/resources/tests/implicitGroupWithFilter.test
+++ b/it/src/main/resources/tests/implicitGroupWithFilter.test
@@ -3,7 +3,7 @@
 
   "data": "zips.data",
 
-  "query": "select avg(pop), sum(pop) from zips where city = 'BOULDER' and state = 'CO'",
+  "query": "select avg(pop), sum(pop) from zips where city = \"BOULDER\" and state = \"CO\"",
 
   "predicate": "containsExactly",
   "expected": [

--- a/it/src/main/resources/tests/inBareElement.test
+++ b/it/src/main/resources/tests/inBareElement.test
@@ -1,7 +1,7 @@
 {
     "name": "filter field “in” a bare value",
     "data": "zips.data",
-    "query": "select * from zips where state in 'ME' and pop < 10",
+    "query": "select * from zips where state in \"ME\" and pop < 10",
     "predicate": "equalsExactly",
     "expected": [
         { "city": "BUSTINS ISLAND", "state": "ME",  "pop": 0 ,  "loc": [-70.042247, 43.79602]},

--- a/it/src/main/resources/tests/longCitiesWithLength.test
+++ b/it/src/main/resources/tests/longCitiesWithLength.test
@@ -2,7 +2,7 @@
     "name": "long city names in Colorado",
     "backends": { "mongodb_read_only": "pending" },
     "data": "largeZips.data",
-    "query": "select distinct city, length(city) from largeZips where state='CO' and length(city) >= 10",
+    "query": "select distinct city, length(city) from largeZips where state=\"CO\" and length(city) >= 10",
     "predicate": "containsAtLeast",
     "expected": [{ "city": "GRAND LAKE",       "1": 10 },
                  { "city": "MONTE VISTA",      "1": 11 },

--- a/it/src/main/resources/tests/manySimpleProjections.test
+++ b/it/src/main/resources/tests/manySimpleProjections.test
@@ -3,7 +3,7 @@
 
   "data": "zips.data",
 
-  "query": "select city as a, city as b, city as c, city as d, city as e, city as f from zips where _id = '80301'",
+  "query": "select city as a, city as b, city as c, city as d, city as e, city as f from zips where _id = \"80301\"",
 
   "predicate": "containsExactly",
 

--- a/it/src/main/resources/tests/matchCaseInsensitiveRegex.test
+++ b/it/src/main/resources/tests/matchCaseInsensitiveRegex.test
@@ -1,7 +1,7 @@
 {
     "name": "match on case-insensitive string",
     "data": "zips.data",
-    "query": "select * from zips where city ~* '^bOu'",
+    "query": "select * from zips where city ~* \"^bOu\"",
     "predicate": "containsAtLeast",
     "expected": [
         { "city": "BOUND BROOK",      "state": "NJ", "pop": 11275, "loc": [ -74.539735, 40.568115] },

--- a/it/src/main/resources/tests/matchLikeComplement.test
+++ b/it/src/main/resources/tests/matchLikeComplement.test
@@ -1,7 +1,7 @@
 {
     "name": "match like complement",
     "data": "zips.data",
-    "query": "select city from zips where city not like '%E%'",
+    "query": "select city from zips where city not like \"%E%\"",
     "predicate": "containsAtLeast",
     "expected": [{"city": "AGAWAM"},
                  {"city": "CUSHMAN"},

--- a/it/src/main/resources/tests/matchLikePattern.test
+++ b/it/src/main/resources/tests/matchLikePattern.test
@@ -1,7 +1,7 @@
 {
     "name": "match like pattern",
     "data": "zips.data",
-    "query": "select city from zips where city like '%OULD%CIT%'",
+    "query": "select city from zips where city like \"%OULD%CIT%\"",
     "predicate": "containsAtLeast",
     "expected": [{"city": "GOULD CITY"},
                  {"city": "BOULDER CITY"}]

--- a/it/src/main/resources/tests/matchRegexPattern.test
+++ b/it/src/main/resources/tests/matchRegexPattern.test
@@ -1,7 +1,7 @@
 {
     "name": "match regex pattern",
     "data": "zips.data",
-    "query": "select city from zips where city ~ 'OULD.{0,2} CIT'",
+    "query": "select city from zips where city ~ \"OULD.{0,2} CIT\"",
     "predicate": "containsExactly",
     "expected": [{"city": "GOULD CITY"},
                  {"city": "BOULDER CITY"}]

--- a/it/src/main/resources/tests/matchRegexPatternWithExpressions.test
+++ b/it/src/main/resources/tests/matchRegexPatternWithExpressions.test
@@ -5,9 +5,9 @@
   "data": "largeZips.data",
 
   "query":
-    "select distinct city, city ~ 'OUL', 'some text with BOULDER in it' ~ city
+    "select distinct city, city ~ \"OUL\", \"some text with BOULDER in it\" ~ city
       from largeZips
-      where city ~ '^B[^ ]+ER$' and 'BOULDER or BEELER' ~ city",
+      where city ~ \"^B[^ ]+ER$\" and \"BOULDER or BEELER\" ~ city",
 
   "predicate": "containsExactly",
 

--- a/it/src/main/resources/tests/multilineLike.test
+++ b/it/src/main/resources/tests/multilineLike.test
@@ -1,7 +1,7 @@
 {
     "name": "match LIKE with multiple lines",
     "data": "slamengine_commits.data",
-    "query": "select count(*) from slamengine_commits where commit.message like 'Merge%'",
+    "query": "select count(*) from slamengine_commits where commit.message like \"Merge%\"",
     "predicate": "equalsExactly",
     "expected": [{ "0": 13 }]
 }

--- a/it/src/main/resources/tests/multistageFlatten.test
+++ b/it/src/main/resources/tests/multistageFlatten.test
@@ -2,12 +2,12 @@
     "name": "multi-flatten with fields at various depths",
     "data": "nested_foo.data",
     "query": "select * from nested_foo where (
-                foo              LIKE '%zap%' OR
-                foo[*]           LIKE '%15%' OR
-                foo[*][*]        LIKE '%meh%' OR
-                foo[*][*].baz    LIKE '%moo%' OR
-                foo[*][*].baz[*] LIKE '%quu%' OR
-                a                LIKE '%13%')",
+                foo              LIKE \"%zap%\" OR
+                foo[*]           LIKE \"%15%\" OR
+                foo[*][*]        LIKE \"%meh%\" OR
+                foo[*][*].baz    LIKE \"%moo%\" OR
+                foo[*][*].baz[*] LIKE \"%quu%\" OR
+                a                LIKE \"%13%\")",
     "FIXME": "Should use `containsExactly`, but see issue #732.",
     "predicate": "equalsExactly",
     "expected": [

--- a/it/src/main/resources/tests/multitypeFlatten.test
+++ b/it/src/main/resources/tests/multitypeFlatten.test
@@ -3,9 +3,9 @@
     "backends": { "mongodb_read_only": "pending", "mongodb_3_2": "pending" },
     "data": "nested_foo.data",
     "query": "select * from nested_foo where (
-                foo{*} LIKE '%15%' OR
+                foo{*} LIKE \"%15%\" OR
                 foo{*} = 15 OR
-                foo[*] LIKE '%15%' OR
+                foo[*] LIKE \"%15%\" OR
                 foo[*] = 15)",
     "predicate": "containsExactly",
     "expected": [

--- a/it/src/main/resources/tests/negatedRegex.test
+++ b/it/src/main/resources/tests/negatedRegex.test
@@ -2,7 +2,7 @@
     "name": "negate matches in filter and projection",
     "backends": { "mongodb_read_only": "pending" },
     "data": "largeZips.data",
-    "query": "select city, city !~ 'A' from largeZips where city !~ 'CHI'",
+    "query": "select city, city !~ \"A\" from largeZips where city !~ \"CHI\"",
     "predicate": "containsAtLeast",
     "expected": [
         { "city": "CUSHMAN",     "1": false },

--- a/it/src/main/resources/tests/projectCaseInsensitiveRegex.test
+++ b/it/src/main/resources/tests/projectCaseInsensitiveRegex.test
@@ -2,7 +2,7 @@
     "name": "case-insensitive regex in projections",
     "backends": { "mongodb_read_only": "pending" },
     "data": "largeZips.data",
-    "query": "select city, city ~* 'boU', city !~* 'Bou' from largeZips",
+    "query": "select city, city ~* \"boU\", city !~* \"Bou\" from largeZips",
     "NB": "Should also test `doesNotContain`, see SD-577.",
     "predicate": "containsAtLeast",
     "expected": [

--- a/it/src/main/resources/tests/projectFieldWithFlatten.test
+++ b/it/src/main/resources/tests/projectFieldWithFlatten.test
@@ -2,7 +2,7 @@
     "name": "project unrelated field with object flatten",
     "backends": { "mongodb_read_only": "pending" },
     "data": "usa_factbook.data",
-    "query": "select intro from usa_factbook where geo{*}.text = '19,924 km'",
+    "query": "select intro from usa_factbook where geo{*}.text = \"19,924 km\"",
     "predicate": "containsExactly",
     "expected": [
         { "intro": { "background": { "text": "Britain's American colonies broke with the mother country in 1776 and were recognized as the new nation of the United States of America following the Treaty of Paris in 1783. During the 19th and 20th centuries, 37 new states were added to the original 13 as the nation expanded across the North American continent and acquired a number of overseas possessions. The two most traumatic experiences in the nation's history were the Civil War (1861-65), in which a northern Union of states defeated a secessionist Confederacy of 11 southern slave states, and the Great Depression of the 1930s, an economic downturn during which about a quarter of the labor force lost its jobs. Buoyed by victories in World Wars I and II and the end of the Cold War in 1991, the US remains the world''s most powerful nation state. Since the end of World War II, the economy has achieved relatively steady growth, low unemployment and inflation, and rapid advances in technology." } } }]

--- a/it/src/main/resources/tests/projectIndexFromGroupWithFilter.test
+++ b/it/src/main/resources/tests/projectIndexFromGroupWithFilter.test
@@ -2,7 +2,7 @@
     "name": "project index from group with filter",
     "backends": { "mongodb_read_only": "pending" },
     "data": "slamengine_commits.data",
-    "query": "select parents[0].sha, count(*) as count from slamengine_commits where parents[0].sha like '5%' group by parents[0].sha",
+    "query": "select parents[0].sha, count(*) as count from slamengine_commits where parents[0].sha like \"5%\" group by parents[0].sha",
     "predicate": "containsExactly",
     "expected": [
         { "count": 1, "sha": "53d2e5684d9403194dff1cc63423c2590038d1c0" },

--- a/it/src/main/resources/tests/simpleDistinct.test
+++ b/it/src/main/resources/tests/simpleDistinct.test
@@ -3,7 +3,7 @@
 
   "data": "olympics.data",
 
-  "query": "select distinct discipline, event from olympics where event like '%pursuit'",
+  "query": "select distinct discipline, event from olympics where event like \"%pursuit\"",
 
   "predicate": "containsExactly",
 

--- a/it/src/main/resources/tests/singleElementSet.test
+++ b/it/src/main/resources/tests/singleElementSet.test
@@ -1,7 +1,7 @@
 {
     "name": "filter field in single-element set",
     "data": "zips.data",
-    "query": "select * from zips where state in ('MA') and pop < 10",
+    "query": "select * from zips where state in (\"MA\") and pop < 10",
     "predicate": "equalsExactly",
     "expected": [
         { "city": "CAMBRIDGE", "state": "MA", "pop": 0, "loc": [-71.141879, 42.364005] }]

--- a/it/src/main/resources/tests/wildcardWithExtraProjections.test
+++ b/it/src/main/resources/tests/wildcardWithExtraProjections.test
@@ -2,7 +2,7 @@
   "name": "wildcard with additional projections (and filtering)",
   "backends": { "mongodb_read_only": "pending" },
   "data": "zips.data",
-  "query": "select *, concat(city, concat(', ', state)), city = 'BOULDER' from zips where city like 'BOULDER%'",
+  "query": "select *, concat(city, concat(\", \", state)), city = \"BOULDER\" from zips where city like \"BOULDER%\"",
   "predicate": "containsExactly",
   "expected": [
     { "value": {  "_id": "80301", "city": "BOULDER",          "loc": [ -105.21426, 40.049733 ],  "pop": 18174.0, "state": "CO", "1": "BOULDER, CO",          "2": true  } },

--- a/it/src/main/resources/tests/zipsByCityLength.test
+++ b/it/src/main/resources/tests/zipsByCityLength.test
@@ -4,7 +4,7 @@
     "data": "largeZips.data",
     "query": "select length(city) as len, count(*) as cnt
                 from largeZips
-                where state != 'MI'
+                where state != \"MI\"
                 group by length(city)",
     "predicate": "containsExactly",
     "expected": [{ "cnt":   2, "len":  3 },

--- a/web/src/test/scala/quasar/api/services/query/ExecuteServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/query/ExecuteServiceSpec.scala
@@ -205,8 +205,7 @@ class ExecuteServiceSpec extends Specification with FileSystemFixture with Scala
           destination = Some(printPath(destination)),
           state = filesystem.state,
           status = Status.BadRequest,
-          response = _ must_== Json("error" := "end of input; ErrorToken(illegal character)")
-        )
+          response = _ must_== Json("error" := "end of input; ErrorToken(end of input)"))
       }
     }
   }

--- a/web/src/test/scala/quasar/api/services/query/QueryServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/query/QueryServiceSpec.scala
@@ -73,7 +73,7 @@ class QueryServiceSpec extends org.specs2.mutable.Specification with FileSystemF
             query = Some(Query("select date where")),
             state = filesystem.state,
             status = Status.BadRequest,
-            response = (_: Json) must_== Json("error" := "end of input; ErrorToken(illegal character)")
+            response = (_: Json) must_== Json("error" := "end of input; ErrorToken(end of input)")
           )
         }
 


### PR DESCRIPTION
SD-1404 #done

Fix our tokenizer to not rely on any external parsers, and *cough* fix
the queries that needed to be updated because of this change.