### PR TITLE
SD-1517 – Make JS plan for join conditions optional.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- [SD-1517] fix handling of join conditions containing flattening

--- a/it/src/main/resources/tests/nonJsJoinCondition.test
+++ b/it/src/main/resources/tests/nonJsJoinCondition.test
@@ -1,0 +1,15 @@
+{
+    "name": "flatten one side of a join condition",
+    "backends": { "mongodb_read_only": "pending" },
+    "data": "zips.data",
+    "query": "select z1.city as city1, z1.loc, z2.city as city2, z2.pop from zips as z1 join zips as z2 on z1.loc[*] = z2.pop",
+    "predicate": "containsExactly",
+    "expected": [
+        { "city1": "WYNNEWOOD", "loc": [-75.275984, 40], "city2": "VAN HORNESVILLE", "pop": 40 },
+        { "city1": "WYNNEWOOD", "loc": [-75.275984, 40], "city2": "SELBYVILLE",      "pop": 40 },
+        { "city1": "WYNNEWOOD", "loc": [-75.275984, 40], "city2": "STAR PRAIRIE",    "pop": 40 },
+        { "city1": "WYNNEWOOD", "loc": [-75.275984, 40], "city2": "MERIDEN",         "pop": 40 },
+        { "city1": "WYNNEWOOD", "loc": [-75.275984, 40], "city2": "FELT",            "pop": 40 },
+        { "city1": "WYNNEWOOD", "loc": [-75.275984, 40], "city2": "NEWKIRK",         "pop": 40 },
+        { "city1": "WYNNEWOOD", "loc": [-75.275984, 40], "city2": "VIDAL",           "pop": 40 }]
+}

--- a/it/src/main/resources/tests/symmetricNonJsJoinCondition.test
+++ b/it/src/main/resources/tests/symmetricNonJsJoinCondition.test
@@ -1,0 +1,10 @@
+{
+    "name": "flattening both sides of a join condition",
+    "backends": { "mongodb_read_only": "pending" },
+    "data": "zips.data",
+    "query": "select z1.city as city1, z1.loc as loc1, z2.city as city2, z2.loc as loc2 from zips as z1 join largeZips as z2 on z1.loc[*] = z2.loc[*] where z1.city < z2.city",
+    "predicate": "containsExactly",
+    "expected": [
+        { "city1": "GERLAW",    "loc1": [-90.622765, 40.999519], "city2": "SAINT PETERS", "loc2": [-90.622765, 38.78024]  },
+        { "city1": "GLEN DALE", "loc1": [-80.732263, 39.959732], "city2": "PHILADELPHIA", "loc2": [-75.202445, 39.959732] }]
+}


### PR DESCRIPTION
We only ever use the JS plan from either the left or right side of the
condition, this change allows one to fail, in which case we use the
other. Also handle the case where _neither_ has a JS plan.