### PR TITLE
Add IfUndefined (??) and Range (..) binops to SQL².

### DIFF
--- a/CHANGELOG/feature.md
+++ b/CHANGELOG/feature.md
@@ -1,0 +1,2 @@
+- added “if undefined’ (`??`) and “range” (`..`) operators to SQL²
+- restored short-circuiting of constant plans

--- a/core/src/main/scala/quasar/sql/ast.scala
+++ b/core/src/main/scala/quasar/sql/ast.scala
@@ -134,6 +134,8 @@ sealed abstract class BinaryOperator(val sql: String) {
   override def toString = sql
 }
 
+final case object IfUndefined  extends BinaryOperator("??")
+final case object Range        extends BinaryOperator("..")
 final case object Or           extends BinaryOperator("or")
 final case object And          extends BinaryOperator("and")
 final case object Eq           extends BinaryOperator("=")

--- a/core/src/main/scala/quasar/std/relations.scala
+++ b/core/src/main/scala/quasar/std/relations.scala
@@ -145,6 +145,19 @@ trait RelationsLib extends Library {
     },
     basicUntyper)
 
+  val IfUndefined = BinaryFunc(
+    Mapping,
+    "(??)",
+    "This is the only way to recognize an undefined value. If the first argument is undefined, return the second argument, otherwise, return the first.",
+    Type.Top,
+    Func.Input2(Type.Top, Type.Top),
+    noSimplification,
+    partialTyper {
+      case Sized(Type.Bottom, fallback) => fallback
+      case Sized(value,       fallback) => value ⨿ fallback
+    },
+    partialUntyper[nat._2] { case t => Func.Input2(t, t) })
+
   val And = BinaryFunc(
     Mapping,
     "(AND)",
@@ -257,7 +270,7 @@ trait RelationsLib extends Library {
   def unaryFunctions: List[GenericFunc[nat._1]] = Not :: Nil
 
   def binaryFunctions: List[GenericFunc[nat._2]] =
-    Eq :: Neq :: Lt :: Lte :: Gt :: Gte :: And :: Or :: Coalesce :: Nil
+    Eq :: Neq :: Lt :: Lte :: Gt :: Gte :: IfUndefined :: And :: Or :: Coalesce :: Nil
 
   def ternaryFunctions: List[GenericFunc[nat._3]] = Between :: Cond :: Nil
 

--- a/core/src/main/scala/quasar/std/structural.scala
+++ b/core/src/main/scala/quasar/std/structural.scala
@@ -199,6 +199,8 @@ trait StructuralLib extends Library {
     Func.Input2(AnyArray, Int),
     noSimplification,
     partialTyperV[nat._2] {
+      case Sized(v1, Const(Data.Set(elems))) =>
+        elems.traverse(e => v1.arrayElem(Const(e))).map(Coproduct(_))
       case Sized(v1, v2) => v1.arrayElem(v2)
     },
     basicUntyper)

--- a/core/src/test/scala/quasar/DataArbitrary.scala
+++ b/core/src/test/scala/quasar/DataArbitrary.scala
@@ -30,7 +30,6 @@ trait DataArbitrary {
       Gen.oneOf(
         Gen.listOf(for { c <- Gen.alphaChar; d <- simpleData } yield c.toString -> d).map(t => Data.Obj(ListMap(t: _*))),
         Gen.listOf(simpleData).map(Data.Arr(_)),
-        Gen.listOf(simpleData).map(Data.Set(_)),
         // Tricky cases:
         Gen.const(Data.Obj(ListMap("$date" -> Data.Str("Jan 1")))),
         SafeInt.map(x =>

--- a/core/src/test/scala/quasar/fs/mount/view.scala
+++ b/core/src/test/scala/quasar/fs/mount/view.scala
@@ -135,7 +135,7 @@ class ViewFSSpec extends Specification with ScalaCheck with TreeMatchers {
     "translate simple read to query" in {
       val p = rootDir[Sandboxed] </> dir("view") </> file("simpleZips")
       val expr = parseExpr("select * from zips")
-      val lp = queryPlan(expr, Variables.empty).run.run._2.toOption.get
+      val lp = queryPlan(expr, Variables.empty, 0L, None).run.run._2.toOption.get
 
       val views = Map(p -> expr)
 
@@ -146,7 +146,7 @@ class ViewFSSpec extends Specification with ScalaCheck with TreeMatchers {
       } yield ()).run
 
       val exp = (for {
-        h   <- query.unsafe.eval(lp)
+        h   <- query.unsafe.eval(lp.valueOr(_ => scala.sys.error("impossible constant plan")))
         _   <- query.transforms.fsErrToExec(
                 query.unsafe.more(h))
         _   <- query.transforms.fsErrToExec(

--- a/core/src/test/scala/quasar/types.scala
+++ b/core/src/test/scala/quasar/types.scala
@@ -733,8 +733,11 @@ class TypesSpec extends Specification with ScalaCheck with ValidationMatchers wi
     }
 
     "encode constant types as their data encoding" ! prop { data: Data =>
-      val exp = DataCodec.Precise.encode(data) map (jd => Json((("Const", jd))))
-      Right(typJson(Const(data))) must_== exp.toEither
+      val exp = DataCodec.Precise.encode(data)
+      exp.isRight ==> {
+        Right(typJson(Const(data))) must_==
+          exp.map(jd => Json((("Const", jd)))).toEither
+      }
     }
 
     "encode arrays as an array of types" ! prop { types: List[Type] =>

--- a/it/src/main/resources/tests/ifUndefined.test
+++ b/it/src/main/resources/tests/ifUndefined.test
@@ -1,0 +1,17 @@
+{
+    "name": "handle undefined values",
+    "backends": { "mongodb_read_only": "pending" },
+    "data": "zips.data",
+    "query": "select foo ?? pop, city ?? false from zips",
+    "predicate": "containsAtLeast",
+    "expected": [{ "0": 15338.0, "1": "AGAWAM"       },
+                 { "0": 36963.0, "1": "CUSHMAN"      },
+                 { "0":  4546.0, "1": "BARRE"        },
+                 { "0": 10579.0, "1": "BELCHERTOWN"  },
+                 { "0":  1240.0, "1": "BLANDFORD"    },
+                 { "0":  3706.0, "1": "BRIMFIELD"    },
+                 { "0":  1688.0, "1": "CHESTER"      },
+                 { "0":   177.0, "1": "CHESTERFIELD" },
+                 { "0": 23396.0, "1": "CHICOPEE"     },
+                 { "0": 31495.0, "1": "CHICOPEE"     }]
+}

--- a/it/src/test/scala/quasar/ResultFileQueryRegressionSpec.scala
+++ b/it/src/test/scala/quasar/ResultFileQueryRegressionSpec.scala
@@ -43,7 +43,7 @@ class ResultFileQueryRegressionSpec
 
     for {
       tmpFile <- hoistM(manage.tempFile(DataDir)).liftM[Process]
-      outFile <- query.executeQuery(expr, vars, tmpFile).liftM[Process]
+      outFile <- fsQ.executeQuery(expr, vars, tmpFile).liftM[Process]
       cleanup =  hoistM(manage.delete(tmpFile)).whenM(outFile ≟ tmpFile)
       data    <- read.scanAll(outFile)
                    .translate(hoistM)

--- a/it/src/test/scala/quasar/StreamingQueryRegressionSpec.scala
+++ b/it/src/test/scala/quasar/StreamingQueryRegressionSpec.scala
@@ -19,7 +19,10 @@ package quasar
 import quasar.regression._
 import quasar.sql.Sql
 
-import matryoshka.Fix
+import scala.{None}
+
+import eu.timepit.refined.auto._
+import matryoshka.{Fix}
 
 class StreamingQueryRegressionSpec
   extends QueryRegressionTest[FileSystemIO](QueryRegressionTest.externalFS) {
@@ -27,5 +30,5 @@ class StreamingQueryRegressionSpec
   val suiteName = "Streaming Queries"
 
   def queryResults(expr: Fix[Sql], vars: Variables) =
-    query.evaluateQuery(expr, vars)
+    fsQ.evaluateQuery(expr, vars, 0L, None)
 }

--- a/it/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
@@ -22,6 +22,7 @@ import quasar._
 import quasar.fs._
 import quasar.fs.mount.MountConfig
 import quasar.fp._
+import quasar.main.FilesystemQueries
 import quasar.physical.mongodb.Collection
 import quasar.regression._
 import quasar.specs2._
@@ -56,6 +57,7 @@ class MongoDbFileSystemSpec
   val query  = QueryFile.Ops[FileSystemIO]
   val write  = WriteFile.Ops[FileSystemIO]
   val manage = ManageFile.Ops[FileSystemIO]
+  val fsQ = new FilesystemQueries[FileSystemIO]
 
   type X[A] = Process[manage.M, A]
 
@@ -241,7 +243,7 @@ class MongoDbFileSystemSpec
             def check0(expr: Fix[Sql]) =
               (run(query.fileExists(file)).unsafePerformSync ==== false) and
               (errP.getOption(
-                runExec(query.executeQuery(expr, Variables.fromMap(Map()), out))
+                runExec(fsQ.executeQuery(expr, Variables.fromMap(Map()), out))
                   .run.value.unsafePerformSync
               ) must beSome(file))
 

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -20,6 +20,7 @@ import quasar.Predef._
 import quasar._
 import quasar.fp._
 import quasar.fs._
+import quasar.main.FilesystemQueries
 import quasar.fs.mount.{MountConfig, Mounts, hierarchical}
 import quasar.physical.mongodb.fs.MongoDBFsType
 import quasar.sql, sql.{Query, Sql}
@@ -72,6 +73,7 @@ abstract class QueryRegressionTest[S[_]: Functor](
   val query  = QueryFile.Ops[S]
   val write  = WriteFile.Ops[S]
   val manage = ManageFile.Ops[S]
+  val fsQ    = new FilesystemQueries[S]
 
   /** A name to identify the suite in test output. */
   def suiteName: String

--- a/main/src/main/scala/quasar/main/FilesystemQueries.scala
+++ b/main/src/main/scala/quasar/main/FilesystemQueries.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.main
+
+import quasar.Predef._
+import quasar.{Data, queryPlan, Variables}
+import quasar.fp.numeric._
+import quasar.fs._
+import quasar.sql.Sql
+
+import eu.timepit.refined.auto._
+import matryoshka.Fix
+import scalaz.{Failure => _, Lens => _, _}, Scalaz._
+import scalaz.stream.Process
+
+class FilesystemQueries[S[_]](implicit val Q: QueryFile.Ops[S]) {
+  import Q.transforms._
+
+  // TODO[scalaz]: Shadow the scalaz.Monad.monadMTMAB SI-2712 workaround
+  import EitherT.eitherTMonad
+
+  /** Returns the source of values from the result of executing the given
+    * SQL^2 query.
+    */
+  def evaluateQuery(
+    query: Fix[Sql], vars: Variables, off: Natural, lim: Option[Positive]):
+      Process[CompExecM, Data] =
+    queryPlan(query, vars, off, lim).sequenceU.fold(
+      Process(_: _*),
+      compToCompExec(_)
+        .liftM[Process]
+        .flatMap(Q.evaluate(_).translate[CompExecM](execToCompExec)))
+
+  /** Returns the path to the result of executing the given SQL^2 query
+    * using the given output file if possible.
+    */
+  def executeQuery(
+    query: Fix[Sql], vars: Variables, out: AFile)(
+    implicit W: WriteFile.Ops[S], MF: ManageFile.Ops[S]):
+      CompExecM[AFile] =
+    compToCompExec(queryPlan(query, vars, 0L, None))
+      .flatMap(lp => execToCompExec(lp.fold(
+        d => fsErrToExec(W.saveThese(out, d.toVector).flatMap(fse => EitherT.fromDisjunction(fse.headOption <\/ out))),
+        Q.execute(_, out))))
+}

--- a/main/src/main/scala/quasar/main/prettify.scala
+++ b/main/src/main/scala/quasar/main/prettify.scala
@@ -85,7 +85,6 @@ object Prettify {
         }
       data match {
         case Data.Arr(value) =>  \/-(value.zipWithIndex.flatMap { case (c, i) => prepend(IndexSeg(i), c) })
-        case Data.Set(value) =>  \/-(value.zipWithIndex.flatMap { case (c, i) => prepend(IndexSeg(i), c) })
         case Data.Obj(value) =>  \/-(value.toList.flatMap { case (f, c) => prepend(FieldSeg(f), c) })
         case _               => -\/ (data)
       }

--- a/main/src/test/scala/quasar/main/prettify.scala
+++ b/main/src/test/scala/quasar/main/prettify.scala
@@ -63,13 +63,6 @@ class PrettifySpecs extends Specification with ScalaCheck with DisjunctionMatche
         Path(FieldSeg("arr"), IndexSeg(1)) -> Data.Str("b"))
     }
 
-    "find set indices" in {
-      val data = Data.Obj(ListMap("set" -> Data.Set(List(Data.Str("a"), Data.Str("b")))))
-      flatten(data) must_== ListMap(
-        Path(FieldSeg("set"), IndexSeg(0)) -> Data.Str("a"),
-        Path(FieldSeg("set"), IndexSeg(1)) -> Data.Str("b"))
-    }
-
     "find nested array indices" in {
       val data = Data.Obj(ListMap(
         "arr" -> Data.Arr(List(
@@ -244,7 +237,6 @@ class PrettifySpecs extends Specification with ScalaCheck with DisjunctionMatche
     def isFlat(data: Data) = data match {
       case Data.Obj(_) => false
       case Data.Arr(_) => false
-      case Data.Set(_) => false
       case _ => true
     }
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/bsoncodec.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/bsoncodec.scala
@@ -38,7 +38,7 @@ object BsonCodec {
 
       case Data.Arr(value) => value.traverse(fromData).map(Bson.Arr.apply _)
 
-      case Data.Set(value) => value.traverse(fromData).map(Bson.Arr.apply _)
+      case Data.Set(value) => \/ left (NonRepresentableData(data))
 
       case Data.Timestamp(value) => \/ right (Bson.Date(value))
 

--- a/mongodb/src/test/scala/quasar/physical/mongodb/bson.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/bson.scala
@@ -79,14 +79,14 @@ class BsonSpecs extends Specification with ScalaCheck {
 
     "correspond to Data.toJs where toData is defined" ! prop { (bson: Bson) =>
       val data = BsonCodec.toData(bson)
-      (data != Data.NA) ==> {
+      (data != Data.NA && !data.isInstanceOf[Data.Set]) ==> {
         data match {
           case Data.Int(x) =>
             // NB: encoding int as Data loses size info
             (bson.toJs must_== jscore.Call(jscore.ident("NumberInt"), List(jscore.Literal(Js.Str(x.shows)))).toJs) or
               (bson.toJs must_== jscore.Call(jscore.ident("NumberLong"), List(jscore.Literal(Js.Str(x.shows)))).toJs)
           case _ =>
-            bson.toJs must_== data.toJs.toJs
+            bson.toJs.some must_== data.toJs.map(_.toJs)
         }
       }
     }.setGen(simpleGen)

--- a/mongodb/src/test/scala/quasar/physical/mongodb/bsoncodec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/bsoncodec.scala
@@ -85,18 +85,18 @@ class BsonCodecSpecs extends Specification with ScalaCheck with DisjunctionMatch
       // Which is to say, every Bson value that results from conversion
       // can be converted to Data and back to Bson, recovering the same
       // Bson value.
-      fromData(data).fold(
-        err => scala.sys.error(err.toString),
-        bson => fromData(toData(bson)) must beRightDisjunction(bson))
+      val v = fromData(data)
+      v.isRight ==> {
+        v.flatMap(bson => fromData(toData(bson))) must_== v
+      }
     }
   }
 
   "round trip to repr (all Data types)" ! prop { (data: Data) =>
-    BsonCodec.fromData(data).fold(
-      err => scala.sys.error(err.message),
-      bson => {
-        val wrapped = Bson.Doc(ListMap("value" -> bson))
-        Bson.fromRepr(wrapped.repr) must_== wrapped
-      })
+      val v = fromData(data)
+      v.isRight ==> {
+        val wrapped = v.map(bson => Bson.Doc(ListMap("value" -> bson)))
+        wrapped.map(w => Bson.fromRepr(w.repr)) must_== wrapped
+      }
   }
 }

--- a/web/src/main/scala/quasar/api/services/data.scala
+++ b/web/src/main/scala/quasar/api/services/data.scala
@@ -51,7 +51,7 @@ object data {
     case req @ GET -> AsPath(path) :? Offset(offsetParam) +& Limit(limitParam) =>
       respond_((offsetOrInvalid(offsetParam) |@| limitOrInvalid(limitParam)) { (offset, limit) =>
         val requestedFormat = MessageFormat.fromAccept(req.headers.get(Accept))
-        download[S](requestedFormat, path, offset.getOrElse(0L), limit)
+        download[S](requestedFormat, path, offset, limit)
       })
 
     case req @ POST -> AsFilePath(path) =>

--- a/web/src/main/scala/quasar/api/services/package.scala
+++ b/web/src/main/scala/quasar/api/services/package.scala
@@ -22,6 +22,7 @@ import quasar.fs._
 import quasar.fp.numeric._
 
 import argonaut._, Argonaut._
+import eu.timepit.refined.auto._
 import org.http4s._
 import org.http4s.dsl._
 import org.http4s.headers.`Content-Type`
@@ -52,8 +53,8 @@ package object services {
 
   def offsetOrInvalid(
     offsetParam: Option[ValidationNel[ParseFailure, Natural]]
-  ): ApiError \/ Option[Natural] =
-    valueOrInvalid("offset", offsetParam)
+  ): ApiError \/ Natural =
+    valueOrInvalid("offset", offsetParam).map(_.getOrElse(0L))
 
   def valueOrInvalid[F[_]: Traverse, A](
     paramName: String,

--- a/web/src/main/scala/quasar/api/services/query/package.scala
+++ b/web/src/main/scala/quasar/api/services/query/package.scala
@@ -18,7 +18,6 @@ package quasar.api.services
 
 import quasar.Predef._
 import quasar._, api._
-import quasar.fp._
 import quasar.fp.numeric._
 import quasar.sql.{Sql, Query}
 
@@ -64,7 +63,7 @@ package object query {
     req: Request,
     offset: Option[ValidationNel[ParseFailure, Natural]],
     limit: Option[ValidationNel[ParseFailure, Positive]]):
-      ApiError \/ (Fix[Sql], Option[Natural], Option[Positive]) =
+      ApiError \/ (Fix[Sql], Natural, Option[Positive]) =
     for {
       dir <- decodedDir(req.uri.path)
       qry <- queryParam(req.multiParams)
@@ -78,14 +77,6 @@ package object query {
 
   def requestVars(req: Request) = Variables(req.params.collect {
     case (k, v) if k.startsWith(VarPrefix) => (VarName(k.substring(VarPrefix.length)), VarValue(v)) })
-
-  def addOffsetLimit[T[_[_]]: Corecursive](query: T[Sql], offset: Option[Natural], limit: Option[Positive]):
-      T[Sql] = {
-    val skipped = offset.fold(
-      query)(
-      o => sql.binop(query, sql.intLiteral[T[Sql]](o.get).embed, sql.Offset).embed)
-    limit.fold(skipped)(l => sql.binop(skipped, sql.intLiteral[T[Sql]](l.get).embed, sql.Limit).embed)
-  }
 
   private val VarPrefix = "var."
 }

--- a/web/src/test/scala/quasar/api/MessageFormatSpec.scala
+++ b/web/src/test/scala/quasar/api/MessageFormatSpec.scala
@@ -115,10 +115,11 @@ class MessageFormatSpec extends org.specs2.mutable.Specification {
       val simpleData = List(
         Data.Obj(ListMap("a" -> Data.Int(1))),
         Data.Obj(ListMap("b" -> Data.Int(2))),
-        Data.Obj(ListMap("c" -> Data.Set(List(Data.Int(3))))))
+        Data.Obj(ListMap("c" -> Data.Arr(List(Data.Int(3))))))
       val simpleExpected = List("a,b,c[0]", "1,,", ",2,", ",,3").mkString("", "\r\n", "\r\n")
       def test(data: List[Data], expectedEncoding: String, format: Csv) =
         format.encode(Process.emitAll(data): Process[Task,Data]).runLog.unsafePerformSync.mkString("") must_== expectedEncoding
+
       "simple" >> test(
         data = simpleData,
         expectedEncoding = simpleExpected,

--- a/web/src/test/scala/quasar/api/services/query/ExecuteServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/query/ExecuteServiceSpec.scala
@@ -33,6 +33,7 @@ import quasar.sql.Sql
 
 import argonaut.{Json => AJson, _}, Argonaut._
 import eu.timepit.refined.api.Refined
+import eu.timepit.refined.auto._
 import eu.timepit.refined.numeric.{NonNegative, Positive => RPositive}
 import eu.timepit.refined.scalacheck.numeric._
 import matryoshka.Fix
@@ -128,7 +129,7 @@ class ExecuteServiceSpec extends Specification with FileSystemFixture with Scala
   def toLP(q: String, vars: Variables): Fix[LogicalPlan] =
       sql.fixParser.parse(sql.Query(q)).fold(
         error => scala.sys.error(s"could not compile query: $q due to error: $error"),
-        ast => quasar.queryPlan(ast,vars).run.value.toOption.get)
+        ast => quasar.queryPlan(ast, vars, 0L, None).run.value.toOption.get).valueOr(_ => scala.sys.error("unsupported constant plan"))
 
   "Execute" should {
     "execute a simple query" >> {
@@ -264,7 +265,7 @@ class ExecuteServiceSpec extends Specification with FileSystemFixture with Scala
           err => scala.sys.error("Parse failed: " + err.toString))
 
         val phases: PhaseResults =
-          queryPlan(expr, Variables.empty).run.written
+          queryPlan(expr, Variables.empty, 0L, None).run.written
 
         post[ApiError](fileSystem)(
           path = fs.parent,
@@ -285,7 +286,7 @@ class ExecuteServiceSpec extends Specification with FileSystemFixture with Scala
           err => scala.sys.error("Parse failed: " + err.toString))
 
         val phases: PhaseResults =
-          queryPlan(expr, Variables.empty).run.written
+          queryPlan(expr, Variables.empty, 0L, None).run.written
 
         post[ApiError](failingExecPlan(msg, fileSystem))(
           path = rootDir,


### PR DESCRIPTION
- More squeezing `Set` out of `Data`. It’s now an error if Data.Set gets
to Mongo.
- remove duplicated planning in `compileToLP`
- Restore short-circuiting of constant plans.
- Decouple `Sql` from `QueryFile` algebra
- unify handling of offset/limit, and make it frontend-agnostic
- move planner tests on constants to compiler tests