### PR TITLE
fix patent infinite loop in MongoDbIO's Catchable

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- [SD-1426] fix hang in the MongoDB backend in certain error conditions

--- a/core/src/main/scala/quasar/physical/mongodb/MongoDbIO.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/MongoDbIO.scala
@@ -341,7 +341,7 @@ object MongoDbIO {
       override def map[A, B](fa: MongoDbIO[A])(f: A => B) = fa map f
       def point[A](a: => A) = new MongoDbIO(Kleisli(_ => Task.now(a)))
       def bind[A, B](fa: MongoDbIO[A])(f: A => MongoDbIO[B]) = fa flatMap f
-      def fail[A](t: Throwable) = fail(t)
+      def fail[A](t: Throwable) = MongoDbIO.fail(t)
       def attempt[A](fa: MongoDbIO[A]) = fa.attempt
     }
 

--- a/it/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
@@ -106,6 +106,20 @@ class MongoDbFileSystemSpec
           }
         }
 
+        "fail to save data to DB path" in {
+          val path = rootDir </> file("foo")
+
+          runLogT(run, write.save(path, Process(Data.Obj(ListMap("a" -> Data.Int(1)))))).run.run must_==
+            -\/(FileSystemError.pathError(PathError2.invalidPath(path, "path names a database, but no collection")))
+        }
+
+        "fail to append data to DB path" in {
+          val path = rootDir </> file("foo")
+
+          runLogT(run, write.append(path, Process(Data.Obj(ListMap("a" -> Data.Int(1)))))).run.run must_==
+            -\/(FileSystemError.pathError(PathError2.invalidPath(path, "path names a database, but no collection")))
+        }
+
         step(invalidData.flatMap(p => runT(run)(manage.delete(p))).runVoid)
       }
 


### PR DESCRIPTION
See SD-1426

One way to make this happen was to attempt to save a document at a path directly under the root of a MongoDB mount, whereas appending to the same path would give the correct error.