### PR TITLE
[SD-1338] Fix duplicate field name leading to silent misbehaving

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- [SD-1338] Fix issue where a duplicated alias or fields with the same name would lead to a column being dropped from the output instead of producing a clear compilation error message

--- a/core/src/main/scala/quasar/semantics.scala
+++ b/core/src/main/scala/quasar/semantics.scala
@@ -62,6 +62,9 @@ object SemanticError {
   final case class MissingField(name: String) extends SemanticError {
     def message = "No field named '" + name + "' exists"
   }
+  final case class DuplicateFieldName(name: String) extends SemanticError {
+    def message = s"Field named $name is duplicated"
+  }
   final case class MissingIndex(index: Int) extends SemanticError {
     def message = "No element exists at array index '" + index
   }

--- a/core/src/test/scala/quasar/compiler.scala
+++ b/core/src/test/scala/quasar/compiler.scala
@@ -1244,6 +1244,21 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
       compile("select (case when bar.a = 1 then 'ok' else foo end) from bar, baz") must beLeftDisjunction
     }
 
+    "fail with duplicate alias" in {
+      compile("select car.name as name, owner.name as name from owners as owner join cars as car on car._id = owner.carId") must
+        beLeftDisjunction("DuplicateFieldName(name)")
+    }
+
+    "fail when two projections have the same field name" in {
+      compile("select car.name, owner.name from owners as owner join cars as car on car._id = owner.carId") must
+        beLeftDisjunction("DuplicateFieldName(name)")
+    }
+
+    "fail when a field name conflicts with an alias" in {
+      compile("select car.name as name, owner.name from owners as owner join cars as car on car._id = owner.carId") must
+        beLeftDisjunction("DuplicateFieldName(name)")
+    }
+
     "translate free variable" in {
       testLogicalPlanCompile("select name from zips where age < :age",
         Let('__tmp0, read("zips"),


### PR DESCRIPTION
A duplicated alias or field name would lead to a column being dropped from the output instead of producing a clear compilation error message