### PR TITLE
Backport the fix from 9.2.2.

### DIFF
--- a/CHANGELOG/bugfix.md
+++ b/CHANGELOG/bugfix.md
@@ -1,0 +1,2 @@
+- backport of v9.2.2 fix: [SD-1574] when running on a single-core, web server would hang and not respond to any request
+View

--- a/scripts/afterSuccess
+++ b/scripts/afterSuccess
@@ -7,7 +7,7 @@ source "$(dirname $0)/constants"
 
 # Only run for the first travis job
 if [[ "${TRAVIS_JOB_NUMBER##*.}" == "1" ]]; then
-  "$SCRIPT_DIR/publishJarIfMaster"
+  "$SCRIPT_DIR/publishJarOnUpstream"
   # Upload coverage information to codecov.io (BETA)
   pip install --user codecov && codecov
 fi

--- a/scripts/publishJarOnUpstream
+++ b/scripts/publishJarOnUpstream
@@ -14,8 +14,8 @@ if [[ ! -v GITHUB_TOKEN ]] ; then
     exit 0
 fi
 
-# only publish on quasar-analytics/quasar#master
-if [[ "$TRAVIS" == "true" && "$TRAVIS_BRANCH" == "master" && "$TRAVIS_REPO_SLUG" == "quasar-analytics/quasar" ]] ; then
+# only publish on quasar-analytics/quasar
+if [[ "$TRAVIS" == "true" && "$TRAVIS_BRANCH" =~ '^(master$|backport/)' && "$TRAVIS_REPO_SLUG" == "quasar-analytics/quasar" ]] ; then
   "$SBT" 'project web'    githubRelease
 else
   echo "GITHUB_TOKEN defined, but Travis not running in quasar-analytics/quasar#master, so skipping publish"


### PR DESCRIPTION
Fixes a case where we would hang on single-core machines.

Take 2 – this time with a better branch name, and a (hopefully) correct Travis script.