### PR TITLE
avoid blocking in the default executor's thread pool

### DIFF
--- a/CHANGELOG/bugfix.md
+++ b/CHANGELOG/bugfix.md
@@ -1,0 +1,1 @@
+- [SD-1574] when running on a single-core, web server would hang and not respond to any request

--- a/web/src/main/scala/quasar/server/Http4sUtils.scala
+++ b/web/src/main/scala/quasar/server/Http4sUtils.scala
@@ -25,7 +25,7 @@ import org.http4s.server.blaze.BlazeBuilder
 import org.http4s.server.{Server => Http4sServer}
 import scalaz.concurrent.Task
 import scalaz._, Scalaz._
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 import scalaz.stream.Process
 import scalaz.stream.async
 import shapeless._
@@ -46,13 +46,10 @@ object Http4sUtils {
   def waitForInput: Task[Unit] = {
     import java.lang.System
 
-    val sleep = Task.delay(java.lang.Thread.sleep(250))
-                    .handle { case _: java.lang.InterruptedException => () }
-
     val inputPresent = Task.delay(Option(System.console).nonEmpty && System.in.available() > 0)
                            .handle { case _ => false }
 
-    Process.eval(sleep *> inputPresent).repeat.takeWhile(!_).run
+    Process.eval(inputPresent.after(250.milliseconds)).repeat.takeWhile(!_).run
   }
 
   def openBrowser(port: Int): Task[Unit] = {


### PR DESCRIPTION
Use `Task.after` rather than `Thread.sleep`.

When running on a single-core machine, scalaz's default executor
service uses a pool of exactly one thread. `waitForInput` was blocking
that thread continuously, so requests would just hang.

This fix was verified (applied to 8.0.1) on @damonLL's single-core Ubuntu image.