### PR TITLE
Push filtering ahead of joins that already have conditions

### DIFF
--- a/CHANGELOG/4.1.2.md
+++ b/CHANGELOG/4.1.2.md
@@ -1,0 +1,1 @@
+- [SD-1418] optimize inner joins (written with `join`) with one-sided conditions (in `where`) by pushing filtering ahead of the join

--- a/core/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/core/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -3278,30 +3278,29 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             $unwind(DocField(BsonField.Name("right"))),
             $project(
               reshape(
-                "city"   ->
+                "__tmp11"   ->
                   $cond(
                     $and(
                       $lte($literal(Bson.Doc(ListMap())), $field("right")),
                       $lt($field("right"), $literal(Bson.Arr(Nil)))),
-                    $field("right", "city"),
+                    $field("right"),
                     $literal(Bson.Undefined)),
-                "__tmp11" -> $field("right"),
-                "__tmp12" -> $field("right", "pop"),
-                "__tmp13" -> $field("left"),
-                "__tmp14" -> $field("left", "pop"),
-                "__tmp15" -> $lt($field("left", "pop"), $field("right", "pop"))),
+                "__tmp12" -> $$ROOT),
+              IgnoreId),
+            $project(
+              reshape(
+                "city"    -> $field("__tmp11", "city"),
+                "__tmp13" -> $field("__tmp12", "right"),
+                "__tmp14" -> $field("__tmp12", "right", "pop"),
+                "__tmp15" -> $field("__tmp12", "left"),
+                "__tmp16" -> $field("__tmp12", "left", "pop"),
+                "__tmp17" ->
+                  $lt(
+                    $field("__tmp12", "left", "pop"),
+                    $field("__tmp12", "right", "pop"))),
               IgnoreId),
             $match(Selector.And(
-              Selector.Doc(BsonField.Name("__tmp11") -> Selector.Type(BsonType.Doc)),
-              Selector.Or(
-                Selector.Doc(BsonField.Name("__tmp12") -> Selector.Type(BsonType.Int32)),
-                Selector.Doc(BsonField.Name("__tmp12") -> Selector.Type(BsonType.Int64)),
-                Selector.Doc(BsonField.Name("__tmp12") -> Selector.Type(BsonType.Dec)),
-                Selector.Doc(BsonField.Name("__tmp12") -> Selector.Type(BsonType.Text)),
-                Selector.Doc(BsonField.Name("__tmp12") -> Selector.Type(BsonType.Date)),
-                Selector.Doc(BsonField.Name("__tmp12") -> Selector.Type(BsonType.Bool))),
-              Selector.Doc(
-                BsonField.Name("__tmp13") -> Selector.Type(BsonType.Doc)),
+              Selector.Doc(BsonField.Name("__tmp13") -> Selector.Type(BsonType.Doc)),
               Selector.Or(
                 Selector.Doc(BsonField.Name("__tmp14") -> Selector.Type(BsonType.Int32)),
                 Selector.Doc(BsonField.Name("__tmp14") -> Selector.Type(BsonType.Int64)),
@@ -3310,7 +3309,16 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
                 Selector.Doc(BsonField.Name("__tmp14") -> Selector.Type(BsonType.Date)),
                 Selector.Doc(BsonField.Name("__tmp14") -> Selector.Type(BsonType.Bool))),
               Selector.Doc(
-                BsonField.Name("__tmp15") -> Selector.Eq(Bson.Bool(true))))),
+                BsonField.Name("__tmp15") -> Selector.Type(BsonType.Doc)),
+              Selector.Or(
+                Selector.Doc(BsonField.Name("__tmp16") -> Selector.Type(BsonType.Int32)),
+                Selector.Doc(BsonField.Name("__tmp16") -> Selector.Type(BsonType.Int64)),
+                Selector.Doc(BsonField.Name("__tmp16") -> Selector.Type(BsonType.Dec)),
+                Selector.Doc(BsonField.Name("__tmp16") -> Selector.Type(BsonType.Text)),
+                Selector.Doc(BsonField.Name("__tmp16") -> Selector.Type(BsonType.Date)),
+                Selector.Doc(BsonField.Name("__tmp16") -> Selector.Type(BsonType.Bool))),
+              Selector.Doc(
+                BsonField.Name("__tmp17") -> Selector.Eq(Bson.Bool(true))))),
             $project(
               reshape("city" -> $field("city")),
               ExcludeId)),

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.1.1"
+version in ThisBuild := "4.1.2"


### PR DESCRIPTION
A little more normalization of the incoming plan was sufficient to get the existing rewriting to recognize the additional case mentioned in SD-1418.

Specifically, we now "hoist" Lets that appear in the arguments of Invoke and Typecheck. Note: this is safe only if there is no possibility of introducing spurious shadowing, which we arrange for by first normalizing the names (which ensures they are all unique). Therefore this PR adds a couple of additional rewrites to `optimize`, and also makes the rewrites even more sensitive to being applied in the correct sequence.

The fallout was surprisingly modest:
- only 6 compiler tests needed to be updated for Lets moving around
- only 1 planner test needed updating. See my comment on the commit.