### PR TITLE
[SD-1825] Respond to http4s MessageFailure with BadRequest

### DIFF
--- a/CHANGELOG/bugfix.md
+++ b/CHANGELOG/bugfix.md
@@ -1,0 +1,1 @@
+- [SD-1825] Respond to http4s MessageFailure with BadRequest


### PR DESCRIPTION
Adds middleware to handle any `MessageFailure`s produced, turning them into `ApiError`s.