### PR TITLE
SD-1239 Prevent changing to a non-existent directory in the repl

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- [SD-1239] Prevent changing to a non-existent directory in the repl


### PR DESCRIPTION
Ensure the directory exists before changing to it the repl.