### PR TITLE
Initial version of normalization.

### DIFF
--- a/CHANGELOG/bugfix.md
+++ b/CHANGELOG/bugfix.md
@@ -1,0 +1,1 @@
+-Work on QScript normalization.

--- a/core/src/main/scala/quasar/qscript/ElideBuckets.scala
+++ b/core/src/main/scala/quasar/qscript/ElideBuckets.scala
@@ -27,6 +27,8 @@ import simulacrum.typeclass
   type InnerPure = IT[QScriptPure[IT, ?]]
 
   def purify: F[InnerPure] => QScriptPure[IT, InnerPure]
+  // #1: F[_]](implicit QSC :<: F, )
+  // #2: transformations work across Free
 }
 
 object ElideBuckets extends ElideBucketsInstances {

--- a/core/src/main/scala/quasar/qscript/Mergeable.scala
+++ b/core/src/main/scala/quasar/qscript/Mergeable.scala
@@ -17,6 +17,7 @@
 package quasar.qscript
 
 import quasar.Predef._
+import quasar.namegen._
 
 import simulacrum.typeclass
 import scalaz._
@@ -25,7 +26,7 @@ import scalaz._
   type IT[F[_]]
 
   def mergeSrcs(fm1: FreeMap[IT], fm2: FreeMap[IT], a1: A, a2: A):
-      Option[Merge[IT, A]]
+      OptionT[State[NameGen, ?], Merge[IT, A]]
 }
 
 object Mergeable {
@@ -40,8 +41,7 @@ object Mergeable {
         left: FreeMap[T],
         right: FreeMap[T],
         p1: Const[A, Unit],
-        p2: Const[A, Unit]):
-          Option[Merge[T, Const[A, Unit]]] =
+        p2: Const[A, Unit]) =
         ma.mergeSrcs(left, right, p1.getConst, p2.getConst).map {
           case AbsMerge(src, l, r) => AbsMerge(Const(src), l, r)
         }
@@ -58,8 +58,7 @@ object Mergeable {
         left: FreeMap[IT],
         right: FreeMap[IT],
         cp1: Coproduct[F, G, Unit],
-        cp2: Coproduct[F, G, Unit]):
-          Option[Merge[IT, Coproduct[F, G, Unit]]] = {
+        cp2: Coproduct[F, G, Unit]) = {
         (cp1.run, cp2.run) match {
           case (-\/(left1), -\/(left2)) =>
             mf.mergeSrcs(left, right, left1, left2).map {
@@ -69,7 +68,7 @@ object Mergeable {
             mg.mergeSrcs(left, right, right1, right2).map {
               case AbsMerge(src, left, right) => AbsMerge(Coproduct(\/-(src)), left, right)
             }
-          case (_, _) => None
+          case (_, _) => OptionT.none
         }
       }
     }

--- a/core/src/main/scala/quasar/qscript/Normalizable.scala
+++ b/core/src/main/scala/quasar/qscript/Normalizable.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript
+
+import quasar.Predef._
+import quasar.fp._
+import quasar.qscript.MapFunc._
+
+import matryoshka._, Recursive.ops._, FunctorT.ops._
+import matryoshka.patterns._
+import scalaz._
+import simulacrum.typeclass
+
+@typeclass trait Normalizable[F[_]] {
+  def normalize: F ~> F
+
+  // NB: This is overly complicated due to the use of Free instead of Mu[CoEnv]
+  def normalizeMapFunc[T[_[_]]: Recursive: Corecursive: EqualT, A](fm: Free[MapFunc[T, ?], A]):
+      Free[MapFunc[T, ?], A] =
+    fm.ana[Mu, CoEnv[A, MapFunc[T, ?], ?]](CoEnv.freeIso[A, MapFunc[T, ?]].reverseGet)
+      .transCata[CoMF[T, A, ?]](repeatedly(MapFunc.normalize))
+      .cata(CoEnv.freeIso[A, MapFunc[T, ?]].get)
+}
+
+trait NormalizableInstances0 {
+  /** This case matches _everything_. I.e., if something _isn’t_ normalizable,
+    * then normalization is identity.
+    */
+  implicit def default[F[_]]: Normalizable[F] = new Normalizable[F] {
+    def normalize = new (F ~> F) {
+      def apply[A](sp: F[A]) = sp
+    }
+  }
+}
+
+trait NormalizableInstances extends NormalizableInstances0 {
+  implicit def coproduct[F[_], G[_]](
+    implicit F: Normalizable[F], G: Normalizable[G]):
+      Normalizable[Coproduct[F, G, ?]] =
+    new Normalizable[Coproduct[F, G, ?]] {
+      def normalize = new (Coproduct[F, G, ?] ~> Coproduct[F, G, ?]) {
+        def apply[A](sp: Coproduct[F, G, A]) =
+          Coproduct(sp.run.bimap(F.normalize(_), G.normalize(_)))
+      }
+    }
+}
+
+object Normalizable extends NormalizableInstances

--- a/core/src/main/scala/quasar/qscript/QScriptBucket.scala
+++ b/core/src/main/scala/quasar/qscript/QScriptBucket.scala
@@ -16,7 +16,6 @@
 
 package quasar.qscript
 
-import quasar.ejson.{Int => _, _}
 import quasar.Predef._
 import quasar.fp._
 
@@ -58,7 +57,7 @@ sealed abstract class QScriptBucket[T[_[_]], A] {
     extends QScriptBucket[T, A]
 
 object QScriptBucket {
-  implicit def equal[T[_[_]]](implicit eqTEj: Equal[T[EJson]]): Delay[Equal, QScriptBucket[T, ?]] =
+  implicit def equal[T[_[_]]: EqualT]: Delay[Equal, QScriptBucket[T, ?]] =
     new Delay[Equal, QScriptBucket[T, ?]] {
       def apply[A](eq: Equal[A]) =
         Equal.equal {
@@ -96,7 +95,7 @@ object QScriptBucket {
       }
     }
 
-  implicit def show[T[_[_]]](implicit shEj: Show[T[EJson]]): Delay[Show, QScriptBucket[T, ?]] =
+  implicit def show[T[_[_]]: ShowT]: Delay[Show, QScriptBucket[T, ?]] =
     new Delay[Show, QScriptBucket[T, ?]] {
       def apply[A](sh: Show[A]): Show[QScriptBucket[T, A]] =
         Show.show {
@@ -131,7 +130,7 @@ object QScriptBucket {
         left: FreeMap[IT],
         right: FreeMap[IT],
         p1: QScriptBucket[IT, Unit],
-        p2: QScriptBucket[IT, Unit]): Option[Merge[IT, QScriptBucket[IT, Unit]]] = None
+        p2: QScriptBucket[IT, Unit]) = OptionT(state(None))
     }
 
   implicit def bucketable[T[_[_]]: Corecursive]:

--- a/core/src/main/scala/quasar/qscript/ReduceFunc.scala
+++ b/core/src/main/scala/quasar/qscript/ReduceFunc.scala
@@ -20,7 +20,7 @@ import quasar._
 import quasar.fp._
 import quasar.std.StdLib._
 
-import scalaz._
+import scalaz._, Scalaz._
 
 sealed trait ReduceFunc[A]
 
@@ -51,6 +51,18 @@ object ReduceFunc {
         case Arbitrary(a) => Cord("Arbitrary(") ++ show.show(a) ++ Cord(")")
       }
     }
+
+  implicit val traverse: Traverse[ReduceFunc] = new Traverse[ReduceFunc] {
+    def traverseImpl[G[_]: Applicative, A, B](fa: ReduceFunc[A])(f: (A) ⇒ G[B]) =
+      fa match {
+        case Count(a) => f(a) ∘ (Count(_))
+        case Sum(a) => f(a) ∘ (Sum(_))
+        case Min(a) => f(a) ∘ (Min(_))
+        case Max(a) => f(a) ∘ (Max(_))
+        case Avg(a) => f(a) ∘ (Avg(_))
+        case Arbitrary(a) => f(a) ∘ (Arbitrary(_))
+      }
+  }
 
   def translateReduction[A]: UnaryFunc => A => ReduceFunc[A] = {
     case agg.Count     => Count(_)

--- a/core/src/main/scala/quasar/qscript/package.scala
+++ b/core/src/main/scala/quasar/qscript/package.scala
@@ -80,14 +80,15 @@ package object qscript {
     implicit val show: Show[JoinSide] = Show.showFromToString
   }
 
-  type FreeUnit[T[_[_]], F[_]] = Free[F, Unit]
+  type FreeUnit[F[_]] = Free[F, Unit]
 
-  type FreeMap[T[_[_]]] = FreeUnit[T, MapFunc[T, ?]]
-  type FreeQS[T[_[_]]] = FreeUnit[T, QScriptInternal[T, ?]]
+  type FreeMap[T[_[_]]] = FreeUnit[MapFunc[T, ?]]
+  type FreeQS[T[_[_]]] = FreeUnit[QScriptInternal[T, ?]]
 
   type JoinFunc[T[_[_]]] = Free[MapFunc[T, ?], JoinSide]
 
-  def UnitF[T[_[_]]] = Free.point[MapFunc[T, ?], Unit](())
+  def UnitF[T[_[_]]] = ().point[Free[MapFunc[T, ?], ?]]
+
   final case class AbsMerge[T[_[_]], A, Q[_[_[_]]]](
     src: A,
     left: Q[T],

--- a/foundation/src/main/scala/quasar/fp/enumeratee.scala
+++ b/foundation/src/main/scala/quasar/fp/enumeratee.scala
@@ -17,6 +17,7 @@
 package quasar.fp
 
 import quasar.Predef._
+
 import scalaz._
 import scalaz.iteratee._
 

--- a/foundation/src/main/scala/quasar/fp/package.scala
+++ b/foundation/src/main/scala/quasar/fp/package.scala
@@ -560,4 +560,48 @@ package object fp
     */
   def recover[F[_], A](φ: Algebra[F, A]): Algebra[CoEnv[A, F, ?], A] =
     interpret(ι, φ)
+
+  object Inj {
+    def unapply[F[_], G[_], A](g: G[A])(implicit F: F :<: G): Option[F[A]] =
+      F.prj(g)
+  }
+
+  @typeclass trait EqualT[T[_[_]]] {
+    def equal[F[_]](tf1: T[F], tf2: T[F])(implicit del: Delay[Equal, F]): Boolean
+    def equalT[F[_]](delay: Delay[Equal, F]): Equal[T[F]] =
+      Equal.equal[T[F]](equal[F](_, _)(delay))
+  }
+
+  implicit val equalTFix: EqualT[Fix] = new EqualT[Fix] {
+    def equal[F[_]](tf1: Fix[F], tf2: Fix[F])(implicit del: Delay[Equal, F]): Boolean =
+      del(equalT[F](del)).equal(tf1.unFix, tf2.unFix)
+  }
+
+  implicit def equalTEqual[T[_[_]], F[_]](implicit T: EqualT[T], F: Delay[Equal, F]):
+      Equal[T[F]] =
+    T.equalT[F](F)
+
+  @typeclass trait ShowT[T[_[_]]] {
+    def show[F[_]](tf: T[F])(implicit del: Delay[Show, F]): Cord =
+      Cord(shows(tf))
+    def shows[F[_]](tf: T[F])(implicit del: Delay[Show, F]): String =
+      show(tf).toString
+    def showT[F[_]](delay: Delay[Show, F]): Show[T[F]] =
+      Show.show[T[F]](show[F](_)(delay))
+  }
+
+  implicit val showTFix: ShowT[Fix] = new ShowT[Fix] {
+    override def show[F[_]](tf: Fix[F])(implicit del: Delay[Show, F]): Cord =
+      del(showT[F](del)).show(tf.unFix)
+  }
+
+  implicit def showTShow[T[_[_]], F[_]](implicit T: ShowT[T], F: Delay[Show, F]):
+      Show[T[F]] =
+    T.showT[F](F)
+
+  def elgotM[M[_]: Monad, F[_]: Traverse, A, B](a: A)(φ: F[B] => M[B], ψ: A => M[B \/ F[A]]):
+      M[B] = {
+    def h(a: A): M[B] = ψ(a) >>= (_.traverse(_.traverse(h) >>= φ).map(_.merge))
+    h(a)
+  }
 }


### PR DESCRIPTION
Implement EqualT and ShowT.

This allows us to toss a bunch of explicit constraints on `T[EJson]`. We
still have a couple extra `Show` constraints for debugging
normalization.

Coalesce any Map into a preceding ThetaJoin.

Make a Normalizable type class.

MapFunc normalization is now applied across all components in the tree.

Would be better to apply all the QScript transformations across all the
FreeQS structures, but Free gets in the way currently.

Make QScript conversion available to backends.

Adding NameGen to Mergeable.