### PR TITLE
SD-1518 Error when fn applied to wrong number of args

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- [SD-1518] Error when fn applied to wrong number of args

--- a/core/src/test/scala/quasar/compiler.scala
+++ b/core/src/test/scala/quasar/compiler.scala
@@ -1273,6 +1273,16 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     }
   }
 
+  "error when too few arguments passed to a function" in {
+    fullCompile("""select substring("foo") from zips""")
+      .toEither must beLeft(contain("3,1"))
+  }
+
+  "error when too many arguments passed to a function" in {
+    fullCompile("select count(*, 1, 2, 4) from zips")
+      .toEither must beLeft(contain("1,4"))
+  }
+
   "reduceGroupKeys" should {
     import Compiler.reduceGroupKeys
 


### PR DESCRIPTION
Also improves the error message when fewer than the required number of arguments is supplied.