### PR TITLE
SD-1509 Readable JSON data codec should render NA values as null

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- [SD-1509] Render NA values as JSON null in readable Data codec

--- a/README.md
+++ b/README.md
@@ -502,6 +502,7 @@ time      | `"10:30:05"`    | `{ "$time": "10:30:05" }` | HH:MM[:SS[:.SSS]]
 interval  | `"PT12H34M"`    | `{ "$interval": "P7DT12H34M" }` | Note: year/month not currently supported.
 binary    | `"TE1OTw=="`    | `{ "$binary": "TE1OTw==" }` | BASE64-encoded.
 object id | `"abc"`         | `{ "$oid": "abc" }` |
+error     | `null`          | `{ "$na": null }` | A runtime error occurred producing or representing this value.
 
 
 ### CSV

--- a/core/src/main/scala/quasar/codec.scala
+++ b/core/src/main/scala/quasar/codec.scala
@@ -161,7 +161,7 @@ object DataCodec {
 
         case Id(value)        => \/-(jString(value))
 
-        case `NA`             => \/-(jString("NA"))
+        case `NA`             => \/-(jNull)
       }
     }
 

--- a/core/src/main/scala/quasar/repl/Repl.scala
+++ b/core/src/main/scala/quasar/repl/Repl.scala
@@ -231,7 +231,7 @@ object Repl {
     P: ConsoleIO.Ops[S]
   ): Free[S, Unit] = {
     def formatJson(codec: DataCodec)(data: Data) =
-      DataCodec.Precise.encode(data).fold(
+      codec.encode(data).fold(
         err => "error: " + err.shows,
         _.pretty(minspace))
 

--- a/core/src/test/scala/quasar/codec.scala
+++ b/core/src/test/scala/quasar/codec.scala
@@ -150,7 +150,7 @@ class DataCodecSpecs extends Specification with ScalaCheck with DisjunctionMatch
       "encode set"       in { DataCodec.render(Data.Set(List(Data.Int(0), Data.Int(1), Data.Int(2)))) must beRightDisjunction("[ 0, 1, 2 ]") }
       "encode binary"    in { DataCodec.render(Data.Binary(Array[Byte](76, 77, 78, 79))) must beRightDisjunction("\"TE1OTw==\"") }
       "encode objectId"  in { DataCodec.render(Data.Id("abc")) must beRightDisjunction("\"abc\"") }
-      "encode NA"        in { DataCodec.render(Data.NA) must beRightDisjunction("\"NA\"") }
+      "encode NA"        in { DataCodec.render(Data.NA) must beRightDisjunction("null") }
     }
 
     "round-trip" ! prop { (data: Data) =>


### PR DESCRIPTION
Instead of rendering `Data.NA` as `"NA"`, the "readable" `Data` codec now renders them as the more idiomatic JSON `null`.

SD-1509 #done