### PR TITLE
SD-837 Constant folding for aggregation functions

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- [SD-837] Constant folding for aggregation functions

--- a/core/src/main/scala/quasar/logicalplan.scala
+++ b/core/src/main/scala/quasar/logicalplan.scala
@@ -272,21 +272,50 @@ object LogicalPlan {
   type SemDisj[A] = NonEmptyList[SemanticError] \/ A
 
   def inferTypes(typ: Type, term: Fix[LogicalPlan]):
-      SemValidation[Typed[LogicalPlan]] =
+      SemValidation[Typed[LogicalPlan]] = {
+
+    def inferInvoke(
+      func: Func,
+      args: List[Fix[LogicalPlan]])(
+      argType: ((Type, Fix[LogicalPlan])) => Type
+    ): SemValidation[LogicalPlan[Typed[LogicalPlan]]] = for {
+      types <- func.untype(typ)
+      args0 <- types.align(args).traverseU(_.onlyBoth match {
+                 case Some(both @ (t, arg)) =>
+                   inferTypes(argType(both), arg).disjunction
+                 case None =>
+                   SemanticError.WrongArgumentCount(func, types.length, args.length)
+                     .wrapNel.left
+               }).validation
+    } yield InvokeF[Typed[LogicalPlan]](func, args0)
+
     (term.unFix match {
-      case ReadF(c)          => success(ReadF[Typed[LogicalPlan]](c))
-      case ConstantF(d)      => success(ConstantF[Typed[LogicalPlan]](d))
-      case InvokeF(f, args)  => for {
-        types <- f.untype(typ)
-        args0 <- types.align(args).traverseU(_.onlyBoth match {
-                   case Some((t, arg)) =>
-                     inferTypes(t, arg).disjunction
-                   case None =>
-                     SemanticError.WrongArgumentCount(f, types.length, args.length)
-                       .wrapNel.left
-                 }).validation
-      } yield InvokeF[Typed[LogicalPlan]](f, args0)
-      case FreeF(n)          => success(FreeF[Typed[LogicalPlan]](n))
+      case ReadF(c) =>
+        success(ReadF[Typed[LogicalPlan]](c))
+
+      case ConstantF(d) =>
+        success(ConstantF[Typed[LogicalPlan]](d))
+
+      case InvokeF(f @ Reduction(_, _, _, _, _, _, _), args) =>
+        // NB: In order to support folding of constant sets passed to reduction
+        //     functions, we change the expected type in these cases to be a
+        //     `Set(A)` instead of just `A` when the argument is a constant set
+        //     as otherwise unification will fail as the expected type will be
+        //     some non-Set-typed `A` and the type of `Const(Data.Set(A))` is
+        //     `Set(A)`. Note that unification will still fail as expected if
+        //     the constant set has members of the wrong type.
+        inferInvoke(f, args) {
+          case (t, arg @ Fix(ConstantF(Data.Set(_)))) if !Type.AnySet.contains(t) =>
+            Type.Set(t)
+          case (t, _) => t
+        }
+
+      case InvokeF(f, args) =>
+        inferInvoke(f, args)(_._1)
+
+      case FreeF(n) =>
+        success(FreeF[Typed[LogicalPlan]](n))
+
       case LetF(n, form, in) =>
         inferTypes(typ, in).flatMap { in0 =>
           val fTyp = in0.collect {
@@ -294,10 +323,13 @@ object LogicalPlan {
           }.concatenate(Type.TypeGlbMonoid)
           inferTypes(fTyp, form).map(LetF[Typed[LogicalPlan]](n, _, in0))
         }
+
       case TypecheckF(expr, t, cont, fallback) =>
         (inferTypes(t, expr) ⊛ inferTypes(typ, cont) ⊛ inferTypes(typ, fallback))(
           TypecheckF[Typed[LogicalPlan]](_, t, _, _))
+
     }).map(Cofree(typ, _))
+  }
 
   private def lift[A](v: SemDisj[A]): NameT[SemDisj, A] =
     quasar.namegen.lift[SemDisj](v)

--- a/core/src/main/scala/quasar/std/agg.scala
+++ b/core/src/main/scala/quasar/std/agg.scala
@@ -19,7 +19,14 @@ package quasar.std
 import quasar.Predef._
 import quasar._
 
-import scalaz._, Validation.success
+import org.threeten.bp.Duration
+import scalaz._, Validation.{success, failureNel}
+import scalaz.std.list._
+import scalaz.std.option._
+import scalaz.syntax.bifunctor._
+import scalaz.syntax.traverse._
+import scalaz.syntax.std.list._
+import scalaz.syntax.std.option._
 
 trait AggLib extends Library {
   private val reflexiveUntyper: Func.Untyper =
@@ -29,45 +36,136 @@ trait AggLib extends Library {
     Type.Int, Type.Top :: Nil,
     noSimplification,
     partialTyper {
-      case List(Type.Const(Data.Set(Nil))) => Type.Const(Data.Int(0))
-      case List(_)                         => Type.Int
+      case List(Type.Const(Data.Set(xs))) => Type.Const(Data.Int(xs.length))
+      case List(_)                        => Type.Int
     },
     basicUntyper)
 
   val Sum = Reduction("SUM", "Sums the values in a set",
     Type.Numeric ⨿ Type.Interval, Type.Numeric ⨿ Type.Interval :: Nil,
     noSimplification,
-    partialTyper {
-      case List(Type.Const(Data.Set(Nil)))  => Type.Const(Data.Int(0))
-      case List(Type.Set(t))                => t
-      case List(t)                          => t
+    partialTyperV {
+      case List(Type.Const(Data.Set(Nil))) =>
+        success(Type.Const(Data.Int(0)))
+
+      case List(Type.Const(s @ Data.Set(xs))) if s.dataType == Type.Set(Type.Int) =>
+        intSet(xs)
+          .map(ys => Type.Const(Data.Int(ys.sum)))
+          .validationNel
+
+      case List(Type.Const(s @ Data.Set(xs))) if s.dataType == Type.Set(Type.Dec) =>
+        decSet(xs)
+          .map(ys => Type.Const(Data.Dec(ys.sum)))
+          .validationNel
+
+      case List(Type.Const(s @ Data.Set(xs))) if s.dataType == Type.Set(Type.Interval) =>
+        ivlSet(xs)
+          .map(ys => Type.Const(Data.Interval(ys.foldLeft(Duration.ZERO)(_ plus _))))
+          .validationNel
+
+      case List(t) =>
+        success(t)
     },
     reflexiveUntyper)
 
   val Min = Reduction("MIN", "Finds the minimum in a set of values",
     Type.Comparable, Type.Comparable :: Nil,
     noSimplification,
-    reflexiveTyper,
+    partialTyperV {
+      case List(Type.Const(Data.Set(xs))) =>
+        reduceComparableSet(Data.Comparable.min)(xs)
+          .map(c => Type.Const(c.value))
+
+      case List(t) =>
+        success(t)
+    },
     reflexiveUntyper)
 
   val Max = Reduction("MAX", "Finds the maximum in a set of values",
     Type.Comparable, Type.Comparable :: Nil,
     noSimplification,
-    reflexiveTyper,
+    partialTyperV {
+      case List(Type.Const(Data.Set(xs))) =>
+        reduceComparableSet(Data.Comparable.max)(xs)
+          .map(c => Type.Const(c.value))
+
+      case List(t) =>
+        success(t)
+    },
     reflexiveUntyper)
 
   val Avg = Reduction("AVG", "Finds the average in a set of numeric values",
     Type.Numeric ⨿ Type.Interval, Type.Numeric ⨿ Type.Interval :: Nil,
     noSimplification,
-    constTyper(Type.Dec),
+    partialTyperV {
+      case List(Type.Const(Data.Set(Nil))) =>
+        expectedNonEmptySet
+
+      case List(Type.Const(Data.Set(xs))) =>
+        numSet(xs)
+          .map(ns => Type.Const(Data.Dec(ns.sum / ns.length)))
+          .validationNel
+
+      case List(t) =>
+        success(t)
+    },
     reflexiveUntyper)
 
   val Arbitrary = Reduction("ARBITRARY", "Returns an arbitrary value from a set",
     Type.Top, Type.Top :: Nil,
     noSimplification,
-    reflexiveTyper,
+    partialTyperV {
+      case List(Type.Const(Data.Set(Nil))) =>
+        expectedNonEmptySet
+
+      case List(Type.Const(Data.Set(x :: xs))) =>
+        success(Type.Const(x))
+
+      case List(t) =>
+        success(t)
+    },
     reflexiveUntyper)
 
   def functions = Count :: Sum :: Min :: Max :: Avg :: Arbitrary :: Nil
+
+  ////
+
+  private val errSetF = Functor[SemanticError \/ ?].compose[List]
+
+  private def expectedNonEmptySet[A]: ValidationNel[SemanticError, A] =
+    failureNel(SemanticError.DomainError(Data.Set(Nil), some("Expected non-empty Set")))
+
+  private def reduceComparableSet(
+    f: (Data.Comparable, Data.Comparable) => Option[Data.Comparable]
+  ): List[Data] => ValidationNel[SemanticError, Data.Comparable] =
+    _.toNel.fold(expectedNonEmptySet[Data.Comparable])(xs =>
+      xs.traverse(Data.Comparable(_))
+        .flatMap(ys => ys.tail.foldLeftM(ys.head)(f))
+        .toSuccessNel(SemanticError.DomainError(
+          Data.Set(xs.list),
+          some("Expected Set of comparable values"))))
+
+  private val numSet: List[Data] => SemanticError \/ List[BigDecimal] =
+    set =>
+      errSetF.map(ivlSet(set))(d => BigDecimal(d.toMillis))
+        .orElse(errSetF.map(intSet(set))(BigDecimal(_)))
+        .orElse(decSet(set))
+        .leftAs(SemanticError.DomainError(Data.Set(set), some("Expected Set of numeric values")))
+
+  private val ivlSet: List[Data] => SemanticError \/ List[Duration] =
+    homogenizedPF({ case Data.Interval(d) => d }, "Expected Set(Interval)")
+
+  private val decSet: List[Data] => SemanticError \/ List[BigDecimal] =
+    homogenizedPF({ case Data.Dec(n) => n }, "Expected Set(Dec)")
+
+  private val intSet: List[Data] => SemanticError \/ List[BigInt] =
+    homogenizedPF({ case Data.Int(n) => n }, "Expected Set(Int)")
+
+  private def homogenizedPF[A](f: PartialFunction[Data, A], err: String): List[Data] => SemanticError \/ List[A] =
+    homogenized(f.lift, err)
+
+  private def homogenized[A](f: Data => Option[A], err: String): List[Data] => SemanticError \/ List[A] =
+    set => set.traverseU(f) \/> SemanticError.DomainError(Data.Set(set), some(err))
 }
+
 object AggLib extends AggLib

--- a/core/src/test/scala/quasar/std/AggLibSpec.scala
+++ b/core/src/test/scala/quasar/std/AggLibSpec.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.std
+
+import quasar.Predef._
+import quasar.{Data, Type}
+import quasar.DataArbitrary, DataArbitrary._
+import quasar.specs2.ValidationMatchers
+
+import org.specs2.{mutable, ScalaCheck}
+import org.threeten.bp.Duration
+import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.NonEmptyList
+import scalaz.std.anyVal._
+import scalaz.syntax.foldable1._
+
+class AggLibSpec extends mutable.Specification with ScalaCheck with ValidationMatchers {
+  import AggLib._
+
+  "Arbitrary" should {
+    "type a nonempty constant set to the constant first value" ! prop { xs: NonEmptyList[Data] =>
+      Arbitrary(Type.Const(Data.Set(xs.list))) must beSuccessful(Type.Const(xs.head))
+    }
+
+    "error when applied to an empty constant set" >> {
+      Arbitrary(Type.Const(Data.Set(Nil))) must beFailing
+    }
+  }
+
+  "Avg" should {
+    "type a constant Int set to the constant average of values" ! prop { n: BigInt =>
+      val s = Data.Set(List(Data.Int(n), Data.Int(n + 2)))
+      Avg(Type.Const(s)) must beSuccessful(Type.Const(Data.Dec(BigDecimal(n + 1))))
+    }
+
+    "type a constant Dec set to the constant average of values" ! prop { n0: Double =>
+      val n = BigDecimal(n0)
+      val s = Data.Set(List(Data.Dec(n), Data.Dec(n / 2.0)))
+      Avg(Type.Const(s)) must beSuccessful(Type.Const(Data.Dec(n * 0.75)))
+    }
+
+    "type a constant Interval set to the constant average of values" ! prop { n: Int =>
+      val dur = Duration.ofMillis(n.toLong)
+      val s = Data.Set(List(Data.Interval(dur), Data.Interval(dur.plusMillis(2))))
+      Avg(Type.Const(s)) must beSuccessful(Type.Const(Data.Dec(n.toLong + 1)))
+    }
+
+    "error when applied to an empty constant set" >> {
+      Avg(Type.Const(Data.Set(Nil))) must beFailing
+    }
+  }
+
+  "Count" should {
+    "type a constant set as the constant length" ! prop { xs: List[Int] =>
+      Count(Type.Const(Data.Set(xs.map(Data.Int(_))))) must beSuccessful(Type.Const(Data.Int(xs.length)))
+    }
+  }
+
+  "Max" should {
+    "type a constant set as the constant max value" ! prop { xs: NonEmptyList[Int] =>
+      Max(Type.Const(Data.Set(xs.list.map(Data.Int(_))))) must
+        beSuccessful(Type.Const(Data.Int(xs.maximum1)))
+    }
+
+    "error when applied to an empty constant set" >> {
+      Max(Type.Const(Data.Set(Nil))) must beFailing
+    }
+  }
+
+  "Min" should {
+    "type a constant set as the constant min value" ! prop { xs: NonEmptyList[Int] =>
+      Min(Type.Const(Data.Set(xs.list.map(Data.Int(_))))) must
+        beSuccessful(Type.Const(Data.Int(xs.minimum1)))
+    }
+
+    "error when applied to an empty constant set" >> {
+      Min(Type.Const(Data.Set(Nil))) must beFailing
+    }
+  }
+
+  "Sum" should {
+    "type a constant Int set to the constant Int sum of values" ! prop { xs: NonEmptyList[BigInt] =>
+      val s = Data.Set(xs.list map (Data.Int(_)))
+      Sum(Type.Const(s)) must beSuccessful(Type.Const(Data.Int(xs.list.sum)))
+    }
+
+    "type a constant Dec set to the constant Dec sum of values" ! prop { xs: NonEmptyList[Double] =>
+      val ys = xs.list map (BigDecimal(_))
+      val s = Data.Set(ys map (Data.Dec(_)))
+      Sum(Type.Const(s)) must beSuccessful(Type.Const(Data.Dec(ys.sum)))
+    }
+
+    "type a constant Interval set to the constant Interval sum of values" ! prop { xs: NonEmptyList[Int] =>
+      val milliss = xs.list map (_.toLong)
+      val s = Data.Set(milliss map (n => Data.Interval(Duration.ofMillis(n))))
+      Sum(Type.Const(s)) must beSuccessful(Type.Const(Data.Interval(Duration.ofMillis(milliss.sum))))
+    }
+
+    "type an empty constant set to constant Int(0)" >> {
+      Sum(Type.Const(Data.Set(Nil))) must beSuccessful(Type.Const(Data.Int(0)))
+    }
+  }
+}


### PR DESCRIPTION
Implements constant folding for all of the functions in `AggLib`.

In order to get constant sets passed to these functions to typecheck, I modified type inference to infer a set-based type for an argument which itself was a constant set. I chose to do this during inference rather than typechecking as we perform the former top-down, which provides the necessary context to make this decision vs the bottom-up process of typechecking.

This is admittedly a bit smelly, but seemed to at least be contained since we only apply this transformation when the function being applied is a `Reduction`. I also tried just adding `Set` types to the domain of the reduction functions, but that had the unintended side-effect of generating lots of unecessary runtime typechecks for the additional types (which only exist to support constants), not to mention confusing the type signatures of those functions.

I've implemented the behavior as requested in the ticket, though after some discussion with @mossprescott I realize this behavior will likely be unexpected to those coming from SQL, hopefully the upcoming MRA spec will help to clarify this.