### PR TITLE
Add the read-only config to the regression tests using the Free arch.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- add regression tests for a read-only configuration

--- a/core/src/main/scala/quasar/physical/mongodb/WorkflowExecutor.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/WorkflowExecutor.scala
@@ -263,7 +263,7 @@ private[mongodb] abstract class WorkflowExecutor[F[_]: Monad, C] {
     }
   }
 
-  /** This tries to turn a Pipline into a simpler operation (eg, `count()` or
+  /** This tries to turn a Pipeline into a simpler operation (eg, `count()` or
     * `find()`) and falls back to a pipeline if it can’t.
     */
   // TODO: This should really be handled when building the WorkflowTask, but

--- a/it/src/test/scala/quasar/ResultFileQueryRegressionSpec.scala
+++ b/it/src/test/scala/quasar/ResultFileQueryRegressionSpec.scala
@@ -27,7 +27,8 @@ import scalaz.std.vector._
 import scalaz.syntax.monad._
 
 class ResultFileQueryRegressionSpec
-  extends QueryRegressionTest[FileSystemIO](QueryRegressionTest.externalFS) {
+  extends QueryRegressionTest[FileSystemIO](
+    QueryRegressionTest.externalFS.map(_.filterNot(fs => TestConfig.isMongoReadOnly(fs.name)))) {
 
   val read = ReadFile.Ops[FileSystemIO]
 

--- a/it/src/test/scala/quasar/fs/ReadFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/ReadFilesSpec.scala
@@ -66,10 +66,12 @@ class ReadFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT) w
   def deleteForReading(run: Run): FsTask[Unit] =
     runT(run)(manage.delete(readsPrefix))
 
-  fileSystemShould { _ => implicit run =>
+  fileSystemShould { fs =>
+    implicit val run = fs.testInterpM
+
     "Reading Files" should {
       // Load read-only data
-      step((deleteForReading(run).run.void *> loadForReading(run).run.void).run)
+      step((deleteForReading(fs.setupInterpM).run.void *> loadForReading(fs.setupInterpM).run.void).run)
 
       "open returns PathNotFound when file DNE" >>* {
         val dne = rootDir </> dir("doesnt") </> file("exist")
@@ -169,7 +171,7 @@ class ReadFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT) w
         (r.runEither must beRight(l)) and (r.runEither must beRight(l))
       }
 
-      step(deleteForReading(run).runVoid)
+      step(deleteForReading(fs.setupInterpM).runVoid)
     }; ()
   }
 }

--- a/it/src/test/scala/quasar/fs/WriteFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/WriteFilesSpec.scala
@@ -17,6 +17,7 @@
 package quasar.fs
 
 import quasar.Predef._
+import quasar.TestConfig
 import quasar.fp._
 
 import monocle.std.{disjunction => D}
@@ -25,7 +26,9 @@ import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 import scalaz.stream._
 
-class WriteFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT) {
+class WriteFilesSpec extends FileSystemTest[FileSystem](
+  FileSystemTest.allFsUT.map(_.filterNot(fs => TestConfig.isMongoReadOnly(fs.name)))) {
+
   import FileSystemTest._, FileSystemError._
   import WriteFile._
 
@@ -39,9 +42,11 @@ class WriteFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT) 
   def deleteForWriting(run: Run): FsTask[Unit] =
     runT(run)(manage.delete(writesPrefix))
 
-  fileSystemShould { _ => implicit run =>
+  fileSystemShould { fs =>
+    implicit val run = fs.testInterpM
+
     "Writing Files" should {
-      step(deleteForWriting(run).runVoid)
+      step(deleteForWriting(fs.setupInterpM).runVoid)
 
       "opening a file should create it" >>* {
         val f = writesPrefix </> dir("opencreates") </> file("f1")
@@ -106,7 +111,7 @@ class WriteFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT) 
           .runEither must beRight(containTheSameElementsAs(List(descendant1, descendant2)))
       }
 
-      step(deleteForWriting(run).runVoid)
+      step(deleteForWriting(fs.setupInterpM).runVoid)
     }; ()
   }
 }

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -63,7 +63,7 @@ abstract class QueryRegressionTest[S[_]: Functor](
   val write  = WriteFile.Ops[S]
   val manage = ManageFile.Ops[S]
 
-  /** A name to idetify the suite in test output. */
+  /** A name to identify the suite in test output. */
   def suiteName: String
 
   /** Return the results of evaluating the given query as a stream. */
@@ -73,15 +73,15 @@ abstract class QueryRegressionTest[S[_]: Functor](
 
   lazy val tests = regressionTests(TestsRoot, knownFileSystems).run
 
-  fileSystemShould { name => implicit run =>
+  fileSystemShould { fs =>
     suiteName should {
-      step(prepareTestData(tests, run).run)
+      step(prepareTestData(tests, fs.setupInterpM).run)
 
       tests.toList foreach { case (f, t) =>
-        regressionExample(f, t, name, run)
+        regressionExample(f, t, fs.name, fs.testInterpM)
       }
 
-      step(runT(run)(manage.delete(DataDir)).runVoid)
+      step(runT(fs.setupInterpM)(manage.delete(DataDir)).runVoid)
     }; ()
   }
 
@@ -256,8 +256,8 @@ object QueryRegressionTest {
     for {
       uts    <- extFs
       mntDir =  rootDir </> dir("hfs-mnt")
-      hfsUts <- uts.traverse(ut => hierarchicalFSIO(mntDir, ut.run) map { f =>
-                  ut.copy(run = f).contramap(chroot.fileSystem[FileSystemIO](ut.testDir))
+      hfsUts <- uts.traverse(ut => hierarchicalFSIO(mntDir, ut.testInterp) map { f =>
+                  ut.copy(testInterp = f).contramap(chroot.fileSystem[FileSystemIO](ut.testDir))
                 })
     } yield hfsUts
   }


### PR DESCRIPTION
See SD-1189

Put the additional "setup/insert" interpreter and some other useful stuff into FileSystemUT, modify tests to use it as needed, and mark some tests as either `skipped` with read-only backends or else explicitly run them only on read-write.