### PR TITLE
Fix two memory leaks

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,3 @@
+- Fix two memory leaks:
+   - one was about 30 KiB each time a query was parsed
+   - the other was 2.3 MiB per hour, regardless of activity

--- a/core/src/main/scala/quasar/fs/mount/MountConfig.scala
+++ b/core/src/main/scala/quasar/fs/mount/MountConfig.scala
@@ -20,7 +20,7 @@ import quasar.Predef._
 import quasar.{Variables, VarName, VarValue}
 import quasar.fp.prism._
 import quasar.fs.FileSystemType
-import quasar.sql, sql.{Expr, SQLParser}
+import quasar.sql, sql.{Expr}
 
 import argonaut._, Argonaut._
 import monocle.Prism
@@ -105,7 +105,7 @@ object MountConfig {
       scheme   <- parsed.scheme \/> s"missing URI scheme: $parsed"
       _        <- (scheme == "sql2".ci) either (()) or s"unrecognized scheme: $scheme"
       queryStr <- parsed.params.get("q") \/> s"missing query: $uri"
-      query    <- new SQLParser().parse(sql.Query(queryStr)).leftMap(_.message)
+      query    <- sql.parse(sql.Query(queryStr)).leftMap(_.message)
       vars     =  Variables(parsed.multiParams collect {
                     case (n, vs) if n.startsWith(VarPrefix) => (
                       VarName(n.substring(VarPrefix.length)),

--- a/core/src/main/scala/quasar/repl/Repl.scala
+++ b/core/src/main/scala/quasar/repl/Repl.scala
@@ -24,7 +24,7 @@ import quasar.effect._
 import quasar.fp._, free.freeCatchable
 import quasar.fs.{Path => QPath, _}
 import quasar.fs.mount._
-import quasar.sql.SQLParser
+import quasar.sql
 
 import pathy.Path, Path._
 import scalaz.{Failure => _, _}, Scalaz._
@@ -174,7 +174,7 @@ object Repl {
             for {
               state <- RS.get
               out   =  state.cwd </> file(name)
-              expr  <- DF.unattempt_(SQLParser.parseInContext(q, QPath.fromAPath(state.cwd)).leftMap(_.message))
+              expr  <- DF.unattempt_(sql.parseInContext(q, QPath.fromAPath(state.cwd)).leftMap(_.message))
               query =  Q.executeQuery(expr, Variables.fromMap(state.variables), out)
               _     <- runQuery(state, query)(p =>
                         P.println(
@@ -184,7 +184,7 @@ object Repl {
           },
           for {
             state <- RS.get
-            expr  <- DF.unattempt_(SQLParser.parseInContext(q, QPath.fromAPath(state.cwd)).leftMap(_.message))
+            expr  <- DF.unattempt_(sql.parseInContext(q, QPath.fromAPath(state.cwd)).leftMap(_.message))
             query =  Q.evaluateQuery(expr, Variables.fromMap(state.variables)).take(state.summaryCount+1).runLog
             _     <- runQuery(state, query)(
                       ds => summarize[S](state.summaryCount, state.format)(ds))

--- a/core/src/main/scala/quasar/sql/package.scala
+++ b/core/src/main/scala/quasar/sql/package.scala
@@ -27,7 +27,7 @@ package object sql {
   type Expr = Fix[ExprF]
 
 
-  private def parser = new SQLParser()
+  private val parser = new SQLParser()
 
   val parse: Query => (ParsingError \/ Expr) = parser.parse
 

--- a/core/src/main/scala/quasar/sql/package.scala
+++ b/core/src/main/scala/quasar/sql/package.scala
@@ -26,6 +26,19 @@ import scalaz._, Scalaz._
 package object sql {
   type Expr = Fix[ExprF]
 
+
+  private def parser = new SQLParser()
+
+  val parse: Query => (ParsingError \/ Expr) = parser.parse
+
+  def parseInContext(sql: Query, basePath: Path):
+      ParsingError \/ Expr =
+    parser.parse(sql)
+      .flatMap(relativizePaths(_, basePath).bimap(
+        ParsingPathError,
+        _.transAna(repeatedly(normalizeƒ))))
+
+
   def CrossRelation(left: SqlRelation[Expr], right: SqlRelation[Expr]) =
     JoinRelation(left, right, InnerJoin, BoolLiteral(true))
 

--- a/core/src/main/scala/quasar/sql/parser.scala
+++ b/core/src/main/scala/quasar/sql/parser.scala
@@ -41,7 +41,7 @@ object ParsingError {
 
 final case class Query(value: String)
 
-class SQLParser extends StandardTokenParsers {
+private[sql] class SQLParser extends StandardTokenParsers {
   class SqlLexical extends StdLexical with RegexParsers {
     override type Elem = super.Elem
 
@@ -427,13 +427,4 @@ class SQLParser extends StandardTokenParsers {
     }
 
   def parse(sql: Query): ParsingError \/ Expr = parseExpr(sql.value)
-}
-
-object SQLParser {
-  def parseInContext(sql: Query, basePath: Path):
-      ParsingError \/ Expr =
-    new SQLParser().parse(sql)
-      .flatMap(relativizePaths(_, basePath).bimap(
-        ParsingPathError,
-        _.transAna(repeatedly(normalizeƒ))))
 }

--- a/core/src/main/scala/quasar/variables.scala
+++ b/core/src/main/scala/quasar/variables.scala
@@ -18,7 +18,7 @@ package quasar
 
 import quasar.Predef._
 import quasar.SemanticError._
-import quasar.sql._
+import quasar.sql.{Expr, ExprF, Query, VariF}
 
 import matryoshka._, Recursive.ops._
 import scalaz._, Scalaz._
@@ -40,7 +40,7 @@ object Variables {
     case VariF(name) =>
       vars.value.get(VarName(name)).fold[SemanticError \/ Expr](
         UnboundVariable(VarName(name)).left)(
-        varValue => (new SQLParser()).parseExpr(varValue.value)
+        varValue => sql.parse(Query(varValue.value))
           .leftMap(VariableParseError(VarName(name), varValue, _)))
     case x => Fix(x).right
   }

--- a/core/src/test/scala/quasar/fs/mount/HierarchicalFileSystemSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/HierarchicalFileSystemSpec.scala
@@ -129,7 +129,7 @@ class HierarchicalFileSystemSpec extends mutable.Specification with FileSystemFi
       val joinQry =
         "select f.x, q.y from `/bar/mntA/foo` as f inner join `/foo/mntC/quux` as q on f.id = q.id"
 
-      val lp = new SQLParser().parse(Query(joinQry)).toOption
+      val lp = parse(Query(joinQry)).toOption
         .flatMap(expr => queryPlan(expr, Variables(Map())).run.value.toOption)
         .get
 

--- a/core/src/test/scala/quasar/helpers.scala
+++ b/core/src/test/scala/quasar/helpers.scala
@@ -18,7 +18,7 @@ package quasar
 
 import quasar.Predef._
 import quasar.fs._
-import quasar.sql.{SQLParser, Query}
+import quasar.sql.{Query}
 import quasar.std._
 
 import matryoshka._
@@ -33,7 +33,7 @@ trait CompilerHelpers extends Specification with TermLogicalPlanMatchers {
 
   val compile: String => String \/ Fix[LogicalPlan] = query => {
     for {
-      select <- SQLParser.parseInContext(Query(query), Path("./")).leftMap(_.toString)
+      select <- sql.parseInContext(Query(query), Path("./")).leftMap(_.toString)
       attr   <- AllPhases(select).leftMap(_.toString)
       cld    <- Compiler.compile(attr).leftMap(_.toString)
     } yield cld

--- a/it/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
@@ -209,7 +209,6 @@ class MongoDbFileSystemSpec
           val dne = testPrefix map (_ </> file("__DNE__"))
           val q = dne map (p => f(posixCodec.printPath(p)))
           val xform = QueryFile.Transforms[query.F]
-          val parser = new sql.SQLParser()
 
           import xform._
 
@@ -241,7 +240,7 @@ class MongoDbFileSystemSpec
                   .run.value.run
               ) must beSome(file))
 
-            parser.parse(sql.Query(f(posixCodec.printPath(file)))) fold (
+            sql.parse(sql.Query(f(posixCodec.printPath(file)))) fold (
               err => ko(s"Parsing failed: ${err.shows}"),
               check0)
           }

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -22,7 +22,7 @@ import quasar.fp._
 import quasar.fs.{Path => QPath, _}
 import quasar.fs.mount.{MountConfig, Mounts, hierarchical}
 import quasar.physical.mongodb.fs.MongoDBFsType
-import quasar.sql._
+import quasar.sql, sql.{Expr, Query}
 
 import java.io.{File, FileInputStream}
 import scala.io.Source
@@ -154,7 +154,7 @@ abstract class QueryRegressionTest[S[_]: Functor](
       toCompExec compose injectTask
 
     val parseTask: Task[Expr] =
-      SQLParser.parseInContext(Query(qry), DataPath)
+      sql.parseInContext(Query(qry), DataPath)
         .fold(e => Task.fail(new RuntimeException(e.message)), _.point[Task])
 
     f(parseTask).liftM[Process] flatMap (queryResults(_, Variables.fromMap(vars)))

--- a/web/src/main/scala/quasar/api/services/query/compile.scala
+++ b/web/src/main/scala/quasar/api/services/query/compile.scala
@@ -23,7 +23,7 @@ import quasar.api.ToQResponse.ops._
 import quasar.fs.{Path => QPath}
 import quasar.fp._
 import quasar.fp.numeric._
-import quasar.sql.{ParsingError, SQLParser}
+import quasar.sql.{ParsingError}
 
 import argonaut._, Argonaut._
 import matryoshka.Fix
@@ -55,7 +55,7 @@ object compile {
       case req @ GET -> AsPath(path) :? QueryParam(query) +& Offset(offset) +& Limit(limit) => respond(
         offsetOrInvalid[S](offset).tuple(limitOrInvalid[S](limit))
           .traverse[Free[S, ?], QResponse[S], ParsingError \/ QResponse[S]] { case (offset, limit) =>
-            SQLParser.parseInContext(query, QPath.fromAPath(path))
+            sql.parseInContext(query, QPath.fromAPath(path))
               .traverse[Free[S, ?], ParsingError, QResponse[S]](expr =>
                 explainQuery(expr, offset, limit, vars(req)))
         })

--- a/web/src/test/scala/quasar/api/services/MountServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/MountServiceSpec.scala
@@ -19,7 +19,7 @@ package quasar.api.services
 import quasar.Predef._
 import quasar.{Variables}
 import quasar.api._
-import quasar.sql.{Expr}
+import quasar.sql, sql.{Expr}
 import quasar.effect.{KeyValueStore}
 import quasar.fp._
 import quasar.fs._
@@ -42,7 +42,7 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
   val StubFs = FileSystemType("stub")
 
   def viewConfig(q: String, vars: (String, String)*): (Expr, Variables) =
-    ((new quasar.sql.SQLParser).parse(quasar.sql.Query(q)).toOption.get,
+    (sql.parse(quasar.sql.Query(q)).toOption.get,
       Variables(Map(vars.map { case (n, v) =>
         quasar.VarName(n) -> quasar.VarValue(v) }: _*)))
 

--- a/web/src/test/scala/quasar/api/services/query/ExecuteServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/query/ExecuteServiceSpec.scala
@@ -91,7 +91,7 @@ class ExecuteServiceSpec extends Specification with FileSystemFixture with Scala
   def selectAllLP(file: AFile) = LogicalPlan.Invoke(IdentityLib.Squash,List(LogicalPlan.Read(QPath.fromAPath(file))))
 
   def toLP(q: String, vars: Variables): Fix[LogicalPlan] =
-      (new sql.SQLParser()).parse(sql.Query(q)).toOption.map { ast =>
+      sql.parse(sql.Query(q)).toOption.map { ast =>
         quasar.queryPlan(ast,vars).run.value.toOption.get
       }.getOrElse(scala.sys.error("could not compile: " + q))
 


### PR DESCRIPTION
See [SD-950](https://slamdata.atlassian.net/browse/SD-950).

This fixes two leaks that showed up pretty quickly with some profiling and a very simple shell script to generate a steady request load.

The one that presumably was causing the crashes reported by the user was the `waitForInput` loop, which would consume 100s of MB over the course of a week even with no requests coming in.