### PR TITLE
A little cleanup

### DIFF
--- a/CHANGELOG/bugfix.md
+++ b/CHANGELOG/bugfix.md
@@ -1,0 +1,2 @@
+- remove a couple of unused, redundant utility functions
+- convert to ops on String parseBigInt/BigDecimal to be consistent with scalaz

--- a/build.sbt
+++ b/build.sbt
@@ -206,7 +206,7 @@ lazy val main = project
   .settings(name := "quasar-main-internal")
   .dependsOn(mongodb % "test->test;compile->compile")
   .settings(oneJarSettings: _*)
-  .enablePlugins(AutomateHeaderPlugin, BuildInfoPlugin)
+  .enablePlugins(AutomateHeaderPlugin)
 
 // filesystems (backends)
 
@@ -214,7 +214,7 @@ lazy val mongodb = project
   .settings(name := "quasar-mongodb-internal")
   .dependsOn(core % "test->test;compile->compile")
   .settings(oneJarSettings: _*)
-  .enablePlugins(AutomateHeaderPlugin, BuildInfoPlugin)
+  .enablePlugins(AutomateHeaderPlugin)
 
 // frontends
 

--- a/core/src/main/scala/quasar/fp/package.scala
+++ b/core/src/main/scala/quasar/fp/package.scala
@@ -19,6 +19,8 @@ package quasar
 import quasar.Predef._
 import quasar.RenderTree.ops._
 
+import java.lang.NumberFormatException
+
 import monocle.{Lens, Prism}
 import scalaz.{Lens => _, _}, Liskov._, Scalaz._
 import scalaz.stream._
@@ -339,6 +341,19 @@ trait SKI {
 }
 object SKI extends SKI
 
+trait StringOps {
+  final implicit class StringOps(val s: String) {
+    // NB: see scalaz's `parseInt`, et al.
+    // These will appear in scalaz 7.3.
+
+    def parseBigInt: Validation[NumberFormatException, BigInt] =
+      Validation.fromTryCatchThrowable[BigInt, NumberFormatException](BigInt(s))
+
+    def parseBigDecimal: Validation[NumberFormatException, BigDecimal] =
+      Validation.fromTryCatchThrowable[BigDecimal, NumberFormatException](BigDecimal(s))
+  }
+}
+
 package object fp
     extends TreeInstances
     with ListMapInstances
@@ -352,7 +367,8 @@ package object fp
     with ProcessOps
     with QFoldableOps
     with PrismInstances
-    with SKI {
+    with SKI
+    with StringOps {
   sealed trait Polymorphic[F[_], TC[_]] {
     def apply[A: TC]: TC[F[A]]
   }
@@ -399,18 +415,6 @@ package object fp
     }
     (as.reverse, bs.reverse)
   }
-
-  def parseInt(str: String): Option[Int] =
-    \/.fromTryCatchNonFatal(str.toInt).toOption
-
-  def parseBigInt(str: String): Option[BigInt] =
-    \/.fromTryCatchNonFatal(BigInt(str)).toOption
-
-  def parseDouble(str: String): Option[Double] =
-    \/.fromTryCatchNonFatal(str.toDouble).toOption
-
-  def parseBigDecimal(str: String): Option[BigDecimal] =
-    \/.fromTryCatchNonFatal(BigDecimal(str)).toOption
 
   /** Accept a value (forcing the argument expression to be evaluated for its
     * effects), and then discard it, returning Unit. Makes it explicit that

--- a/it/src/test/scala/quasar/regression/PredicateSpec.scala
+++ b/it/src/test/scala/quasar/regression/PredicateSpec.scala
@@ -282,10 +282,9 @@ class PredicateSpec extends Specification with ScalaCheck {
     }
 
     "reject with any leading" ! prop { (a: Vector[Json], b: Vector[Json], c: Vector[Json]) =>
-      (a.nonEmpty && b != a.take(b.length) && b.nonEmpty) ==> {
-        val expected = b
-        val result = a ++ b ++ c
-
+      val expected = b
+      val result = a ++ b ++ c
+      (a.nonEmpty && b.nonEmpty && result.take(b.length) != b) ==> {
         run(pred, expected, result) must beLike { case Failure(msg, _, _, _) => msg must contain("does not match") }
       }
     }

--- a/main/src/main/scala/quasar/main/prettify.scala
+++ b/main/src/main/scala/quasar/main/prettify.scala
@@ -150,11 +150,9 @@ object Prettify {
     else if (str == "true") Some(Data.Bool(true))
     else if (str == "false") Some(Data.Bool(false))
     else
-      parseBigInt(str).fold(
-        parseBigDecimal(str).fold(
-          DataCodec.Readable.decode(Json.jString(str)).toOption)(
-          x => Some(Data.Dec(x))))(
-        n => Some(Data.Int(n)))
+      str.parseBigInt.toOption.map(Data.Int(_)) orElse
+        str.parseBigDecimal.toOption.map(Data.Dec(_)) orElse
+          DataCodec.Readable.decode(Json.jString(str)).toOption
   }
 
   /**


### PR DESCRIPTION
- delete `parseInt` and `parseDouble`; they're provided by scalaz
- recast `parseBigInt` and `parseBigDecimal` as ops on String, to parallel scalaz
