### PR TITLE
SD-1839 MongoDB: generate temp file names in same directory as hint path

### DIFF
--- a/CHANGELOG/bugfix.md
+++ b/CHANGELOG/bugfix.md
@@ -1,0 +1,1 @@
+- [SD-1839] MongoDB: generate temp file names in same directory as hint path


### PR DESCRIPTION
Previously, we were generating temp files under the first directory of the hint path, i.e.

```
hint = /foo/bar/baz
tmp = /foo/2348ujsdlf.tmp
```

this changes it so we always create the temp file in the directory itself, if the hint path is a directory, or in the hint's parent if it is a file.

This makes temp file location more predictable which makes the permissions required for operations that involve temp files in quasar-advanced more predictable (which is the motivating problem here).