### PR TITLE
SD-1544 WriteFile#save should not succeed when the src process fails

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- [SD-1544] WriteFile#save should not succeed when the src process fails

--- a/core/src/main/scala/quasar/fs/ManageFile.scala
+++ b/core/src/main/scala/quasar/fs/ManageFile.scala
@@ -151,7 +151,7 @@ object ManageFile {
       new Ops[S]
   }
 
-  implicit def RenderManageFile[A] =
+  implicit def renderTree[A]: RenderTree[ManageFile[A]] =
     new RenderTree[ManageFile[A]] {
       def render(mf: ManageFile[A]) = mf match {
         case Move(scenario, semantics) => NonTerminal(List("Move"), semantics.toString.some,

--- a/core/src/main/scala/quasar/fs/QueryFile.scala
+++ b/core/src/main/scala/quasar/fs/QueryFile.scala
@@ -293,8 +293,7 @@ object QueryFile {
       new Transforms[F]
   }
 
-
-  implicit def RenderQueryFile[A]: RenderTree[QueryFile[A]] =
+  implicit def renderTree[A]: RenderTree[QueryFile[A]] =
     new RenderTree[QueryFile[A]] {
       def render(qf: QueryFile[A]) = qf match {
         case ExecutePlan(lp, out) => NonTerminal(List("ExecutePlan"), None, List(lp.render, out.render))


### PR DESCRIPTION
`WriteFile#save` would still end up writing the file when the source process halted due to an error, this fixes the function to correctly abort, cleanup and avoid writing the (possibly partial) file.