### PR TITLE
[SD-1350] Fix restarting server on new port through REST API

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- Fix restarting server on new port through REST API


### PR DESCRIPTION
As documented on `startServers`, the `Process` of servers must be run in order for the restarting behavior to work correctly. The implementation of `startAndWait` assumed that line 153 was not blocking and that line 154 was having the opportunity to run. That assumption turned out to be invalid. `runAsync` states that “Any pure, non-asynchronous computation at the head of this `Task` will be forced in the calling thread. At the first `Async` encountered, control to whatever thread backs the `Async` and this function returns immediately.”. This basically means that if the `Task` being `runAsync` does not contain any tasks that were constructed using `Task.apply` or on which we later called `Task.fork`, `runAsync` will actually never run on another Thread and simply block on the current Thread.

This is what was happening to us so by calling `Task.fork` we allow `runAsync` to be non-blocking and `servers.run` as part of the server initialization.