### PR TITLE
expose mappings from config to a key and connectionUri

### DIFF
--- a/CHANGELOG/bugfix.md
+++ b/CHANGELOG/bugfix.md
@@ -1,0 +1,1 @@
+- [SD-1569] changes to allow for third-party Mounting interpreters


### PR DESCRIPTION
...as used in the JSON codec.

Required by forthcoming PR for SD-1569.