### PR TITLE
Add dependency on si2712fix-plugin.

### DIFF
--- a/CHANGELOG/bugfix.md
+++ b/CHANGELOG/bugfix.md
@@ -1,0 +1,1 @@
+- Added a dependency on the SI-2712 fix.

--- a/build.sbt
+++ b/build.sbt
@@ -45,8 +45,9 @@ lazy val commonSettings = Seq(
     "JBoss repository" at "https://repository.jboss.org/nexus/content/repositories/",
     "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases",
     "bintray/non" at "http://dl.bintray.com/non/maven"),
-  addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.7.1"),
-  addCompilerPlugin("org.scalamacros" % "paradise"       % "2.1.0" cross CrossVersion.full),
+  addCompilerPlugin("org.spire-math" %% "kind-projector"   % "0.7.1"),
+  addCompilerPlugin("org.scalamacros" % "paradise"         % "2.1.0" cross CrossVersion.full),
+  addCompilerPlugin("com.milessabin"  % "si2712fix-plugin" % "1.2.0" cross CrossVersion.full),
 
   ScoverageKeys.coverageHighlighting := true,
 

--- a/core/src/main/scala/quasar/Predef.scala
+++ b/core/src/main/scala/quasar/Predef.scala
@@ -76,8 +76,6 @@ object Predef extends LowPriorityImplicits {
   @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Throw"))
   def ??? : Nothing = throw new java.lang.RuntimeException("not implemented")
 
-  def implicitly[T](implicit e: T) = P.implicitly[T](e)
-
   @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.ExplicitImplicitTypes"))
   implicit def $conforms[A]: P.<:<[A, A] = P.$conforms[A]
   implicit def ArrowAssoc[A]: A => P.ArrowAssoc[A] = P.ArrowAssoc[A] _

--- a/core/src/main/scala/quasar/RenderTree.scala
+++ b/core/src/main/scala/quasar/RenderTree.scala
@@ -194,7 +194,7 @@ object RenderTree extends RenderTreeInstances {
           case RenderedTree(_, _, Nil) => state[Int, Cord](Cord(""))
           case RenderedTree(_, _, children) => {
             for {
-              nodes <- children.map(render(_)).sequenceU
+              nodes <- children.traverse(render(_))
             } yield nodes.map(cn => Cord("  ") ++ n ++ " -> " ++ cn.name ++ ";\n" ++ cn.dot).concatenate
           }
         }
@@ -343,6 +343,11 @@ object RenderTree extends RenderTreeInstances {
   }
 
   val windowCount = new java.util.concurrent.atomic.AtomicInteger()
+
+  implicit def ntRenderTree[F[_], A: RenderTree](
+    implicit F: RenderTree ~> (RenderTree ∘ F)#λ):
+      RenderTree[F[A]] =
+    F(RenderTree[A])
 
   implicit def fixRenderTree[F[_]](implicit RF: RenderTree ~> λ[α => RenderTree[F[α]]]):
       RenderTree[Fix[F]] =

--- a/core/src/main/scala/quasar/codec.scala
+++ b/core/src/main/scala/quasar/codec.scala
@@ -80,11 +80,11 @@ object DataCodec {
         // For Object, if we find one of the above keys, which means we serialized something particular
         // to the precise encoding, wrap this object in another object with a single field with the name ObjKey
         case Obj(value) => for {
-          obj <- value.toList.map { case (k, v) => encode(v).map(k -> _) }.sequenceU.map(Json.obj(_: _*))
+          obj <- value.toList.traverse { case (k, v) => encode(v).map(k -> _) }.map(Json.obj(_: _*))
         } yield value.keys.find(_.startsWith("$")).fold(obj)(κ(Json.obj(ObjKey -> obj)))
 
-        case Arr(value) => value.map(encode).sequenceU.map(vs => Json.array(vs: _*))
-        case Set(value) => value.map(encode).sequenceU.map(vs => Json.obj(SetKey -> Json.array(vs: _*)))
+        case Arr(value) => value.traverse(encode).map(vs => Json.array(vs: _*))
+        case Set(value) => value.traverse(encode).map(vs => Json.obj(SetKey -> Json.array(vs: _*)))
 
         case Timestamp(value) => \/-(Json.obj(TimestampKey -> jString(value.toString)))
         case Date(value)      => \/-(Json.obj(DateKey      -> jString(value.toString)))
@@ -108,7 +108,7 @@ object DataCodec {
           case _           => \/-(Data.Dec(num.toBigDecimal))
         },
         str => \/-(Data.Str(str)),
-        arr => arr.map(decode).sequenceU.map(Data.Arr(_)),
+        arr => arr.traverse(decode).map(Data.Arr(_)),
         obj => {
           import std.DateLib._
 
@@ -116,7 +116,7 @@ object DataCodec {
             (a \/> UnexpectedValueError(expected, json)) flatMap f
 
           def decodeObj(obj: JsonObject): DataEncodingError \/ Data =
-            obj.toList.map { case (k, v) => decode(v).map(k -> _) }.sequenceU.map(pairs => Data.Obj(ListMap(pairs: _*)))
+            obj.toList.traverse { case (k, v) => decode(v).map(k -> _) }.map(pairs => Data.Obj(ListMap(pairs: _*)))
 
           obj.toList match {
             case (`TimestampKey`, value) :: Nil => unpack(value.string, "string value for $timestamp")(parseTimestamp(_).leftMap(err => ParseError(err.message)))
@@ -124,7 +124,7 @@ object DataCodec {
             case (`TimeKey`, value) :: Nil      => unpack(value.string, "string value for $time")(parseTime(_).leftMap(err => ParseError(err.message)))
             case (`IntervalKey`, value) :: Nil  => unpack(value.string, "string value for $interval")(parseInterval(_).leftMap(err => ParseError(err.message)))
             case (`ObjKey`, value) :: Nil       => unpack(value.obj,    "object value for $obj")(decodeObj)
-            case (`SetKey`, value) :: Nil       => unpack(value.array,  "a list of values for $set")(_.map(decode).sequenceU.map(Data.Set(_)))
+            case (`SetKey`, value) :: Nil       => unpack(value.array,  "a list of values for $set")(_.traverse(decode).map(Data.Set(_)))
             case (`BinaryKey`, value) :: Nil    => unpack(value.string, "string value for $binary") { str =>
               \/.fromTryCatchNonFatal(Data.Binary(new sun.misc.BASE64Decoder().decodeBuffer(str))).leftMap(_ => UnexpectedValueError("BASE64-encoded data", json))
             }
@@ -148,9 +148,9 @@ object DataCodec {
         case Dec(x)   => \/-(jNumber(JsonBigDecimal(x)))
         case Str(s)   => \/-(jString(s))
 
-        case Obj(value) => value.toList.map { case (k, v) => encode(v).map(k -> _) }.sequenceU.map(Json.obj(_: _*))
-        case Arr(value) => value.map(encode).sequenceU.map(vs => Json.array(vs: _*))
-        case Set(value) => value.map(encode).sequenceU.map(vs => Json.array(vs: _*))
+        case Obj(value) => value.toList.traverse { case (k, v) => encode(v).map(k -> _) }.map(Json.obj(_: _*))
+        case Arr(value) => value.traverse(encode).map(vs => Json.array(vs: _*))
+        case Set(value) => value.traverse(encode).map(vs => Json.array(vs: _*))
 
         case Timestamp(value) => \/-(jString(value.toString))
         case Date(value)      => \/-(jString(value.toString))
@@ -183,7 +183,7 @@ object DataCodec {
               parseInterval(str))
           \/-(converted.flatMap(_.toList).headOption.getOrElse(Data.Str(str)))
         },
-        arr => arr.map(decode).sequenceU.map(Data.Arr(_)),
-        obj => obj.toList.map { case (k, v) => decode(v).map(k -> _) }.sequenceU.map(pairs => Data.Obj(ListMap(pairs: _*))))
+        arr => arr.traverse(decode).map(Data.Arr(_)),
+        obj => obj.toList.traverse { case (k, v) => decode(v).map(k -> _) }.map(pairs => Data.Obj(ListMap(pairs: _*))))
   }
 }

--- a/core/src/main/scala/quasar/config/writeConfig.scala
+++ b/core/src/main/scala/quasar/config/writeConfig.scala
@@ -18,7 +18,8 @@ package quasar.config
 
 import quasar.Predef._
 import quasar.effect._
-import quasar.fp.{free, TaskRef}
+import quasar.fp.{TaskRef}
+import quasar.fp.free
 import quasar.fs.{APath}
 import quasar.fs.mount._
 
@@ -47,10 +48,7 @@ object writeConfig {
       val refToTask: ConfigRef ~> Task = AtomicRef.fromTaskRef(ref)
 
       val write: Cfg => Task[Unit] = configOps.toFile(_, loc)
-      def writing: ConfigRef ~> ConfigRefPlusTaskM =
-        AtomicRef.onSet[Cfg](write)(
-          implicitly, implicitly, implicitly,
-          Inject[ConfigRefF, ConfigRefPlusTask]) // NB: this one is not resolved
+      def writing: ConfigRef ~> ConfigRefPlusTaskM = AtomicRef.onSet[Cfg](write)
 
       val refToTaskF: ConfigRefPlusTask ~> Task =
         free.interpret2[ConfigRefF, Task, Task](

--- a/core/src/main/scala/quasar/csv/csv.scala
+++ b/core/src/main/scala/quasar/csv/csv.scala
@@ -85,7 +85,7 @@ object CsvDetect {
     val subtext = text.take(TestChars)
     (parser.parse(subtext) ++ Stream.continually(\/-(Record(Nil)))).take(TestRecords + 1) match {
       case header #:: rows =>
-        ((header |@| rows.toList.sequenceU) { (header, rows) =>
+        ((header |@| rows.toList.sequence) { (header, rows) =>
           TestResult(header.size, rows.map(_.size))
         }).toOption
 

--- a/core/src/main/scala/quasar/fp/free/package.scala
+++ b/core/src/main/scala/quasar/fp/free/package.scala
@@ -24,10 +24,9 @@ import scalaz.syntax.monad._
 import scalaz.concurrent.Task
 
 package object free {
-  type Coproduct3[F[_], G[_], H[_], A] = Coproduct[F, Coproduct[G, H, ?], A]
-  type Coproduct4[F[_], G[_], H[_], I[_], A] = Coproduct[F, Coproduct3[G, H, I, ?], A]
-  type Coproduct5[F[_], G[_], H[_], I[_], J[_], A] = Coproduct[F, Coproduct4[G, H, I, J, ?], A]
-  type Coproduct6[F[_], G[_], H[_], I[_], J[_], K[_], A] = Coproduct[F, Coproduct5[G, H, I, J, K, ?], A]
+  sealed abstract class :+:[F[_], G[_]] {
+    type λ[A] = Coproduct[F, G, A]
+  }
 
   /** Given `F[_]` and `G[_]` such that `F :<: G`, lifts a natural transformation
     * `F ~> F` to `G ~> G`.
@@ -66,33 +65,36 @@ package object free {
       def apply[A](sa: S[A]) = S.prj(sa).fold(g(sa))(f)
     }
 
-  def interpret2[F[_], G[_], M[_]](f: F ~> M, g: G ~> M): Coproduct[F, G, ?] ~> M =
-    new (Coproduct[F, G, ?] ~> M) {
-      def apply[A](fa: Coproduct[F, G, A]) =
+  def interpret2[F[_], G[_], M[_]](f: F ~> M, g: G ~> M): (F :+: G)#λ ~> M =
+    new ((F :+: G)#λ ~> M) {
+      def apply[A](fa: (F :+: G)#λ[A]) =
         fa.run.fold(f, g)
     }
 
-  def interpret3[F[_], G[_], H[_], M[_]](f: F ~> M, g: G ~> M, h: H ~> M): Coproduct3[F, G, H, ?] ~> M =
-    new (Coproduct3[F, G, H, ?] ~> M) {
-      def apply[A](fa: Coproduct3[F, G, H, A]) =
+  def interpret3[F[_], G[_], H[_], M[_]](f: F ~> M, g: G ~> M, h: H ~> M): (F :+: (G :+: H)#λ)#λ ~> M =
+    new ((F :+: (G :+: H)#λ)#λ ~> M) {
+      def apply[A](fa: (F :+: (G :+: H)#λ)#λ[A]) =
         fa.run.fold(f, interpret2(g, h)(_))
     }
 
-  def interpret4[F[_], G[_], H[_], I[_], M[_]](f: F ~> M, g: G ~> M, h: H ~> M, i: I ~> M): Coproduct4[F, G, H, I, ?] ~> M =
-    new (Coproduct4[F, G, H, I, ?] ~> M) {
-      def apply[A](fa: Coproduct4[F, G, H, I, A]) =
+  def interpret4[F[_], G[_], H[_], I[_], M[_]](f: F ~> M, g: G ~> M, h: H ~> M, i: I ~> M):
+      (F :+: (G :+: (H :+: I)#λ)#λ)#λ ~> M =
+    new ((F :+: (G :+: (H :+: I)#λ)#λ)#λ ~> M) {
+      def apply[A](fa: (F :+: (G :+: (H :+: I)#λ)#λ)#λ[A]) =
         fa.run.fold(f, interpret3(g, h, i)(_))
     }
 
-  def interpret5[F[_], G[_], H[_], I[_], J[_], M[_]](f: F ~> M, g: G ~> M, h: H ~> M, i: I ~> M, j: J ~> M): Coproduct5[F, G, H, I, J, ?] ~> M =
-    new (Coproduct5[F, G, H, I, J, ?] ~> M) {
-      def apply[A](fa: Coproduct5[F, G, H, I, J, A]) =
+  def interpret5[F[_], G[_], H[_], I[_], J[_], M[_]](f: F ~> M, g: G ~> M, h: H ~> M, i: I ~> M, j: J ~> M):
+      (F :+: (G :+: (H :+: (I :+: J)#λ)#λ)#λ)#λ ~> M =
+    new ((F :+: (G :+: (H :+: (I :+: J)#λ)#λ)#λ)#λ ~> M) {
+      def apply[A](fa: (F :+: (G :+: (H :+: (I :+: J)#λ)#λ)#λ)#λ[A]) =
         fa.run.fold(f, interpret4(g, h, i, j)(_))
     }
 
-  def interpret6[F[_], G[_], H[_], I[_], J[_], K[_], M[_]](f: F ~> M, g: G ~> M, h: H ~> M, i: I ~> M, j: J ~> M, k: K ~> M): Coproduct6[F, G, H, I, J, K, ?] ~> M =
-    new (Coproduct6[F, G, H, I, J, K, ?] ~> M) {
-      def apply[A](fa: Coproduct6[F, G, H, I, J, K, A]) =
+  def interpret6[F[_], G[_], H[_], I[_], J[_], K[_], M[_]](f: F ~> M, g: G ~> M, h: H ~> M, i: I ~> M, j: J ~> M, k: K ~> M):
+      (F :+: (G :+: (H :+: (I :+: (J :+: K)#λ)#λ)#λ)#λ)#λ ~> M =
+    new ((F :+: (G :+: (H :+: (I :+: (J :+: K)#λ)#λ)#λ)#λ)#λ ~> M) {
+      def apply[A](fa: (F :+: (G :+: (H :+: (I :+: (J :+: K)#λ)#λ)#λ)#λ)#λ[A]) =
         fa.run.fold(f, interpret5(g, h, i, j, k)(_))
     }
 

--- a/core/src/main/scala/quasar/fs/InMemory.scala
+++ b/core/src/main/scala/quasar/fs/InMemory.scala
@@ -318,7 +318,7 @@ object InMemory {
       m     <- contentsL.st
       sufxs =  m.keys.toStream.map(_ relativeTo src).unite
       files =  sufxs map (src </> _) zip (sufxs map (dst </> _))
-      r0    <- files.traverseU { case (sf, df) => EitherT(moveFile(sf, df, s)) }.run
+      r0    <- files.traverse { case (sf, df) => EitherT(moveFile(sf, df, s)) }.run
       r1    =  r0 flatMap (_.nonEmpty either (()) or pathErr(pathNotFound(src)))
     } yield r1
 
@@ -344,7 +344,7 @@ object InMemory {
     for {
       m  <- contentsL.st
       ss =  m.keys.toStream.map(_ relativeTo d).unite
-      r0 <- ss.traverseU(f => EitherT(deleteFile(d </> f))).run
+      r0 <- ss.traverse(f => EitherT(deleteFile(d </> f))).run
       r1 =  r0 flatMap (_.nonEmpty either (()) or pathErr(pathNotFound(d)))
     } yield r1
 

--- a/core/src/main/scala/quasar/fs/QueryFile.scala
+++ b/core/src/main/scala/quasar/fs/QueryFile.scala
@@ -98,6 +98,9 @@ object QueryFile {
   final case class FileExists(file: AFile)
     extends QueryFile[Boolean]
 
+  // TODO[scalaz]: Shadow the scalaz.Monad.monadMTMAB SI-2712 workaround
+  import EitherT.eitherTMonad
+
   @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.NonUnitStatements"))
   final class Ops[S[_]](implicit S0: Functor[S], S1: QueryFileF :<: S)
     extends LiftedOps[QueryFile, S] {

--- a/core/src/main/scala/quasar/fs/mount/EvaluatorMounter.scala
+++ b/core/src/main/scala/quasar/fs/mount/EvaluatorMounter.scala
@@ -18,7 +18,8 @@ package quasar.fs.mount
 
 import quasar.Predef.Unit
 import quasar.effect._
-import quasar.fp.{liftFT, injectNT, free}
+import quasar.fp.{liftFT, injectNT}
+import quasar.fp.free, free.{:+:}
 import quasar.fs.FileSystem
 import hierarchical.MountedResultHF
 
@@ -91,9 +92,8 @@ final class EvaluatorMounter[F[_], S[_]: Functor](
 
   ////
 
-  private type ViewEff0[A] = Coproduct[MonotonicSeqF, FileSystem, A]
-  private type ViewEff1[A] = Coproduct[ViewStateF, ViewEff0, A]
-  private type ViewEff[A]  = Coproduct[MountConfigsF, ViewEff1, A]
+  private type ViewEff[A] =
+    (MountConfigsF :+: (ViewStateF :+: (MonotonicSeqF :+: FileSystem)#λ)#λ)#λ[A]
 
   private val fsMounter = FileSystemMounter[F](fsDef)
 

--- a/core/src/main/scala/quasar/fs/mount/Mounts.scala
+++ b/core/src/main/scala/quasar/fs/mount/Mounts.scala
@@ -38,7 +38,7 @@ final class Mounts[A] private (val toMap: Map[ADir, A]) {
     if (toMap contains d)
       ().right
     else
-      toMap.keys.toStream.traverseU_ { mnt =>
+      toMap.keys.toStream.traverse_ { mnt =>
         mnt.relativeTo(d)
           .as("existing mount below: " + posixCodec.printPath(mnt))
           .toLeftDisjunction(()) *>

--- a/core/src/main/scala/quasar/fs/package.scala
+++ b/core/src/main/scala/quasar/fs/package.scala
@@ -22,7 +22,7 @@ import quasar.fp._
 import quasar.fp.free._
 
 import pathy.Path, Path._
-import scalaz.{Failure => _, _}, Scalaz._
+import scalaz.{Failure => _, :+: => _, _}, Scalaz._
 
 package object fs {
   type ReadFileF[A]    = Coyoneda[ReadFile, A]
@@ -30,10 +30,8 @@ package object fs {
   type ManageFileF[A]  = Coyoneda[ManageFile, A]
   type QueryFileF[A]   = Coyoneda[QueryFile, A]
 
-  type FileSystem0[A] = Coproduct[WriteFileF, ManageFileF, A]
-  type FileSystem1[A] = Coproduct[ReadFileF, FileSystem0, A]
-  /** FileSystem[A] = QueryFileF or ReadFileF or WriteFileF or ManageFileF */
-  type FileSystem[A]  = Coproduct[QueryFileF, FileSystem1, A]
+  type FileSystem[A] =
+    (QueryFileF :+: (ReadFileF :+: (WriteFileF :+: ManageFileF)#λ)#λ)#λ[A]
 
   type AbsPath[T] = pathy.Path[Abs,T,Sandboxed]
   type RelPath[T] = pathy.Path[Rel,T,Sandboxed]

--- a/core/src/main/scala/quasar/jscore/package.scala
+++ b/core/src/main/scala/quasar/jscore/package.scala
@@ -198,17 +198,17 @@ package object jscore {
         case LiteralF(lit)           => G.point(LiteralF(lit))
         case IdentF(name)            => G.point(IdentF(name))
         case AccessF(expr, key)      => G.apply2(f(expr), f(key))(AccessF(_, _))
-        case CallF(expr, args)       => G.apply2(f(expr), args.map(f).sequence)(CallF(_, _))
-        case NewF(name, args)        => G.map(args.map(f).sequence)(NewF(name, _))
+        case CallF(expr, args)       => G.apply2(f(expr), args.traverse(f))(CallF(_, _))
+        case NewF(name, args)        => G.map(args.traverse(f))(NewF(name, _))
         case IfF(cond, cons, alt)    => G.apply3(f(cond), f(cons), f(alt))(IfF(_, _, _))
         case UnOpF(op, arg)          => G.map(f(arg))(UnOpF(op, _))
         case BinOpF(op, left, right) => G.apply2(f(left), f(right))(BinOpF(op, _, _))
-        case ArrF(values)            => G.map(values.map(f).sequence)(ArrF(_))
+        case ArrF(values)            => G.map(values.traverse(f))(ArrF(_))
         case FunF(params, body)      => G.map(f(body))(FunF(params, _))
         case ObjF(values)            => G.map((values ∘ f).sequence)(ObjF(_))
         case LetF(name, expr, body)  => G.apply2(f(expr), f(body))(LetF(name, _, _))
-        case SpliceObjectsF(srcs)    => G.map(srcs.map(f).sequence)(SpliceObjectsF(_))
-        case SpliceArraysF(srcs)     => G.map(srcs.map(f).sequence)(SpliceArraysF(_))
+        case SpliceObjectsF(srcs)    => G.map(srcs.traverse(f))(SpliceObjectsF(_))
+        case SpliceArraysF(srcs)     => G.map(srcs.traverse(f))(SpliceArraysF(_))
       }
     }
   }

--- a/core/src/main/scala/quasar/optimizer.scala
+++ b/core/src/main/scala/quasar/optimizer.scala
@@ -86,7 +86,7 @@ object Optimizer {
     case InvokeF(DeleteField, List(src, field)) =>
       src._2.map(_.filterNot(_ == field._1))
     case InvokeF(MakeObject, List(field, src)) => Some(List(field._1))
-    case InvokeF(ObjectConcat, srcs) => srcs.map(_._2).sequence.map(_.flatten)
+    case InvokeF(ObjectConcat, srcs) => srcs.traverse(_._2).map(_.flatten)
     // NB: the remaining InvokeF cases simply pass through or combine shapes
     //     from their inputs. It would be great if this information could be
     //     handled generically by the type system.

--- a/core/src/main/scala/quasar/sql/ast.scala
+++ b/core/src/main/scala/quasar/sql/ast.scala
@@ -79,8 +79,8 @@ object Sql {
     }
   }
 
-  implicit def ToExprAlgebraOps[A](a: Algebra[Sql, A]): AlgebraOps[Sql, A] =
-    ToAlgebraOps[Sql, A](a)
+  implicit def toExprAlgebraOps[A](a: Algebra[Sql, A]): AlgebraOps[Sql, A] =
+    toAlgebraOps[Sql, A](a)
 }
 
 @Lenses final case class Select[A] private[sql] (

--- a/core/src/main/scala/quasar/std/agg.scala
+++ b/core/src/main/scala/quasar/std/agg.scala
@@ -165,7 +165,7 @@ trait AggLib extends Library {
     homogenized(f.lift, err)
 
   private def homogenized[A](f: Data => Option[A], err: String): List[Data] => SemanticError \/ List[A] =
-    set => set.traverseU(f) \/> SemanticError.DomainError(Data.Set(set), some(err))
+    set => set.traverse(f) \/> SemanticError.DomainError(Data.Set(set), some(err))
 }
 
 object AggLib extends AggLib

--- a/core/src/test/scala/quasar/csv/csv.scala
+++ b/core/src/test/scala/quasar/csv/csv.scala
@@ -45,7 +45,7 @@ class CsvSpec extends Specification {
   }
 
   "bestParse" should {
-    def parse(text: String) = bestParse(CsvParser.AllParsers)(text).map(_.toList.sequenceU).join
+    def parse(text: String) = bestParse(CsvParser.AllParsers)(text).map(_.toList.sequence).join
 
     "parse standard format" in {
       parse(Standard) must_==

--- a/core/src/test/scala/quasar/fs/FileSystemFixture.scala
+++ b/core/src/test/scala/quasar/fs/FileSystemFixture.scala
@@ -144,6 +144,9 @@ trait FileSystemFixture {
     amendWrites(writeFile),
     liftMT[InMemoryFs, ReadWriteT] compose manageFile)
 
+  // TODO[scalaz]: Shadow the scalaz.Monad.monadMTMAB SI-2712 workaround
+  import StateT.stateTMonadState
+
   object MemFixTask extends SpecializedInterpreter[FileSystem, MemStateFix](
     interpretTerm = hoistFix compose readWrite
   ) {

--- a/core/src/test/scala/quasar/fs/WriteFileSpec.scala
+++ b/core/src/test/scala/quasar/fs/WriteFileSpec.scala
@@ -54,6 +54,9 @@ class WriteFileSpec extends Specification with ScalaCheck with FileSystemFixture
       s"$n should consume input and close write handle when finished" ! prop {
         (f: AFile, xs: Vector[Data]) =>
 
+        // TODO[scalaz]: Shadow the scalaz.Monad.monadMTMAB SI-2712 workaround
+        import EitherT.eitherTMonad
+
         val p = wt(f, xs.toProcess).drain ++ read.scanAll(f)
 
         type Result[A] = FileSystemErrT[MemStateTask,A]

--- a/core/src/test/scala/quasar/scalacheck/package.scala
+++ b/core/src/test/scala/quasar/scalacheck/package.scala
@@ -24,11 +24,11 @@ import scalaz.scalacheck.ScalaCheckBinding._
 
 package object scalacheck {
   def nonEmptyListSmallerThan[A: Arbitrary](n: Int): Arbitrary[NonEmptyList[A]] = {
-    val listGen = Gen.containerOfN[List,A](n, implicitly[Arbitrary[A]].arbitrary)
-    Apply[Arbitrary].apply2[A, List[A], NonEmptyList[A]](implicitly[Arbitrary[A]], Arbitrary(listGen))((a, rest) =>
+    val listGen = Gen.containerOfN[List,A](n, Arbitrary.arbitrary[A])
+    Apply[Arbitrary].apply2[A, List[A], NonEmptyList[A]](Arbitrary(Arbitrary.arbitrary[A]), Arbitrary(listGen))((a, rest) =>
       NonEmptyList.nel(a, IList.fromList(rest)))
   }
 
   def listSmallerThan[A: Arbitrary](n: Int): Arbitrary[List[A]] =
-    Arbitrary(Gen.containerOfN[List,A](n,implicitly[Arbitrary[A]].arbitrary))
+    Arbitrary(Gen.containerOfN[List,A](n, Arbitrary.arbitrary[A]))
 }

--- a/it/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
@@ -214,6 +214,9 @@ class MongoDbFileSystemSpec
 
           import xform._
 
+          // TODO[scalaz]: Shadow the scalaz.Monad.monadMTMAB SI-2712 workaround
+          import EitherT.eitherTMonad
+
           val runExec: CompExecM ~> FileSystemErrT[PhaseResultT[Task, ?], ?] = {
             type X0[A] = PhaseResultT[Task, A]
             type X1[A] = FileSystemErrT[X0, A]

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -137,6 +137,9 @@ abstract class QueryRegressionTest[S[_]: Functor](
     run: Run
   ): Task[Result] = {
     val liftRun: CompExecM ~> Task = {
+      // TODO[scalaz]: Shadow the scalaz.Monad.monadMTMAB SI-2712 workaround
+      import EitherT.eitherTMonad
+
       type H1[A] = PhaseResultT[Task, A]
       type H2[A] = SemanticErrsT[H1, A]
       type H3[A] = FileSystemErrT[H2, A]

--- a/it/src/test/scala/quasar/regression/package.scala
+++ b/it/src/test/scala/quasar/regression/package.scala
@@ -17,21 +17,21 @@
 package quasar
 
 import quasar.Predef.{Long, Map}
-import quasar.fs.{QueryFile, FileSystem, ADir}
-import quasar.fp.{free, TaskRef}
 import quasar.effect._
+import quasar.fp.{TaskRef}
+import quasar.fp.free, free.{:+:}
+import quasar.fs.{QueryFile, FileSystem, ADir}
 
 import scalaz.{Failure => _, _}
-import scalaz.syntax.apply._
 import scalaz.concurrent._
+import scalaz.syntax.apply._
 
 package object regression {
   import quasar.fs.mount.hierarchical.MountedResultHF
 
-  type FileSystemIO[A] = Coproduct[Task, FileSystem, A]
+  type FileSystemIO[A] = (Task :+: FileSystem)#λ[A]
 
-  type HfsIO0[A] = Coproduct[MountedResultHF, Task, A]
-  type HfsIO[A]  = Coproduct[MonotonicSeqF, HfsIO0, A]
+  type HfsIO[A] = (MonotonicSeqF :+: (MountedResultHF :+: Task)#λ)#λ[A]
 
   val interpretHfsIO: Task[HfsIO ~> Task] = {
     import QueryFile.ResultHandle

--- a/mongodb/src/main/scala/quasar/physical/mongodb/WorkflowExecutor.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/WorkflowExecutor.scala
@@ -35,6 +35,9 @@ private[mongodb] abstract class WorkflowExecutor[F[_]: Monad, C] {
   import MapReduce._
   import WorkflowExecutor.WorkflowCursor
 
+  // TODO[scalaz]: Shadow the scalaz.Monad.monadMTMAB SI-2712 workaround
+  import EitherT.eitherTMonad
+
   /** Execute the given aggregation pipeline with the given collection as
     * input.
     */
@@ -206,7 +209,7 @@ private[mongodb] abstract class WorkflowExecutor[F[_]: Monad, C] {
 
       case PureTask(Bson.Arr(vs)) =>
         for {
-          docs <- vs.toList.traverseU {
+          docs <- vs.toList.traverse {
                     case doc @ Bson.Doc(_) => doc.right
                     case other             => other.left
                   } fold (unableToStore[List[Bson.Doc]], _.point[N])

--- a/mongodb/src/main/scala/quasar/physical/mongodb/collection.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/collection.scala
@@ -48,7 +48,7 @@ object Collection {
       tpl  <- dbNameAndRest(path)
       (db, r) = tpl
       ss   <- r.toNel.toRightDisjunction("path names a database, but no collection")
-      segs <- ss.traverseU(CollectionSegmentParser(_))
+      segs <- ss.traverse(CollectionSegmentParser(_))
       coll =  segs.toList mkString "."
       len  =  utf8length(db) + 1 + utf8length(coll)
       _    <- if (len > 120)

--- a/mongodb/src/main/scala/quasar/physical/mongodb/expression/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/expression/package.scala
@@ -207,7 +207,7 @@ package object expression {
         case Bson.Text(v)         => js(Js.Str(v))
         case Bson.Null            => js(Js.Null)
         case Bson.Doc(values)     => values.map { case (k, v) => jscore.Name(k) -> const(v) }.sequenceU.map(jscore.Obj(_))
-        case Bson.Arr(values)     => values.toList.map(const(_)).sequenceU.map(jscore.Arr(_))
+        case Bson.Arr(values)     => values.toList.traverse(const(_)).map(jscore.Arr(_))
         case o @ Bson.ObjectId(_) => \/-(toJsObjectId(o))
         case d @ Bson.Date(_)     => \/-(toJsDate(d))
         // TODO: implement the rest of these (see SD-451)
@@ -471,7 +471,7 @@ package object expression {
     * handling. */
   def toJsƒ(t: ExprOp[(Fix[ExprOp], PlannerError \/ JsFn)]): PlannerError \/ JsFn = {
     def expr = Fix(t.map(_._1))
-    def js = t.map(_._2).sequenceU
+    def js = t.traverse(_._2)
     translate.lift(expr).getOrElse(js.flatMap(toJsSimpleƒ))
   }
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/fs/managefile.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/fs/managefile.scala
@@ -91,7 +91,7 @@ object managefile {
       colls    <- userCollectionsInDir(src)
       srcFiles =  colls map (_.asFile)
       dstFiles =  srcFiles.map(_ relativeTo (src) map (dst </> _)).unite
-      _        <- srcFiles zip dstFiles traverseU {
+      _        <- srcFiles zip dstFiles traverse {
                     case (s, d) => moveFile(s, d, sem)
                   }
     } yield ()
@@ -175,7 +175,7 @@ object managefile {
 
       case Some(_) =>
         collectionsInDir(dir)
-          .flatMap(_.traverseU_(c => dropCollection(c).liftM[FileSystemErrT]))
+          .flatMap(_.traverse_(dropCollection(_).liftM[FileSystemErrT]))
 
       case None if depth(dir) == 0 =>
         dropAllDatabases.liftM[FileSystemErrT]

--- a/mongodb/src/main/scala/quasar/physical/mongodb/fs/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/fs/package.scala
@@ -17,11 +17,11 @@
 package quasar.physical.mongodb
 
 import quasar.Predef._
-import quasar.{EnvironmentError, EnvErrT, EnvErr, EnvErrF}
-import quasar.{NameGenerator => NG}
+import quasar.{EnvironmentError, EnvErrT, EnvErr, EnvErrF, NameGenerator => NG}
 import quasar.config._
 import quasar.effect.Failure
 import quasar.fp._
+import quasar.fp.free.{:+:}
 import quasar.fs._
 import quasar.fs.mount.{ConnectionUri, FileSystemDef}
 import quasar.physical.mongodb.fs.bsoncursor._
@@ -92,8 +92,7 @@ package object fs {
 
   ////
 
-  private type Eff0[A] = Coproduct[EnvErrF, CfgErrF, A]
-  private type Eff[A]  = Coproduct[Task, Eff0, A]
+  private type Eff[A] = (Task :+: (EnvErrF :+: CfgErrF)#λ)#λ[A]
 
   private def findDefaultDb: MongoDbIO[Option[DefaultDb]] =
     (for {

--- a/mongodb/src/main/scala/quasar/physical/mongodb/fs/queryfile.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/fs/queryfile.scala
@@ -81,6 +81,9 @@ private final class QueryFileInterpreter[C](
   import Recursive.ops._
   import queryfile._
 
+  // TODO[scalaz]: Shadow the scalaz.Monad.monadMTMAB SI-2712 workaround
+  import WriterT.writerTMonadListen
+
   type QRT[F[_], A] = QueryRT[F, C, A]
   type MQ[A]        = QRT[MongoDbIO, A]
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/optimize/optimize.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/optimize/optimize.scala
@@ -218,7 +218,7 @@ package object optimize {
 
     /** Map from old grouped names to new names and mapping of expressions. */
     def renameProjectGroup(r: Reshape, g: Grouped): Option[ListMap[BsonField.Name, List[BsonField.Name]]] = {
-      val s = r.value.toList.map {
+      val s = r.value.toList.traverse {
         case (newName, \/-($var(v))) =>
           v.path match {
             case List(oldHead @ BsonField.Name(_)) =>
@@ -231,7 +231,7 @@ package object optimize {
       def multiListMap[A, B](ts: List[(A, B)]): ListMap[A, List[B]] =
         ts.foldLeft(ListMap[A,List[B]]()) { case (map, (a, b)) => map + (a -> (map.get(a).getOrElse(List[B]()) :+ b)) }
 
-      s.sequenceU.map(multiListMap)
+      s.map(multiListMap)
     }
 
     def inlineProjectGroup(r: Reshape, g: Grouped): Option[Grouped] = {

--- a/mongodb/src/main/scala/quasar/physical/mongodb/reshape.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/reshape.scala
@@ -52,7 +52,7 @@ final case class Reshape(value: ListMap[BsonField.Name, Reshape.Shape]) {
   def toJs: PlannerError \/ JsFn =
     value.map { case (key, expr) =>
       key.asText -> expr.fold(_.toJs, expression.toJs)
-    }.sequenceU.map { l => JsFn(JsFn.defaultName,
+    }.sequence.map { l => JsFn(JsFn.defaultName,
       jscore.Obj(l.map { case (k, v) => jscore.Name(k) -> v(jscore.Ident(JsFn.defaultName)) }))
     }
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/selector.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/selector.scala
@@ -42,7 +42,7 @@ sealed trait Selector {
 
   def mapUpFieldsM[M[_]: Monad](f: BsonField => M[BsonField]): M[Selector] =
     this match {
-      case Doc(pairs)       => pairs.toList.map { case (field, expr) => f(field).map(_ -> expr) }.sequenceU.map(ps => Doc(ps.toListMap))
+      case Doc(pairs)       => pairs.toList.traverse { case (field, expr) => f(field).map(_ -> expr) }.map(ps => Doc(ps.toListMap))
       case And(left, right) => (left.mapUpFieldsM(f) |@| right.mapUpFieldsM(f))(And(_, _))
       case Or(left, right)  => (left.mapUpFieldsM(f) |@| right.mapUpFieldsM(f))(Or(_, _))
       case Nor(left, right) => (left.mapUpFieldsM(f) |@| right.mapUpFieldsM(f))(Nor(_, _))

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflowop.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflowop.scala
@@ -145,9 +145,7 @@ object Workflow {
           G.apply(f(src))($SimpleMap(_, exprs, scope))
         case $Reduce(src, fn, scope)  => G.apply(f(src))($Reduce(_, fn, scope))
         case $FoldLeft(head, tail)    =>
-          G.apply2(
-            f(head), Traverse[NonEmptyList].sequence(tail.map(f)))(
-            $FoldLeft(_, _))
+          G.apply2(f(head), tail.traverse(f))($FoldLeft(_, _))
         // NB: Would be nice to replace the rest of this impl with the following
         //     line, but the invariant definition of Traverse doesn’t allow it.
         // case p: PipelineF[_]          => PipelineFTraverse.traverseImpl(p)(f)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,7 +32,7 @@ object Dependencies {
     "io.argonaut"       %% "argonaut-scalaz"           % "6.2-M1"                 % "compile, test",
     "org.jboss.aesh"    %  "aesh"                      % "0.66.8"                  % "compile, test",
     "org.typelevel"     %% "shapeless-scalaz"          % slcVersion               % "compile, test",
-    "com.slamdata"      %% "matryoshka-core"           % "0.9.0"                  % "compile",
+    "com.slamdata"      %% "matryoshka-core"           % "0.10.2"                 % "compile",
     "com.slamdata"      %% "pathy-core"                % pathyVersion             % "compile",
     "com.github.mpilquist" %% "simulacrum"             % "0.7.0"                  % "compile, test",
     "org.http4s"        %% "http4s-core"               % http4sVersion            % "compile",

--- a/web/src/main/scala/quasar/api/package.scala
+++ b/web/src/main/scala/quasar/api/package.scala
@@ -94,15 +94,15 @@ package object api {
       def strings(json: Json): String \/ List[String] =
         json.string.map(str => \/-(str :: Nil)).getOrElse(
           json.array.map { vs =>
-            vs.map(v => v.string \/> ("expected string in array; found: " + v.toString)).sequenceU
+            vs.traverse(v => v.string \/> ("expected string in array; found: " + v.toString))
           }.getOrElse(-\/("expected a string or array of strings; found: " + json)))
 
       for {
         json <- Parse.parse(param).leftMap("parse error (" + _ + ")").disjunction
         obj <- json.obj \/> ("expected a JSON object; found: " + json.toString)
-        values <- obj.toList.map { case (k, v) =>
+        values <- obj.toList.traverse { case (k, v) =>
           strings(v).map(CaseInsensitiveString(k) -> _)
-        }.sequenceU
+        }
       } yield Map(values: _*)
     }
 

--- a/web/src/main/scala/quasar/api/services/RestApi.scala
+++ b/web/src/main/scala/quasar/api/services/RestApi.scala
@@ -81,7 +81,7 @@ object RestApi {
   }
 
   def defaultMiddleware: HttpMiddleware =
-    cors <<< gzip <<< HeaderParam <<< passOptions
+    (cors(_)) <<< gzip <<< HeaderParam <<< passOptions
 
   val cors: HttpMiddleware =
     CORS(_, CORSConfig(

--- a/web/src/main/scala/quasar/api/services/package.scala
+++ b/web/src/main/scala/quasar/api/services/package.scala
@@ -70,7 +70,7 @@ package object services {
     param: F[ValidationNel[ParseFailure, A]],
     msg: NonEmptyList[ParseFailure] => String
   ): ApiError \/ F[A] =
-    param.traverseU(_.disjunction.leftMap(nel =>
+    param.traverse(_.disjunction.leftMap(nel =>
       ApiError.fromMsg_(BadRequest withReason "Invalid query parameter.", msg(nel))))
 
   def requiredHeader(key: HeaderKey.Extractable, request: Request): ApiError \/ key.HeaderT =

--- a/web/src/main/scala/quasar/api/services/query/compile.scala
+++ b/web/src/main/scala/quasar/api/services/query/compile.scala
@@ -63,7 +63,7 @@ object compile {
 
     QHttpService {
       case req @ GET -> _ :? Offset(offset) +& Limit(limit) =>
-        respond(parsedQueryRequest(req, offset, limit) traverseU {
+        respond(parsedQueryRequest(req, offset, limit) traverse {
           case (expr, offset, limit) =>
             explainQuery(expr, offset, limit, requestVars(req))
         })

--- a/web/src/main/scala/quasar/api/services/query/execute.scala
+++ b/web/src/main/scala/quasar/api/services/query/execute.scala
@@ -78,14 +78,13 @@ object execute {
                   sandboxAbs(res.map(unsandbox(path) </> _).merge))
 
               parseRes tuple absDestination
-            } traverseU { case (expr, out) =>
+            } traverse { case (expr, out) =>
               Q.executeQuery(expr, requestVars(req), out).run.run.run map {
                 case (phases, result) =>
                   result.leftMap(_.toApiError).flatMap(_.leftMap(_.toApiError))
                     .bimap(_ :+ ("phases" := phases), f => Json(
                       "out"    := posixCodec.printPath(f),
-                      "phases" := phases
-                    ))
+                      "phases" := phases))
               }
             })
           }

--- a/web/src/test/scala/quasar/api/QResponseSpec.scala
+++ b/web/src/test/scala/quasar/api/QResponseSpec.scala
@@ -34,7 +34,7 @@ class QResponseSpec extends mutable.Specification {
   import QResponse.{PROCESS_EFFECT_THRESHOLD_BYTES, HttpResponseStreamFailureException}
   import QResponseSpec._
 
-  type StrIO[A]  = Coproduct[Str, Task, A]
+  type StrIO[A] = Coproduct[Str, Task, A]
   type StrIOM[A] = Free[StrIO, A]
 
   def str(s: String): StrIOM[String] =

--- a/web/src/test/scala/quasar/api/services/DataServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/DataServiceSpec.scala
@@ -19,16 +19,13 @@ package quasar.api.services
 import quasar.Predef._
 import quasar.Data
 import quasar.DataArbitrary._
-import quasar.api._
-import quasar.api.ApiErrorEntityDecoder._
-import quasar.api.MessageFormat.JsonContentType
-import quasar.api.MessageFormatGen._
+import quasar.api._,
+  ApiErrorEntityDecoder._, MessageFormat.JsonContentType, MessageFormatGen._
 import quasar.api.matchers._
-import quasar.fs._
-import quasar.fs.PathArbitrary._
-import quasar.fp._
+import quasar.fp._, PathyCodecJson._
+import quasar.fp.free.{:+:}
 import quasar.fp.numeric._
-import quasar.fp.PathyCodecJson._
+import quasar.fs._, PathArbitrary._
 
 import argonaut.Json
 import argonaut.Argonaut._
@@ -60,8 +57,7 @@ class DataServiceSpec extends Specification with ScalaCheck with FileSystemFixtu
   import FileSystemFixture.{ReadWriteT, ReadWrites, amendWrites}
   import PathError.{pathExists, pathNotFound}
 
-  type Eff0[A] = Coproduct[FileSystemFailureF, FileSystem, A]
-  type Eff[A]  = Coproduct[Task, Eff0, A]
+  type Eff[A] = (Task :+: (FileSystemFailureF :+: FileSystem)#λ)#λ[A]
   type EffM[A] = Free[Eff, A]
 
   def effRespOr(fs: FileSystem ~> Task): Eff ~> ResponseOr =

--- a/web/src/test/scala/quasar/api/services/MetadataServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/MetadataServiceSpec.scala
@@ -17,16 +17,14 @@
 package quasar.api.services
 
 import quasar.Predef._
-import quasar.api._
-import quasar.api.matchers._
-import quasar.api.ApiErrorEntityDecoder._
 import quasar.{Variables, VariablesArbitrary}
+import quasar.api._, ApiErrorEntityDecoder._
+import quasar.api.matchers._
 import quasar.effect.KeyValueStore
-import quasar.fp.{liftMT, free}
+import quasar.fp.liftMT
+import quasar.fp.free
 import quasar.fp.prism._
-import quasar.fs._
-import quasar.fs.PathArbitrary._
-import quasar.fs.InMemory._
+import quasar.fs._, InMemory._, PathArbitrary._
 import quasar.fs.mount._
 import quasar.sql._
 

--- a/web/src/test/scala/quasar/api/services/RestApiSpecs.scala
+++ b/web/src/test/scala/quasar/api/services/RestApiSpecs.scala
@@ -19,7 +19,8 @@ package quasar.api.services
 import quasar.Predef._
 import quasar.api._
 import quasar.effect.{KeyValueStore, Failure}
-import quasar.fp.{free, liftMT, TaskRef}
+import quasar.fp.{liftMT, TaskRef}
+import quasar.fp.free, free.{:+:}
 import quasar.fs._
 import quasar.fs.mount._
 
@@ -34,9 +35,8 @@ import scalaz.concurrent.Task
 class RestApiSpecs extends Specification {
   import InMemory._
 
-  type Eff0[A] = Coproduct[FileSystemFailureF, MountingFileSystem, A]
-  type Eff1[A] = Coproduct[MountConfigsF, Eff0, A]
-  type Eff[A]  = Coproduct[Task, Eff1, A]
+  type Eff[A] =
+    (Task :+: (MountConfigsF :+: (FileSystemFailureF :+: MountingFileSystem)#λ)#λ)#λ[A]
 
   "OPTIONS" should {
     val mount = new (Mounting ~> Task) {

--- a/web/src/test/scala/quasar/api/services/query/QueryFixture.scala
+++ b/web/src/test/scala/quasar/api/services/query/QueryFixture.scala
@@ -17,9 +17,11 @@
 package quasar.api.services.query
 
 import quasar.Predef._
-import quasar._, api._, fp._, fs._
+import quasar.api._
+import quasar.fp._
+import quasar.fp.free.{:+:}
 import quasar.fp.numeric._
-import quasar.fs.InMemory._
+import quasar.fs._, InMemory._
 import quasar.sql._
 import quasar.sql.fixpoint._
 
@@ -32,8 +34,7 @@ import scalaz.concurrent.Task
 object queryFixture {
   import quasar.api.PathUtils.pathUri
 
-  type Eff0[A] = Coproduct[FileSystemFailureF, FileSystem, A]
-  type Eff[A]  = Coproduct[Task, Eff0, A]
+  type Eff[A] = (Task :+: (FileSystemFailureF :+: FileSystem)#λ)#λ[A]
 
   case class Query(
     q: String,


### PR DESCRIPTION
This has allowed a few things so far:

- removing `implicitly` from our Predef,
- replacing `traverseU`, etc. with `traverse`, and
- removing various implicit parameter lists from calls.

There are additional improvements we can make with this, but we should
address them as we come across them.

Unfortunately, also ran into an ambiguous `monadMTMAB` implicit, so
added TODOs around getting rid of that.

Also,

- added a `RenderTree` instance to resolve natural transformation
  instances,
- replaced some `.map(...).sequence` with `.traverse(...)`,
- updated Matryoshka to 0.10.2 (which also has the SI-2712 fix), and
- replaced `CoproductN` with `:+:` syntax (which seems to infer better
  for some reason).