### PR TITLE
Allow non-literals in SQL set literals

### DIFF
--- a/CHANGELOG/major.md
+++ b/CHANGELOG/major.md
@@ -1,0 +1,4 @@
+- [SD-1516] allow non-literals in SQL set literals
+- SQL `IN` no longer (accidentally) works on arrays
+- select now has MRA set semantics, rather than SQL row semantics
+- eliminate `Set` from the type system

--- a/core/src/main/scala/quasar/data.scala
+++ b/core/src/main/scala/quasar/data.scala
@@ -84,9 +84,7 @@ object Data {
 
   final case class Set(value: List[Data]) extends Data {
     def dataType =
-      Type.Set(value.foldLeft[Type](
-        Type.Bottom)(
-        (acc, d) => Type.lub(acc, d.dataType)))
+      value.foldLeft[Type](Type.Bottom)((acc, d) => Type.lub(acc, d.dataType))
     def toJs = jscore.Arr(value.map(_.toJs))
   }
 

--- a/core/src/main/scala/quasar/physical/mongodb/planner.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/planner.scala
@@ -57,12 +57,8 @@ object MongoDbPlanner extends Planner[Crystallized] {
       Type => Option[In => Out] =
         typ => f.lift(typ).fold(
           typ match {
-            case Type.Interval =>
-              generateTypeCheck(or)(f)(Type.Dec)
-            case Type.Arr(_)
-               | Type.Set(_)
-               | Type.FlexArr(_, _, _) ⨿ Type.Set(_)  =>
-              generateTypeCheck(or)(f)(Type.AnyArray)
+            case Type.Interval => generateTypeCheck(or)(f)(Type.Dec)
+            case Type.Arr(_) => generateTypeCheck(or)(f)(Type.AnyArray)
             case Type.Timestamp
                | Type.Timestamp ⨿ Type.Date
                | Type.Timestamp ⨿ Type.Date ⨿ Type.Time =>

--- a/core/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
@@ -1133,6 +1133,22 @@ object WorkflowBuilder {
           }
         case (CollectionBuilderF(_, _, _), DocBuilderF(_, _)) => delegate
 
+        case (ValueBuilderF(Bson.Doc(map1)), CollectionBuilderF(_, base, _)) =>
+          emit(SpliceBuilder(wb2,
+            combine(
+              Doc(map1.map { case (k, v) => BsonField.Name(k) -> \/-($literal(v)) }),
+              Expr(\/-($$ROOT)))(List(_, _))))
+        case (CollectionBuilderF(_, _, _), ValueBuilderF(Bson.Doc(_))) =>
+          delegate
+
+        case (ValueBuilderF(Bson.Doc(map1)), SpliceBuilderF(src, structure)) =>
+          emit(SpliceBuilder(src,
+            combine(
+              List(Doc(map1.map { case (k, v) => BsonField.Name(k) -> \/-($literal(v)) })),
+              structure)(_ ++ _)))
+        case (SpliceBuilderF(_, _), ValueBuilderF(Bson.Doc(_))) =>
+          delegate
+
         case (
           DocBuilderF(s1 @ Fix(
             ArraySpliceBuilderF(_, _)),

--- a/core/src/main/scala/quasar/std/agg.scala
+++ b/core/src/main/scala/quasar/std/agg.scala
@@ -48,17 +48,17 @@ trait AggLib extends Library {
       case List(Type.Const(Data.Set(Nil))) =>
         success(Type.Const(Data.Int(0)))
 
-      case List(Type.Const(s @ Data.Set(xs))) if s.dataType == Type.Set(Type.Int) =>
+      case List(Type.Const(s @ Data.Set(xs))) if s.dataType == Type.Int =>
         intSet(xs)
           .map(ys => Type.Const(Data.Int(ys.sum)))
           .validationNel
 
-      case List(Type.Const(s @ Data.Set(xs))) if s.dataType == Type.Set(Type.Dec) =>
+      case List(Type.Const(s @ Data.Set(xs))) if s.dataType == Type.Dec =>
         decSet(xs)
           .map(ys => Type.Const(Data.Dec(ys.sum)))
           .validationNel
 
-      case List(Type.Const(s @ Data.Set(xs))) if s.dataType == Type.Set(Type.Interval) =>
+      case List(Type.Const(s @ Data.Set(xs))) if s.dataType == Type.Interval =>
         ivlSet(xs)
           .map(ys => Type.Const(Data.Interval(ys.foldLeft(Duration.ZERO)(_ plus _))))
           .validationNel

--- a/core/src/main/scala/quasar/std/math.scala
+++ b/core/src/main/scala/quasar/std/math.scala
@@ -77,9 +77,9 @@ trait MathLib extends Library {
     case t             => success(t          :: t          :: Nil)
   }
 
-  /**
-   * Adds two numeric values, promoting to decimal if either operand is decimal.
-   */
+  /** Adds two numeric values, promoting to decimal if either operand is
+    * decimal.
+    */
   val Add = Mapping("(+)", "Adds two numeric or temporal values",
     MathAbs, MathAbs :: MathRel :: Nil,
     new Func.Simplifier {

--- a/core/src/main/scala/quasar/std/set.scala
+++ b/core/src/main/scala/quasar/std/set.scala
@@ -29,14 +29,7 @@ trait SetLib extends Library {
   private def setTyper(f: Func.Typer): Func.Typer =
     ts => f(ts).map {
       case x @ Type.Const(Data.Set(_)) => x
-      case x @ Type.Set(_)             => x
-      case rez                         => rez // ⨿ Type.Set(rez)
-    }
-  def setUntyper(f: Type => ValidationNel[SemanticError, List[Type]]):
-      Func.Untyper =
-    untyper {
-      case Type.Set(t)             => f(t)
-      case t                       => f(t)
+      case rez                         => rez
     }
 
   val Take = Sifting("(LIMIT)", "Takes the first N elements from a set",
@@ -48,10 +41,9 @@ trait SetLib extends Library {
       case Type.Const(Data.Set(s)) :: Type.Const(Data.Int(n)) :: Nil
           if n.isValidInt =>
         Type.Const(Data.Set(s.take(n.intValue)))
-      case Type.Set(t) :: _ :: Nil => t
-      case t           :: _ :: Nil => t
+      case t :: _ :: Nil => t
     }),
-    setUntyper(t => success(t :: Type.Int :: Nil)))
+    untyper(t => success(t :: Type.Int :: Nil)))
 
   val Drop = Sifting("(OFFSET)", "Drops the first N elements from a set",
     Type.Top, Type.Top :: Type.Int :: Nil,
@@ -66,16 +58,15 @@ trait SetLib extends Library {
       case Type.Const(Data.Set(s)) :: Type.Const(Data.Int(n)) :: Nil
           if n.isValidInt =>
         Type.Const(Data.Set(s.drop(n.intValue)))
-      case Type.Set(t) :: _ :: Nil => t
-      case t           :: _ :: Nil => t
+      case t :: _ :: Nil => t
     }),
-    setUntyper(t => success(t :: Type.Int :: Nil)))
+    untyper(t => success(t :: Type.Int :: Nil)))
 
   val OrderBy = Sifting("ORDER BY", "Orders a set by the natural ordering of a projection on the set",
     Type.Top, Type.Top :: Type.Top :: Type.Top :: Nil,
     noSimplification,
     setTyper(partialTyper { case set :: _ :: _ :: Nil => set }),
-    setUntyper(t => success(t :: Type.Top :: Type.Top :: Nil)))
+    untyper(t => success(t :: Type.Top :: Type.Top :: Nil)))
 
   val Filter = Sifting("WHERE", "Filters a set to include only elements where a projection is true",
     Type.Top, Type.Top :: Type.Bool :: Nil,
@@ -90,7 +81,7 @@ trait SetLib extends Library {
       case _   :: Type.Const(Data.False) :: Nil => Type.Const(Data.Set(Nil))
       case set :: _                      :: Nil => set
     }),
-    setUntyper(t => success(t :: Type.Bool :: Nil)))
+    untyper(t => success(t :: Type.Bool :: Nil)))
 
   val InnerJoin = Transformation(
     "INNER JOIN",
@@ -103,7 +94,7 @@ trait SetLib extends Library {
       case List(_, Type.Const(Data.Set(Nil)), _) => Type.Const(Data.Set(Nil))
       case List(s1, s2, _) => Type.Obj(Map("left" -> s1, "right" -> s2), None)
     }),
-    setUntyper(t =>
+    untyper(t =>
       (t.objectField(Type.Const(Data.Str("left"))) |@| t.objectField(Type.Const(Data.Str("right"))))((l, r) =>
         l :: r :: Type.Bool :: Nil)))
 
@@ -119,7 +110,7 @@ trait SetLib extends Library {
       case List(s1, s2, _) =>
         Type.Obj(Map("left" -> s1, "right" -> (s2 ⨿ Type.Null)), None)
     }),
-    setUntyper(t =>
+    untyper(t =>
       (t.objectField(Type.Const(Data.Str("left"))) |@| t.objectField(Type.Const(Data.Str("right"))))((l, r) =>
         l :: r :: Type.Bool :: Nil)))
 
@@ -134,7 +125,7 @@ trait SetLib extends Library {
       case List(_, Type.Const(Data.Set(Nil)), _) => Type.Const(Data.Set(Nil))
       case List(s1, s2, _) => Type.Obj(Map("left" -> (s1 ⨿ Type.Null), "right" -> s2), None)
     }),
-    setUntyper(t =>
+    untyper(t =>
       (t.objectField(Type.Const(Data.Str("left"))) |@| t.objectField(Type.Const(Data.Str("right"))))((l, r) =>
         l :: r :: Type.Bool :: Nil)))
 
@@ -149,7 +140,7 @@ trait SetLib extends Library {
       case List(s1, s2, _) =>
         Type.Obj(Map("left" -> (s1 ⨿ Type.Null), "right" -> (s2 ⨿ Type.Null)), None)
     }),
-    setUntyper(t =>
+    untyper(t =>
       (t.objectField(Type.Const(Data.Str("left"))) |@| t.objectField(Type.Const(Data.Str("right"))))((l, r) =>
         l :: r :: Type.Bool :: Nil)))
 
@@ -157,19 +148,19 @@ trait SetLib extends Library {
     Type.Top, Type.Top :: Type.Top :: Nil,
     noSimplification,
     setTyper(partialTyper { case s1 :: _ :: Nil => s1 }),
-    setUntyper(t => success(t :: Type.Top :: Nil)))
+    untyper(t => success(t :: Type.Top :: Nil)))
 
   val Distinct = Sifting("DISTINCT", "Discards all but the first instance of each unique value",
     Type.Top, Type.Top :: Nil,
     noSimplification,
     setTyper(partialTyper { case a :: Nil => a}),
-    setUntyper(t => success(t :: Nil)))
+    untyper(t => success(t :: Nil)))
 
   val DistinctBy = Sifting("DISTINCT BY", "Discards all but the first instance of the first argument, based on uniqueness of the second argument",
     Type.Top, Type.Top :: Type.Top :: Nil,
     noSimplification,
     setTyper(partialTyper { case a :: _ :: Nil => a }),
-    setUntyper(t => success(t :: Type.Top :: Nil)))
+    untyper(t => success(t :: Type.Top :: Nil)))
 
   val Union = Transformation("(UNION ALL)",
     "Creates a new set with all the elements of each input set, keeping duplicates.",
@@ -180,7 +171,7 @@ trait SetLib extends Library {
       case List(s1, Type.Const(Data.Set(Nil))) => s1
       case List(s1, s2)                        => s1 ⨿ s2
     }),
-    setUntyper(t => success(t :: t :: Nil)))
+    untyper(t => success(t :: t :: Nil)))
 
   val Intersect = Transformation("(INTERSECT ALL)",
     "Creates a new set with only the elements that exist in both input sets, keeping duplicates.",
@@ -189,7 +180,7 @@ trait SetLib extends Library {
     setTyper(partialTyper {
       case List(s1, s2) => if (s1 == s2) s1 else Type.Const(Data.Set(Nil))
     }),
-    setUntyper(t => success(t :: t :: Nil)))
+    untyper(t => success(t :: t :: Nil)))
 
   val Except = Transformation("(EXCEPT)",
     "Removes the elements of the second set from the first set.",
@@ -201,7 +192,7 @@ trait SetLib extends Library {
       }
     },
     setTyper(partialTyper { case List(s1, _) => s1 }),
-    setUntyper(t => success(t :: Type.Top :: Nil)))
+    untyper(t => success(t :: Type.Top :: Nil)))
 
   // TODO: Handle “normal” functions without creating Funcs. They should be in
   //       a separate functor and inlined prior to getting this far. It will
@@ -210,14 +201,14 @@ trait SetLib extends Library {
   val In = Mapping(
     "(in)",
     "Determines whether a value is in a given set.",
-    Type.Bool, Type.Top :: Type.AnySet :: Nil,
+    Type.Bool, Type.Top :: Type.Top :: Nil,
     new Func.Simplifier {
       def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
           case InvokeF(_, List(item, set)) => set.project match {
             case ConstantF(Data.Set(_)) => Within(item, StructuralLib.UnshiftArray(set).embed).some
             case ConstantF(_)           => RelationsLib.Eq(item, set).some
-            case _                      => None
+            case lp                     => Within(item, StructuralLib.UnshiftArray(set).embed).some
           }
           case _ => None
         }
@@ -253,12 +244,9 @@ trait SetLib extends Library {
     partialTyper {
       case Type.Const(const) :: Type.Const(Data.Set(s)) :: Nil =>
         Type.Const(Data.Set(s.map(κ(const))))
-      case const :: Type.Const(Data.Set(s)) :: Nil => Type.Set(const)
-      case const :: Type.Set(_)             :: Nil => Type.Set(const)
-      // TODO: Correct typing requires MRA
-      case const :: _                       :: Nil => Type.Set(const) // const
+      case const :: _ :: Nil => const
     },
-    setUntyper(t => success(t :: Type.Top :: Nil)))
+    untyper(t => success(t :: Type.Top :: Nil)))
 
   def functions =
     Take :: Drop :: OrderBy :: Filter ::

--- a/core/src/test/scala/quasar/TypeArbitrary.scala
+++ b/core/src/test/scala/quasar/TypeArbitrary.scala
@@ -63,15 +63,12 @@ trait TypeArbitrary {
     right <- complexGen(depth-1, gen)
   } yield left ⨿ right
 
-  def simpleGen: Gen[Type] = Gen.oneOf(terminalGen, simpleConstGen, setGen)
+  def simpleGen: Gen[Type] = Gen.oneOf(terminalGen, simpleConstGen)
 
   def terminalGen: Gen[Type] = Gen.oneOf(Null, Str, Type.Int, Dec, Bool, Binary, Timestamp, Date, Time, Interval)
 
   def simpleConstGen: Gen[Type] = DataArbitrary.simpleData.map(Const(_))
   def constGen: Gen[Type] = Arbitrary.arbitrary[Data].map(Const(_))
-
-  // TODO: can a Set contain constants? objects? arrays?
-  def setGen: Gen[Type] = terminalGen.map(Set(_))
 
   def fieldGen: Gen[(String, Type)] = for {
     c <- Gen.alphaChar

--- a/core/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/core/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -117,11 +117,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
 
     "plan simple constant from collection" in {
       plan("select 1 from zips") must
-        beWorkflow(chain(
-          $read(Collection("db", "zips")),
-          $project(
-            reshape("0" -> $literal(Bson.Int64(1))),
-            IgnoreId)))
+        beWorkflow($pure(Bson.Doc(ListMap("0" -> Bson.Int64(1)))))
     }
 
     // TODO: currently, Data.Obj doesn’t maintain order. The result here will
@@ -744,7 +740,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     }
 
     "plan filter with field containing constant value" in {
-      plan("select * from zips where 43.058514 in loc") must
+      plan("select * from zips where 43.058514 in loc[_]") must
         beWorkflow(chain(
           $read(Collection("db", "zips")),
           $match(Selector.Where(
@@ -771,7 +767,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
 
     "plan filter with field containing other field" in {
       import jscore._
-      plan("select * from zips where pop in loc") must
+      plan("select * from zips where pop in loc[_]") must
         beWorkflow(chain(
           $read(Collection("db", "zips")),
           $match(Selector.Where(

--- a/core/src/test/scala/quasar/std/set.scala
+++ b/core/src/test/scala/quasar/std/set.scala
@@ -33,37 +33,37 @@ class SetSpec extends Specification with ScalaCheck with TypeArbitrary with Vali
 
   "SetLib" should {
     "type taking no results" in {
-      val expr = Take(Type.Set(Type.Int), Type.Const(Data.Int(0)))
+      val expr = Take(Type.Int, Type.Const(Data.Int(0)))
       expr should beSuccessful(Type.Const(Data.Set(Nil)))
     }
 
     "type filtering by false" in {
-      val expr = Filter(Type.Set(Type.Int), Type.Const(Data.Bool(false)))
+      val expr = Filter(Type.Int, Type.Const(Data.Bool(false)))
       expr should beSuccessful(Type.Const(Data.Set(Nil)))
     }
 
     "type inner join on false" in {
-      val expr = InnerJoin(Type.Set(Type.Int), Type.Set(Type.Int), Type.Const(Data.Bool(false)))
+      val expr = InnerJoin(Type.Int, Type.Int, Type.Const(Data.Bool(false)))
       expr should beSuccessful(Type.Const(Data.Set(Nil)))
     }
 
     "type inner join with empty left" in {
-      val expr = InnerJoin(Type.Const(Data.Set(Nil)), Type.Set(Type.Int), Type.Bool)
+      val expr = InnerJoin(Type.Const(Data.Set(Nil)), Type.Int, Type.Bool)
       expr should beSuccessful(Type.Const(Data.Set(Nil)))
     }
 
     "type inner join with empty right" in {
-      val expr = InnerJoin(Type.Set(Type.Int), Type.Const(Data.Set(Nil)), Type.Bool)
+      val expr = InnerJoin(Type.Int, Type.Const(Data.Set(Nil)), Type.Bool)
       expr should beSuccessful(Type.Const(Data.Set(Nil)))
     }
 
     "type left outer join with empty left" in {
-      val expr = LeftOuterJoin(Type.Const(Data.Set(Nil)), Type.Set(Type.Int), Type.Bool)
+      val expr = LeftOuterJoin(Type.Const(Data.Set(Nil)), Type.Int, Type.Bool)
       expr should beSuccessful(Type.Const(Data.Set(Nil)))
     }
 
     "type right outer join with empty right" in {
-      val expr = RightOuterJoin(Type.Set(Type.Int), Type.Const(Data.Set(Nil)), Type.Bool)
+      val expr = RightOuterJoin(Type.Int, Type.Const(Data.Set(Nil)), Type.Bool)
       expr should beSuccessful(Type.Const(Data.Set(Nil)))
     }
 
@@ -72,7 +72,7 @@ class SetSpec extends Specification with ScalaCheck with TypeArbitrary with Vali
       (t1, t2) match {
         case (Const(r), Const(Data.Set(l))) =>
            expr must beSuccessful(Const(Data.Set(l.map(κ(r)))))
-        case (_, _) => expr must beSuccessful(Type.Set(t1))
+        case (_, _) => expr must beSuccessful(t1)
       }
     }
   }

--- a/core/src/test/scala/quasar/types.scala
+++ b/core/src/test/scala/quasar/types.scala
@@ -157,10 +157,6 @@ class TypesSpec extends Specification with ScalaCheck with ValidationMatchers wi
       typecheck(FlexArr(0, None, t1), Arr(List(t2))) must
         beEqualIfSuccess(typecheck(t1, t2))
     }
-
-    "match under Set" ! prop { (t1: Type, t2: Type) =>
-      typecheck(Set(t1), Set(t2)) must beEqualIfSuccess(typecheck(t1, t2))
-    }
   }
 
   "objectField" should {
@@ -264,10 +260,6 @@ class TypesSpec extends Specification with ScalaCheck with ValidationMatchers wi
       foldMap(intToStr)(Const(Data.True)) should_== Const(Data.True) ⨿ Bool
     }
 
-    "cast int to str in set" in {
-      foldMap(intToStr)(Set(Int)) should_== Set(Int) ⨿ Str
-    }
-
     "cast int to str in unknown Obj" in {
       foldMap(intToStr)(Obj(Map(), Some(Int))) should_== Obj(Map(), Some(Int)) ⨿ Str
     }
@@ -293,14 +285,6 @@ class TypesSpec extends Specification with ScalaCheck with ValidationMatchers wi
     "collect non-int" in {
       foldMap(skipInt)(Bool) should_== Bool :: Nil
     }
-
-    "collect set and its child" in {
-      foldMap(skipInt)(Set(Str)) should_== Set(Str) :: Str :: Nil
-    }
-
-    "collect set but skip child" in {
-      foldMap(skipInt)(Set(Int)) should_== Set(Int) :: Nil
-    }
   }
 
   "mapUp" should {
@@ -324,10 +308,6 @@ class TypesSpec extends Specification with ScalaCheck with ValidationMatchers wi
 
     "preserve other const" in {
       mapUp(Const(Data.True))(intToStr) should_== Const(Data.True)
-    }
-
-    "cast int to str in set" in {
-      mapUp(Set(Int))(intToStr) should_== Set(Str)
     }
 
     "cast int to str in product/coproduct" in {
@@ -366,10 +346,6 @@ class TypesSpec extends Specification with ScalaCheck with ValidationMatchers wi
 
     "preserve other const" in {
       mapUpM[Id](Const(Data.True))(intToStr) should_== Const(Data.True)
-    }
-
-    "cast int to str in set" in {
-      mapUpM[Id](Set(Int))(intToStr) should_== Set(Str)
     }
 
     "cast int to str in product/coproduct" in {
@@ -628,13 +604,12 @@ class TypesSpec extends Specification with ScalaCheck with ValidationMatchers wi
     val exConstObj = Const(Data.Obj(Map("a" -> Data.Int(0))))
     val exElem = FlexArr(0, None, Int)
     val exIndexed = Arr(List(Int))
-    val exSet = Set(Int)
 
     val examples =
       List(Top, Bottom, Null, Str, Int, Dec, Bool, Binary, Timestamp, Date, Time, Interval,
           Const(Data.Int(0)),
           Int ⨯ Str, Int ⨿ Str,
-          exField, exNamed, exConstObj, exElem, exIndexed, exSet)
+          exField, exNamed, exConstObj, exElem, exIndexed)
 
     "only fields and objects are objectLike" in {
       examples.filter(_.objectLike) should_== List(exField, exNamed, exConstObj)
@@ -642,10 +617,6 @@ class TypesSpec extends Specification with ScalaCheck with ValidationMatchers wi
 
     "only elems are arrayLike" in {
       examples.filter(_.arrayLike) should_== List(exElem, exIndexed)
-    }
-
-    "only sets are setLike" in {
-      examples.filter(_.setLike) should_== List(exSet)
     }
 
     "empty array constant is arrayLike" in {

--- a/it/src/main/resources/tests/filterOnContains.test
+++ b/it/src/main/resources/tests/filterOnContains.test
@@ -1,7 +1,7 @@
 {
     "name": "filter on contains",
     "data": "zips.data",
-    "query": "select * from zips where 43.058514 in loc",
+    "query": "select * from zips where 43.058514 in loc[_]",
     "predicate": "equalsExactly",
     "expected": [{ "value": { "city": "CANDIA", "state": "NH", "pop": 3557, "_id":"03034", "loc": [-71.304857, 43.058514] } }]
 }

--- a/it/src/main/resources/tests/literalReductionWithNegative.test
+++ b/it/src/main/resources/tests/literalReductionWithNegative.test
@@ -1,0 +1,7 @@
+{
+    "name": "reduce a literal set with negatives",
+    "data": "zips.data",
+    "query": "select max((0, 1, -2, 5)) from zips",
+    "predicate": "equalsExactly",
+    "expected": [{ "0": 5 }]
+}


### PR DESCRIPTION
SD-1516 #done

Also,

- SQL `IN` no longer (accidentally) works on arrays
- select now has MRA set semantics, rather than SQL row semantics
- eliminate `Set` from the type system