### PR TITLE
Change header encoding for paths to comply with the HTTP spec

### DIFF
--- a/CHANGELOG/breaking.md
+++ b/CHANGELOG/breaking.md
@@ -1,0 +1,2 @@
+- [SD-1324] accept/require "path" URL-encoding for `Destination` and `X-FileName` headers.
+- corrected a misleading error message that can be triggered by ill-formed paths in these headers.

--- a/web/src/main/scala/quasar/api/package.scala
+++ b/web/src/main/scala/quasar/api/package.scala
@@ -206,6 +206,9 @@ package object api {
       s"Failed to parse '${UrlCodingUtils.urlDecode(encodedPath)}' as an absolute path.",
       "encodedPath" := encodedPath)
 
+  def transcode(from: PathCodec, to: PathCodec): String => String =
+    from.parsePath(to.unsafePrintPath, to.unsafePrintPath, to.unsafePrintPath, to.unsafePrintPath)
+
   def staticFileService(basePath: String): HttpService = {
     def pathCollector(file: File, config: FileService.Config, req: Request): Task[Option[Response]] = Task.delay {
       if (file.isDirectory) StaticFile.fromFile(new File(file, "index.html"), Some(req))

--- a/web/src/main/scala/quasar/api/services/query/execute.scala
+++ b/web/src/main/scala/quasar/api/services/query/execute.scala
@@ -48,9 +48,9 @@ object execute {
     def destinationFile(fileStr: String): ApiError \/ (Path[Abs,File,Unsandboxed] \/ Path[Rel,File,Unsandboxed]) = {
       val err = -\/(ApiError.apiError(
         BadRequest withReason "Destination must be a file.",
-        "destination" := fileStr))
+        "destination" := transcode(UriPathCodec, posixCodec)(fileStr)))
 
-      posixCodec.parsePath(relFile => \/-(\/-(relFile)), absFile => \/-(-\/(absFile)), κ(err), κ(err))(fileStr)
+      UriPathCodec.parsePath(relFile => \/-(\/-(relFile)), absFile => \/-(-\/(absFile)), κ(err), κ(err))(fileStr)
     }
 
     QHttpService {

--- a/web/src/test/scala/quasar/api/services/DataServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/DataServiceSpec.scala
@@ -461,7 +461,7 @@ class DataServiceSpec extends Specification with ScalaCheck with FileSystemFixtu
         // TODO: Consider if it's possible to invent syntax Move(...)
         val request = Request(
           uri = pathUri(from),
-          headers = Headers(Header("Destination", posixCodec.printPath(to))),
+          headers = Headers(Header("Destination", UriPathCodec.printPath(to))),
           method = Method.MOVE)
         val (service, ref) = serviceRef(state)
         val response = service(request).unsafePerformSync

--- a/web/src/test/scala/quasar/api/services/MountServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/MountServiceSpec.scala
@@ -185,7 +185,7 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
     "MOVE" should {
       import org.http4s.Method.MOVE
 
-      def destination(p: pathy.Path[_, _, Sandboxed]) = Header(Destination.name.value, printPath(p))
+      def destination(p: pathy.Path[_, _, Sandboxed]) = Header(Destination.name.value, UriPathCodec.printPath(p))
 
       "succeed with filesystem mount" ! prop { (srcHead: String, srcTail: RDir, dstHead: String, dstTail: RDir) =>
         // NB: distinct first segments means no possible conflict, but doesn't
@@ -283,7 +283,7 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
       }
     }
 
-    def xFileName(p: pathy.Path[_, _, Sandboxed]) = Header(XFileName.name.value, printPath(p))
+    def xFileName(p: pathy.Path[_, _, Sandboxed]) = Header(XFileName.name.value, UriPathCodec.printPath(p))
 
     "Common" >> {
       import org.http4s.Method.POST
@@ -388,7 +388,7 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
               val cfg = viewConfig("select * from zips where pop < :cutoff", "cutoff" -> "1000")
               val cfgStr = EncodeJson.of[MountConfig].encode(MountConfig.viewConfig(cfg))
 
-              val fs = d </> posixCodec.parseRelDir(printPath(view) + "/").flatMap(sandbox(currentDir, _)).get </> fsSuffix
+              val fs = d </> posixCodec.parseRelDir(posixCodec.printPath(view) + "/").flatMap(sandbox(currentDir, _)).get </> fsSuffix
 
               for {
                 _     <- M.mountFileSystem(fs,StubFs, ConnectionUri("foo")).run.flatMap(orFailF)


### PR DESCRIPTION
See SD-1324

Use `UriPathCodec` instead of `posixCodec` for `Destination` and `X-File-Name` headers. Because the spec allows only an ASCII subset to appear in headers, other characters could get mangled somewhere between the browser and quasar.

Also add a detailed Path section to the README, and correct an overly-specific error message that actually can come up
with any ill-formed path.