### PR TITLE
Allow constant-foldable expressions to be used as LIKE patterns.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- [SD-1523] allow expressions that fold to literals as `LIKE` patterns

--- a/core/src/main/scala/quasar/logicalplan.scala
+++ b/core/src/main/scala/quasar/logicalplan.scala
@@ -399,7 +399,7 @@ object LogicalPlan {
           val (types, constraints, terms) = args.foldMap(a =>
             (List(a.inferred), a.constraints, List(a.plan)))
           lift(ConcatOp.apply(types).disjunction).flatMap[NameGen, ConstrainedPlan](poss => poss match {
-            case Type.Str         => unifyOrCheck(inf, poss, Invoke(string.Concat, terms))
+            case t if Type.Str.contains(t) => unifyOrCheck(inf, poss, Invoke(string.Concat, terms))
             case t if t.arrayLike => unifyOrCheck(inf, poss, Invoke(ArrayConcat, terms))
             case _                => lift(-\/(NonEmptyList(SemanticError.GenericError("can't concat mixed/unknown types"))))
           }).map(cp =>

--- a/it/src/main/resources/tests/likeWithConstantFoldablePattern.test
+++ b/it/src/main/resources/tests/likeWithConstantFoldablePattern.test
@@ -1,0 +1,18 @@
+{
+    "name": "LIKE with constant-foldable pattern",
+    "data": "zips.data",
+    "variables": { "substr": "\"ULDER\"" },
+    "query": "select * from zips where city like (\"%\" || :substr || \"%\")",
+    "predicate": "containsExactly",
+    "expected": [
+        { "city": "BOULDER JUNCTION", "state": "WI", "pop": 563,   "loc": [ -89.632454, 46.111183] },
+        { "city": "BOULDER",          "state": "MT", "pop": 1737,  "loc": [-112.113757, 46.230647] },
+        { "city": "BOULDER",          "state": "CO", "pop": 18174, "loc": [-105.21426,  40.049733] },
+        { "city": "BOULDER",          "state": "CO", "pop": 29384, "loc": [-105.285131, 40.017235] },
+        { "city": "BOULDER",          "state": "CO", "pop": 39860, "loc": [-105.239178, 39.991381] },
+        { "city": "BOULDER",          "state": "CO", "pop": 21550, "loc": [-105.277073, 40.037482] },
+        { "city": "BOULDER",          "state": "WY", "pop": 112,   "loc": [-109.540105, 42.688146] },
+        { "city": "BOULDER",          "state": "UT", "pop": 131,   "loc": [-111.426646, 37.916606] },
+        { "city": "BOULDER CITY",     "state": "NV", "pop": 12920, "loc": [-114.834413, 35.972711] },
+        { "city": "BOULDER CREEK",    "state": "CA", "pop": 9434,  "loc": [-122.133053, 37.149934] }]
+}


### PR DESCRIPTION
SD-1523 #done

This moves the conversion from LIKE => regex into the simplifier (where
it should be) and out of the compiler. Also, non-foldable expressions
are technically allowed now, but aren’t yet supported by the MongoDB
backend (we could implement a LIKE => regex converter in mapReduce to
add support).

There was also a small secondary bug in our handling of the generic `||`
operator, where constant strings would fail to typecheck. That is also fixed.