### PR TITLE
Aggregate all subprojects in `root`.

### DIFF
--- a/CHANGELOG/bugfix.md
+++ b/CHANGELOG/bugfix.md
@@ -1,0 +1,1 @@
+- restore coverage and full testing to the build

--- a/build.sbt
+++ b/build.sbt
@@ -145,7 +145,7 @@ lazy val oneJarSettings =
 
 lazy val root = project.in(file("."))
   .settings(commonSettings: _*)
-  .aggregate(repl, web, it)
+  .aggregate(core, main, mongodb, repl, web, it)
   .enablePlugins(AutomateHeaderPlugin)
 
 lazy val core = project


### PR DESCRIPTION
This is stolen from @drostron’s #1191, in the hopes that it fixes coverage.