### PR TITLE
Revert back to hand-nested effect type aliases

### DIFF
--- a/CHANGELOG/bugfix.md
+++ b/CHANGELOG/bugfix.md
@@ -1,0 +1,1 @@
+- Revert effect types back to hand nesting as the :+: syntax slows down implicit search considerably

--- a/core/src/main/scala/quasar/config/writeConfig.scala
+++ b/core/src/main/scala/quasar/config/writeConfig.scala
@@ -25,7 +25,7 @@ import quasar.fs.mount._
 
 import argonaut.EncodeJson
 import monocle.Lens
-import scalaz.{Lens => _, :+: => _, _}
+import scalaz.{Lens => _, _}
 import scalaz.concurrent.Task
 
 /** Interpreter providing access to configuration, based on some concrete Config type. */
@@ -39,7 +39,7 @@ object writeConfig {
     type ConfigRef[A]  = AtomicRef[Cfg, A]
     type ConfigRefM[A] = Free[ConfigRef, A]
 
-    type ConfigRefPlusTask[A]  = (ConfigRef :+: Task)#λ[A]
+    type ConfigRefPlusTask[A]  = Coproduct[ConfigRef, Task, A]
     type ConfigRefPlusTaskM[A] = Free[ConfigRefPlusTask, A]
 
     // AtomicRef[Cfg, ?] ~> Task (with writing the config file):

--- a/core/src/main/scala/quasar/fs/mount/EvaluatorMounter.scala
+++ b/core/src/main/scala/quasar/fs/mount/EvaluatorMounter.scala
@@ -22,7 +22,7 @@ import quasar.fp.free, free._
 import quasar.fs.FileSystem
 import hierarchical.MountedResultH
 
-import scalaz.{:+: => _, _}
+import scalaz._
 import scalaz.syntax.monad._
 
 /** Handles mount requests, managing a composite `FileSystem` interpreter
@@ -90,8 +90,9 @@ final class EvaluatorMounter[F[_], S[_]](
 
   ////
 
-  private type ViewEff[A] =
-    (MountConfigs :+: (ViewState :+: (MonotonicSeq :+: FileSystem)#λ)#λ)#λ[A]
+  private type ViewEff0[A] = Coproduct[MonotonicSeq, FileSystem, A]
+  private type ViewEff1[A] = Coproduct[ViewState, ViewEff0, A]
+  private type ViewEff[A]  = Coproduct[MountConfigs, ViewEff1, A]
 
   private val fsMounter = FileSystemMounter[F](fsDef)
 

--- a/core/src/main/scala/quasar/fs/mount/hierarchical.scala
+++ b/core/src/main/scala/quasar/fs/mount/hierarchical.scala
@@ -24,7 +24,7 @@ import quasar.fs._
 
 import matryoshka.{free => _, _}, Recursive.ops._
 import pathy.Path._
-import scalaz.{Failure => _, :+: => _, _}, Scalaz._
+import scalaz.{Failure => _, _}, Scalaz._
 
 object hierarchical {
   import QueryFile.ResultHandle

--- a/core/src/main/scala/quasar/fs/mount/package.scala
+++ b/core/src/main/scala/quasar/fs/mount/package.scala
@@ -24,7 +24,7 @@ import quasar.fp.free, free._
 import scala.collection.immutable.Vector
 
 import monocle.Lens
-import scalaz.{Lens => _, :+: => _, _}
+import scalaz.{Lens => _, _}
 import scalaz.concurrent.Task
 
 package object mount {
@@ -32,7 +32,7 @@ package object mount {
 
   type MountConfigs[A] = KeyValueStore[APath, MountConfig, A]
 
-  type MountingFileSystem[A] = (Mounting :+: FileSystem)#λ[A]
+  type MountingFileSystem[A] = Coproduct[Mounting, FileSystem, A]
 
   def interpretMountingFileSystem[M[_]](
     m: Mounting ~> M,
@@ -66,8 +66,9 @@ package object mount {
       KeyValueStore.toState[State[S,?]](l)
   }
 
-  type ViewFileSystem[A] =
-    (MountConfigs :+: (ViewState :+: (MonotonicSeq :+: FileSystem)#λ)#λ)#λ[A]
+  type ViewFileSystem0[A] = Coproduct[MonotonicSeq, FileSystem, A]
+  type ViewFileSystem1[A] = Coproduct[ViewState, ViewFileSystem0, A]
+  type ViewFileSystem[A]  = Coproduct[MountConfigs, ViewFileSystem1, A]
 
   def interpretViewFileSystem[M[_]](
     mc: MountConfigs ~> M,

--- a/core/src/main/scala/quasar/fs/package.scala
+++ b/core/src/main/scala/quasar/fs/package.scala
@@ -22,11 +22,12 @@ import quasar.fp._
 import quasar.fp.free._
 
 import pathy.Path, Path._
-import scalaz.{Failure => _, :+: => _, _}, Scalaz._
+import scalaz.{Failure => _, _}, Scalaz._
 
 package object fs {
-  type FileSystem[A] =
-    (QueryFile :+: (ReadFile :+: (WriteFile :+: ManageFile)#λ)#λ)#λ[A]
+  type FileSystem0[A] = Coproduct[WriteFile, ManageFile, A]
+  type FileSystem1[A] = Coproduct[ReadFile, FileSystem0, A]
+  type FileSystem[A]  = Coproduct[QueryFile, FileSystem1, A]
 
   type AbsPath[T] = pathy.Path[Abs,T,Sandboxed]
   type RelPath[T] = pathy.Path[Rel,T,Sandboxed]

--- a/core/src/test/scala/quasar/fs/mount/FileSystemMounterSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/FileSystemMounterSpec.scala
@@ -26,7 +26,7 @@ import monocle.function.Field1
 import monocle.std.tuple2._
 import pathy.Path._
 import org.specs2.mutable
-import scalaz.{Failure => _, :+: => _, _}
+import scalaz.{Failure => _, _}
 import scalaz.syntax.applicative._
 
 class FileSystemMounterSpec extends mutable.Specification {
@@ -41,7 +41,8 @@ class FileSystemMounterSpec extends mutable.Specification {
 
   type MountedFs[A]  = AtomicRef[ResMnts, A]
 
-  type Eff[A] = (AbortM :+: (Abort :+: MountedFs)#λ)#λ[A]
+  type Eff0[A] = Coproduct[Abort, MountedFs, A]
+  type Eff[A]  = Coproduct[AbortM, Eff0, A]
   type EffM[A] = Free[Eff, A]
 
   type EffR[A] = (ResMnts, String \/ A)

--- a/core/src/test/scala/quasar/fs/mount/HierarchicalFileSystemSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/HierarchicalFileSystemSpec.scala
@@ -29,10 +29,10 @@ import matryoshka.Fix
 import monocle.Lens
 import org.specs2.mutable
 import pathy.Path._
-import scalaz.{Lens => _, Failure => _, :+: => _, _}, Id.Id
+import scalaz.{Lens => _, Failure => _, _}, Id.Id
 import scalaz.syntax.either._
 import scalaz.std.list._
-import shapeless.{Data => _, Coproduct => _, :+: => _, _}
+import shapeless.{Data => _, Coproduct => _, _}
 
 class HierarchicalFileSystemSpec extends mutable.Specification with FileSystemFixture {
   import InMemory.InMemState, FileSystemError._, PathError._
@@ -46,7 +46,8 @@ class HierarchicalFileSystemSpec extends mutable.Specification with FileSystemFi
   type MountedFs[A] = State[MountedState, A]
   type MountedFsE[E, A] = EitherT[MountedFs, E, A]
 
-  type HEff[A]  = (MonotonicSeq :+: (MountedResultH :+: MountedFs)#λ)#λ[A]
+  type HEff0[A] = Coproduct[MountedResultH, MountedFs, A]
+  type HEff[A]  = Coproduct[MonotonicSeq, HEff0, A]
   type HEffM[A] = Free[HEff, A]
 
   type RHandles = Map[ResultHandle, (ADir, ResultHandle)]

--- a/core/src/test/scala/quasar/fs/mount/MounterSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/MounterSpec.scala
@@ -22,13 +22,13 @@ import quasar.fp._, free._
 import quasar.fs.APath
 
 import pathy.Path._
-import scalaz.{:+: => _, _}, Scalaz._
+import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 
 class MounterSpec extends MountingSpec[Mounting] {
   import MountConfig._, MountingError._, MountRequest._
 
-  type MEff[A]  = (Task :+: MountConfigs)#λ[A]
+  type MEff[A] = Coproduct[Task, MountConfigs, A]
 
   val invalidUri = ConnectionUri(uriA.value + "INVALID")
   val invalidCfg = fileSystemConfig(dbType, invalidUri)

--- a/it/src/test/scala/quasar/physical/mongodb/filesystems.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/filesystems.scala
@@ -28,7 +28,7 @@ import quasar.physical.mongodb.fs._
 import quasar.regression._
 
 import com.mongodb.MongoException
-import scalaz.{Failure => _, :+: => _, _}, Scalaz._
+import scalaz.{Failure => _, _}, Scalaz._
 import scalaz.concurrent.Task
 
 object filesystems {
@@ -57,8 +57,9 @@ object filesystems {
 
   ////
 
-  private type MongoEff[A]  =
-    (CfgErr :+: (EnvErr :+: (MongoErr :+: Task)#λ)#λ)#λ[A]
+  private type MongoEff0[A] = Coproduct[MongoErr, Task, A]
+  private type MongoEff1[A] = Coproduct[EnvErr, MongoEff0, A]
+  private type MongoEff[A]  = Coproduct[CfgErr, MongoEff1, A]
   private type MongoEffM[A] = Free[MongoEff, A]
 
   private val envErr = Failure.Ops[EnvironmentError, MongoEff]

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -34,7 +34,7 @@ import matryoshka.Fix
 import org.specs2.execute._
 import org.specs2.specification.core.Fragment
 import pathy.Path, Path._
-import scalaz.{:+: => _, _}, Scalaz._
+import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 import scalaz.stream.{merge => pmerge, _}
 
@@ -300,8 +300,7 @@ object QueryRegressionTest {
         flatMapSNT(hierarchical.fileSystem[Task, HfsIO](Mounts.singleton(mnt, interpFS)))
           .compose(chroot.fileSystem[FileSystem](mnt))
 
-      NaturalTransformation.refl[Task] :+:
-      (free.foldMapNT(hfs) compose g)
+      NaturalTransformation.refl[Task] :+: (free.foldMapNT(hfs) compose g)
     }
 
   implicit val dataEncodeJson: EncodeJson[Data] =

--- a/it/src/test/scala/quasar/regression/package.scala
+++ b/it/src/test/scala/quasar/regression/package.scala
@@ -22,16 +22,17 @@ import quasar.fp.{TaskRef}
 import quasar.fp.free, free._
 import quasar.fs.{QueryFile, FileSystem, ADir}
 
-import scalaz.{Failure => _, :+: => _, _}
+import scalaz.{Failure => _, _}
 import scalaz.concurrent._
 import scalaz.syntax.apply._
 
 package object regression {
   import quasar.fs.mount.hierarchical.MountedResultH
 
-  type FileSystemIO[A] = (Task :+: FileSystem)#λ[A]
+  type FileSystemIO[A] = Coproduct[Task, FileSystem, A]
 
-  type HfsIO[A] = (MonotonicSeq :+: (MountedResultH :+: Task)#λ)#λ[A]
+  type HfsIO0[A] = Coproduct[MountedResultH, Task, A]
+  type HfsIO[A]  = Coproduct[MonotonicSeq, HfsIO0, A]
 
   val interpretHfsIO: Task[HfsIO ~> Task] = {
     import QueryFile.ResultHandle

--- a/mongodb/src/main/scala/quasar/physical/mongodb/fs/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/fs/package.scala
@@ -27,7 +27,7 @@ import quasar.fs.mount.{ConnectionUri, FileSystemDef}
 import quasar.physical.mongodb.fs.bsoncursor._
 
 import com.mongodb.async.client.MongoClient
-import scalaz.{:+: => _, _}
+import scalaz._
 import scalaz.syntax.monad._
 import scalaz.syntax.either._
 import scalaz.syntax.show._
@@ -92,7 +92,8 @@ package object fs {
 
   ////
 
-  private type Eff[A] = (Task :+: (EnvErr :+: CfgErr)#λ)#λ[A]
+  private type Eff0[A] = Coproduct[EnvErr, CfgErr, A]
+  private type Eff[A]  = Coproduct[Task, Eff0, A]
 
   private def findDefaultDb: MongoDbIO[Option[DefaultDb]] =
     (for {

--- a/web/src/test/scala/quasar/api/QResponseSpec.scala
+++ b/web/src/test/scala/quasar/api/QResponseSpec.scala
@@ -22,7 +22,7 @@ import quasar.fp._, free._
 import org.http4s.dsl._
 import org.http4s.headers.Host
 import org.specs2.mutable
-import scalaz.{:+: => _, _}
+import scalaz._
 import scalaz.std.anyVal._
 import scalaz.syntax.applicative._
 import scalaz.syntax.order._

--- a/web/src/test/scala/quasar/api/services/DataServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/DataServiceSpec.scala
@@ -40,7 +40,7 @@ import org.specs2.scalaz.ScalazMatchers._
 import org.specs2.ScalaCheck
 import pathy.Path, Path._
 import pathy.scalacheck.PathyArbitrary._
-import scalaz.{Failure => _, :+: => _, _}, Scalaz._
+import scalaz.{Failure => _, _}, Scalaz._
 import scalaz.concurrent.Task
 import scalaz.scalacheck.ScalazArbitrary._
 import scalaz.stream.Process
@@ -57,7 +57,8 @@ class DataServiceSpec extends Specification with ScalaCheck with FileSystemFixtu
   import FileSystemFixture.{ReadWriteT, ReadWrites, amendWrites}
   import PathError.{pathExists, pathNotFound}
 
-  type Eff[A] = (Task :+: (FileSystemFailure :+: FileSystem)#λ)#λ[A]
+  type Eff0[A] = Coproduct[FileSystemFailure, FileSystem, A]
+  type Eff[A]  = Coproduct[Task, Eff0, A]
   type EffM[A] = Free[Eff, A]
 
   def effRespOr(fs: FileSystem ~> Task): Eff ~> ResponseOr =

--- a/web/src/test/scala/quasar/api/services/MetadataServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/MetadataServiceSpec.scala
@@ -37,7 +37,7 @@ import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
 import pathy.Path._
 import pathy.scalacheck.PathyArbitrary._
-import scalaz.{Lens => _, :+: => _, _}
+import scalaz.{Lens => _, _}
 import scalaz.concurrent.Task
 
 object MetadataFixture {

--- a/web/src/test/scala/quasar/api/services/MountServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/MountServiceSpec.scala
@@ -35,7 +35,7 @@ import org.specs2.mutable.Specification
 import org.specs2.scalaz.ScalazMatchers._
 import pathy.Path, Path._
 import pathy.scalacheck.PathyArbitrary._
-import scalaz.{:+: => _, _}, Scalaz._
+import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 
 class MountServiceSpec extends Specification with ScalaCheck with Http4s with PathUtils {
@@ -45,14 +45,15 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
 
   val StubFs = FileSystemType("stub")
 
-  type Eff[A] = (Task :+: (Mounting :+: MountConfigs)#λ)#λ[A]
+  type Eff0[A] = Coproduct[Mounting, MountConfigs, A]
+  type Eff[A]  = Coproduct[Task, Eff0, A]
 
   val M = Mounting.Ops[Eff]
 
   type HttpSvc = Request => M.F[Response]
 
   def runTest[R: org.specs2.execute.AsResult](f: HttpSvc => M.F[R]): R = {
-    type MEff[A] = (Task :+: MountConfigs)#λ[A]
+    type MEff[A] = Coproduct[Task, MountConfigs, A]
 
     TaskRef(Map[APath, MountConfig]()).flatMap { ref =>
 

--- a/web/src/test/scala/quasar/api/services/RestApiSpecs.scala
+++ b/web/src/test/scala/quasar/api/services/RestApiSpecs.scala
@@ -28,14 +28,15 @@ import org.http4s._, Method.MOVE
 import org.http4s.dsl._
 import org.http4s.headers._
 import org.specs2.mutable.Specification
-import scalaz.{Failure => _, :+: => _, _}
+import scalaz.{Failure => _, _}
 import scalaz.concurrent.Task
 
 class RestApiSpecs extends Specification {
   import InMemory._
 
-  type Eff[A] =
-    (Task :+: (MountConfigs :+: (FileSystemFailure :+: MountingFileSystem)#λ)#λ)#λ[A]
+  type Eff0[A] = Coproduct[FileSystemFailure, MountingFileSystem, A]
+  type Eff1[A] = Coproduct[MountConfigs, Eff0, A]
+  type Eff[A]  = Coproduct[Task, Eff1, A]
 
   "OPTIONS" should {
     val mount = new (Mounting ~> Task) {

--- a/web/src/test/scala/quasar/api/services/query/QueryFixture.scala
+++ b/web/src/test/scala/quasar/api/services/query/QueryFixture.scala
@@ -28,13 +28,14 @@ import quasar.sql.fixpoint._
 import org.http4s._
 import org.specs2.matcher._, MustMatchers._
 import pathy.Path._
-import scalaz.{:+: => _, _}, Scalaz._
+import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 
 object queryFixture {
   import quasar.api.PathUtils.pathUri
 
-  type Eff[A] = (Task :+: (FileSystemFailure :+: FileSystem)#λ)#λ[A]
+  type Eff0[A] = Coproduct[FileSystemFailure, FileSystem, A]
+  type Eff[A]  = Coproduct[Task, Eff0, A]
 
   case class Query(
     q: String,


### PR DESCRIPTION
The :+: syntax causes significant performance degredation in implicit
search for Inject instances on large effect types.