### PR TITLE
Fix regression regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ tmp
 .classpath
 .project
 .settings
+*.sw*
+tags

--- a/CHANGELOG/bugfix.md
+++ b/CHANGELOG/bugfix.md
@@ -1,0 +1,1 @@
+- Don't attempt to run regression test files that start with a dot.

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -218,7 +218,7 @@ abstract class QueryRegressionTest[S[_]: Functor](
     testDir: RDir,
     knownBackends: Set[BackendName]
   ): Task[Map[RFile, RegressionTest]] =
-    descendantsMatching(testDir, """.*\.test"""r)
+    descendantsMatching(testDir, """^([^.].*)\.test"""r) // don't match file names with a leading .
       .map(f =>
         (loadRegressionTest(f) >>= verifyBackends(knownBackends)) strengthL
           (f relativeTo testDir).get)


### PR DESCRIPTION
Running regression tests, I got the error:
```
[debug] Running TaskDef(quasar.StreamingQueryRegressionSpec, specs2 Specification fingerprint, false, [SuiteSelector])
java.nio.charset.MalformedInputException: Input length = 2
	at java.nio.charset.CoderResult.throwException(CoderResult.java:281)
	at sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:339)
	at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:178)
	at java.io.InputStreamReader.read(InputStreamReader.java:184)
	at java.io.BufferedReader.read1(BufferedReader.java:210)
	at java.io.BufferedReader.read(BufferedReader.java:286)
	at java.io.Reader.read(Reader.java:140)
	at scala.io.BufferedSource.mkString(BufferedSource.scala:96)
	at quasar.regression.QueryRegressionTest.quasar$regression$QueryRegressionTest$$$anonfun$46(QueryRegressionTest.scala:262)
	at quasar.regression.QueryRegressionTest$lambda$$textContents$1.apply(QueryRegressionTest.scala:262)
	at quasar.regression.QueryRegressionTest$lambda$$textContents$1.apply(QueryRegressionTest.scala:262)
```
Printing out the file path at `QueryRegressionTest.scala:262` showed
```
FileIn(DirIn(DirIn(DirIn(DirIn(DirIn(Current,DirName(it)),DirName(src)),DirName(main)),DirName(resources)),DirName(tests)),FileName(.caseWithGroup.test.swp))
```
which showed the problem - the regression file regex was matching on files beginning with `.`, and then trying to load that `.swp` file as the regression test file. This PR fixes that.