### PR TITLE
SD-1846 Correct generation of mongo collection prefix from dir path

### DIFF
--- a/CHANGELOG/bugfix.md
+++ b/CHANGELOG/bugfix.md
@@ -1,0 +1,1 @@
+- [SD-1846] Correct generation of mongo collection prefix from dir path

--- a/it/src/test/scala/quasar/fs/ManageFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/ManageFilesSpec.scala
@@ -163,6 +163,29 @@ class ManageFilesSpec extends FileSystemTest[FileSystem](
           .runOption must beSome(pathErr(pathNotFound(d1)))
       }
 
+      "[SD-1846] moving a directory with a name that is a prefix of another directory" >> {
+        val pnt = managePrefix </> dir("SD-1846")
+        val uf1 = pnt </> dir("Untitled Folder")   </> file("one")
+        val uf2 = pnt </> dir("Untitled Folder 1") </> file("two")
+        val uf3 = pnt </> dir("Untitled Folder 2") </> file("three")
+
+        val thirdDoc: Vector[Data] =
+          Vector(Data.Obj(ListMap("c" -> Data.Int(1))))
+
+        val src = pnt </> dir("Untitled Folder")
+        val dst = pnt </> dir("Untitled Folder 1") </> dir("Untitled Folder")
+
+        val setupAndMove =
+          write.saveThese(uf1, oneDoc)     *>
+          write.saveThese(uf2, anotherDoc) *>
+          write.saveThese(uf3, thirdDoc)   *>
+          manage.moveDir(src, dst, MoveSemantics.FailIfExists)
+
+        (runT(run)(setupAndMove).runOption must beNone) and
+        (runLogT(run, read.scanAll(dst </> file("one"))).runEither must beRight(oneDoc)) and
+        (run(query.fileExists(src </> file("one"))).unsafePerformSync must beFalse)
+      }
+
       "deleting a nonexistent file returns PathNotFound" >> {
         val f = managePrefix </> file("delfilenotfound")
         runT(run)(manage.delete(f)).runEither must beLeft(pathErr(pathNotFound(f)))

--- a/mongodb/src/main/scala/quasar/physical/mongodb/collection.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/collection.scala
@@ -41,7 +41,23 @@ final case class Collection(databaseName: String, collectionName: String) {
 
 object Collection {
 
-  def fromPath(path: APath): PathError \/ Collection = {
+  /** The collection represented by the given file. */
+  def fromFile(file: AFile): PathError \/ Collection =
+    fromPath(file)
+
+  /** The collection prefix represented by the given directory. */
+  def prefixFromDir(dir: ADir): PathError \/ String =
+    fromPath(dir) map (_.collectionName + ".")
+
+  /** Returns the database name determined by the given path. */
+  def dbNameFromPath(path: APath): PathError \/ String =
+    dbNameAndRest(path) bimap (PathError.invalidPath(path, _), _._1)
+
+  /** Returns the directory name derived from the given database name. */
+  def dirNameFromDbName(dbName: String): DirName =
+    DirName(DatabaseNameUnparser(dbName))
+
+  private def fromPath(path: APath): PathError \/ Collection = {
     import PathError._
 
     val collResult = for {
@@ -58,14 +74,6 @@ object Collection {
 
     collResult leftMap (invalidPath(path, _))
   }
-
-  /** Returns the database name determined by the given path. */
-  def dbNameFromPath(path: APath): PathError \/ String =
-    dbNameAndRest(path) bimap (PathError.invalidPath(path, _), _._1)
-
-  /** Returns the directory name derived from the given database name. */
-  def dirNameFromDbName(dbName: String): DirName =
-    DirName(DatabaseNameUnparser(dbName))
 
   private def dbNameAndRest(path: APath): String \/ (String, IList[String]) =
     flatten(None, None, None, Some(_), Some(_), path)

--- a/mongodb/src/main/scala/quasar/physical/mongodb/fs/queryfile.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/fs/queryfile.scala
@@ -91,7 +91,7 @@ private final class QueryFileInterpreter[C](
 
   def apply[A](qf: QueryFile[A]) = qf match {
     case ExecutePlan(lp, out) => (for {
-      dst  <- EitherT(Collection.fromPath(out)
+      dst  <- EitherT(Collection.fromFile(out)
                 .leftMap(pathErr(_))
                 .point[MongoLogWF])
       coll <- handlePlan(lp,
@@ -151,7 +151,7 @@ private final class QueryFileInterpreter[C](
       }).liftM[QRT]
 
     case FileExists(file) =>
-      Collection.fromPath(file).fold(
+      Collection.fromFile(file).fold(
         κ(false.point[MQ]),
         coll => MongoDbIO.collectionExists(coll).liftM[QRT])
   }
@@ -260,16 +260,16 @@ private final class QueryFileInterpreter[C](
 
   private def checkPathsExist(lp: Fix[LogicalPlan]): MongoLogWFR[Unit] = {
     // Documentation on `QueryFile` guarantees absolute paths, so calling `mkAbsolute`
-    def checkPathExists(p: AFile): MongoFsM[Unit] = for {
-      coll <- EitherT.fromDisjunction[MongoDbIO](Collection.fromPath(p))
+    def checkFileExists(f: AFile): MongoFsM[Unit] = for {
+      coll <- EitherT.fromDisjunction[MongoDbIO](Collection.fromFile(f))
                 .leftMap(pathErr(_))
       _    <- EitherT(MongoDbIO.collectionExists(coll)
-                .map(_ either (()) or pathErr(PathError.pathNotFound(p))))
+                .map(_ either (()) or pathErr(PathError.pathNotFound(f))))
     } yield ()
 
     EitherT[MongoLogWF, FileSystemError, Unit](
       (LogicalPlan.paths(lp)
-        .traverse_(path => checkPathExists(mkAbsolute(rootDir, path))).run
+        .traverse_(file => checkFileExists(mkAbsolute(rootDir, file))).run
         .liftM[QRT]: MQ[FileSystemError \/ Unit])
         .liftM[PhaseResultT])
   }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/fs/readfile.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/fs/readfile.scala
@@ -111,7 +111,7 @@ object readfile {
         h    <- recordCursor(f, cur)
       } yield h
 
-    Collection.fromPath(f).fold(
+    Collection.fromFile(f).fold(
       err  => pathErr(err).left.point[MongoRead],
       coll => collectionExists(coll).liftM[ReadStateT].ifM(
                 openCursor0(coll) map (_.right[FileSystemError]),

--- a/mongodb/src/main/scala/quasar/physical/mongodb/fs/writefile.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/fs/writefile.scala
@@ -37,7 +37,7 @@ object writefile {
   val interpret: WriteFile ~> MongoWrite = new (WriteFile ~> MongoWrite) {
     def apply[A](wf: WriteFile[A]) = wf match {
       case Open(file) =>
-        Collection.fromPath(file) fold (
+        Collection.fromFile(file) fold (
           err => pathErr(err).left.point[MongoWrite],
           col => ensureCollection(col).liftM[WriteStateT] *>
                  recordCollection(file, col) map \/.right)

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner.scala
@@ -945,7 +945,7 @@ object MongoDbPlanner {
     node => node match {
       case ReadF(path) =>
         // Documentation on `QueryFile` guarantees absolute paths, so calling `mkAbsolute`
-        state(Collection.fromPath(mkAbsolute(rootDir, path)).bimap(PlanPathError, WorkflowBuilder.read))
+        state(Collection.fromFile(mkAbsolute(rootDir, path)).bimap(PlanPathError, WorkflowBuilder.read))
       case ConstantF(data) =>
         state(BsonCodec.fromData(data).bimap(
           κ(NonRepresentableData(data)),

--- a/mongodb/src/test/scala/quasar/physical/mongodb/collection.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/collection.scala
@@ -28,108 +28,104 @@ import pathy.scalacheck._
 
 class CollectionSpec extends Specification with ScalaCheck with DisjunctionMatchers {
 
-  "Collection.fromPath" should {
+  "Collection.fromFile" should {
 
     "handle simple name" in {
-      Collection.fromPath(rootDir </> dir("db") </> file("foo")) must
+      Collection.fromFile(rootDir </> dir("db") </> file("foo")) must
         beRightDisjunction(Collection("db", "foo"))
     }
 
     "handle simple relative path" in {
-      Collection.fromPath(rootDir </> dir("db") </> dir("foo") </> file("bar")) must
+      Collection.fromFile(rootDir </> dir("db") </> dir("foo") </> file("bar")) must
         beRightDisjunction(Collection("db", "foo.bar"))
     }
 
     "escape leading '.'" in {
-      Collection.fromPath(rootDir </> dir("db") </> file(".hidden")) must
+      Collection.fromFile(rootDir </> dir("db") </> file(".hidden")) must
         beRightDisjunction(Collection("db", "\\.hidden"))
     }
 
     "escape '.' with path separators" in {
-      Collection.fromPath(rootDir </> dir("db") </> dir("foo") </> file("bar.baz")) must
+      Collection.fromFile(rootDir </> dir("db") </> dir("foo") </> file("bar.baz")) must
         beRightDisjunction(Collection("db", "foo.bar\\.baz"))
     }
 
     "escape '$'" in {
-      Collection.fromPath(rootDir </> dir("db") </> file("foo$")) must
+      Collection.fromFile(rootDir </> dir("db") </> file("foo$")) must
         beRightDisjunction(Collection("db", "foo\\d"))
     }
 
     "escape '\\'" in {
-      Collection.fromPath(rootDir </> dir("db") </> file("foo\\bar")) must
+      Collection.fromFile(rootDir </> dir("db") </> file("foo\\bar")) must
         beRightDisjunction(Collection("db", "foo\\\\bar"))
     }
 
     "accept path with 120 characters" in {
       val longName = Stream.continually("A").take(117).mkString
-      Collection.fromPath(rootDir </> dir("db") </> file(longName)) must
+      Collection.fromFile(rootDir </> dir("db") </> file(longName)) must
         beRightDisjunction(Collection("db", longName))
     }
 
     "reject path longer than 120 characters" in {
       val longName = Stream.continually("B").take(118).mkString
-      Collection.fromPath(rootDir </> dir("db") </> file(longName)) must beLeftDisjunction
+      Collection.fromFile(rootDir </> dir("db") </> file(longName)) must beLeftDisjunction
     }
 
     "reject path that translates to more than 120 characters" in {
       val longName = "." + Stream.continually("C").take(116).mkString
-      Collection.fromPath(rootDir </> dir("db") </> file(longName)) must beLeftDisjunction
+      Collection.fromFile(rootDir </> dir("db") </> file(longName)) must beLeftDisjunction
     }
 
     "preserve space" in {
-      Collection.fromPath(rootDir </> dir("db") </> dir("foo") </> file("bar baz")) must
+      Collection.fromFile(rootDir </> dir("db") </> dir("foo") </> file("bar baz")) must
         beRightDisjunction(Collection("db", "foo.bar baz"))
     }
 
-    "reject path without db or collection" in {
-      Collection.fromPath(rootDir) must beLeftDisjunction
-    }
-
     "reject path with db but no collection" in {
-      Collection.fromPath(rootDir </> dir("db")) must beLeftDisjunction
+      Collection.fromFile(rootDir </> file("db")) must beLeftDisjunction
     }
 
     "escape space in db name" in {
-      Collection.fromPath(rootDir </> dir("db 1") </> file("foo")) must
+      Collection.fromFile(rootDir </> dir("db 1") </> file("foo")) must
         beRightDisjunction(Collection("db+1", "foo"))
     }
 
     "escape leading dot in db name" in {
-      Collection.fromPath(rootDir </> dir(".trash") </> file("foo")) must
+      Collection.fromFile(rootDir </> dir(".trash") </> file("foo")) must
         beRightDisjunction(Collection("~trash", "foo"))
     }
 
     "escape MongoDB-reserved chars in db name" in {
-      Collection.fromPath(rootDir </> dir("db/\\\"") </> file("foo")) must
+      Collection.fromFile(rootDir </> dir("db/\\\"") </> file("foo")) must
         beRightDisjunction(Collection("db%div%esc%quot", "foo"))
     }
 
     "escape Windows-only MongoDB-reserved chars in db name" in {
-      Collection.fromPath(rootDir </> dir("db*<>:|?") </> file("foo")) must
+      Collection.fromFile(rootDir </> dir("db*<>:|?") </> file("foo")) must
         beRightDisjunction(Collection("db%mul%lt%gt%colon%bar%qmark", "foo"))
     }
 
     "escape escape characters in db name" in {
-      Collection.fromPath(rootDir </> dir("db%+~") </> file("foo")) must
+      Collection.fromFile(rootDir </> dir("db%+~") </> file("foo")) must
         beRightDisjunction(Collection("db%%%add%tilde", "foo"))
     }
 
     "fail with sequence of escapes exceeding maximum length" in {
-      Collection.fromPath(rootDir </> dir("~:?~:?~:?~:") </> file("foo")) must beLeftDisjunction
+      Collection.fromFile(rootDir </> dir("~:?~:?~:?~:") </> file("foo")) must beLeftDisjunction
     }
 
     "succeed with db name of exactly 64 bytes when encoded" in {
       val dbName = List.fill(64/4)("💩").mkString
-      Collection.fromPath(rootDir </> dir(dbName) </> file("foo")) must beRightDisjunction
+      Collection.fromFile(rootDir </> dir(dbName) </> file("foo")) must beRightDisjunction
     }
 
     "fail with db name exceeding 64 bytes when encoded" in {
       val dbName = List.fill(64/4 + 1)("💩").mkString
-      Collection.fromPath(rootDir </> dir(dbName) </> file("foo")) must beLeftDisjunction
+      Collection.fromFile(rootDir </> dir(dbName) </> file("foo")) must beLeftDisjunction
     }
 
     "succeed with crazy char" in {
-      Collection.fromPath(rootDir </> dir("*_") </> dir("_ⶡ\\݅ ᐠ") </> file("儨")) must
+      Collection.fromFile(rootDir </> dir("*_") </> dir("_ⶡ\\݅ ᐠ") </> file("儨")) must
         beRightDisjunction
     }
 
@@ -138,7 +134,7 @@ class CollectionSpec extends Specification with ScalaCheck with DisjunctionMatch
       val notTooLong = posixCodec.printPath(f).length < 30
       // NB: as long as the path is not too long, it should convert to something that's legal
       notTooLong ==> {
-        Collection.fromPath(f).fold(
+        Collection.fromFile(f).fold(
           err => scala.sys.error(err.toString),
           coll => {
             Result.foreach(" ./\\*<>:|?") { c => coll.databaseName.toList must not(contain(c)) }
@@ -148,7 +144,7 @@ class CollectionSpec extends Specification with ScalaCheck with DisjunctionMatch
 
     "round-trip" ! prop { f: AbsFileOf[SpecialStr] =>
       // NB: the path might be too long to convert
-      val r = Collection.fromPath(f.path)
+      val r = Collection.fromFile(f.path)
       (r.isRight) ==> {
         r.fold(
           err  => scala.sys.error(err.toString),
@@ -159,7 +155,21 @@ class CollectionSpec extends Specification with ScalaCheck with DisjunctionMatch
       // has a good change of being refused by MongoDB because many of the characters generated by SpecialStr have large
       // utf-encodings so we retryUntil we find an appropriate one even if that is somewhat dangerous (unbounded execution time)
       // For this particular test, execution time does not seem to be a large concern (couple seconds).
-    }.set(maxSize = 120).setGen(PathOf.absFileOfArbitrary[SpecialStr].arbitrary.retryUntil(f => Collection.fromPath(f.path).isRight))
+    }.set(maxSize = 120).setGen(PathOf.absFileOfArbitrary[SpecialStr].arbitrary.retryUntil(f => Collection.fromFile(f.path).isRight))
+  }
+
+  "Collection.prefixFromDir" should {
+    "return a collection prefix" in {
+      Collection.prefixFromDir(rootDir </> dir("foo") </> dir("bar")) must beRightDisjunction("bar.")
+    }
+
+    "reject path without collection" in {
+      Collection.prefixFromDir(rootDir </> dir("foo")) must beLeftDisjunction
+    }
+
+    "reject path without db or collection" in {
+      Collection.prefixFromDir(rootDir) must beLeftDisjunction
+    }
   }
 
   "Collection.asFile" should {


### PR DESCRIPTION
Previously, when generating a collection prefix from a directory path, we failed to terminate the prefix with a `.`, thus it would match too many collection names, namely anything it was a string prefix of, for example the directory `/foo/bar/Untitled Folder/` would translate to the collection prefix `bar.Untitled Folder` and thus would match all of `bar.Untitled Folder.somefile`, `bar.Untitled Folder 1.somefile`, `bar.Untitled Folder and anything else.anotherfile`.

This corrects the problem by formalizing that collections can only be created from file paths and dir paths represent prefixes. So now the collection prefix from `/foo/bar/Untitled Folder/` is now `bar.Untitled Folder.`.