### PR TITLE
Remove mountingLens from ConfigOps

### DIFF
--- a/CHANGELOG/bugfix.md
+++ b/CHANGELOG/bugfix.md
@@ -1,0 +1,1 @@
+Remove mountingLens from ConfigOps

--- a/core/src/main/scala/quasar/config/CoreConfig.scala
+++ b/core/src/main/scala/quasar/config/CoreConfig.scala
@@ -23,11 +23,10 @@ import monocle.macros.Lenses
 
 @Lenses final case class CoreConfig(mountings: MountingsConfig)
 
-object CoreConfig extends ConfigOps[CoreConfig] {
-
-  val mountingsLens = CoreConfig.mountings
-
-  val default = CoreConfig(MountingsConfig.empty)
+object CoreConfig {
+  implicit val configOps = new ConfigOps[CoreConfig] {
+    val default = CoreConfig(MountingsConfig.empty)
+  }
 
   implicit val codec = casecodec1(CoreConfig.apply, CoreConfig.unapply)("mountings")
 }

--- a/core/src/test/scala/quasar/config/ConfigSpec.scala
+++ b/core/src/test/scala/quasar/config/ConfigSpec.scala
@@ -26,12 +26,12 @@ import org.specs2.scalaz._
 import pathy._, Path._
 import scalaz._, concurrent.Task, Scalaz._
 
-abstract class ConfigSpec[Config: CodecJson] extends Specification with DisjunctionMatchers {
+abstract class ConfigSpec[Config: CodecJson: ConfigOps] extends Specification with DisjunctionMatchers {
   import FsPath._, ConfigError._
 
   sequential
 
-  def configOps: ConfigOps[Config]
+  def configOps = ConfigOps[Config]
   def sampleConfig(uri: ConnectionUri): Config
 
   val host = "mongodb://foo:bar@mongo.example.com:12345"

--- a/it/src/test/scala/quasar/server/ServiceSpec.scala
+++ b/it/src/test/scala/quasar/server/ServiceSpec.scala
@@ -37,12 +37,12 @@ import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 
 class ServiceSpec extends mutable.Specification {
-  implicit val configOps: ConfigOps[WebConfig] = WebConfig
+  val configOps = ConfigOps[WebConfig]
 
   val client = org.http4s.client.blaze.defaultClient
 
   def withServer[A]
-    (port: Int = 8888, webConfig: WebConfig = WebConfig.default)
+    (port: Int = 8888, webConfig: WebConfig = configOps.default)
     (f: Uri => Task[A])
     : String \/ A = {
     val uri = Uri(authority = Some(Authority(port = Some(port))))
@@ -68,7 +68,7 @@ class ServiceSpec extends mutable.Specification {
     "POST view" in {
       val port = Http4sUtils.anyAvailablePort.unsafePerformSync
 
-      val r = withServer(port, WebConfig.default) { baseUri: Uri =>
+      val r = withServer(port, configOps.default) { baseUri: Uri =>
         client.fetch(
           Request(
               uri = baseUri / "mount" / "fs",
@@ -89,7 +89,7 @@ class ServiceSpec extends mutable.Specification {
     "PUT view" in {
       val port = Http4sUtils.anyAvailablePort.unsafePerformSync
 
-      val r = withServer(port, WebConfig.default) { baseUri: Uri =>
+      val r = withServer(port, configOps.default) { baseUri: Uri =>
         client.fetch(
           Request(
               uri = baseUri / "mount" / "fs" / "a",
@@ -115,7 +115,7 @@ class ServiceSpec extends mutable.Specification {
 
       val webConfig = WebConfig.mountings.set(
         MountingsConfig(Map(srcPath -> viewConfig)))(
-        WebConfig.default)
+        configOps.default)
 
       val r = withServer(port, webConfig) { baseUri: Uri =>
         client.fetch(
@@ -164,7 +164,7 @@ class ServiceSpec extends mutable.Specification {
       val webConfig = WebConfig.mountings.set(
         MountingsConfig(Map(
           srcPath -> viewConfig) ++ fileSystemConfigs))(
-        WebConfig.default)
+        configOps.default)
 
       val r = withServer(port, webConfig) { baseUri: Uri =>
         client.fetch(
@@ -194,7 +194,7 @@ class ServiceSpec extends mutable.Specification {
       val webConfig = WebConfig.mountings.set(
         MountingsConfig(Map(
           (srcPath </> file("view")) -> viewConfig) ++ fileSystemConfigs))(
-        WebConfig.default)
+        configOps.default)
 
       val r = withServer(port, webConfig) { baseUri: Uri =>
         client.fetch(

--- a/main/src/main/scala/quasar/main/package.scala
+++ b/main/src/main/scala/quasar/main/package.scala
@@ -18,10 +18,10 @@ package quasar
 
 import quasar.Predef._
 
-import quasar.config.{writeConfig, ConfigOps, FsFile}
+import quasar.config.ConfigOps
 import quasar.effect._
 import quasar.fp._
-import quasar.fp.free.{:+:}
+import quasar.fp.free.:+:
 import quasar.fs._
 import quasar.fs.mount._
 import quasar.fs.mount.hierarchical._
@@ -195,14 +195,8 @@ package object main {
       evalNT[Task, Map[APath, MountConfig]](Map()) compose interpret
     }
 
-    def write[C: EncodeJson]
-      (ref: TaskRef[C], loc: Option[FsFile])
-      (implicit configOps: ConfigOps[C])
-      : MountConfigs ~> Task =
-      writeConfig(configOps)(ref, loc)
-
-    /** Interprets `MountConfigsF`, persisting changes to a config file. */
-    def durableFile[C: EncodeJson](write: MountConfigs ~> Task): MntCfgsIO ~> Task =
+    /** Interprets `MountConfigsF`, persisting changes via the write interpreter. */
+    def durable[C: EncodeJson](write: MountConfigs ~> Task): MntCfgsIO ~> Task =
       free.interpret2[MountConfigsF, Task, Task](
         Coyoneda.liftTF[MountConfigs, Task](write),
         NaturalTransformation.refl)

--- a/main/src/test/scala/quasar/config/CoreConfigSpec.scala
+++ b/main/src/test/scala/quasar/config/CoreConfigSpec.scala
@@ -30,8 +30,6 @@ import pathy.Path._
 class CoreConfigSpec extends ConfigSpec[CoreConfig] with ScalaCheck {
   import CoreConfigArbitrary._
 
-  def configOps: ConfigOps[CoreConfig] = CoreConfig
-
   def sampleConfig(uri: ConnectionUri): CoreConfig = {
     CoreConfig(MountingsConfig(Map(
       rootDir -> MountConfig.fileSystemConfig(MongoDBFsType, uri)

--- a/web/src/main/scala/quasar/config/WebConfig.scala
+++ b/web/src/main/scala/quasar/config/WebConfig.scala
@@ -23,11 +23,11 @@ import monocle._, macros.Lenses
 
 @Lenses final case class WebConfig(server: ServerConfig, mountings: MountingsConfig)
 
-object WebConfig extends ConfigOps[WebConfig] {
+object WebConfig {
+  implicit val configOps: ConfigOps[WebConfig] = new ConfigOps[WebConfig] {
+    val default = WebConfig(ServerConfig(ServerConfig.DefaultPort), MountingsConfig.empty)
+  }
 
   implicit val codecJson: CodecJson[WebConfig] =
     casecodec2(WebConfig.apply, WebConfig.unapply)("server", "mountings")
-  val mountingsLens = WebConfig.mountings
-
-  val default = WebConfig(ServerConfig(ServerConfig.DefaultPort), MountingsConfig.empty)
 }

--- a/web/src/test/scala/quasar/config/WebConfigSpec.scala
+++ b/web/src/test/scala/quasar/config/WebConfigSpec.scala
@@ -25,8 +25,6 @@ import pathy.Path._
 
 class WebConfigSpec extends ConfigSpec[WebConfig] {
 
-  def configOps: ConfigOps[WebConfig] = WebConfig
-
   def sampleConfig(uri: ConnectionUri): WebConfig = WebConfig(
     server = ServerConfig(92),
     mountings = MountingsConfig(Map(


### PR DESCRIPTION
- Motivated by downstream needs for SD-1667
- Also brings `ConfigOps` closer to its typeclass disposition