### PR TITLE
Some parser changes while writing the SQL² grammar.

### DIFF
--- a/CHANGELOG/feature.md
+++ b/CHANGELOG/feature.md
@@ -1,0 +1,2 @@
+- `between`, `in`, and `like` can all now have an optional leading `is` (before the optional `not`);
+- `is` and `is not` can now be applied to any expression, not just literal `null`, `true`, and `false` (equivalent to `=` and `!=`, respectively).

--- a/core/src/main/scala/quasar/physical/mongodb/planner.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/planner.scala
@@ -162,8 +162,6 @@ object MongoDbPlanner extends Planner[Crystallized] {
         case And => makeSimpleBinop(jscore.And)
         case Or  => makeSimpleBinop(jscore.Or)
         case Not => makeSimpleUnop(jscore.Not)
-        case IsNull =>
-          Arity1(BinOp(jscore.Eq, _, Literal(Js.Null)))
         case In | Within =>
           Arity2((value, array) =>
             BinOp(jscore.Neq,
@@ -509,11 +507,6 @@ object MongoDbPlanner extends Planner[Crystallized] {
         case (Gt, _)  => reversibleRelop(Gt)
         case (Gte, _) => reversibleRelop(Gte)
 
-        case (IsNull, _ :: Nil) => \/-((
-          { case f :: Nil => Selector.Doc(f -> Selector.Eq(Bson.Null)) },
-          List(There(0, Here))))
-        case (IsNull, _) => -\/(UnsupportedPlan(node, None))
-
         case (In | Within, _)  =>
           relop(
             Selector.In.apply _,
@@ -798,10 +791,6 @@ object MongoDbPlanner extends Planner[Crystallized] {
         case Lte        => expr2($lte(_, _))
         case Gt         => expr2($gt(_, _))
         case Gte        => expr2($gte(_, _))
-
-        case IsNull     =>
-          lift(Arity1(HasWorkflow)).flatMap(
-            mapExpr(_)($eq(_, $literal(Bson.Null))))
 
         case Coalesce   => expr2($ifNull(_, _))
 

--- a/core/src/main/scala/quasar/sql/ast.scala
+++ b/core/src/main/scala/quasar/sql/ast.scala
@@ -126,7 +126,6 @@ sealed abstract class UnaryOperator(val sql: String) extends (Expr => Expr) {
 }
 
 final case object Not                 extends UnaryOperator("not")
-final case object IsNull              extends UnaryOperator("is_null")
 final case object Exists              extends UnaryOperator("exists")
 final case object Positive            extends UnaryOperator("+")
 final case object Negative            extends UnaryOperator("-")

--- a/core/src/main/scala/quasar/sql/package.scala
+++ b/core/src/main/scala/quasar/sql/package.scala
@@ -172,7 +172,6 @@ package object sql {
         case FlattenArrayValues  => "(" + expr._2 + ")[:*]"
         case ShiftArrayIndices   => "(" + expr._2 + ")[_:]"
         case ShiftArrayValues    => "(" + expr._2 + ")[:_]"
-        case IsNull              => "(" + expr._2 + ") is null"
         case _ =>
           val s = List(op.sql, "(", expr._2, ")") mkString " "
           // NB: dis-ambiguates the query in case this is the leading projection

--- a/core/src/main/scala/quasar/std/relations.scala
+++ b/core/src/main/scala/quasar/std/relations.scala
@@ -106,16 +106,6 @@ trait RelationsLib extends Library {
     },
     basicUntyper)
 
-  val IsNull = Mapping("IS_NULL", "Determines if a value is the special value Null. May or may not be equivalent to applying Eq to the value and Null.",
-    Type.Bool, Type.Top :: Nil,
-    noSimplification,
-    partialTyper {
-      case List(Type.Const(Data.Null)) => Type.Const(Data.Bool(true))
-      case List(Type.Const(_))         => Type.Const(Data.Bool(false))
-      case List(_)                     => Type.Bool
-    },
-    basicUntyper)
-
   val And = Mapping("(AND)", "Performs a logical AND of two boolean values",
     Type.Bool, Type.Bool :: Type.Bool :: Nil,
     new Func.Simplifier {
@@ -207,7 +197,7 @@ trait RelationsLib extends Library {
       case t         => success(t ⨿ Type.Null :: Type.Top :: Nil)
     })
 
-  def functions = Eq :: Neq :: Lt :: Lte :: Gt :: Gte :: Between :: IsNull :: And :: Or :: Not :: Cond :: Coalesce :: Nil
+  def functions = Eq :: Neq :: Lt :: Lte :: Gt :: Gte :: Between :: And :: Or :: Not :: Cond :: Coalesce :: Nil
 
   def flip(f: Mapping): Option[Mapping] = f match {
     case Eq  => Some(Eq)

--- a/core/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/core/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -966,7 +966,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           $read(Collection("db", "zips")),
           $match(
             Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
-              BsonField.Name("city") -> Selector.NotExpr(Selector.Eq(Bson.Null)))))))
+              BsonField.Name("city") -> Selector.Expr(Selector.Neq(Bson.Null)))))))
     }
 
     "plan filter with both index and field projections" in {

--- a/core/src/test/scala/quasar/sql/ExprArbitrary.scala
+++ b/core/src/test/scala/quasar/sql/ExprArbitrary.scala
@@ -120,8 +120,7 @@ trait ExprArbitrary {
           FlattenMapKeys,   FlattenArrayIndices,
           FlattenMapValues, FlattenArrayValues,
           ShiftMapKeys,     ShiftArrayIndices,
-          ShiftMapValues,   ShiftArrayValues,
-          IsNull))(
+          ShiftMapValues,   ShiftArrayValues))(
         Unop(_, _)),
       2 -> (for {
         fn  <- Gen.oneOf(agg.Sum, agg.Count, agg.Avg, string.Length, structural.MakeArray)

--- a/core/src/test/scala/quasar/sql/SqlParserSpec.scala
+++ b/core/src/test/scala/quasar/sql/SqlParserSpec.scala
@@ -269,6 +269,24 @@ class SQLParserSpec extends Specification with ScalaCheck with DisjunctionMatche
       parser.parse(q) must beRightDisjunction
     }
 
+    "parse is (not) as (!)=" in {
+      val q1 = "select * from zips where pop is 1000 and city is not \"BOULDER\""
+      val q2 = "select * from zips where pop = 1000 and city != \"BOULDER\""
+      parser.parse(q1) must_== parser.parse(q2)
+    }
+
+    "parse `in` and `like` with optional `is`" in {
+      val q1 = "select * from zips where pop is in (1000, 2000) and city is like \"BOU%\""
+      val q2 = "select * from zips where pop in (1000, 2000) and city like \"BOU%\""
+      parser.parse(q1) must_== parser.parse(q2)
+    }
+
+    "parse `not in` and `not like` with optional `is`" in {
+      val q1 = "select * from zips where pop is not in (1000, 2000) and city is not like \"BOU%\""
+      val q2 = "select * from zips where pop not in (1000, 2000) and city not like \"BOU%\""
+      parser.parse(q1) must_== parser.parse(q2)
+    }
+
     "parse nested joins left to right" in {
       val q1 = "select * from a cross join b cross join c"
       val q2 = "select * from (a cross join b) cross join c"

--- a/core/src/test/scala/quasar/std/relations.scala
+++ b/core/src/test/scala/quasar/std/relations.scala
@@ -76,20 +76,6 @@ class RelationsSpec extends Specification with ScalaCheck with TypeArbitrary wit
       expr should beSuccessful(Const(Bool(true)))
     }
 
-    "fold isNull with null" in {
-      val expr = IsNull(Const(Null))
-      expr should beSuccessful(Const(Bool(true)))
-    }
-
-    "fold isNull" ! prop { (t1 : Type) =>
-      val expr = IsNull(t1)
-      expr must beSuccessful(t1 match {
-        case Const(Null) => Const(Bool(true))
-        case Const(_)    => Const(Bool(false))
-        case _           => Type.Bool
-      })
-    }
-
     // TODO: similar for the rest of the simple relations
 
     "fold cond with true" ! prop { (t1 : Type, t2 : Type) =>


### PR DESCRIPTION
* collapse `is`/`is not` syntax into `relational_suffix` and generalize
  it to be equivalent to `=`/`!=`;
* `negatable_suffix`es can now have an optional leading `is`, to
  parallel the other `is not` construction (e.g., `where foo is not between 3
  and 10`);
* remove the `IsNull` function (it’s equivalent to `Eq(_, Null)` now,
  and allowing it to be generated in arbitraries broke round-tripping
  tests); and
* extract function syntax into its own parse rule, and explicitly match
  `is_null` to avoid a breaking change.