### PR TITLE
remove the last two uses of shapeless's deriveEqual

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- improve compile time

--- a/core/src/main/scala/quasar/fp/package.scala
+++ b/core/src/main/scala/quasar/fp/package.scala
@@ -114,6 +114,8 @@ sealed trait TreeInstances extends LowPriorityTreeInstances {
   implicit val StringRenderTree: RenderTree[String] =
     RenderTree.fromToString[String]("String")
 
+  implicit val SymbolEqual: Equal[Symbol] = Equal.equalA
+
   implicit def PathRenderTree[B,T,S]: RenderTree[pathy.Path[B,T,S]] =
     new RenderTree[pathy.Path[B,T,S]] {
       // NB: the implicit Show instance in scope here ends up being a circular

--- a/core/src/main/scala/quasar/fs/path.scala
+++ b/core/src/main/scala/quasar/fs/path.scala
@@ -112,12 +112,14 @@ final case class Path(dir: List[DirNode], file: Option[FileNode]) {
 }
 
 object Path {
-  implicit def ShowPath: Show[Path] = new Show[Path] {
+  implicit def show: Show[Path] = new Show[Path] {
     override def show(v: Path) = Cord(v.pathname)
   }
 
-  implicit val PathOrder: scala.Ordering[Path] =
+  implicit val ordering: scala.Ordering[Path] =
     scala.Ordering[(String, Boolean)].on(p => (p.pathname, p.pureDir))
+
+  implicit val equal: Equal[Path] = Equal.equalA
 
   val Root = Path(Nil, None)
 

--- a/core/src/main/scala/quasar/logicalplan.scala
+++ b/core/src/main/scala/quasar/logicalplan.scala
@@ -24,7 +24,6 @@ import quasar.namegen._
 
 import matryoshka._, Recursive.ops._, FunctorT.ops._
 import scalaz._, Scalaz._, Validation.{success, failure}, Validation.FlatMap._
-import shapeless.contrib.scalaz.instances.deriveEqual
 
 sealed trait LogicalPlan[A]
 object LogicalPlan {

--- a/core/src/main/scala/quasar/physical/mongodb/bson.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/bson.scala
@@ -308,6 +308,9 @@ object BsonField {
 
     override def toString = s"""BsonField.Name("$value")"""
   }
+  object Name {
+    implicit val equal: Equal[Name] = Equal.equalA
+  }
 
   final case class Path(values: NonEmptyList[Name]) extends BsonField {
     def flatten = values

--- a/core/src/main/scala/quasar/physical/mongodb/expression/package.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/expression/package.scala
@@ -32,7 +32,7 @@ package object expression {
   type Expression = Fix[ExprOp]
 
   def $field(field: String, others: String*): Expression =
-    $var(DocField(others.map(BsonField.Name).foldLeft[BsonField](BsonField.Name(field))(_ \ _)))
+    $var(DocField(others.map(BsonField.Name(_)).foldLeft[BsonField](BsonField.Name(field))(_ \ _)))
 
   val $$ROOT = $var(DocVar.ROOT())
   val $$CURRENT = $var(DocVar.CURRENT())

--- a/core/src/main/scala/quasar/physical/mongodb/package.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/package.scala
@@ -42,5 +42,5 @@ package object mongodb {
 
   // TODO: parameterize over label (SD-512)
   def freshName: State[NameGen, BsonField.Name] =
-    quasar.namegen.freshName("tmp").map(BsonField.Name)
+    quasar.namegen.freshName("tmp").map(BsonField.Name(_))
 }

--- a/core/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
@@ -28,7 +28,6 @@ import quasar.jscore, jscore.{JsCore, JsFn}
 
 import matryoshka._, Recursive.ops._, FunctorT.ops._
 import scalaz._, Scalaz._
-import shapeless.contrib.scalaz.instances.deriveEqual
 
 sealed trait WorkflowBuilderF[+A]
 

--- a/core/src/main/scala/quasar/physical/mongodb/workflowop.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/workflowop.scala
@@ -449,7 +449,7 @@ object Workflow {
 
   def simpleShape(op: Workflow): Option[List[BsonField.Name]] = op.unFix match {
     case $Pure(Bson.Doc(value))          =>
-      value.keys.toList.map(BsonField.Name).some
+      value.keys.toList.map(BsonField.Name(_)).some
     case $Project(_, Reshape(value), id) =>
       (if (id == IncludeId) IdName :: value.keys.toList
       else value.keys.toList).some

--- a/core/src/test/scala/quasar/physical/mongodb/workflowbuilder.scala
+++ b/core/src/test/scala/quasar/physical/mongodb/workflowbuilder.scala
@@ -462,8 +462,6 @@ class WorkflowBuilderSpec
         city   <- lift(projectField(read, "city"))
         filtered = filter(city, List(flat), { case p :: Nil => Selector.Doc(p -> Selector.Lt(Bson.Int32(1000))) })
 
-        _=println(filtered.show)
-
         rez    <- build(filtered)
       } yield rez).evalZero
 


### PR DESCRIPTION
This improves incremental compile time for the two files involved (workflowbuilder and logicalplan) by from about 100s to less than 10s.

From-scratch compile time is reduced by about 50% for me.

Will try to confirm some improvement in Travis before merging.