### PR TITLE
fix one randomly failing test

### DIFF
--- a/CHANGELOG/bugfix.md
+++ b/CHANGELOG/bugfix.md
@@ -1,0 +1,1 @@
+- [SD-1572] fix random build failures in DataServiceSpec

--- a/web/src/test/scala/quasar/api/services/MetadataServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/MetadataServiceSpec.scala
@@ -109,7 +109,7 @@ class MetadataServiceSpec extends Specification with ScalaCheck with FileSystemF
 
         service(s.state, Map())(Request(uri = pathUri(s.dir)))
           .as[Json].unsafePerformSync must_== Json("children" := childNodes.sorted)
-      }
+      }.set(minTestsOk = 10)  // NB: this test is slow because NonEmptyDir instances are still relatively large
 
       "and mounts when any children happen to be mount points" ! prop { (
         fName: FileName,


### PR DESCRIPTION
See SD-1572.

- use `maxSize` to keep the generated data relatively small
- set `minTestsOk` to 10, since 1 seems to confuse specs2/scalacheck
- fix spelling of the disposition header
- rename the test, since the disposition header actually doesn't affect
the zipping behavior