### PR TITLE
fix check for no backend configuration in regression test

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- fail regression tests if no backend configuration is present

--- a/it/src/test/scala/quasar/TestConfig.scala
+++ b/it/src/test/scala/quasar/TestConfig.scala
@@ -109,12 +109,10 @@ object TestConfig {
     )
 
     TestConfig.testDataPrefix flatMap { prefix =>
-      if (TestConfig.backendNames.isEmpty)
-        Task.fail(noBackendsFound)
-      else
-        TestConfig.backendNames.toIList
-          .traverse(n => fileSystemNamed(n, prefix).run)
-          .map(_.unite)
+      TestConfig.backendNames.toIList
+        .traverse(n => fileSystemNamed(n, prefix).run)
+        .map(_.unite)
+        .flatMap(uts => if (uts.isEmpty) Task.fail(noBackendsFound) else Task.now(uts))
     }
   }
 


### PR DESCRIPTION
Probably has been broken for some time, but only recently encountered.