### PR TITLE
SD-824 Standardize and enrich REST API errors

### DIFF
--- a/CHANGELOG/major.md
+++ b/CHANGELOG/major.md
@@ -1,0 +1,4 @@
+- [SD-824] Standardize and enrich REST API errors
+  - Refactor HierarchicalFileSystemError to be more meaningful.
+  - Convert all errors into a common ApiError for serialization to HTTP responses.
+  - Include any additional detail possible for a given error in the response.

--- a/README.md
+++ b/README.md
@@ -442,6 +442,29 @@ Takes a port number in the body, and attempts to restart the server on that port
 Removes any configured port, reverting to the default (20223) and restarting, as with `PUT`.
 
 
+## Error Responses
+
+Error responses from the REST api have the following form
+
+```
+{
+  "error": {
+    "status": <succinct message>,
+    "detail": {
+      "field1": <JSON>,
+      "field2": <JSON>,
+      ...
+      "fieldN": <JSON>
+    }
+  }
+}
+```
+
+The `status` field will always be present and will contain a succinct description of the error in english, the same content will be used as the status message of the HTTP response itself. The `detail` field is optional and, if present, will contain a JSON object with additional information about the error.
+
+Examples of `detail` fields would be a backend-specific error message, detailed type information for type errors in queries, the actual invalid arguments presented to a function, etc. These fields are error-specific, however, if the error is going to include a more detailed error message, it will found under the `message` field in the `detail` object.
+
+
 ## Request Headers
 
 Request headers may be supplied via a query parameter in case the client is unable to send arbitrary headers (e.g. browsers, in certain circumstances). The parameter name is `request-headers` and the value should be a JSON-formatted string containing an object whose fields are named for the corresponding header and whose values are strings or arrays of strings. If any header appears both in the `request-headers` query parameter and also as an ordinary header, the query parameter takes precedence.

--- a/core/src/main/scala/quasar/fp/prism.scala
+++ b/core/src/main/scala/quasar/fp/prism.scala
@@ -16,15 +16,21 @@
 
 package quasar.fp
 
+import quasar.Predef.Unit
+
 import monocle.Prism
 import scalaz._
 
 trait PrismInstances {
-  import Liskov.<~<
+  import Liskov.<~<, Leibniz.===
 
   // TODO: See if we can implement this once for all tuples using shapeless.
   implicit class PrismOps[A, B](prism: Prism[A, B]) {
-    def apply(b: B): A = prism.reverseGet(b)
+    def apply()(implicit ev: B === Unit): A =
+      ev.subst[Prism[A, ?]](prism).reverseGet(())
+
+    def apply(b: B): A =
+      prism.reverseGet(b)
 
     def apply[C, D](c: C, d: D)(implicit ev: (C, D) <~< B): A =
       apply(ev((c, d)))

--- a/core/src/main/scala/quasar/semantics.scala
+++ b/core/src/main/scala/quasar/semantics.scala
@@ -42,9 +42,6 @@ object SemanticError {
   final case class FunctionNotFound(name: String) extends SemanticError {
     def message = "The function '" + name + "' could not be found in the standard library"
   }
-  final case class FunctionNotBound(node: Expr) extends SemanticError {
-    def message = "A function was not bound to the node " + node
-  }
   final case class TypeError(expected: Type, actual: Type, hint: Option[String]) extends SemanticError {
     def message = "Expected type " + expected + " but found " + actual + hint.map(": " + _).getOrElse("")
   }

--- a/web/src/main/scala/quasar/api/ApiError.scala
+++ b/web/src/main/scala/quasar/api/ApiError.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api
+
+import quasar.Predef._
+
+import argonaut._, Argonaut._
+import org.http4s.Status
+import scalaz.{Equal, Show}
+import scalaz.std.anyVal._
+import scalaz.std.list._
+import scalaz.std.string._
+import scalaz.std.tuple._
+import scalaz.syntax.std.boolean._
+
+final case class ApiError(status: Status, detail: JsonObject) {
+  def +: (jassoc: JsonAssoc): ApiError =
+    copy(detail = jassoc +: detail)
+
+  def :+ (jassoc: JsonAssoc): ApiError =
+    copy(detail = detail + (jassoc._1, jassoc._2))
+}
+
+object ApiError {
+  def apiError(status: Status, details: JsonAssoc*): ApiError =
+    apply(status, JsonObject.from(details.toList))
+
+  def fromStatus(status: Status): ApiError =
+    apiError(status)
+
+  /** Convenience for adding a detailed message in a standardized way, the
+    * resulting response will include a `message` field in the `detail` object
+    * refering to the contents of `msg`.
+    */
+  def fromMsg(status: Status, msg: String, addlDetails: JsonAssoc*): ApiError =
+    ("message" := msg) +: apiError(status, addlDetails: _*)
+
+  def fromMsg_(status: Status, msg: String): ApiError =
+    fromMsg(status, msg)
+
+  implicit val encodeJson: EncodeJson[ApiError] =
+    EncodeJson(err =>
+      ("status" :=  err.status.reason) ->:
+      ("detail" :?= err.detail.isNotEmpty.option(jObject(err.detail))) ->?:
+      jEmptyObject)
+
+  implicit val equal: Equal[ApiError] =
+    Equal.equalBy(ae => (ae.status.code, ae.status.reason, ae.detail))
+
+  implicit val show: Show[ApiError] =
+    Show.showFromToString
+}

--- a/web/src/main/scala/quasar/api/QResponse.scala
+++ b/web/src/main/scala/quasar/api/QResponse.scala
@@ -117,9 +117,6 @@ object QResponse {
       qr => qr.headers.get(key))(
       h  => _.modifyHeaders(_.put(h)))
 
-  def error[S[_]](status: Status, s: String): QResponse[S] =
-    json(status, Json("error" := s))
-
   def json[A: EncodeJson, S[_]](status: Status, a: A): QResponse[S] =
     string[S](status, a.asJson.pretty(minspace)).modifyHeaders(_.put(
       `Content-Type`(MediaType.`application/json`, Some(Charset.`UTF-8`))))

--- a/web/src/main/scala/quasar/api/ToApiError.scala
+++ b/web/src/main/scala/quasar/api/ToApiError.scala
@@ -1,0 +1,390 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api
+
+import quasar.Predef._
+import quasar.{Data, DataCodec}
+import quasar.{EnvironmentError, Planner, SemanticError}
+import quasar.RenderTree.ops._
+import quasar.fs._
+import quasar.fs.mount.{Mounting, MountingError}
+import quasar.fs.mount.hierarchical.HierarchicalFileSystemError
+import quasar.fp._, PathyCodecJson._
+import quasar.physical.mongodb.WorkflowExecutionError
+import quasar.sql._
+
+import argonaut._, Argonaut._
+import com.mongodb.MongoException
+import org.http4s._, Status._
+import pathy.Path._
+import scalaz.NonEmptyList
+
+abstract class ToApiError[A] {
+  def toApiError(a: A): ApiError
+}
+
+object ToApiError extends ToApiErrorInstances {
+  def apply[A](implicit A: ToApiError[A]): ToApiError[A] = A
+
+  def error[A](f: A => ApiError): ToApiError[A] =
+    new ToApiError[A] { def toApiError(a: A) = f(a) }
+
+  object ops {
+    final implicit class ToApiErrorOps[A](val a: A) extends scala.AnyVal {
+      def toApiError(implicit A: ToApiError[A]): ApiError =
+        A.toApiError(a)
+    }
+  }
+}
+
+sealed abstract class ToApiErrorInstances {
+  import ToApiError._, ops._
+  import ApiError._
+  import ReadFile.ReadHandle
+  import WriteFile.WriteHandle
+  import QueryFile.ResultHandle
+
+  implicit def decodeFailureToApiError: ToApiError[DecodeFailure] =
+    error {
+      case MediaTypeMissing(expectedMediaTypes) =>
+        apiError(
+          BadRequest withReason "Media type missing.",
+          "supportedMediaTypes" := expectedMediaTypes.map(_.renderString))
+
+      case MediaTypeMismatch(messageType, expectedMediaTypes) =>
+        apiError(
+          UnsupportedMediaType,
+          "requestedMediaType"  := messageType.renderString,
+          "supportedMediaTypes" := expectedMediaTypes.map(_.renderString))
+
+      case other =>
+        fromMsg_(
+          BadRequest withReason "Unable to decode request body.",
+          other.msg)
+    }
+
+  implicit def environmentErrorQResponse: ToApiError[EnvironmentError] = {
+    import EnvironmentError._
+    error {
+      case ConnectionFailed(msg) =>
+        fromMsg_(
+          InternalServerError withReason "Connection to backend failed.",
+          s"Connection failed: $msg.")
+
+      case InsufficientPermissions(msg) =>
+        fromMsg_(
+          InternalServerError withReason "Insufficient backend permssions.",
+          s"Insufficient permissions: $msg.")
+
+      case InvalidCredentials(msg) =>
+        fromMsg_(
+          InternalServerError withReason "Invalid backend credentials.",
+          s"Invalid credentials: $msg")
+
+      case UnsupportedVersion(name, ver) =>
+        apiError(
+          InternalServerError withReason s"Unsupported $name version.",
+          "backendName" := name,
+          "version"     := ver)
+    }
+  }
+
+  implicit def fileSystemErrorResponse: ToApiError[FileSystemError] = {
+    import FileSystemError._
+    error {
+      case PathErr(e) =>
+        e.toApiError
+      case PlannerError(lp, e) =>
+        e.toApiError :+ ("logicalPlan" := lp.render)
+      case UnknownReadHandle(ReadHandle(path, id)) =>
+        apiError(
+          InternalServerError withReason "Unknown read handle.",
+          "path"     := path,
+          "handleId" := id)
+      case UnknownWriteHandle(WriteHandle(path, id)) =>
+        apiError(
+          InternalServerError withReason "Unknown write handle.",
+          "path"     := path,
+          "handleId" := id)
+      case UnknownResultHandle(ResultHandle(id)) =>
+        apiError(
+          InternalServerError withReason "Unknown result handle.",
+          "handleId" := id)
+      case PartialWrite(numFailed) =>
+        apiError(
+          InternalServerError withReason "Failed to write some values.",
+          "failedCount" := numFailed)
+      case WriteFailed(data, reason) =>
+        val res = fromMsg_(
+          InternalServerError withReason "Failed to write data.",
+          s"Failed to write data: $reason.")
+        encodeData(data).fold(res)(json => ("data" := json) +: res)
+    }
+  }
+
+  implicit def hierarchicalFileSystemErrorToApiError: ToApiError[HierarchicalFileSystemError] = {
+    import HierarchicalFileSystemError._
+    error {
+      case NoMountsDefined =>
+        fromStatus(BadRequest withReason "No mounts defined.")
+    }
+  }
+
+  implicit def mongoExceptionToApiError: ToApiError[MongoException] =
+    error(merr => fromMsg_(
+      InternalServerError withReason "MongoDB error.",
+      merr.getMessage))
+
+  implicit def mountingErrorToApiError: ToApiError[MountingError] = {
+    import MountingError._, PathError.InvalidPath
+    error {
+      case PError(InvalidPath(p, rsn)) =>
+        fromMsg(
+          Conflict withReason "Unable to mount at path.",
+          s"Unable to mount at ${posixCodec.printPath(p)} because $rsn",
+          "path" := p)
+
+      case InvalidConfig(cfg, rsns) =>
+        apiError(
+          BadRequest withReason "Invalid mount configuration.",
+          "reasons" := rsns)
+
+      case PError(e) => e.toApiError
+      case EError(e) => e.toApiError
+    }
+  }
+
+  implicit def mountingPathTypeErrorToApiError: ToApiError[Mounting.PathTypeMismatch] =
+    error { err =>
+      val expectedType = refineType(err.path).fold(κ("file"), κ("directory"))
+      fromMsg(
+        BadRequest withReason "Incorrect path type.",
+        s"Incorrect path type, expected a $expectedType.",
+        "path" := err.path)
+    }
+
+  implicit def pathErrorToApiError: ToApiError[PathError] = {
+    import PathError._
+    error {
+      case PathExists(path) =>
+        apiError(Conflict withReason "Path exists.", "path" := path)
+
+      case PathNotFound(path) =>
+        apiError(NotFound withReason "Path not found.", "path" := path)
+
+      case InvalidPath(path, reason) =>
+        fromMsg(
+          BadRequest withReason "Invalid path.",
+          s"Invalid path: $reason.",
+          "path" := path)
+    }
+  }
+
+  implicit def parsingErrorToApiError: ToApiError[ParsingError] =
+    error {
+      case GenericParsingError(msg) =>
+        fromMsg_(BadRequest withReason "Malformed SQL^2 query.", msg)
+
+      case ParsingPathError(e) =>
+        e.toApiError
+    }
+
+  implicit def parseFailureToApiError: ToApiError[ParseFailure] =
+    error(pf => fromMsg_(BadRequest withReason "Malformed request.", pf.sanitized))
+
+  implicit def plannerErrorToApiError: ToApiError[Planner.PlannerError] = {
+    import Planner._
+    error(err => err match {
+      case NonRepresentableData(data) =>
+        val res = fromMsg_(
+          InternalServerError withReason "Unsupported constant.",
+          err.message)
+        encodeData(data).fold(res)(json => ("data" := json) +: res)
+      case UnsupportedFunction(fn, msg) =>
+        fromMsg(
+          InternalServerError withReason "Unsupported function.",
+          err.message,
+          "functionName" := fn.name)
+      case PlanPathError(e) =>
+        e.toApiError
+      case UnsupportedJoinCondition(cond) =>
+        fromMsg(
+          InternalServerError withReason "Unsupported join condition.",
+          err.message,
+          "joinCondition" := cond.render)
+      case UnsupportedPlan(lp, hint) =>
+        val aerr = fromMsg(
+          InternalServerError withReason "Unsupported query plan.",
+          err.message,
+          "term" := lp.toString)
+        hint.fold(aerr)(rsn => aerr :+ ("reason" := rsn))
+      case FuncApply(fn, exp, act) =>
+        fromMsg(
+          BadRequest withReason "Illegal function argument.",
+          err.message,
+          "functionName" := fn.name,
+          "expectedArg"  := exp,
+          "actualArg"    := act)
+      case FuncArity(fn, ct) =>
+        fromMsg(
+          BadRequest withReason "Wrong number of arguments to function.",
+          err.message,
+          "functionName" := fn.name,
+          "expectedArgs" := fn.arity,
+          "actualArgs"   := ct)
+      case ObjectIdFormatError(oid) =>
+        fromMsg(
+          BadRequest withReason "Invalid ObjectId.",
+          err.message,
+          "objectId" := oid)
+      case NonRepresentableInJS(value) =>
+        fromMsg(
+          InternalServerError withReason "Unable to compile to JavaScript.",
+          err.message,
+          "value" := value)
+      case UnsupportedJS(value) =>
+        fromMsg(
+          InternalServerError withReason "Unsupported JavaScript in query plan.",
+          err.message,
+          "value" := value)
+      case InternalError(msg) =>
+        fromMsg_(InternalServerError withReason "Failed to plan query.", msg)
+    })
+  }
+
+  implicit def semanticErrorToApiError: ToApiError[SemanticError] = {
+    import SemanticError._
+    error(err => err match {
+      case GenericError(msg) =>
+        fromMsg_(BadRequest withReason "Error in query.", msg)
+      case DomainError(data, _) =>
+        val res = fromMsg_(
+          BadRequest withReason "Illegal argument.",
+          err.message)
+        encodeData(data).fold(res)(json => res :+ ("data" := json))
+      case FunctionNotFound(name) =>
+        fromMsg(
+          BadRequest withReason "Unknown function.",
+          err.message,
+          "functionName" := name)
+      case TypeError(exp, act, _) =>
+        fromMsg(
+          BadRequest withReason "Type error.",
+          err.message,
+          "expectedType" := exp,
+          "actualType"   := act)
+      case VariableParseError(vname, vval, cause) =>
+        fromMsg(
+          BadRequest withReason "Malformed query variable.",
+          err.message,
+          "varName"  := vname.value,
+          "varValue" := vval.value,
+          "cause"    := cause.toApiError)
+      case UnboundVariable(vname) =>
+        fromMsg(
+          BadRequest withReason "Unbound variable.",
+          err.message,
+          "varName" := vname.value)
+      case DuplicateRelationName(name) =>
+        fromMsg(
+          BadRequest withReason "Duplicate relation name.",
+          err.message,
+          "relName" := name)
+      case NoTableDefined(node) =>
+        fromMsg(
+          BadRequest withReason "No table defined.",
+          err.message,
+          "sql" := node.render)
+      case MissingField(name) =>
+        fromMsg(
+          BadRequest withReason "Missing field.",
+          err.message,
+          "fieldName" := name)
+      case DuplicateFieldName(name) =>
+        fromMsg(
+          BadRequest withReason "Duplicate field name.",
+          err.message,
+          "fieldName" := name)
+      case MissingIndex(i) =>
+        fromMsg(
+          BadRequest withReason "No element at index.",
+          err.message,
+          "index" := i)
+      case WrongArgumentCount(fn, exp, act) =>
+        fromMsg(
+          BadRequest withReason "Wrong number of arguments to function.",
+          err.message,
+          "functionName" := fn.name,
+          "expectedArgs" := exp,
+          "actualArgs"   := act)
+      case ExpectedLiteral(expr) =>
+        fromMsg(
+          BadRequest withReason "Literal value expected.",
+          err.message,
+          "sql" := expr.render)
+      case AmbiguousReference(expr, _) =>
+        fromMsg(
+          BadRequest withReason "Ambiguous table reference.",
+          err.message,
+          "sql" := expr.render)
+      case DateFormatError(fn, str, _) =>
+        fromMsg(
+          BadRequest withReason "Malformed date/time string.",
+          err.message,
+          "functionName" := fn.name,
+          "input"        := str)
+      case other =>
+        fromMsg_(
+          InternalServerError withReason "Compilation error.",
+          other.message)
+    })
+  }
+
+  implicit def workflowExecutionErrorToApiError: ToApiError[WorkflowExecutionError] = {
+    import WorkflowExecutionError._
+    error {
+      case InvalidTask(task, rsn) =>
+        fromMsg(
+          InternalServerError withReason "Invalid workflow task.",
+          s"Invalid workflow task: $rsn.",
+          "workflowTask" := task.render)
+
+      case InsertFailed(bson, rsn) =>
+        fromMsg(
+          BadRequest withReason "Unable to insert data.",
+          s"Unable to insert data: $rsn",
+          "data" := bson.toString)
+
+      case NoDatabase =>
+        fromMsg_(
+          InternalServerError withReason "No database.",
+          "Unable to determine a database in which to store temporary collections.")
+    }
+  }
+
+  implicit def nonEmptyListToApiError[A: ToApiError]: ToApiError[NonEmptyList[A]] =
+    error { nel =>
+      val herr = nel.head.toApiError
+      val stat = Status.fromInt(herr.status.code) getOrElse herr.status
+      apiError(stat, "errors" := nel.map(_.toApiError))
+    }
+
+  ////
+
+  private def encodeData(data: Data): Option[Json] =
+    DataCodec.Precise.encode(data).toOption
+}

--- a/web/src/main/scala/quasar/api/ToQResponse.scala
+++ b/web/src/main/scala/quasar/api/ToQResponse.scala
@@ -17,19 +17,11 @@
 package quasar.api
 
 import quasar.Predef._
-import quasar.{EnvironmentError, Planner, SemanticErrors}
-import quasar.fs._
-import quasar.fs.mount.{Mounting, MountingError}
-import quasar.fs.mount.hierarchical.HierarchicalFileSystemError
 import quasar.fp._
-import quasar.physical.mongodb.WorkflowExecutionError
-import quasar.sql.ParsingError
 
 import argonaut._, Argonaut._
-import com.mongodb.MongoException
-import org.http4s._, Status._
-import pathy.Path._
-import scalaz._, syntax.show._
+import org.http4s._, Status.Ok
+import scalaz._
 import scalaz.concurrent.Task
 
 trait ToQResponse[A, S[_]] {
@@ -51,130 +43,31 @@ object ToQResponse extends ToQResponseInstances {
 }
 
 sealed abstract class ToQResponseInstances extends ToQResponseInstances0 {
-  import ToQResponse._, ops._
+  import ToQResponse.{response, ops}, ops._
+  import ToApiError.ops._
+
+  implicit def apiErrorQResponse[S[_]]: ToQResponse[ApiError, S] =
+    response(err => QResponse.json(err.status, Json("error" := err)))
+
+  implicit def toApiErrorQResponse[A: ToApiError, S[_]]: ToQResponse[A, S] =
+    response(_.toApiError.toResponse)
 
   implicit def disjunctionQResponse[A, B, S[_]]
     (implicit ev1: ToQResponse[A, S], ev2: ToQResponse[B, S])
     : ToQResponse[A \/ B, S] =
       response(_.fold(ev1.toResponse, ev2.toResponse))
 
-  implicit def environmentErrorQResponse[S[_]]: ToQResponse[EnvironmentError, S] =
-    response(ee => QResponse.error(InternalServerError, ee.shows))
-
-  implicit def fileSystemErrorResponse[S[_]]: ToQResponse[FileSystemError, S] = {
-    import FileSystemError._
-
-    response {
-      case PathErr(e)                => e.toResponse
-      case PlannerError(_, e)          => e.toResponse
-      case UnknownReadHandle(handle)   => QResponse.error(InternalServerError, s"Unknown read handle: $handle")
-      case UnknownWriteHandle(handle)  => QResponse.error(InternalServerError, s"Unknown write handle: $handle")
-      case UnknownResultHandle(handle) => QResponse.error(InternalServerError, s"Unknown result handle: $handle")
-      case PartialWrite(numFailed)     => QResponse.error(InternalServerError, s"Failed to write $numFailed records")
-      case WriteFailed(data, reason)   => QResponse.error(InternalServerError, s"Failed to write ${data.shows} because of $reason")
-    }
-  }
-
-  implicit def hierarchicalFileSystemErrorToQResponse[S[_]]: ToQResponse[HierarchicalFileSystemError, S] = {
-    import HierarchicalFileSystemError._
-
-    response {
-      case NoMountsDefined =>
-        QResponse.error(BadRequest, "No mounts defined.")
-    }
-  }
-
-  implicit def mountingErrorResponse[S[_]]: ToQResponse[MountingError, S] = {
-    import MountingError._, PathError.InvalidPath
-
-    response {
-      case PError(InvalidPath(p, rsn)) =>
-        QResponse.error(Conflict, s"cannot mount at ${posixCodec.printPath(p)} because $rsn")
-
-      case PError(e)                => e.toResponse
-      case EError(e)                => e.toResponse
-      case InvalidConfig(cfg, rsns) => QResponse.error(BadRequest, rsns.list.mkString("; "))
-    }
-  }
-
-  implicit def mountingPathTypeErrorResponse[S[_]]: ToQResponse[Mounting.PathTypeMismatch, S] =
-    response { err =>
-      val expectedType = refineType(err.path).fold(κ("file"), κ("directory"))
-      QResponse.error(
-        BadRequest,
-        s"wrong path type for mount: ${posixCodec.printPath(err.path)}; $expectedType path required")
-    }
-
-  implicit def pathErrorResponse[S[_]]: ToQResponse[PathError, S] = {
-    import PathError._
-
-    response {
-      case PathExists(path)          => QResponse.error(Conflict, s"${posixCodec.printPath(path)} already exists")
-      case PathNotFound(path)        => QResponse.error(NotFound, s"${posixCodec.printPath(path)} doesn't exist")
-      case InvalidPath(path, reason) => QResponse.error(BadRequest, s"${posixCodec.printPath(path)} is an invalid path because $reason")
-    }
-  }
-
-  implicit def parsingErrorQResponse[S[_]]: ToQResponse[ParsingError, S] =
-    response(pe => QResponse.error(BadRequest, pe.message))
-
-  implicit def parseFailureQResponse[S[_]]: ToQResponse[ParseFailure, S] =
-    response(pf => QResponse.error(BadRequest, pf.sanitized))
-
-  implicit def plannerErrorQResponse[S[_]]: ToQResponse[Planner.PlannerError, S] =
-    response(pe => QResponse.error(BadRequest, pe.shows))
-
-  implicit def semanticErrorQResponse[S[_]]: ToQResponse[SemanticErrors, S] =
-    response(se => QResponse.error(BadRequest, se.shows))
-
-  implicit def workflowExecutionError[S[_]]: ToQResponse[WorkflowExecutionError, S] = {
-    import WorkflowExecutionError._
-
-    response(err => err match {
-      case InvalidTask(_, _) =>
-        QResponse.error(InternalServerError, err.shows)
-
-      case InsertFailed(_, _) =>
-        QResponse.error(BadRequest, err.shows)
-
-      case NoDatabase =>
-        QResponse.error(InternalServerError, err.shows)
-    })
-  }
+  implicit def http4sResponseToQResponse[S[_]: Functor](implicit ev: Task :<: S): ToQResponse[Response, S] =
+    response(r => QResponse(
+      status = r.status,
+      headers = r.headers,
+      body = r.body.translate[Free[S, ?]](injectFT[Task, S])))
 
   implicit def qResponseToQResponse[S[_]]: ToQResponse[QResponse[S], S] =
     response(ι)
 
-  implicit def http4sResponseToQResponse[S[_]: Functor](implicit ev: Task :<: S): ToQResponse[Response, S] =
-    response(r =>
-      QResponse(
-        status = r.status,
-        headers = r.headers,
-        body = r.body.translate[Free[S, ?]](injectFT[Task, S])))
-
-  implicit def decodeFailureToQResponse[S[_]]: ToQResponse[DecodeFailure, S] =
-    response{
-      case MediaTypeMissing(expectedMediaTypes) =>
-        val expected = expectedMediaTypes.map(_.renderString).mkString(", ")
-        QResponse.json(
-          UnsupportedMediaType,
-          Json(
-            "error" := s"Request has no media type. Please specify a media type in the following ranges: $expected",
-            "supported media types" := jArray(expectedMediaTypes.map(m => jString(m.renderString)).toList)))
-      case MediaTypeMismatch(messageType, expectedMediaTypes) =>
-        val actual = messageType.renderString
-        val expected = expectedMediaTypes.map(_.renderString).mkString(", ")
-        QResponse.json(
-          UnsupportedMediaType,
-          Json(
-            "error" := s"Request has an unsupported media type. Please specify a media type in the following ranges: $expected",
-            "supported media types" := jArray(expectedMediaTypes.map(m => jString(m.renderString)).toList)))
-      case other =>
-        QResponse.error(BadRequest, other.msg)
-    }
-
-  implicit def mongoExceptionToQResponse[S[_]]: ToQResponse[MongoException, S] =
-    response(merr => QResponse.error(InternalServerError, s"MongoDB Error: ${merr.getMessage}"))
+  implicit def statusToQResponse[S[_]]: ToQResponse[Status, S] =
+    response(QResponse.empty[S] withStatus _)
 
   implicit def stringQResponse[S[_]]: ToQResponse[String, S] =
     response(QResponse.string(Ok, _))

--- a/web/src/main/scala/quasar/api/ToQResponse.scala
+++ b/web/src/main/scala/quasar/api/ToQResponse.scala
@@ -79,8 +79,8 @@ sealed abstract class ToQResponseInstances extends ToQResponseInstances0 {
     import HierarchicalFileSystemError._
 
     response {
-      case MultipleMountsApply(_, _) =>
-        QResponse.error(BadRequest, "The request could not be handled by a unique mounted filesystem.")
+      case NoMountsDefined =>
+        QResponse.error(BadRequest, "No mounts defined.")
     }
   }
 

--- a/web/src/main/scala/quasar/api/services/query/execute.scala
+++ b/web/src/main/scala/quasar/api/services/query/execute.scala
@@ -19,17 +19,17 @@ package quasar.api.services.query
 import quasar.Predef._
 import quasar._
 import quasar.api._
+import quasar.api.ToApiError.ops._
 import quasar.api.services._
-import quasar.api.ToQResponse.ops._
 import quasar.fp._
 import quasar.fs._
-import quasar.sql.Query
+import quasar.sql.{Expr, Query}
 
 import argonaut._, Argonaut._
 import org.http4s.headers.Accept
 import org.http4s._
 import org.http4s.dsl._
-import pathy.Path._
+import pathy.Path, Path._
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 
@@ -38,56 +38,52 @@ object execute {
   def service[S[_]: Functor](implicit S0: QueryFileF :<: S,
                                       S1: Task :<: S,
                                       S2: FileSystemFailureF :<: S): QHttpService[S] = {
+    val Q = QueryFile.Ops[S]
 
     val removePhaseResults = new (FileSystemErrT[PhaseResultT[Free[S,?], ?], ?] ~> FileSystemErrT[Free[S,?], ?]) {
       def apply[A](t: FileSystemErrT[PhaseResultT[Free[S,?], ?], A]): FileSystemErrT[Free[S,?], A] =
         EitherT[Free[S,?],FileSystemError,A](t.run.value)
     }
 
-    val Q = QueryFile.Ops[S]
+    def destinationFile(fileStr: String): ApiError \/ (Path[Abs,File,Unsandboxed] \/ Path[Rel,File,Unsandboxed]) = {
+      val err = -\/(ApiError.apiError(
+        BadRequest withReason "Destination must be a file.",
+        "destination" := fileStr))
+
+      posixCodec.parsePath(relFile => \/-(\/-(relFile)), absFile => \/-(-\/(absFile)), κ(err), κ(err))(fileStr)
+    }
 
     QHttpService {
-      case req @ GET -> _ :? Offset(offset) +& Limit(limit) => respond(
-        parseQueryRequest[S](req, offset, limit).map { case (path, query, offset, limit) =>
-          sql.parseInContext(query, path).map(
-            expr => queryPlan(addOffsetLimit(expr, offset, limit), vars(req)).run.value.map(
-              logicalPlan => {
-                val requestedFormat = MessageFormat.fromAccept(req.headers.get(Accept))
-                formattedDataResponse(
-                  requestedFormat,
-                  Q.evaluate(logicalPlan).translate[FileSystemErrT[Free[S, ?], ?]](removePhaseResults))
-              }
-            )
-          )
-        }.point[Free[S, ?]]
-      )
+      case req @ GET -> _ :? Offset(offset) +& Limit(limit) =>
+        respond_(parsedQueryRequest(req, offset, limit) map { case (xpr, off, lim) =>
+          queryPlan(addOffsetLimit(xpr, off, lim), requestVars(req))
+            .run.value map (lp => formattedDataResponse(
+              MessageFormat.fromAccept(req.headers.get(Accept)),
+              Q.evaluate(lp).translate[FileSystemErrT[Free[S, ?], ?]](removePhaseResults)))
+        })
+
       case req @ POST -> AsDirPath(path) =>
-        Free.liftF(S1.inj(EntityDecoder.decodeString(req))).flatMap { query =>
-          if (query == "") postContentMustContainQuery[S]
-          else {
-            respond(requiredHeader[S](Destination, req)
-              .traverse[Free[S, ?], QResponse[S], QResponse[S]] { destination =>
-                val parseRes = sql.parseInContext(Query(query), path)
-                  .leftMap(_.toResponse[S])
-                val destinationFile = posixCodec.parsePath(
-                  relFile => \/-(\/-(relFile)),
-                  absFile => \/-(-\/(absFile)),
-                  relDir => -\/(QResponse.error[S](BadRequest, "Destination must be a file")),
-                  absDir => -\/(QResponse.error[S](BadRequest, "Destination must be a file")))(destination.value)
-                // Add path of query if destination is a relative file or else just jump through Sandbox hoop
-                val absDestination: QResponse[S] \/ AFile = destinationFile.flatMap(f =>
-                  sandbox(rootDir, f.fold(ι, relFile => unsandbox(path) </> relFile)).map(rootDir </> _) \/>
-                    QResponse.error[S](BadRequest, "Destination file is invalid"))
-                respond(parseRes.tuple(absDestination)
-                  .traverse[Free[S, ?], QResponse[S], SemanticErrors \/ (FileSystemError \/ Json)] {
-                    case (expr, out) =>
-                      Q.executeQuery(expr, vars(req), out).run.run.run map { case (phases, result) =>
-                        result.map(_.map(rfile => Json(
-                          "out"    := posixCodec.printPath(rfile),
-                          "phases" := phases)))
-                      }
-                  })
-              })
+        free.lift(EntityDecoder.decodeString(req)).into[S] flatMap { query =>
+          if (query.isEmpty) {
+            respond_(bodyMustContainQuery)
+          } else {
+            respond(requiredHeader(Destination, req) flatMap { destination =>
+              val parseRes: ApiError \/ Expr =
+                sql.parseInContext(Query(query), path)
+                  .leftMap(_.toApiError)
+
+              val absDestination: ApiError \/ AFile =
+                destinationFile(destination.value) map (res =>
+                  sandboxAbs(res.map(unsandbox(path) </> _).merge))
+
+              parseRes tuple absDestination
+            } traverseU { case (expr, out) =>
+              Q.executeQuery(expr, requestVars(req), out).run.run.run map { case (phases, result) =>
+                result.map(_.map(rfile => Json(
+                  "out"    := posixCodec.printPath(rfile),
+                  "phases" := phases)))
+              }
+            })
           }
         }
     }

--- a/web/src/test/scala/quasar/api/ApiErrorEntityDecoder.scala
+++ b/web/src/test/scala/quasar/api/ApiErrorEntityDecoder.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api
+
+import quasar.Predef._
+
+import argonaut._, Argonaut._
+import org.http4s.{DecodeResult => _, _}
+import org.http4s.argonaut._
+import scalaz.EitherT
+import scalaz.concurrent.Task
+import scalaz.syntax.applicative._
+
+object ApiErrorEntityDecoder {
+  implicit val apiErrorEntityDecoder: EntityDecoder[ApiError] =
+    EntityDecoder.decodeBy(MediaType.`application/json`) {
+      case res @ Response(status, _, _, _, _) =>
+        res.attemptAs[Json] flatMap { json =>
+          EitherT.fromDisjunction[Task](fromJson(status, json.hcursor).toDisjunction)
+            .leftMap { case (msg, _) => ParseFailure(
+              "Failed to decode JSON as an ApiError",
+              s"JSON: $json, reason: $msg")
+            }
+        }
+
+      case Request(_, _, _, _, _, _) =>
+        EitherT.left(ParseFailure("ApiError is only decodable from a Response.", "").point[Task])
+    }
+
+  private def fromJson(status: Status, hc: HCursor): DecodeResult[ApiError] =
+    (hc --\ "error" --\ "detail").as[Option[Json]]
+      .map(_.flatMap(_.obj) getOrElse JsonObject.empty)
+      .tuple((hc --\ "error" --\ "status").as[String])
+      .map { case (o, s) => ApiError(status withReason s, o) }
+}

--- a/web/src/test/scala/quasar/api/matchers.scala
+++ b/web/src/test/scala/quasar/api/matchers.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api
+
+import quasar.Predef._
+
+import argonaut._, Argonaut._
+import org.http4s.Status, Status._
+import org.specs2.matcher._
+import org.specs2.scalaz._
+import scalaz.std.anyVal._
+import scalaz.std.list._
+import scalaz.std.string._
+
+object matchers {
+  import MustMatchers._
+  import ScalazMatchers._
+  import ApiError.apiError
+
+  def beApiErrorLike[A](a: A)(implicit A: ToApiError[A]): Matcher[ApiError] =
+    equal(A.toApiError(a))
+
+  def beApiErrorWithMessage(status: Status, otherFields: JsonAssoc*): Matcher[ApiError] =
+    (haveSameCodeAndReason(status) ^^ { (_: ApiError).status }) and
+    (equal(JsonObject.from(otherFields.toList)) ^^ { (_: ApiError).detail - "message" }) and
+    (haveFields("message" :: otherFields.map(_._1).toList : _*) ^^ { (_: ApiError).detail })
+
+  def beHeaderMissingError(name: String): Matcher[ApiError] =
+    equal(apiError(
+      BadRequest withReason s"'$name' header missing.",
+      "headerName" := name))
+
+  private def haveSameCodeAndReason(status: Status): Matcher[Status] =
+    (equal(status.code) ^^ { (_: Status).code }) and
+    (equal(status.reason) ^^ { (_: Status).reason })
+
+  private def haveFields(fields: JsonField*): Matcher[JsonObject] =
+    contain(exactly(fields : _*)) ^^ { (_: JsonObject).fields }
+}


### PR DESCRIPTION
A breaking change implementing the enrichment and standardization features for REST API errors as described in [SD-824](https://slamdata.atlassian.net/browse/SD-824).

* More meaningful HierarchicalFileSystemError
* Introduces ApiError as a single datatype to represent an error to be conveyed via HTTP
* Adds conversions from all errors to ApiError in lieu of converting directly to a response for consistency, including error-specific data where applicable