### PR TITLE
SD-1329 Fix moving and deleting toplevel folders (databases) on mongo mounts

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- [SD-1329] Fix moving and deleting mongo databases via filesystem

--- a/core/src/main/scala/quasar/physical/mongodb/MongoDbIO.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/MongoDbIO.scala
@@ -245,7 +245,7 @@ object MongoDbIO {
       case FailIfExists => false
     }
 
-    if (src == dst)
+    if (src === dst)
       ().point[MongoDbIO]
     else
       collection(src)

--- a/core/src/main/scala/quasar/physical/mongodb/collection.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/collection.scala
@@ -97,6 +97,10 @@ object Collection {
   def dbNameFromPath(path: APath): PathError2 \/ String =
     dbNameAndRest(path) bimap (PathError2.invalidPath(path, _), _._1)
 
+  /** Returns the directory name derived from the given database name. */
+  def dirNameFromDbName(dbName: String): DirName =
+    DirName(DatabaseNameUnparser(dbName))
+
   private def dbNameAndRest(path: APath): String \/ (String, IList[String]) =
     flatten(None, None, None, Some(_), Some(_), path)
       .toIList.unite.uncons(
@@ -192,7 +196,10 @@ object Collection {
     }
   }
 
-  implicit val CollectionRenderTree: RenderTree[Collection] =
+  implicit val order: Order[Collection] =
+    Order.orderBy(c => (c.databaseName, c.collectionName))
+
+  implicit val renderTree: RenderTree[Collection] =
     new RenderTree[Collection] {
       def render(v: Collection) =
         Terminal(List("Collection"), Some(v.databaseName + "; " + v.collectionName))

--- a/core/src/main/scala/quasar/physical/mongodb/fs/fsops.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/fs/fsops.scala
@@ -47,6 +47,12 @@ object fsops {
                 else ().point[MongoFsM]
     } yield cs
 
+  /** The user (non-system) collections having a prefix equivalent to the given
+    * directory path.
+    */
+  def userCollectionsInDir(dir: ADir): MongoFsM[Vector[Collection]] =
+    collectionsInDir(dir) map (_.filterNot(_.collectionName startsWith "system."))
+
   /** A filesystem `PathName` representing the first segment of a collection name
     * relative to the given parent directory.
     */

--- a/core/src/main/scala/quasar/physical/mongodb/package.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/package.scala
@@ -28,6 +28,9 @@ import scalaz._
 
 package object mongodb {
   type BsonCursor         = AsyncBatchCursor[BsonDocument]
+
+  type MongoErr[A]        = Failure[MongoException, A]
+  type MongoErrF[A]       = Coyoneda[MongoErr, A]
   type MongoErrT[F[_], A] = EitherT[F, MongoException, A]
 
   type WorkflowExecErr[A]        = Failure[WorkflowExecutionError, A]

--- a/core/src/test/scala/quasar/fs/SpecialStr.scala
+++ b/core/src/test/scala/quasar/fs/SpecialStr.scala
@@ -21,8 +21,6 @@ import quasar.Predef._
 
 import org.scalacheck.{Arbitrary, Gen}
 import scalaz.Show
-import scalaz.syntax.functor._
-import scalaz.std.list._
 
 /** A random string that favors special characters with more frequency. */
 final case class SpecialStr(str: String) extends scala.AnyVal
@@ -30,10 +28,12 @@ final case class SpecialStr(str: String) extends scala.AnyVal
 object SpecialStr {
   implicit val specialStrArbitrary: Arbitrary[SpecialStr] =
     Arbitrary {
-      val specialFreqs = "$./\\_~ *+-".toList map (Gen.const) strengthL 10
+      val specialChars =
+        Gen.oneOf('$', '.', '/', '\\', '_', '~', ' ', '*', '+', '-')
 
       Gen.nonEmptyListOf(Gen.frequency(
-        (100, Arbitrary.arbitrary[Char]) :: specialFreqs : _*
+        (9, Arbitrary.arbitrary[Char]),
+        (1, specialChars)
       )) map (cs => SpecialStr(cs.mkString))
     }
 

--- a/core/src/test/scala/quasar/physical/mongodb/collection.scala
+++ b/core/src/test/scala/quasar/physical/mongodb/collection.scala
@@ -380,6 +380,12 @@ class CollectionSpec extends Specification with ScalaCheck with DisjunctionMatch
         rootDir </> dir("foo") </> file("")
     }
   }
+
+  "dbName <-> dirName are inverses" ! prop { db: SpecialStr =>
+    import pathy.Path._
+    Collection.dbNameFromPath(rootDir </> dir(db.str))
+      .map(Collection.dirNameFromDbName(_)) must beRightDisjunction(DirName(db.str))
+  }.set(maxSize = 20)
 }
 
 object PathGen {

--- a/it/src/test/scala/quasar/regression/package.scala
+++ b/it/src/test/scala/quasar/regression/package.scala
@@ -50,7 +50,7 @@ package object regression {
 
     val hfsFailTask: HFSFailureF ~> Task =
       Coyoneda.liftTF[HFSFailure, Task](
-        Failure.toTaskFailure[HierarchicalFileSystemError])
+        Failure.toRuntimeError[HierarchicalFileSystemError])
 
     (TaskRef(Map.empty[ResultHandle, (ADir, ResultHandle)]) |@| TaskRef(0L))(
       (handles, ct) => free.interpret4(

--- a/web/src/test/scala/quasar/api/services/RestApiSpecs.scala
+++ b/web/src/test/scala/quasar/api/services/RestApiSpecs.scala
@@ -44,7 +44,7 @@ class RestApiSpecs extends Specification {
     val fs = runFs(InMemState.empty).map(interpretMountingFileSystem(mount, _)).run
     val eff = free.interpret3[Task, FileSystemFailureF, MountingFileSystem, Task](
       NaturalTransformation.refl,
-      Coyoneda.liftTF[FileSystemFailure, Task](Failure.toTaskFailure[FileSystemError]),
+      Coyoneda.liftTF[FileSystemFailure, Task](Failure.toRuntimeError[FileSystemError]),
       fs)
     val service = RestApi.finalizeServices[Eff](
       liftMT[Task, ResponseT].compose[Eff](eff))(


### PR DESCRIPTION
As reported in SD-1329 moving and deleting top-level folders in a mongo mount didn't work. This fixes the problems, which reduced to one of two issues:

* Double "db name escaped" temp file paths from mongo
* Attempts to modify objects in the mongo "system" namespace

these were fixed by, respectively:

* Unescaping database names obtained from a path before using them to construct a new path
* Explicitly handling moving of databases, skipping over objects in the "system" namespace

In attempting to debug this issue, I also discovered there are situations where mongo exceptions weren't being surfaced properly, which is now fixed so unhandled mongo error messages should be exposed via a 500 error in the api.