### PR TITLE
Upgrade Matryoshka to v0.8.0.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- upgrade to Matryoshka 0.8.0

--- a/core/src/main/scala/quasar/compiler.scala
+++ b/core/src/main/scala/quasar/compiler.scala
@@ -23,7 +23,7 @@ import quasar.sql._
 import quasar.std.StdLib._
 import quasar.SemanticAnalysis._, quasar.SemanticError._
 
-import matryoshka.{ToIdOps => toAllOps, _}, Fix._, Recursive.ops._, FunctorT.ops._
+import matryoshka.{ToIdOps => toAllOps, _}, Recursive.ops._, FunctorT.ops._
 import scalaz.{Tree => _, _}, Scalaz._
 
 trait Compiler[F[_]] {
@@ -501,6 +501,6 @@ object Compiler {
           else t.tail
       }
     }
-    ann.ana(rewriteƒ)
+    ann.ana[Fix, LogicalPlan](rewriteƒ)
   }
 }

--- a/core/src/main/scala/quasar/fs/mount/Views.scala
+++ b/core/src/main/scala/quasar/fs/mount/Views.scala
@@ -49,7 +49,7 @@ final case class Views(map: Map[AFile, Fix[LogicalPlan]]) {
   def rewrite(lp: Fix[LogicalPlan]): Fix[LogicalPlan] = rewrite0(lp, Set())
 
   private def rewrite0(lp: Fix[LogicalPlan], expanded: Set[AFile]): Fix[LogicalPlan] = {
-    lp.transCata(once {
+    lp.transCata(orOriginal {
       case LogicalPlan.ReadF(p) =>
         refineTypeAbs(p).swap.toOption.filterNot(expanded contains _).flatMap { file =>
           map.get(file).map { viewLp =>

--- a/core/src/main/scala/quasar/logicalplan.scala
+++ b/core/src/main/scala/quasar/logicalplan.scala
@@ -355,8 +355,8 @@ object LogicalPlan {
   // TODO: This can perhaps be decomposed into separate folds for annotating
   //       with “found” types, folding constants, and adding runtime checks.
   val checkTypesƒ:
-      (Type, LogicalPlan[ConstrainedPlan]) => NameT[SemDisj, ConstrainedPlan] =
-    (inf, term) => {
+      ((Type, LogicalPlan[ConstrainedPlan])) => NameT[SemDisj, ConstrainedPlan] = {
+    case (inf, term) =>
       def applyConstraints(
         poss: Type, constraints: ConstrainedPlan)
         (f: Fix[LogicalPlan] => Fix[LogicalPlan]) =
@@ -409,14 +409,14 @@ object LogicalPlan {
         // TODO: Get the possible type from the LetF
         case FreeF(v) => emit(ConstrainedPlan(inf, Nil, Free(v)))
       }
-    }
+  }
 
   type SemNames[A] = NameT[SemDisj, A]
 
   def ensureCorrectTypes(term: Fix[LogicalPlan]):
       ValidationNel[SemanticError, Fix[LogicalPlan]] =
     inferTypes(Type.Top, term).flatMap(
-      cofCataM[LogicalPlan, SemNames, Type, ConstrainedPlan](_)(checkTypesƒ(_, _)).map(appConst(_, Constant(Data.NA))).evalZero.validation)
+      cofCataM[LogicalPlan, SemNames, Type, ConstrainedPlan](_)(checkTypesƒ).map(appConst(_, Constant(Data.NA))).evalZero.validation)
 
   // TODO: Generalize this to Binder
   def lpParaZygoHistoM[M[_]: Monad, A, B](

--- a/core/src/main/scala/quasar/optimizer.scala
+++ b/core/src/main/scala/quasar/optimizer.scala
@@ -20,7 +20,7 @@ import quasar.Predef._
 import quasar.fp.binder._
 import quasar.namegen._
 
-import matryoshka._, Fix._, Recursive.ops._, FunctorT.ops._, TraverseT.ownOps._
+import matryoshka._, Recursive.ops._, FunctorT.ops._, TraverseT.ownOps._
 import scalaz._, Scalaz._
 
 object Optimizer {

--- a/core/src/main/scala/quasar/physical/mongodb/optimize/optimize.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/optimize/optimize.scala
@@ -168,7 +168,7 @@ package object optimize {
     }
 
     def reorderOps(wf: Workflow): Workflow = {
-      val reordered = wf.transCata(once(reorderOpsƒ))
+      val reordered = wf.transCata(orOriginal(reorderOpsƒ))
       if (reordered == wf) wf else reorderOps(reordered)
     }
 

--- a/core/src/main/scala/quasar/physical/mongodb/planner.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/planner.scala
@@ -28,7 +28,7 @@ import Type._
 import Workflow._
 import javascript._
 
-import matryoshka._, Fix._, Recursive.ops._, TraverseT.ops._
+import matryoshka._, Recursive.ops._, TraverseT.ops._
 import org.threeten.bp.Instant
 import pathy.Path.rootDir
 import scalaz._, Scalaz._
@@ -715,7 +715,7 @@ object MongoDbPlanner extends Planner[Crystallized] {
           args match {
             case List(left, right, comp) =>
               splitConditions(comp).fold[M[WorkflowBuilder]](
-                fail(UnsupportedJoinCondition(Recursive[Cofree[?[_], (Input, OutputM[WorkflowBuilder])]].convertTo(comp))))(
+                fail(UnsupportedJoinCondition(Recursive[Cofree[?[_], (Input, OutputM[WorkflowBuilder])]].convertTo[LogicalPlan, Fix](comp))))(
                 c => {
                   val (leftKeys, rightKeys) = c.unzip
                   lift((HasWorkflow(left) |@|
@@ -1096,7 +1096,7 @@ object MongoDbPlanner extends Planner[Crystallized] {
 
     (for {
       cleaned <- log("Logical Plan (reduced typechecks)")(liftError(logical.cataM[PlannerError \/ ?, Fix[LogicalPlan]](Optimizer.assumeReadObjƒ)))
-      align <- log("Logical Plan (aligned joins)")       (liftError(cleaned.apo(elideJoinCheckƒ).cataM(alignJoinsƒ ⋘ repeatedly(Optimizer.simplifyƒ))))
+      align <- log("Logical Plan (aligned joins)")       (liftError(cleaned.apo(elideJoinCheckƒ).cataM(alignJoinsƒ ⋘ repeatedly(Optimizer.simplifyƒ[Fix]))))
       prep <- log("Logical Plan (projections preferred)")(Optimizer.preferProjections(align).point[M])
       wb   <- log("Workflow Builder")                    (swizzle(swapM(lpParaZygoHistoS(prep)(annotateƒ, wfƒ))))
       wf1  <- log("Workflow (raw)")                      (swizzle(build(wb)))

--- a/core/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
@@ -340,7 +340,7 @@ object WorkflowBuilder {
             xs <- inner.map { case (n, x) =>
                     jscore.Select(jscore.Ident(js.param), n.value) -> exprToJs(x)
                   }.sequenceU.toOption
-            expr1 <- js.expr.apoM[Fix, jscore.JsCoreF, Option] {
+            expr1 <- js.expr.apoM[Fix, Option, jscore.JsCoreF] {
                     case t @ jscore.Access(b, _) if b == jscore.Ident(js.param) =>
                       xs.get(t).map(_(jscore.Ident(js.param)).unFix.map(_.left))
                     case t => t.unFix.map(_.right[JsCore]).some

--- a/core/src/main/scala/quasar/physical/mongodb/workflowop.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/workflowop.scala
@@ -565,7 +565,7 @@ object Workflow {
     }
 
     val finished =
-      deleteUnusedFields(reorderOps(op.transCata(once(simplifyGroupƒ))))
+      deleteUnusedFields(reorderOps(op.transCata(orOriginal(simplifyGroupƒ))))
 
     def fixShape(wf: Workflow) =
       Workflow.simpleShape(wf).fold(

--- a/core/src/main/scala/quasar/std/library.scala
+++ b/core/src/main/scala/quasar/std/library.scala
@@ -20,21 +20,13 @@ import quasar.Predef._
 import quasar.fp._
 import quasar.{Func, LogicalPlan, Type, SemanticError}
 
-import matryoshka._, Recursive.ops._
-import scalaz._, Scalaz._, Validation.{success, failure}
+import matryoshka._
+import scalaz._, Validation.{success, failure}
 
 trait Library {
   protected val noSimplification: Func.Simplifier = new Func.Simplifier {
     def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
       None
-  }
-
-  object IsInvoke {
-    def unapply[T[_[_]]: Recursive](lp: LogicalPlan[T[LogicalPlan]]):
-        Option[(Func, List[LogicalPlan[T[LogicalPlan]]])] = lp match {
-      case LogicalPlan.InvokeF(func, args) => (func, args.map(_.project)).some
-      case _                               => None
-    }
   }
 
   protected def constTyper(codomain: Type): Func.Typer = { args =>

--- a/core/src/main/scala/quasar/std/math.scala
+++ b/core/src/main/scala/quasar/std/math.scala
@@ -20,7 +20,7 @@ import quasar.Predef._
 import quasar.fp._
 import quasar.{Data, Func, LogicalPlan, Type, Mapping, SemanticError}, LogicalPlan._, SemanticError._
 
-import matryoshka._, Recursive.ops._
+import matryoshka._
 import scalaz._, Scalaz._, Validation.{success, failure}
 
 trait MathLib extends Library {
@@ -85,9 +85,9 @@ trait MathLib extends Library {
     new Func.Simplifier {
       def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
-          case IsInvoke(_, List(x, ZeroF())) => x.some
-          case IsInvoke(_, List(ZeroF(), x)) => x.some
-          case _                             => None
+          case InvokeF(_, List(Embed(x), Embed(ZeroF()))) => x.some
+          case InvokeF(_, List(Embed(ZeroF()), Embed(x))) => x.some
+          case _                                          => None
         }
     },
     (partialTyper {
@@ -114,9 +114,9 @@ trait MathLib extends Library {
     new Func.Simplifier {
       def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
-          case IsInvoke(_, List(x, OneF())) => x.some
-          case IsInvoke(_, List(OneF(), x)) => x.some
-          case _                            => None
+          case InvokeF(_, List(Embed(x), Embed(OneF()))) => x.some
+          case InvokeF(_, List(Embed(OneF()), Embed(x))) => x.some
+          case _                                         => None
         }
     },
     (partialTyper {
@@ -137,8 +137,8 @@ trait MathLib extends Library {
     new Func.Simplifier {
       def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
-          case IsInvoke(_, List(x, OneF())) => x.some
-          case _                            => None
+          case InvokeF(_, List(Embed(x), Embed(OneF()))) => x.some
+          case _                                         => None
         }
     },
     (partialTyper {
@@ -162,12 +162,9 @@ trait MathLib extends Library {
     new Func.Simplifier {
       def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
-          case IsInvoke(_, List(x, ZeroF())) => x.some
-          case InvokeF(_, List(c, x)) => c.project match {
-            case ZeroF() => Negate(x).some
-            case _       => None
-          }
-          case _ => None
+          case InvokeF(_, List(Embed(x),       Embed(ZeroF()))) => x.some
+          case InvokeF(_, List(Embed(ZeroF()), x))              => Negate(x).some
+          case _                                                => None
         }
     },
     (partialTyper {
@@ -196,8 +193,8 @@ trait MathLib extends Library {
     new Func.Simplifier {
       def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
-          case IsInvoke(_, List(x, OneF())) => x.some
-          case _                            => None
+          case InvokeF(_, List(Embed(x), Embed(OneF()))) => x.some
+          case _                                         => None
         }
     },
     (partialTyperV {

--- a/core/src/main/scala/quasar/std/relations.scala
+++ b/core/src/main/scala/quasar/std/relations.scala
@@ -121,9 +121,9 @@ trait RelationsLib extends Library {
     new Func.Simplifier {
       def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
-          case IsInvoke(_, List(ConstantF(Data.True), r)) => r.some
-          case IsInvoke(_, List(l, ConstantF(Data.True))) => l.some
-          case _                                          => None
+          case InvokeF(_, List(Embed(ConstantF(Data.True)), Embed(r))) => r.some
+          case InvokeF(_, List(Embed(l), Embed(ConstantF(Data.True)))) => l.some
+          case _                                                       => None
         }
     },
     partialTyper {
@@ -141,9 +141,9 @@ trait RelationsLib extends Library {
     new Func.Simplifier {
       def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
-          case IsInvoke(_, List(ConstantF(Data.False), r)) => r.some
-          case IsInvoke(_, List(l, ConstantF(Data.False))) => l.some
-          case _                                           => None
+          case InvokeF(_, List(Embed(ConstantF(Data.False)), Embed(r))) => r.some
+          case InvokeF(_, List(Embed(l), Embed(ConstantF(Data.False)))) => l.some
+          case _                                                        => None
         }
     },
     partialTyper {
@@ -170,9 +170,9 @@ trait RelationsLib extends Library {
     new Func.Simplifier {
       def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
-          case IsInvoke(_, List(ConstantF(Data.True),  c, _)) => c.some
-          case IsInvoke(_, List(ConstantF(Data.False), _, a)) => a.some
-          case _                                              => None
+          case InvokeF(_, List(Embed(ConstantF(Data.True)),  Embed(c), _)) => c.some
+          case InvokeF(_, List(Embed(ConstantF(Data.False)), _, Embed(a))) => a.some
+          case _                                                           => None
         }
     },
     partialTyper {
@@ -189,9 +189,9 @@ trait RelationsLib extends Library {
     new Func.Simplifier {
       def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
-          case IsInvoke(_, List(ConstantF(Data.Null), second)) => second.some
-          case IsInvoke(_, List(first, ConstantF(Data.Null)))  => first.some
-          case _                                               => None
+          case InvokeF(_, List(Embed(ConstantF(Data.Null)), Embed(second))) => second.some
+          case InvokeF(_, List(Embed(first), Embed(ConstantF(Data.Null))))  => first.some
+          case _                                                            => None
         }
     },
     partialTyper {

--- a/core/src/main/scala/quasar/std/set.scala
+++ b/core/src/main/scala/quasar/std/set.scala
@@ -49,7 +49,8 @@ trait SetLib extends Library {
     Type.Top, Type.Top :: Type.Int :: Nil,
     new Func.Simplifier {
       def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) = orig match {
-        case IsInvoke(_, List(set, ConstantF(Data.Int(n)))) if n == 0 =>
+        case InvokeF(_, List(Embed(set), Embed(ConstantF(Data.Int(n)))))
+            if n == 0 =>
           set.some
         case _ => None
       }
@@ -73,8 +74,9 @@ trait SetLib extends Library {
     new Func.Simplifier {
       def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) =
         orig match {
-          case IsInvoke(_, List(set, ConstantF(Data.True))) => set.some
-          case _                                            => None
+          case InvokeF(_, List(Embed(set), Embed(ConstantF(Data.True)))) =>
+            set.some
+          case _ => None
         }
     },
     setTyper(partialTyper {
@@ -187,8 +189,9 @@ trait SetLib extends Library {
     Type.Top, Type.Top :: Type.Top :: Nil,
     new Func.Simplifier {
       def apply[T[_[_]]: Recursive: Corecursive](orig: LogicalPlan[T[LogicalPlan]]) = orig match {
-        case IsInvoke(_, List(set, ConstantF(Data.Set(Nil)))) => set.some
-        case _                                                => None
+        case InvokeF(_, List(Embed(set), Embed(ConstantF(Data.Set(Nil))))) =>
+          set.some
+        case _ => None
       }
     },
     setTyper(partialTyper { case List(s1, _) => s1 }),

--- a/core/src/test/scala/quasar/matchers.scala
+++ b/core/src/test/scala/quasar/matchers.scala
@@ -20,7 +20,7 @@ import quasar.Predef._
 import quasar.RenderTree.ops._
 import quasar.fp._
 
-import matryoshka._, Fix._, FunctorT.ops._
+import matryoshka._, FunctorT.ops._
 import org.specs2.matcher._
 import scalaz._, Scalaz._
 
@@ -38,7 +38,7 @@ trait TermLogicalPlanMatchers {
   case class equalToPlan(expected: Fix[LogicalPlan])
       extends Matcher[Fix[LogicalPlan]] {
     def apply[S <: Fix[LogicalPlan]](s: Expectable[S]) = {
-      val normed = s.value.transCata(repeatedly(Optimizer.simplifyƒ))
+      val normed = s.value.transCata(repeatedly(Optimizer.simplifyƒ[Fix]))
       val diff = (normed.render diff expected.render).shows
       result(
         expected ≟ normed,

--- a/core/src/test/scala/quasar/optimizer.scala
+++ b/core/src/test/scala/quasar/optimizer.scala
@@ -19,7 +19,7 @@ package quasar
 import quasar.Predef._
 import quasar.std._
 
-import matryoshka._, Fix._, FunctorT.ops._
+import matryoshka._, FunctorT.ops._
 import org.specs2.mutable._
 import pathy.Path._
 
@@ -34,7 +34,7 @@ class OptimizerSpec extends Specification with CompilerHelpers with TreeMatchers
 
     "inline trivial binding" in {
       Let('tmp0, read("foo"), Free('tmp0))
-        .transCata(repeatedly(Optimizer.simplifyƒ)) must
+        .transCata(repeatedly(Optimizer.simplifyƒ[Fix])) must
         beTree(read("foo"))
     }
 
@@ -43,7 +43,7 @@ class OptimizerSpec extends Specification with CompilerHelpers with TreeMatchers
         makeObj(
           "bar" -> ObjectProject(Free('tmp0), Constant(Data.Str("bar"))),
           "baz" -> ObjectProject(Free('tmp0), Constant(Data.Str("baz")))))
-        .transCata(repeatedly(Optimizer.simplifyƒ)) must
+        .transCata(repeatedly(Optimizer.simplifyƒ[Fix])) must
         beTree(
           Let('tmp0, read("foo"),
             makeObj(
@@ -53,7 +53,7 @@ class OptimizerSpec extends Specification with CompilerHelpers with TreeMatchers
 
     "completely inline stupid lets" in {
       Let('tmp0, read("foo"), Let('tmp1, Free('tmp0), Free('tmp1)))
-        .transCata(repeatedly(Optimizer.simplifyƒ)) must
+        .transCata(repeatedly(Optimizer.simplifyƒ[Fix])) must
         beTree(read("foo"))
     }
 
@@ -62,7 +62,7 @@ class OptimizerSpec extends Specification with CompilerHelpers with TreeMatchers
         Let('tmp0, read("bar"),
           makeObj(
             "bar" -> ObjectProject(Free('tmp0), Constant(Data.Str("bar"))))))
-        .transCata(repeatedly(Optimizer.simplifyƒ)) must
+        .transCata(repeatedly(Optimizer.simplifyƒ[Fix])) must
         beTree(
           makeObj(
             "bar" -> ObjectProject(read("bar"), Constant(Data.Str("bar")))))
@@ -74,7 +74,7 @@ class OptimizerSpec extends Specification with CompilerHelpers with TreeMatchers
           Let('tmp0, read("bar"),
             makeObj(
               "bar" -> ObjectProject(Free('tmp0), Constant(Data.Str("bar")))))))
-        .transCata(repeatedly(Optimizer.simplifyƒ)) must
+        .transCata(repeatedly(Optimizer.simplifyƒ[Fix])) must
         beTree(
           Invoke(ObjectProject, List(
             read("foo"),
@@ -89,7 +89,7 @@ class OptimizerSpec extends Specification with CompilerHelpers with TreeMatchers
             makeObj(
               "bar" -> ObjectProject(Free('tmp0), Constant(Data.Str("bar"))),
               "baz" -> ObjectProject(Free('tmp0), Constant(Data.Str("baz")))))))
-        .transCata(repeatedly(Optimizer.simplifyƒ)) must
+        .transCata(repeatedly(Optimizer.simplifyƒ[Fix])) must
         beTree(
           Invoke(ObjectProject, List(
             read("foo"),
@@ -110,7 +110,7 @@ class OptimizerSpec extends Specification with CompilerHelpers with TreeMatchers
               MakeArray[FLP](
                 ObjectProject(Free('tmp1), Constant(Data.Str("name"))))),
             Free('tmp2))))
-        .transCata(repeatedly(Optimizer.simplifyƒ)) must
+        .transCata(repeatedly(Optimizer.simplifyƒ[Fix])) must
         beTree(
           Let('tmp1,
             makeObj(

--- a/core/src/test/scala/quasar/physical/mongodb/optimize.scala
+++ b/core/src/test/scala/quasar/physical/mongodb/optimize.scala
@@ -39,7 +39,7 @@ class OptimizeSpecs extends Specification with TreeMatchers {
           Grouped(ListMap(
             BsonField.Name("city") -> $last($field("city")))),
           $field("city").right))
-        .transCata(once(simplifyGroupƒ)) must
+        .transCata(orOriginal(simplifyGroupƒ)) must
       beTree(chain(
         $read(Collection("db", "zips")),
         $group(
@@ -60,7 +60,7 @@ class OptimizeSpecs extends Specification with TreeMatchers {
           Reshape(ListMap(
             BsonField.Name("0") -> $field("city").right,
             BsonField.Name("1") -> $field("state").right)).left))
-        .transCata(once(simplifyGroupƒ)) must
+        .transCata(orOriginal(simplifyGroupƒ)) must
       beTree(chain(
         $read(Collection("db", "zips")),
         $group(
@@ -83,7 +83,7 @@ class OptimizeSpecs extends Specification with TreeMatchers {
           Reshape(ListMap(
             BsonField.Name("0") -> $field("city").right)).left))
 
-      lp.transCata(once(simplifyGroupƒ)) must beTree(lp)
+      lp.transCata(orOriginal(simplifyGroupƒ)) must beTree(lp)
     }
 
   }

--- a/core/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/core/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -27,7 +27,7 @@ import quasar.specs2.PendingWithAccurateCoverage
 
 import scala.Either
 
-import matryoshka._, Recursive.ops._, Fix._
+import matryoshka._, Recursive.ops._
 import org.scalacheck._
 import org.specs2.execute.Result
 import org.specs2.mutable._

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,7 +34,7 @@ object Dependencies {
     "io.argonaut"       %% "argonaut"                  % "6.1"          % "compile, test",
     "org.jboss.aesh"    %  "aesh"                      % "0.55"         % "compile, test",
     "org.typelevel"     %% "shapeless-scalaz"          % slcVersion     % "compile, test",
-    "com.slamdata"      %% "matryoshka-core"           % "0.1.0"        % "compile",
+    "com.slamdata"      %% "matryoshka-core"           % "0.8.0"        % "compile",
     "com.slamdata"      %% "pathy-core"                % pathyVersion   % "compile",
     "com.github.mpilquist" %% "simulacrum"             % "0.7.0"        % "compile, test",
     "org.http4s"        %% "http4s-core"               % http4sVersion  % "compile",


### PR DESCRIPTION
Significant changes are

- generalization of Elgot algebras;
- renaming `once` to `orOriginal`;
- `Embed.unapply`, which obsoletes `IsInvoke`; and
- remove `import Fix._`[†].

[†]: Removing this import requires that we add a bunch of type
annotations. But that’s helpful, because it makes it easier to
generalize over `T`, and it shows where we need to use kinda-curried
types in Matryoshka.