### PR TITLE
SD-1524 Capture debug info for runtime errors during query execution

### DIFF
--- a/CHANGELOG/minor.md
+++ b/CHANGELOG/minor.md
@@ -1,0 +1,3 @@
+- [SD-1524] Capture debug info for runtime errors during query exec
+  - Adds a new class of error describing failures during plan execution
+  - Ensures that runtime failures during MongoDB plan execution are trapped and returned as values.

--- a/README.md
+++ b/README.md
@@ -261,17 +261,39 @@ This API method returns the name where the results are stored, as an absolute pa
 }
 ```
 
-If an error occurs while compiling or executing the query, a 500 response is
-produced, with this content:
+If the query fails to compile, a 400 response is produced with a JSON body similar to the following:
 
 ```json
 {
-  "error": "[very large error text]",
-  "phases": [
-    ...
-  ]
+  "status": "Bad Request",
+  "detail": {
+    "errors" [
+      <all errors produced during compilation, each an object with `status` and `detail` fields>
+    ],
+    "phases": [
+      <see the following sections>
+    ]
+  }
 }
 ```
+
+If an error occurs while executing the query on a backend, a 500 response is produced, with this content:
+
+```json
+{
+  "status": <general error description>,
+  "detail": {
+    "message": <specific error description>,
+    "phases": [
+      <see the following sections>
+    ],
+    "logicalPlan": <tree of objects describing the logical plan the query compiled to>,
+    "cause": <optional, backend-specific error>
+  }
+}
+```
+
+the `cause` field is optional and the `detail` object may also contain additional, backend-specific fields.
 
 The `phases` array contains a sequence of objects containing the result from
 each phase of the query compilation process. A phase may result in a tree of

--- a/core/src/main/scala/quasar/fs/Empty.scala
+++ b/core/src/main/scala/quasar/fs/Empty.scala
@@ -122,5 +122,5 @@ object Empty {
     pathErr(pathNotFound(p)).left.point[F]
 
   private def unsupportedPlan[F[_]: Applicative, A](lp: Fix[LogicalPlan]): F[FileSystemError \/ A] =
-    plannerError(lp, UnsupportedPlan(lp.unFix, None)).left.point[F]
+    planningFailed(lp, UnsupportedPlan(lp.unFix, None)).left.point[F]
 }

--- a/core/src/main/scala/quasar/fs/InMemory.scala
+++ b/core/src/main/scala/quasar/fs/InMemory.scala
@@ -234,7 +234,7 @@ object InMemory {
     }
 
     private def unsupported(lp: Fix[LogicalPlan]) =
-      plannerError(lp, UnsupportedPlan(
+      planningFailed(lp, UnsupportedPlan(
         lp.unFix,
         some("In Memory interpreter does not currently support this plan")))
   }

--- a/core/src/main/scala/quasar/fs/mount/EvaluatorMounter.scala
+++ b/core/src/main/scala/quasar/fs/mount/EvaluatorMounter.scala
@@ -20,7 +20,7 @@ import quasar.Predef.Unit
 import quasar.effect._
 import quasar.fp.{liftFT, injectNT, free}
 import quasar.fs.FileSystem
-import hierarchical.{HFSFailureF, MountedResultHF}
+import hierarchical.MountedResultHF
 
 import scalaz._
 import scalaz.syntax.monad._
@@ -37,8 +37,7 @@ final class EvaluatorMounter[F[_], S[_]: Functor](
 )(implicit S0: F :<: S,
            S1: MonotonicSeqF :<: S,
            S2: ViewStateF :<: S,
-           S3: MountedResultHF :<: S,
-           S4: HFSFailureF :<: S) {
+           S3: MountedResultHF :<: S) {
 
   import MountRequest._, FileSystemDef.DefinitionResult
 
@@ -148,8 +147,7 @@ object EvaluatorMounter {
   )(implicit S0: F :<: S,
              S1: MonotonicSeqF :<: S,
              S2: ViewStateF :<: S,
-             S3: MountedResultHF :<: S,
-             S4: HFSFailureF :<: S
+             S3: MountedResultHF :<: S
   ): EvaluatorMounter[F, S] =
     new EvaluatorMounter[F, S](fsDef)
 }

--- a/core/src/main/scala/quasar/fs/package.scala
+++ b/core/src/main/scala/quasar/fs/package.scala
@@ -52,7 +52,6 @@ package object fs {
 
   type PathSegment = DirName \/ FileName
 
-  type PathErr2T[F[_], A] = EitherT[F, PathError, A]
   type FileSystemFailure[A] = Failure[FileSystemError, A]
   type FileSystemFailureF[A] = Coyoneda[FileSystemFailure, A]
   type FileSystemErrT[F[_], A] = EitherT[F, FileSystemError, A]

--- a/core/src/main/scala/quasar/fs/transformPaths.scala
+++ b/core/src/main/scala/quasar/fs/transformPaths.scala
@@ -227,7 +227,7 @@ object transformPaths {
     FileSystemError.pathErr composeLens PathError.errorPath
 
   private val fsPlannerError: Optional[FileSystemError, Fix[LogicalPlan]] =
-    FileSystemError.plannerError composeLens _1
+    FileSystemError.planningFailed composeLens _1
 
   private def transformErrorPath(
     f: AbsPath ~> AbsPath

--- a/core/src/main/scala/quasar/physical/mongodb/fs/package.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/fs/package.scala
@@ -37,8 +37,6 @@ import scalaz.concurrent.Task
 package object fs {
   import FileSystemDef.{DefinitionError, DefErrT}
 
-  type WFTask[A] = WorkflowExecErrT[Task, A]
-
   val MongoDBFsType = FileSystemType("mongodb")
 
   final case class DefaultDb(run: String) extends scala.AnyVal
@@ -55,8 +53,7 @@ package object fs {
     defDb: Option[DefaultDb]
   )(implicit
     S0: Task :<: S,
-    S1: MongoErrF :<: S,
-    S2: WorkflowExecErrF :<: S
+    S1: MongoErrF :<: S
   ): EnvErrT[Task, FileSystem ~> Free[S, ?]] = {
     val runM = Hoist[EnvErrT].hoist(MongoDbIO.runNT(client))
 
@@ -77,8 +74,7 @@ package object fs {
 
   def mongoDbFileSystemDef[S[_]: Functor](implicit
     S0: Task :<: S,
-    S1: MongoErrF :<: S,
-    S2: WorkflowExecErrF :<: S
+    S1: MongoErrF :<: S
   ): FileSystemDef[Free[S, ?]] = FileSystemDef.fromPF[Free[S, ?]] {
     case (MongoDBFsType, uri) =>
       type M[A] = Free[S, A]

--- a/core/src/main/scala/quasar/physical/mongodb/package.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/package.scala
@@ -33,8 +33,6 @@ package object mongodb {
   type MongoErrF[A]       = Coyoneda[MongoErr, A]
   type MongoErrT[F[_], A] = EitherT[F, MongoException, A]
 
-  type WorkflowExecErr[A]        = Failure[WorkflowExecutionError, A]
-  type WorkflowExecErrF[A]       = Coyoneda[WorkflowExecErr, A]
   type WorkflowExecErrT[F[_], A] = EitherT[F, WorkflowExecutionError, A]
 
   type JavaScriptPrg           = Vector[Js.Stmt]

--- a/it/src/test/scala/quasar/physical/mongodb/filesystems.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/filesystems.scala
@@ -58,19 +58,17 @@ object filesystems {
   ////
 
   private type MongoEff0[A] = Coproduct[MongoErrF, Task, A]
-  private type MongoEff1[A] = Coproduct[WorkflowExecErrF, MongoEff0, A]
-  private type MongoEff2[A] = Coproduct[EnvErrF, MongoEff1, A]
-  private type MongoEff[A]  = Coproduct[CfgErrF, MongoEff2, A]
+  private type MongoEff1[A] = Coproduct[EnvErrF, MongoEff0, A]
+  private type MongoEff[A]  = Coproduct[CfgErrF, MongoEff1, A]
   private type MongoEffM[A] = Free[MongoEff, A]
 
   private val envErr =
     Failure.Ops[EnvironmentError, MongoEff](implicitly, Inject[EnvErrF, MongoEff])
 
   private val mongoEffToTask: MongoEff ~> Task =
-    interpret5[CfgErrF, EnvErrF, WorkflowExecErrF, MongoErrF, Task, Task](
+    interpret4[CfgErrF, EnvErrF, MongoErrF, Task, Task](
       Coyoneda.liftTF[CfgErr, Task](Failure.toRuntimeError[ConfigError]),
       Coyoneda.liftTF[EnvErr, Task](Failure.toRuntimeError[EnvironmentError]),
-      Coyoneda.liftTF[WorkflowExecErr, Task](Failure.toRuntimeError[WorkflowExecutionError]),
       Coyoneda.liftTF[MongoErr, Task](Failure.toTaskFailure[MongoException]),
       NaturalTransformation.refl)
 

--- a/web/src/main/scala/quasar/api/ApiError.scala
+++ b/web/src/main/scala/quasar/api/ApiError.scala
@@ -33,6 +33,12 @@ final case class ApiError(status: Status, detail: JsonObject) {
 
   def :+ (jassoc: JsonAssoc): ApiError =
     copy(detail = detail + (jassoc._1, jassoc._2))
+
+  def +?: (maybeAssoc: Option[JsonAssoc]): ApiError =
+    maybeAssoc.fold(this)(_ +: this)
+
+  def :?+ (maybeAssoc: Option[JsonAssoc]): ApiError =
+    maybeAssoc.fold(this)(this :+ _)
 }
 
 object ApiError {

--- a/web/src/main/scala/quasar/server/package.scala
+++ b/web/src/main/scala/quasar/server/package.scala
@@ -19,9 +19,8 @@ package quasar
 import quasar.api._
 import quasar.fp._
 import quasar.fs.{FileSystemError, FileSystemFailure, FileSystemFailureF}
-import quasar.fs.mount.hierarchical.{HierarchicalFileSystemError, HFSFailure, HFSFailureF}
 import quasar.main._
-import quasar.physical.mongodb.{MongoErr, MongoErrF, WorkflowExecutionError, WorkflowExecErr, WorkflowExecErrF}
+import quasar.physical.mongodb.{MongoErr, MongoErrF}
 
 import com.mongodb.MongoException
 import scalaz.{Coyoneda, ~>}
@@ -30,11 +29,9 @@ import scalaz.concurrent.Task
 package object server {
   /** Interpretes errors into `Response`s, for use in web services. */
   def toResponseOr(evalCfgsIO: MntCfgsIO ~> Task): CfgsErrsIOM ~> ResponseOr = {
-    val f = free.interpret5[FileSystemFailureF, MongoErrF, WorkflowExecErrF, HFSFailureF, MntCfgsIO, ResponseOr](
+    val f = free.interpret3[FileSystemFailureF, MongoErrF, MntCfgsIO, ResponseOr](
       Coyoneda.liftTF[FileSystemFailure, ResponseOr](failureResponseOr[FileSystemError]),
       Coyoneda.liftTF[MongoErr, ResponseOr](failureResponseOr[MongoException]),
-      Coyoneda.liftTF[WorkflowExecErr, ResponseOr](failureResponseOr[WorkflowExecutionError]),
-      Coyoneda.liftTF[HFSFailure, ResponseOr](failureResponseOr[HierarchicalFileSystemError]),
       liftMT[Task, ResponseT] compose evalCfgsIO)
 
     hoistFree(f: CfgsErrsIO ~> ResponseOr)


### PR DESCRIPTION
* Add 'ExecutionFailed' case to 'FileSystemError'
* Convert HierarchicalFileSystemErrors to ExecutionFailed instead of failure effect
* Convert WorkflowExecutionError to ExecutionFailed
* Catch Mongo exceptions in QueryFile interpreter and return as ExecutionFailed