### PR TITLE
Close backend connections after running regression tests

### DIFF
--- a/CHANGELOG/minor.md
+++ b/CHANGELOG/minor.md
@@ -1,0 +1,3 @@
+- make regression tests more robust by closing backend connections after they're used
+- allow relative paths in queries (e.g. `` select * from `../zips` ``)
+- increase MongoDB connection timeout to 10 seconds

--- a/core/src/main/scala/quasar/fs/mount/EvaluatorMounter.scala
+++ b/core/src/main/scala/quasar/fs/mount/EvaluatorMounter.scala
@@ -130,7 +130,7 @@ final class EvaluatorMounter[F[_], S[_]: Functor](
     for {
       vws    <- views[T].get
       mnts   <- mounts[T].get
-      evals  =  mnts.map(_._1)
+      evals  =  mnts.map(_.run)
       mnted  =  hierarchical.fileSystem[F, S](evals)
       injSeq =  liftFT[S] compose injectNT[MonotonicSeqF, S]
       injVST =  liftFT[S] compose injectNT[ViewStateF, S]

--- a/core/src/main/scala/quasar/fs/mount/FileSystemMounter.scala
+++ b/core/src/main/scala/quasar/fs/mount/FileSystemMounter.scala
@@ -55,7 +55,7 @@ final class FileSystemMounter[F[_]](fsDef: FileSystemDef[F]) {
 
     def addMount(fsr: DefinitionResult[F]): MntErrT[M, Unit] = {
       def cleanupOnError(err: String) =
-        free.lift(fsr._2).into[S] as pathError(invalidPath(loc, err))
+        free.lift(fsr.close).into[S] as pathError(invalidPath(loc, err))
 
       EitherT[M, MountingError, Unit](mounts[S].modifyS(mnts =>
         mnts.add(loc, fsr).fold(
@@ -82,7 +82,7 @@ final class FileSystemMounter[F[_]](fsDef: FileSystemDef[F]) {
               (implicit S: F :<: S)
               : Free[S, Unit] = {
 
-    mnts.lookup(loc).map(_._2)
+    mnts.lookup(loc).map(_.close)
       .fold(().point[Free[S, ?]])(free.lift(_).into[S])
   }
 

--- a/core/src/main/scala/quasar/main/package.scala
+++ b/core/src/main/scala/quasar/main/package.scala
@@ -25,7 +25,6 @@ import quasar.fs._
 import quasar.fs.mount._
 import quasar.fs.mount.hierarchical._
 import quasar.physical.mongodb._
-import quasar.physical.mongodb.fs.mongoDbFileSystemDef
 
 import argonaut.EncodeJson
 import com.mongodb.MongoException
@@ -69,9 +68,9 @@ package object main {
     * to a fixed set of effects that filesystems must interpret into.
     */
   val physicalFileSystems: FileSystemDef[PhysFsEffM] =
-    mongoDbFileSystemDef[PhysFsEff]
+    quasar.physical.mongodb.fs.mongoDbFileSystemDef[PhysFsEff]
 
-  /** The intermediate effect FileSystem operations are intepreted into.
+  /** The intermediate effect FileSystem operations are interpreted into.
     *
     * PhysFsEffM \/ MonotonicSeqF \/ ViewStateF \/ MountedResultHF \/ HFSFailureF
     */

--- a/core/src/main/scala/quasar/physical/mongodb/fs/package.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/fs/package.scala
@@ -91,7 +91,7 @@ package object fs {
                       .run
                   ).into[S])
         close  =  free.lift(Task.delay(client.close()).attempt.void).into[S]
-      } yield (fs, close)
+      } yield FileSystemDef.DefinitionResult[M](fs, close)
   }
 
   ////

--- a/core/src/main/scala/quasar/physical/mongodb/util.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/util.scala
@@ -149,7 +149,7 @@ object util {
   ////
 
   // TODO: Externalize
-  private val defaultTimeoutMillis: Int = 5000
+  private val defaultTimeoutMillis: Int = 10000
 
   private def disableMongoLogging: Task[Unit] = {
     import java.util.logging._

--- a/core/src/main/scala/quasar/semantics.scala
+++ b/core/src/main/scala/quasar/semantics.scala
@@ -23,6 +23,7 @@ import quasar.fs.prettyPrint
 import scala.AnyRef
 
 import matryoshka._, Recursive.ops._
+import pathy.Path, Path._
 import scalaz._, Scalaz._, Validation.{success, failure}
 import shapeless.contrib.scalaz._
 
@@ -83,6 +84,9 @@ object SemanticError {
   }
   final case class DateFormatError(func: Func, str: String, hint: Option[String]) extends SemanticError {
     def message = "Date/time string could not be parsed as " + func.name + ": " + str + hint.map(" (" + _ + ")").getOrElse("")
+  }
+  final case class InvalidPathError(path: Path[_, File, _], hint: Option[String]) extends SemanticError {
+    def message = "Invalid path: " + posixCodec.unsafePrintPath(path) + hint.map(" (" + _ + ")").getOrElse("")
   }
 }
 

--- a/core/src/main/scala/quasar/sql/ast.scala
+++ b/core/src/main/scala/quasar/sql/ast.scala
@@ -18,8 +18,6 @@ package quasar.sql
 
 import quasar.Predef._
 
-import quasar.fs._
-
 import scala.Any
 
 import matryoshka._
@@ -158,7 +156,7 @@ sealed trait SqlRelation[A] {
     collect(this).groupBy(_._1).mapValues(_.map(_._2))
   }
 
-  def mapPathsM[F[_]: Monad](f: FPath => F[FPath]): F[SqlRelation[A]] = this match {
+  def mapPathsM[F[_]: Monad](f: FUPath => F[FUPath]): F[SqlRelation[A]] = this match {
     case TableRelationAST(path, alias) => f(path).map(TableRelationAST(_, alias))
     case rel @ JoinRelation(left, right, _, _) =>
       (left.mapPathsM(f) |@| right.mapPathsM(f))((l,r) => rel.copy(left = l, right = r))
@@ -170,7 +168,7 @@ sealed trait NamedRelation[A] extends SqlRelation[A] {
   def aliasName: String
 }
 
-final case class TableRelationAST[A](tablePath: FPath, alias: Option[String])
+final case class TableRelationAST[A](tablePath: FUPath, alias: Option[String])
     extends NamedRelation[A] {
   def aliasName = alias.getOrElse(fileName(tablePath).value)
 }

--- a/core/src/main/scala/quasar/sql/parser.scala
+++ b/core/src/main/scala/quasar/sql/parser.scala
@@ -389,7 +389,7 @@ private[sql] class SQLParser extends StandardTokenParsers {
     ident ~ opt(keyword("as") ~> ident) ^? Function.unlift {
       case ident ~ alias =>
         val filePath = posixCodec.parsePath(Some(_),Some(_),_ => None, _ => None)(ident)
-        filePath.map(p => TableRelationAST[Expr](sandboxCurrent(p), alias))
+        filePath.map(p => TableRelationAST[Expr](p, alias))
     } |
     op("(") ~> (
       (expr ~ op(")") ~ keyword("as") ~ ident ^^ {

--- a/core/src/test/scala/quasar/fs/mount/FileSystemMounterSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/FileSystemMounterSpec.scala
@@ -79,7 +79,7 @@ class FileSystemMounterSpec extends mutable.Specification {
     }
 
   def fsResult(sig: String): DefinitionResult[AbortM] =
-    (abortFs, abort.fail(sig))
+    DefinitionResult[AbortM](abortFs, abort.fail(sig))
 
   val fsDef = FileSystemDef.fromPF {
     case (typ, _) if typ == testType =>

--- a/core/src/test/scala/quasar/fs/mount/ViewMounterSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/ViewMounterSpec.scala
@@ -56,7 +56,7 @@ class ViewMounterSpec extends mutable.Specification {
       val selStar = Fix(sql.SelectF(
         sql.SelectAll,
         Nil,
-        Some(sql.TableRelationAST[sql.Expr](rootDir[Sandboxed] </> dir("foo") </> file("bar"), None)),
+        Some(sql.TableRelationAST[sql.Expr](rootDir </> dir("foo") </> file("bar"), None)),
         None, None, None))
 
       val f = rootDir </> dir("mnt") </> file("selectStar")

--- a/core/src/test/scala/quasar/fs/mount/ViewsSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/ViewsSpec.scala
@@ -67,6 +67,16 @@ class ViewsSpec extends Specification with ScalaCheck with TreeMatchers {
         Read(rootDir </> dir("foo") </> file("zips")))
     }
 
+    // TODO: Pending SD-1548, but doesn't compile because the path can't be sandboxed
+    // "trivial read with relative path through parent" in {
+    //   val vs = Views(Map(
+    //     (rootDir </> dir("foo") </> file("justZips")) ->
+    //       Read(parentDir1(currentDir) </> file("zips"))))
+    //
+    //   vs.rewrite(Read(rootDir </> dir("foo") </> file("justZips"))) must beTree(
+    //     Read(rootDir </> file("zips")))
+    // }
+
     "non-trivial" in {
       val inner =
         Let('tmp0, Read(rootDir </> file("zips")),

--- a/core/src/test/scala/quasar/helpers.scala
+++ b/core/src/test/scala/quasar/helpers.scala
@@ -68,7 +68,7 @@ trait CompilerHelpers extends Specification with TermLogicalPlanMatchers {
   def testTypedLogicalPlanCompile(query: String, expected: Fix[LogicalPlan]) =
     fullCompile(query).toEither must beRight(equalToPlan(expected))
 
-  def read(file: String): Fix[LogicalPlan] = LogicalPlan.Read(sandboxCurrent(posixCodec.parsePath(Some(_), Some(_), κ(None), κ(None))(file).get))
+  def read(file: String): Fix[LogicalPlan] = LogicalPlan.Read(sandboxCurrent(posixCodec.parsePath(Some(_), Some(_), κ(None), κ(None))(file).get).get)
 
   type FLP = Fix[LogicalPlan]
   implicit def toFix[F[_]](unFixed: F[Fix[F]]): Fix[F] = Fix(unFixed)

--- a/core/src/test/scala/quasar/physical/mongodb/collection.scala
+++ b/core/src/test/scala/quasar/physical/mongodb/collection.scala
@@ -210,7 +210,10 @@ class CollectionSpec extends Specification with ScalaCheck with DisjunctionMatch
   }
 
   "dbName <-> dirName are inverses" ! prop { db: SpecialStr =>
-    Collection.dbNameFromPath(rootDir </> dir(db.str))
-      .map(Collection.dirNameFromDbName(_)) must beRightDisjunction(DirName(db.str))
+    val name = Collection.dbNameFromPath(rootDir </> dir(db.str))
+    // NB: can fail if the path has enough multi-byte chars to exceed 64 bytes
+    name.isRight ==> {
+      name.map(Collection.dirNameFromDbName(_)) must beRightDisjunction(DirName(db.str))
+    }
   }.set(maxSize = 20)
 }

--- a/core/src/test/scala/quasar/sql/ExprArbitrary.scala
+++ b/core/src/test/scala/quasar/sql/ExprArbitrary.scala
@@ -54,7 +54,7 @@ trait ExprArbitrary {
     val simple = for {
         n <- Arbitrary.arbitrary[FPath]
         a <- Gen.option(Gen.alphaChar.map(_.toString))
-      } yield TableRelationAST[Expr](n, a)
+      } yield TableRelationAST[Expr](pathy.Path.unsandbox(n), a)
     if (depth <= 0) simple
     else Gen.frequency(
       5 -> simple,

--- a/it/src/main/resources/tests/joins/3WayJoin.test
+++ b/it/src/main/resources/tests/joins/3WayJoin.test
@@ -1,8 +1,11 @@
 {
     "name": "perform 3-way inner equi-join",
     "backends": { "mongodb_read_only": "pending" },
-    "data": "largeZips.data",
-    "query": "select z1.city, z2.state from largeZips as z1 join largeZips as z2 on z1._id = z2._id join largeZips as z3 on z2._id = z3._id",
+    "data": "../largeZips.data",
+    "query": "select z1.city, z2.state
+              from `../largeZips` as z1
+              join `../largeZips` as z2 on z1._id = z2._id
+              join `../largeZips` as z3 on z2._id = z3._id",
     "predicate": "containsAtLeast",
     "expected": [{ "city": "CUSHMAN",           "state": "MA" },
                  { "city": "CHICOPEE",          "state": "MA" },

--- a/it/src/main/resources/tests/joins/constantOnLeft.test
+++ b/it/src/main/resources/tests/joins/constantOnLeft.test
@@ -2,9 +2,9 @@
   "name": "join where the left hand side is constant",
   "backends": { "mongodb_read_only": "pending" },
 
-  "data": "largeZips.data",
+  "data": "../largeZips.data",
 
-  "query": "select a.city, b.state from largeZips as a, largeZips as b where a._id = b._id
+  "query": "select a.city, b.state from `../largeZips` as a, `../largeZips` as b where a._id = b._id
             and \"CA\" = b.state",
 
   "predicate": "containsAtLeast",

--- a/it/src/main/resources/tests/joins/crossJoin.test
+++ b/it/src/main/resources/tests/joins/crossJoin.test
@@ -2,9 +2,9 @@
   "name": "simple join written in 'cross join' form (must be optimized to an inner join or else the join explodes, taking several minutes to complete)",
   "backends": { "mongodb_read_only": "pending" },
 
-  "data": "largeZips.data",
+  "data": "../largeZips.data",
 
-  "query": "select a.city, b.state from largeZips as a, largeZips as b where a._id = b._id",
+  "query": "select a.city, b.state from `../largeZips` as a, `../largeZips` as b where a._id = b._id",
 
   "predicate": "containsAtLeast",
   "expected": [

--- a/it/src/main/resources/tests/joins/crossJoinWithOneSidedConditions.test
+++ b/it/src/main/resources/tests/joins/crossJoinWithOneSidedConditions.test
@@ -2,9 +2,11 @@
   "name": "cross join with conditions that must be pushed ahead of the join (or else the join explodes, taking several minutes to complete)",
   "backends": { "mongodb_read_only": "pending" },
 
-  "data": "largeZips.data",
+  "data": "../largeZips.data",
 
-  "query": "select a.city as a, b.city as b, b.pop - a.pop as diff from largeZips as a, largeZips as b where a._id like \"80301\" and b._id like \"90277\"",
+  "query": "select a.city as a, b.city as b, b.pop - a.pop as diff
+            from `../largeZips` as a, `../largeZips` as b
+            where a._id like \"80301\" and b._id like \"90277\"",
 
   "predicate": "equalsExactly",
   "expected": [

--- a/it/src/main/resources/tests/joins/groupedJoin.test
+++ b/it/src/main/resources/tests/joins/groupedJoin.test
@@ -1,8 +1,10 @@
 {
     "name": "count grouped joined tables",
     "backends": { "mongodb_read_only": "pending" },
-    "data": "slamengine_commits.data",
-    "query": "SELECT p.author.login, COUNT(*) FROM slamengine_commits as p INNER JOIN slamengine_commits as c ON p.sha = c.sha GROUP BY p.author.login",
+    "data": "../slamengine_commits.data",
+    "query": "SELECT p.author.login, COUNT(*)
+              FROM `../slamengine_commits` as p INNER JOIN `../slamengine_commits` as c ON p.sha = c.sha
+              GROUP BY p.author.login",
     "predicate": "containsExactly",
     "expected": [{ "1": 15, "login": "mossprescott" },
                  { "1":  9, "login": "sellout"      },

--- a/it/src/main/resources/tests/joins/innerEquiJoin.test
+++ b/it/src/main/resources/tests/joins/innerEquiJoin.test
@@ -1,8 +1,8 @@
 {
     "name": "perform inner equi-join",
     "backends": { "mongodb_read_only": "pending" },
-    "data": "largeZips.data",
-    "query": "select largeZips.city, z2.state from largeZips join largeZips as z2 on largeZips._id = z2._id",
+    "data": "../largeZips.data",
+    "query": "select largeZips.city, z2.state from `../largeZips` join `../largeZips` as z2 on largeZips._id = z2._id",
     "predicate": "containsAtLeast",
     "expected": [{"city": "ABAC",        "state": "GA"},
                  {"city": "ABBOTT PARK", "state": "IL"},

--- a/it/src/main/resources/tests/joins/innerEquiJoinWithWildcard.test
+++ b/it/src/main/resources/tests/joins/innerEquiJoinWithWildcard.test
@@ -1,8 +1,8 @@
 {
     "name": "perform inner equi-join with wildcard",
     "backends": { "mongodb_read_only": "pending" },
-    "data": "largeZips.data",
-    "query": "select * from largeZips join largeZips as z2 on largeZips._id = z2._id",
+    "data": "../largeZips.data",
+    "query": "select * from `../largeZips` join `../largeZips` as z2 on largeZips._id = z2._id",
     "predicate": "containsAtLeast",
     "expected": [
         {"value": {"_id": "31794", "city": "ABAC",        "loc": [ -83.498867, 31.451722], "pop": 27906, "state": "GA"}},

--- a/it/src/main/resources/tests/joins/joinWithComplexCondition.test
+++ b/it/src/main/resources/tests/joins/joinWithComplexCondition.test
@@ -1,9 +1,9 @@
 {
     "name": "join with complex conditions",
     "backends": { "mongodb_read_only": "pending" },
-    "data": "slamengine_commits.data",
+    "data": "../slamengine_commits.data",
     "query": "select l.sha as child, l.author.login as c_auth, r.sha as parent, r.author.login as p_auth
-              from slamengine_commits as l join slamengine_commits as r
+              from `../slamengine_commits` as l join `../slamengine_commits` as r
               on r.sha = l.parents[0].sha and l.author.login = r.author.login
               where l.author.login || \",\" || r.author.login = \"selloutsellout\"",
     "predicate": "containsAtLeast",

--- a/it/src/main/resources/tests/joins/joinWithMultipleConditions.test
+++ b/it/src/main/resources/tests/joins/joinWithMultipleConditions.test
@@ -1,8 +1,10 @@
 {
     "name": "join with multiple conditions",
     "backends": { "mongodb_read_only": "pending" },
-    "data": "slamengine_commits.data",
-    "query": "select l.sha as child, l.author.login as c_auth, r.sha as parent, r.author.login as p_auth from slamengine_commits as l join slamengine_commits as r on r.sha = l.parents[0].sha and l.author.login = r.author.login",
+    "data": "../slamengine_commits.data",
+    "query": "select l.sha as child, l.author.login as c_auth, r.sha as parent, r.author.login as p_auth
+              from `../slamengine_commits` as l join `../slamengine_commits` as r
+                on r.sha = l.parents[0].sha and l.author.login = r.author.login",
     "predicate": "containsAtLeast",
     "expected": [
         { "child": "b29d8f254e5df2c4d1792f077625924cd1fde2db", "c_auth": "mossprescott",

--- a/it/src/main/resources/tests/joins/joinWithReversedCondition.test
+++ b/it/src/main/resources/tests/joins/joinWithReversedCondition.test
@@ -1,8 +1,9 @@
 {
     "name": "join with reversed condition and complex condition expression",
     "backends": { "mongodb_read_only": "pending" },
-    "data": "slamengine_commits.data",
-    "query": "select l.sha as child, l.author.login as c_auth, r.sha as parent, r.author.login as p_auth from slamengine_commits as l join slamengine_commits as r on r.sha = l.parents[0].sha",
+    "data": "../slamengine_commits.data",
+    "query": "select l.sha as child, l.author.login as c_auth, r.sha as parent, r.author.login as p_auth
+              from `../slamengine_commits` as l join `../slamengine_commits` as r on r.sha = l.parents[0].sha",
     "predicate": "containsAtLeast",
     "expected": [
         { "child": "b29d8f254e5df2c4d1792f077625924cd1fde2db", "c_auth": "mossprescott",

--- a/it/src/main/resources/tests/joins/orderJoinByAlias.test
+++ b/it/src/main/resources/tests/joins/orderJoinByAlias.test
@@ -1,8 +1,8 @@
 {
     "name": "order join by alias",
     "backends": { "mongodb_read_only": "pending" },
-    "data": "largeZips.data",
-    "query": "select z1._id as zip, z2.pop / 1000 as popK from largeZips as z1 inner join largeZips as z2 on z1._id = z2._id order by popK desc",
+    "data": "../largeZips.data",
+    "query": "select z1._id as zip, z2.pop / 1000 as popK from `../largeZips` as z1 inner join `../largeZips` as z2 on z1._id = z2._id order by popK desc",
     "predicate": "equalsInitial",
     "expected": [{ "zip": "60623", "popK": 112.047 },
                  { "zip": "11226", "popK": 111.396 },

--- a/it/src/main/resources/tests/temporal/convertTimestamp.test
+++ b/it/src/main/resources/tests/temporal/convertTimestamp.test
@@ -1,9 +1,9 @@
 {
   "name": "convert epoch milliseconds value to timestamp",
 
-  "data": "days.data",
+  "data": "../days.data",
 
-  "query": "select day, ts, to_timestamp(epoch) as converted from days where ts = to_timestamp(1408255200000) or to_timestamp(epoch) = timestamp(\"2014-08-18T07:00:00Z\")",
+  "query": "select day, ts, to_timestamp(epoch) as converted from `../days` where ts = to_timestamp(1408255200000) or to_timestamp(epoch) = timestamp(\"2014-08-18T07:00:00Z\")",
 
   "predicate": "equalsExactly",
   "expected": [

--- a/it/src/main/resources/tests/temporal/dateFilter.test
+++ b/it/src/main/resources/tests/temporal/dateFilter.test
@@ -1,9 +1,9 @@
 {
   "name": "filter on date part",
 
-  "data": "days.data",
+  "data": "../days.data",
 
-  "query": "select `day` from days where date_part(\"dow\", ts) >= 3",
+  "query": "select `day` from `../days` where date_part(\"dow\", ts) >= 3",
 
   "predicate": "containsExactly",
 

--- a/it/src/main/resources/tests/temporal/days.test
+++ b/it/src/main/resources/tests/temporal/days.test
@@ -1,9 +1,9 @@
 {
   "name": "dow and isodow",
 
-  "data": "days.data",
+  "data": "../days.data",
 
-  "query": "select day, date_part(\"dow\", ts) as dow, date_part(\"isodow\", ts) as isodow from days",
+  "query": "select day, date_part(\"dow\", ts) as dow, date_part(\"isodow\", ts) as isodow from `../days`",
 
   "predicate": "containsExactly",
 

--- a/it/src/main/resources/tests/temporal/filterOnDate.test
+++ b/it/src/main/resources/tests/temporal/filterOnDate.test
@@ -1,7 +1,7 @@
 {
     "name": "filter with date literals",
-    "data": "days.data",
-    "query": "select day from days
+    "data": "../days.data",
+    "query": "select day from `../days`
               where ((ts > date(\"2014-08-17\") and ts <= date(\"2014-08-20\")) and ts != date(\"2014-08-19\"))
                  or ts = date(\"2014-08-22\")",
     "predicate": "containsExactly",

--- a/it/src/main/resources/tests/temporal/invalidDateFilter.test
+++ b/it/src/main/resources/tests/temporal/invalidDateFilter.test
@@ -1,9 +1,9 @@
 {
   "name": "filter on date part, where the field isn't a timestamp",
 
-  "data": "days.data",
+  "data": "../days.data",
 
-  "query": "select day from days where date_part(\"dow\", epoch) >= 3",
+  "query": "select day from `../days` where date_part(\"dow\", epoch) >= 3",
 
   "predicate": "containsExactly",
 

--- a/it/src/main/resources/tests/temporal/time.test
+++ b/it/src/main/resources/tests/temporal/time.test
@@ -2,9 +2,9 @@
   "name": "filter on time_of_day",
   "backends": { "mongodb_read_only": "pending" },
 
-  "data": "days.data",
+  "data": "../days.data",
 
-  "query": "select day, time_of_day(ts) as tod, time_of_day(day) as `not a date`, time_of_day(missing) as missing from days
+  "query": "select day, time_of_day(ts) as tod, time_of_day(day) as `not a date`, time_of_day(missing) as missing from `../days`
     where time_of_day(ts) >= time(\"08:00\") and time_of_day(ts) < time(\"10:20:30.400\")",
 
   "predicate": "containsExactly",

--- a/it/src/main/resources/tests/temporal/timestampsAndIntervals.test
+++ b/it/src/main/resources/tests/temporal/timestampsAndIntervals.test
@@ -1,10 +1,10 @@
 {
   "name": "timestamp and interval syntax",
 
-  "data": "days.data",
+  "data": "../days.data",
 
   "query": "select day, (ts - timestamp(\"2014-08-17T00:00:00.000Z\")) / interval(\"PT1H0M0S\") as hoursSinceSunday
-            from days
+            from `../days`
             where ts < timestamp(\"2014-08-17T12:00:00Z\")
               or ts - interval(\"PT12H\") > timestamp(\"2014-08-22T00:00:00Z\")",
 

--- a/it/src/test/scala/quasar/TaskResource.scala
+++ b/it/src/test/scala/quasar/TaskResource.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar
+
+import quasar.Predef._
+
+import java.util.concurrent.atomic.AtomicLong
+import scalaz._, Scalaz._
+import scalaz.concurrent.{Strategy, Task}
+import scalaz.stream._
+
+sealed abstract class TaskResource[A] {
+  /** Get an instance of the resource, first acquiring it if necessary. */
+  def get: Task[A]
+
+  /** Release the cached instance, if it was ever acquired. */
+  def release: Task[Unit]
+}
+
+object TaskResource {
+  /** "Memo-ized" resource, given an effect to create it and an effect to
+    * dispose of it. Effects are processed asynchronously using the provided
+    * Strategy.
+    * @param acquire Executed exactly once for any number of `get` calls as
+    *   long as `release` is not called.
+    * @param release0 Executed exactly once for any number of `release`
+    *   calls as long as `get` is not called.
+    */
+  def apply[A](acquire: Task[A], execStrat: Strategy)(release0: A => Task[Unit]): Task[TaskResource[A]] = Task delay {
+    val counter = new AtomicLong(0)
+    def nextId: Task[Long] = Task.delay(counter.getAndIncrement)
+
+    sealed trait RsrcState
+    case object Start extends RsrcState
+    case class Acquiring(id: Long) extends RsrcState
+    case class Acquired(a: A) extends RsrcState
+
+    val signal = async.signalOf[RsrcState](Start)
+
+    def orFail[B]: Option[B] => Task[B] = _.cata(Task.now, Task.fail(Cause.Terminated(Cause.End)))
+
+    /** The current value of the signal, or fail if it hasn't been initialized
+      * (and ours is initialized when it's created.) This is the behavior you
+      * presumably want for `Signal.get`, but that method actually uses the
+      * `discrete` stream.
+      */
+    val getCurrent: Task[RsrcState] =
+      signal.continuous.take(1).runLast.flatMap(orFail)
+
+    /** Asynchronously wait for the signal to contain the resource, which
+      * will have been acquired by another thread.
+      */
+    val awaitAcquired: Task[A] =
+      // NB: something effectful is hiding in the `discrete` process
+      Task.delay(signal.discrete.collect { case Acquired(a) => a }.take(1).runLast).join.flatMap(orFail)
+
+    new TaskResource[A] {
+      def get = {
+        def attemptAcquire(id: Long): Task[A] =
+          signal compareAndSet {
+            case Some(Start) => Acquiring(id).some
+            case otherwise   => otherwise
+          } flatMap {
+            case Some(Acquiring(`id`)) => acquire >>= (a => signal.set(Acquired(a)).as(a))
+            case _                     => awaitAcquired
+          }
+
+        getCurrent flatMap {
+          case Acquired(a) => Task.now(a)
+          case _           => nextId >>= attemptAcquire
+        }
+      }
+
+      def release =
+        signal.getAndSet(Start).attempt flatMap {
+          case  \/-(Some(Acquired(a)))           => signal.close *> release0(a)
+          case  \/-(_)                           => Task.now(())
+          case -\/ (Cause.Terminated(Cause.End)) => Task.now(())
+          case -\/ (t)                           => Task.fail(t)
+        }
+    }
+  }
+}

--- a/it/src/test/scala/quasar/fs/ManageFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/ManageFilesSpec.scala
@@ -26,7 +26,7 @@ import scalaz._, Scalaz._
 import scalaz.stream._
 
 class ManageFilesSpec extends FileSystemTest[FileSystem](
-  FileSystemTest.allFsUT.map(_.filterNot(fs => TestConfig.isMongoReadOnly(fs.name)))) {
+    FileSystemTest.allFsUT.map(_.filterNot(fs => TestConfig.isMongoReadOnly(fs.name)))) {
   import FileSystemTest._, FileSystemError._, PathError._
   import ManageFile._
 

--- a/it/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
@@ -359,7 +359,7 @@ class MongoDbFileSystemSpec
 object MongoDbFileSystemSpec {
   // NB: No `chroot` here as we want to test deleting top-level
   //     dirs (i.e. databases).
-  def mongoFsUT: Task[IList[FileSystemUT[FileSystemIO]]] =
+  val mongoFsUT: Task[IList[FileSystemUT[FileSystemIO]]] =
     TestConfig.externalFileSystems {
       case (MountConfig.FileSystemConfig(MongoDBFsType, uri), dir) =>
         quasar.physical.mongodb.filesystems.testFileSystemIO(uri, dir)

--- a/web/src/test/scala/quasar/api/services/query/QueryFixture.scala
+++ b/web/src/test/scala/quasar/api/services/query/QueryFixture.scala
@@ -31,8 +31,6 @@ import scalaz.concurrent.Task
 object queryFixture {
   import quasar.api.PathUtils.pathUri
 
-  type File = pathy.Path[_,pathy.Path.File,Sandboxed]
-
   type Eff0[A] = Coproduct[FileSystemFailureF, FileSystem, A]
   type Eff[A]  = Coproduct[Task, Eff0, A]
 
@@ -68,19 +66,19 @@ object queryFixture {
   def executeService(state: InMemState): HttpService =
     execute.service[Eff].toHttpService(effRespOr(runFs(state).run))
 
-  def selectAll(from: File) = {
+  def selectAll(from: FPath) = {
     val ast = Select(
       SelectAll,
       List(Proj(Splice(None), None)),
-      Some(TableRelationAST(from, None)),
+      Some(TableRelationAST(unsandbox(from), None)),
       None, None, None)
     pprint(ast)
   }
-  def selectAllWithVar(from: File, varName: String) = {
+  def selectAllWithVar(from: FPath, varName: String) = {
     val ast = Select(
       SelectAll,
       List(Proj(Splice(None), None)),
-      Some(TableRelationAST(from, None)),
+      Some(TableRelationAST(unsandbox(from), None)),
       Some(Binop(Ident("pop"),Vari(varName), Gt)),
       None, None)
     pprint(ast)


### PR DESCRIPTION
This solves the problem of long SBT sessions resulting in many open connections piling up and eventually making mongodb unresponsive.

Confirmed that _all_ connections are closed by watching the `mongod` log and by inspecting the heap (which is apparently my new thing).