### PR TITLE
A couple of things for downstream

### DIFF
--- a/CHANGELOG/bugfix.md
+++ b/CHANGELOG/bugfix.md
@@ -1,0 +1,2 @@
+- implement Shrink for ISet and IList
+- move readEnv to quasar.console

--- a/core/src/main/scala/quasar/console.scala
+++ b/core/src/main/scala/quasar/console.scala
@@ -43,4 +43,9 @@ object console {
       _.equalsIgnoreCase("true"),
       false)
   }
+
+  /** Read the value of an environment variable. */
+  def readEnv(name: String): OptionT[Task, String] =
+    Task.delay(System.getenv).liftM[OptionT]
+      .flatMap(env => OptionT(Task.delay(Option(env.get(name)))))
 }

--- a/core/src/test/scala/quasar/scalacheck/package.scala
+++ b/core/src/test/scala/quasar/scalacheck/package.scala
@@ -18,8 +18,8 @@ package quasar
 
 import quasar.Predef._
 
-import org.scalacheck.{Gen, Arbitrary}
-import scalaz.{Apply, NonEmptyList, IList}
+import org.scalacheck.{Gen, Arbitrary, Shrink}
+import scalaz._, Scalaz._
 import scalaz.scalacheck.ScalaCheckBinding._
 
 package object scalacheck {
@@ -31,4 +31,11 @@ package object scalacheck {
 
   def listSmallerThan[A: Arbitrary](n: Int): Arbitrary[List[A]] =
     Arbitrary(Gen.containerOfN[List,A](n, Arbitrary.arbitrary[A]))
+
+
+  implicit def shrinkIList[A](implicit s: Shrink[List[A]]): Shrink[IList[A]] =
+    Shrink(as => s.shrink(as.toList).map(IList.fromFoldable(_)))
+
+  implicit def shrinkISet[A: Order](implicit s: Shrink[Set[A]]): Shrink[ISet[A]] =
+    Shrink(as => s.shrink(as.toSet).map(ISet.fromFoldable(_)))
 }


### PR DESCRIPTION
`readEnv` is used in quasar-advanced; these Shrink instances are useful for debugging test failures.