### PR TITLE
[SD-1568] handle var as relation

### DIFF
--- a/CHANGELOG/feature.md
+++ b/CHANGELOG/feature.md
@@ -1,0 +1,1 @@
+- [SD-1568] handle var as relation (e.g. `select * from :table`)

--- a/core/src/main/scala/quasar/compiler.scala
+++ b/core/src/main/scala/quasar/compiler.scala
@@ -314,6 +314,9 @@ trait Compiler[F[_]] {
         case IdentRelationAST(name, _) =>
           CompilerState.subtableReq(name)
 
+        case VariRelationAST(vari, _) =>
+          fail(UnboundVariable(VarName(vari.symbol)))
+
         case TableRelationAST(path, _) =>
           sandboxCurrent(canonicalize(path)).cata(
             p => emit(LogicalPlan.Read(p)),

--- a/core/src/main/scala/quasar/fs/mount/ViewMounter.scala
+++ b/core/src/main/scala/quasar/fs/mount/ViewMounter.scala
@@ -52,7 +52,7 @@ object ViewMounter {
     (implicit S: MountConfigs :<: S)
     : Free[S, MountingError \/ Unit] = {
     val vc = viewConfig(query, vars)
-    queryPlan(query, vars, 0L, None).run.value.fold(
+    queryPlan(query, vars, fileParent(loc), 0L, None).run.value.fold(
       e => invalidConfig(vc, e.map(_.shows)).left.point[Free[S, ?]],
       κ(mntCfgs[S].put(loc, vc).map(_.right)))
   }
@@ -98,7 +98,7 @@ object ViewMounter {
           f => EitherT[Free[S, ?], SemanticErrors, LogicalPlan[(Set[FPath], Fix[LogicalPlan])]](
             lookup[S](f).run.flatMap[SemanticErrors \/ LogicalPlan[(Set[FPath], Fix[LogicalPlan])]] {
               _.cata(
-                { case (expr, vars) => queryPlan(expr, vars, 0L, None).run.run._2.map(p => collapseData(p.map(absolutize(_, fileParent(f))))) },
+                { case (expr, vars) => queryPlan(expr, vars, fileParent(f), 0L, None).run.run._2.map(p => collapseData(p.map(absolutize(_, fileParent(f))))) },
                   i.right)
                 .map(_.unFix.map((e + f, _)))
                 .point[Free[S, ?]]

--- a/core/src/main/scala/quasar/fs/mount/view.scala
+++ b/core/src/main/scala/quasar/fs/mount/view.scala
@@ -58,7 +58,7 @@ object view {
 
           def vOpen(e: Fix[Sql], v: Variables):
               Free[S, FileSystemError \/ ReadHandle] = {
-            queryPlan(e, v, off, lim).run.value.fold[EitherT[queryUnsafe.F, FileSystemError, ReadHandle]](
+            queryPlan(e, v, fileParent(path), off, lim).run.value.fold[EitherT[queryUnsafe.F, FileSystemError, ReadHandle]](
               e => EitherT[Free[S, ?], FileSystemError, ReadHandle](
                 // TODO: more sensible error?
                 Free.point(pathErr(invalidPath(path, e.shows)).left[ReadHandle])),

--- a/core/src/main/scala/quasar/semantics.scala
+++ b/core/src/main/scala/quasar/semantics.scala
@@ -204,6 +204,8 @@ object SemanticAnalysis {
             case IdentRelationAST(name, aliasOpt) =>
               success(Map(aliasOpt.getOrElse(name) ->
                 IdentRelationAST(name, aliasOpt)))
+            case VariRelationAST(vari, aliasOpt) =>
+              failure((UnboundVariable(VarName(vari.symbol)): SemanticError).wrapNel)
             case TableRelationAST(file, aliasOpt) =>
               success(Map(aliasOpt.getOrElse(prettyPrint(file)) -> TableRelationAST(file, aliasOpt)))
             case ExprRelationAST(_, alias) =>

--- a/core/src/main/scala/quasar/sql/package.scala
+++ b/core/src/main/scala/quasar/sql/package.scala
@@ -149,6 +149,8 @@ package object sql {
     (r match {
       case IdentRelationAST(name, alias) =>
         _qq("`", name) :: alias.map("as " + _).toList
+      case VariRelationAST(vari, alias) =>
+        (":" + vari.symbol) :: alias.map("as " + _).toList
       case TableRelationAST(path, alias) =>
         _qq("`", prettyPrint(path)) :: alias.map("as " + _).toList
       case ExprRelationAST(expr, aliasName) =>
@@ -263,6 +265,8 @@ package object sql {
     r match {
       case IdentRelationAST(name, alias) =>
         G.point(IdentRelationAST(name, alias))
+      case VariRelationAST(vari, alias) =>
+        G.point(VariRelationAST(Vari(vari.symbol), alias))
       case TableRelationAST(name, alias) =>
         G.point(TableRelationAST(name, alias))
       case ExprRelationAST(expr, aliasName) =>
@@ -281,6 +285,9 @@ package object sql {
           case IdentRelationAST(name, alias) =>
             val aliasString = alias.cata(" as " + _, "")
             Terminal("IdentRelation" :: astType, Some(name + aliasString))
+          case VariRelationAST(vari, alias) =>
+            val aliasString = alias.cata(" as " + _, "")
+            Terminal("VariRelation" :: astType, Some(":" + vari.symbol + aliasString))
           case ExprRelationAST(select, alias) =>
             NonTerminal("ExprRelation" :: astType, Some("Expr as " + alias), ra.render(select) :: Nil)
           case TableRelationAST(name, alias) =>

--- a/core/src/main/scala/quasar/sql/parser.scala
+++ b/core/src/main/scala/quasar/sql/parser.scala
@@ -463,7 +463,4 @@ private[sql] class SQLParser[T[_[_]]: Recursive: Corecursive]
 
   val parse: Query => ParsingError \/ T[Sql] =
     parse0(_).map(_.transAna(repeatedly(normalizeƒ)).makeTables(Nil))
-
-  def parseInContext(sql: Query, basePath: ADir): ParsingError \/ T[Sql] =
-    parse(sql).map(_.mkPathsAbsolute(basePath))
 }

--- a/core/src/main/scala/quasar/variables.scala
+++ b/core/src/main/scala/quasar/variables.scala
@@ -17,6 +17,7 @@
 package quasar
 
 import quasar.Predef._
+import quasar.fp.κ
 import quasar.SemanticError._
 import quasar.sql.{Sql, Ident, Query, Select, Vari, TableRelationAST, VariRelationAST}
 
@@ -52,7 +53,7 @@ object Variables {
           val varName = VarName(vari.symbol)
           vars.lookup(varName) flatMap {
             case Fix(Ident(name)) =>
-              posixCodec.parseAbsFile(name).cata(
+              posixCodec.parsePath(Some(_), Some(_), κ(None), κ(None))(name).cata(
                 TableRelationAST(_, alias).right,
                 GenericError("bad path: " + name + " (note: absolute file path required)").left)  // FIXME
             case x =>

--- a/core/src/main/scala/quasar/variables.scala
+++ b/core/src/main/scala/quasar/variables.scala
@@ -18,12 +18,19 @@ package quasar
 
 import quasar.Predef._
 import quasar.SemanticError._
-import quasar.sql.{Sql, Query, Vari}
+import quasar.sql.{Sql, Ident, Query, Select, Vari, TableRelationAST, VariRelationAST}
 
 import matryoshka._, Recursive.ops._
+import pathy.Path.posixCodec
 import scalaz._, Scalaz._
 
-final case class Variables(value: Map[VarName, VarValue])
+final case class Variables(value: Map[VarName, VarValue]) {
+  def lookup(name: VarName): SemanticError \/ Fix[Sql] =
+    value.get(name).fold[SemanticError \/ Fix[Sql]](
+      UnboundVariable(name).left)(
+      varValue => sql.fixParser.parse(Query(varValue.value))
+        .leftMap(VariableParseError(name, varValue, _)))
+}
 final case class VarName(value: String) {
   override def toString = ":" + value
 }
@@ -38,10 +45,22 @@ object Variables {
   def substVarsƒ(vars: Variables):
       AlgebraM[SemanticError \/ ?, Sql, Fix[Sql]] = {
     case Vari(name) =>
-      vars.value.get(VarName(name)).fold[SemanticError \/ Fix[Sql]](
-        UnboundVariable(VarName(name)).left)(
-        varValue => sql.fixParser.parse(Query(varValue.value))
-          .leftMap(VariableParseError(VarName(name), varValue, _)))
+      vars.lookup(VarName(name))
+    case sel @ Select(dist, proj, Some(rel), filter, group, order) =>
+      rel.transformM[SemanticError \/ ?, Fix[Sql]]({
+        case VariRelationAST(vari, alias) =>
+          val varName = VarName(vari.symbol)
+          vars.lookup(varName) flatMap {
+            case Fix(Ident(name)) =>
+              posixCodec.parseAbsFile(name).cata(
+                TableRelationAST(_, alias).right,
+                GenericError("bad path: " + name + " (note: absolute file path required)").left)  // FIXME
+            case x =>
+              GenericError("not a valid table name: " + x).left  // FIXME
+          }
+        case r => r.right
+      }, _.right[SemanticError]).map(rel =>
+        sel.copy(relations = rel.some).embed)
     case x => x.embed.right
   }
 

--- a/core/src/test/scala/quasar/fs/mount/HierarchicalFileSystemSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/HierarchicalFileSystemSpec.scala
@@ -124,7 +124,7 @@ class HierarchicalFileSystemSpec extends mutable.Specification with FileSystemFi
         "select f.x, q.y from `/bar/mntA/foo` as f inner join `/foo/mntC/quux` as q on f.id = q.id"
 
       val lp = fixParser.parse(Query(joinQry)).toOption
-        .flatMap(queryPlan(_, Variables(Map()), 0L, None).run.value.toOption)
+        .flatMap(queryPlan(_, Variables(Map()), rootDir, 0L, None).run.value.toOption)
         .get
 
       runMntd(f(lp.valueOr(_ => scala.sys.error("impossible constant plan")), mntA </> file("out0")).run.value)

--- a/core/src/test/scala/quasar/fs/mount/ViewMounterSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/ViewMounterSpec.scala
@@ -149,7 +149,7 @@ class ViewMounterSpec extends mutable.Specification with ScalaCheck with TreeMat
           Constant(Data.Int(10))).embed
 
       val innerLP =
-        quasar.queryPlan(inner._1, inner._2, 0L, None).run.run._2.toOption.get.valueOr(_ => scala.sys.error("impossible constant plan"))
+        quasar.queryPlan(inner._1, inner._2, fileParent(p), 0L, None).run.run._2.toOption.get.valueOr(_ => scala.sys.error("impossible constant plan"))
 
       val vs = Map[APath, MountConfig](
         p -> MountConfig.viewConfig(inner))
@@ -213,7 +213,7 @@ class ViewMounterSpec extends mutable.Specification with ScalaCheck with TreeMat
       val q = viewConfig(s"select * from `${posixCodec.printPath(p)}` limit 10")
 
       val qlp =
-        quasar.queryPlan(q._1, q._2, 0L, None).run.run._2.toOption.get.valueOr(_ => scala.sys.error("impossible constant plan"))
+        quasar.queryPlan(q._1, q._2, rootDir, 0L, None).run.run._2.toOption.get.valueOr(_ => scala.sys.error("impossible constant plan"))
 
       val vs = Map[APath, MountConfig](p -> MountConfig.viewConfig(q))
 

--- a/core/src/test/scala/quasar/fs/mount/view.scala
+++ b/core/src/test/scala/quasar/fs/mount/view.scala
@@ -125,7 +125,7 @@ class ViewFSSpec extends Specification with ScalaCheck with TreeMatchers {
   }
 
   def parseExpr(query: String) =
-    fixParser.parseInContext(Query(query), rootDir[Sandboxed]).toOption.get
+    fixParser.parse(Query(query)).toOption.get.mkPathsAbsolute(rootDir)
 
   implicit val RenderedTreeRenderTree = new RenderTree[RenderedTree] {
     def render(t: RenderedTree) = t
@@ -135,7 +135,7 @@ class ViewFSSpec extends Specification with ScalaCheck with TreeMatchers {
     "translate simple read to query" in {
       val p = rootDir[Sandboxed] </> dir("view") </> file("simpleZips")
       val expr = parseExpr("select * from zips")
-      val lp = queryPlan(expr, Variables.empty, 0L, None).run.run._2.toOption.get
+      val lp = queryPlan(expr, Variables.empty, rootDir, 0L, None).run.run._2.toOption.get
 
       val views = Map(p -> expr)
 

--- a/core/src/test/scala/quasar/sql/SqlParserSpec.scala
+++ b/core/src/test/scala/quasar/sql/SqlParserSpec.scala
@@ -228,6 +228,10 @@ class SQLParserSpec extends Specification with ScalaCheck with DisjunctionMatche
       parse("""SELECT * FROM zips WHERE zips.dt > :start_time AND zips.dt <= :end_time """).toOption should beSome
     }
 
+    "parse simple query with variable as relation" in {
+      parse("""SELECT * FROM :table""").toOption should beSome
+    }
+
     "parse true and false literals" in {
       parse("""SELECT * FROM zips WHERE zips.isNormalized = TRUE AND zips.isFruityFlavored = FALSE""").toOption should beSome
     }

--- a/it/src/main/resources/tests/var-relation.test
+++ b/it/src/main/resources/tests/var-relation.test
@@ -4,7 +4,7 @@
   "data": "smallZips.data",
 
   "variables": {
-    "table": "`/regression/smallZips`"
+    "table": "`smallZips`"
   },
 
   "query": "select count(*) from :table where pop < 1000",

--- a/it/src/main/resources/tests/var-relation.test
+++ b/it/src/main/resources/tests/var-relation.test
@@ -1,0 +1,17 @@
+{
+  "name": "select from a table named by a variable",
+
+  "data": "smallZips.data",
+
+  "variables": {
+    "table": "`/regression/smallZips`"
+  },
+
+  "query": "select count(*) from :table where pop < 1000",
+
+  "predicate": "equalsExactly",
+
+  "expected": [
+    { "0": 19 }
+  ]
+}

--- a/it/src/test/scala/quasar/ResultFileQueryRegressionSpec.scala
+++ b/it/src/test/scala/quasar/ResultFileQueryRegressionSpec.scala
@@ -33,7 +33,7 @@ class ResultFileQueryRegressionSpec
 
   val suiteName = "ResultFile Queries"
 
-  def queryResults(expr: Fix[Sql], vars: Variables) = {
+  def queryResults(expr: Fix[Sql], vars: Variables, basePath: ADir) = {
     import qfTransforms._
 
     type M[A] = FileSystemErrT[F, A]
@@ -43,7 +43,7 @@ class ResultFileQueryRegressionSpec
 
     for {
       tmpFile <- hoistM(manage.tempFile(DataDir)).liftM[Process]
-      outFile <- fsQ.executeQuery(expr, vars, tmpFile).liftM[Process]
+      outFile <- fsQ.executeQuery(expr, vars, basePath, tmpFile).liftM[Process]
       cleanup =  hoistM(manage.delete(tmpFile)).whenM(outFile ≟ tmpFile)
       data    <- read.scanAll(outFile)
                    .translate(hoistM)

--- a/it/src/test/scala/quasar/StreamingQueryRegressionSpec.scala
+++ b/it/src/test/scala/quasar/StreamingQueryRegressionSpec.scala
@@ -16,6 +16,7 @@
 
 package quasar
 
+import quasar.fs.ADir
 import quasar.regression._
 import quasar.sql.Sql
 
@@ -29,6 +30,6 @@ class StreamingQueryRegressionSpec
 
   val suiteName = "Streaming Queries"
 
-  def queryResults(expr: Fix[Sql], vars: Variables) =
-    fsQ.evaluateQuery(expr, vars, 0L, None)
+  def queryResults(expr: Fix[Sql], vars: Variables, basePath: ADir) =
+    fsQ.evaluateQuery(expr, vars, basePath, 0L, None)
 }

--- a/it/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
@@ -249,7 +249,7 @@ class MongoDbFileSystemSpec
             def check0(expr: Fix[Sql]) =
               (run(query.fileExists(file)).unsafePerformSync ==== false) and
               (errP.getOption(
-                runExec(fsQ.executeQuery(expr, Variables.fromMap(Map()), out))
+                runExec(fsQ.executeQuery(expr, Variables.empty, rootDir, out))
                   .run.value.unsafePerformSync
               ) must beSome(file))
 

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -79,7 +79,7 @@ abstract class QueryRegressionTest[S[_]](
   def suiteName: String
 
   /** Return the results of evaluating the given query as a stream. */
-  def queryResults(expr: Fix[Sql], vars: Variables): Process[CompExecM, Data]
+  def queryResults(expr: Fix[Sql], vars: Variables, basePath: ADir): Process[CompExecM, Data]
 
   ////
 
@@ -175,10 +175,11 @@ abstract class QueryRegressionTest[S[_]](
       toCompExec compose injectTask
 
     val parseTask: Task[Fix[Sql]] =
-      sql.fixParser.parseInContext(Query(qry), loc)
-        .fold(e => Task.fail(new RuntimeException(e.message)), _.point[Task])
+      sql.fixParser.parse(Query(qry))
+        .fold(e => Task.fail(new RuntimeException(e.message)),
+        _.mkPathsAbsolute(loc).point[Task])
 
-    f(parseTask).liftM[Process] flatMap (queryResults(_, Variables.fromMap(vars)))
+    f(parseTask).liftM[Process] flatMap (queryResults(_, Variables.fromMap(vars), loc))
   }
 
   /** Loads all the test data needed by the given tests into the filesystem. */

--- a/web/src/main/scala/quasar/api/services/query/compile.scala
+++ b/web/src/main/scala/quasar/api/services/query/compile.scala
@@ -55,11 +55,12 @@ object compile {
 
     def explainQuery(
       expr: Fix[sql.Sql],
+      vars: Variables,
+      basePath: ADir,
       offset: Natural,
-      limit: Option[Positive],
-      vars: Variables
+      limit: Option[Positive]
     ): Free[S, QResponse[S]] =
-      respond(queryPlan(expr, vars, offset, limit)
+      respond(queryPlan(expr, vars, basePath, offset, limit)
         .run.value.traverse[Free[S, ?], SemanticErrors, QResponse[S]](_.fold(
           κ(Json(
             "physicalPlan" -> jNull,
@@ -80,8 +81,8 @@ object compile {
     QHttpService {
       case req @ GET -> _ :? Offset(offset) +& Limit(limit) =>
         respond(parsedQueryRequest(req, offset, limit) traverse {
-          case (expr, offset, limit) =>
-            explainQuery(expr, offset, limit, requestVars(req))
+          case (expr, basePath, offset, limit) =>
+            explainQuery(expr, requestVars(req), basePath, offset, limit)
         })
     }
   }

--- a/web/src/main/scala/quasar/api/services/query/package.scala
+++ b/web/src/main/scala/quasar/api/services/query/package.scala
@@ -19,6 +19,7 @@ package quasar.api.services
 import quasar.Predef._
 import quasar._, api._
 import quasar.fp.numeric._
+import quasar.fs.ADir
 import quasar.sql.{Sql, Query}
 
 import scala.collection.Seq
@@ -61,14 +62,14 @@ package object query {
     req: Request,
     offset: Option[ValidationNel[ParseFailure, Natural]],
     limit: Option[ValidationNel[ParseFailure, Positive]]):
-      ApiError \/ (Fix[Sql], Natural, Option[Positive]) =
+      ApiError \/ (Fix[Sql], ADir, Natural, Option[Positive]) =
     for {
-      dir <- decodedDir(req.uri.path)
       qry <- queryParam(req.multiParams)
-      xpr <- sql.fixParser.parseInContext(qry, dir) leftMap (_.toApiError)
+      xpr <- sql.fixParser.parse(qry) leftMap (_.toApiError)
+      dir <- decodedDir(req.uri.path)
       off <- offsetOrInvalid(offset)
       lim <- limitOrInvalid(limit)
-    } yield (xpr, off, lim)
+    } yield (xpr, dir, off, lim)
 
   val bodyMustContainQuery: ApiError =
     ApiError.fromStatus(BadRequest withReason "No SQL^2 query found in message body.")

--- a/web/src/test/scala/quasar/api/services/query/ExecuteServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/query/ExecuteServiceSpec.scala
@@ -124,7 +124,7 @@ class ExecuteServiceSpec extends Specification with FileSystemFixture with Scala
   def toLP(q: String, vars: Variables): Fix[LogicalPlan] =
       sql.fixParser.parse(sql.Query(q)).fold(
         error => scala.sys.error(s"could not compile query: $q due to error: $error"),
-        ast => quasar.queryPlan(ast, vars, 0L, None).run.value.toOption.get).valueOr(_ => scala.sys.error("unsupported constant plan"))
+        ast => quasar.queryPlan(ast, vars, rootDir, 0L, None).run.value.toOption.get).valueOr(_ => scala.sys.error("unsupported constant plan"))
 
   "Execute" should {
     "execute a simple query" >> {
@@ -260,7 +260,7 @@ class ExecuteServiceSpec extends Specification with FileSystemFixture with Scala
           err => scala.sys.error("Parse failed: " + err.toString))
 
         val phases: PhaseResults =
-          queryPlan(expr, Variables.empty, 0L, None).run.written
+          queryPlan(expr, Variables.empty, rootDir, 0L, None).run.written
 
         post[ApiError](fileSystem)(
           path = fs.parent,
@@ -281,7 +281,7 @@ class ExecuteServiceSpec extends Specification with FileSystemFixture with Scala
           err => scala.sys.error("Parse failed: " + err.toString))
 
         val phases: PhaseResults =
-          queryPlan(expr, Variables.empty, 0L, None).run.written
+          queryPlan(expr, Variables.empty, rootDir, 0L, None).run.written
 
         post[ApiError](failingExecPlan(msg, fileSystem))(
           path = rootDir,


### PR DESCRIPTION
Two separate changes:

1. parse `:foo` when a "relation" (table/source/collection) is expected, to a new `VariRelationAST` node, and rewrite these in `substVarsƒ` to `TableRelationAST`
2. move the "absolutization" of paths so that it happens _after_ variable substitution, so that a relative path that is supplied by a variable will get rewritten