### PR TITLE
[SD-1844] Fix error where moving fs mounts only updated configuration

### DIFF
--- a/CHANGELOG/bugfix.md
+++ b/CHANGELOG/bugfix.md
@@ -1,0 +1,1 @@
+- [SD-1844] Fix issue where Mounting effects were being circumvented when moving filesytem mounts.

--- a/web/src/test/scala/quasar/api/services/MountServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/MountServiceSpec.scala
@@ -24,10 +24,10 @@ import quasar.effect.KeyValueStore
 import quasar.fp._
 import quasar.fp.free._
 import quasar.fs._, PathArbitrary._
-import quasar.fs.mount._
+import quasar.fs.mount.{MountRequest => MR, _}
 
 import argonaut._, Argonaut._
-import org.http4s._
+import org.http4s._, Status._
 import org.http4s.argonaut._
 import org.specs2.specification.core.Fragments
 import org.specs2.ScalaCheck
@@ -44,31 +44,40 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
   import posixCodec.printPath
   import PathError._
 
-  val StubFs = FileSystemType("stub")
-
   type Eff0[A] = Coproduct[Mounting, MountConfigs, A]
   type Eff[A]  = Coproduct[Task, Eff0, A]
 
+  type Mounted = Set[MR]
+  type TestSvc = Request => Free[Eff, (Response, Mounted)]
+
+  val StubFs = FileSystemType("stub")
+  val fooUri = ConnectionUri("foo")
+  val barUri = ConnectionUri("foo")
+  val invalidUri = ConnectionUri("invalid")
+
   val M = Mounting.Ops[Eff]
 
-  type HttpSvc = Request => M.F[Response]
-
-  def runTest[R: org.specs2.execute.AsResult](f: HttpSvc => M.F[R]): R = {
+  def runTest[A](f: TestSvc => Free[Eff, A]): A = {
     type MEff[A] = Coproduct[Task, MountConfigs, A]
 
-    TaskRef(Map[APath, MountConfig]()).flatMap { ref =>
+    (TaskRef(Set.empty[MR]) |@| TaskRef(Map.empty[APath, MountConfig]))
+      .tupled.flatMap { case (mountedRef, configsRef) =>
 
       val mounter: Mounting ~> Free[MEff, ?] = Mounter[Task, MEff](
         {
-          case MountRequest.MountFileSystem(_, typ, uri @ ConnectionUri("invalid")) =>
-            Task.now(MountingError.invalidConfig(MountConfig.fileSystemConfig(typ, uri),
-              "invalid connectionUri (simulated)".wrapNel).left)
-          case _ =>
-            Task.now(().right)
-        },
-        κ(Task.now(())))
+          case MR.MountFileSystem(_, typ, `invalidUri`) =>
+            MountingError.invalidConfig(
+              MountConfig.fileSystemConfig(typ, invalidUri),
+              "invalid connectionUri (simulated)".wrapNel
+            ).left.point[Task]
 
-      val store: MountConfigs ~> Task = KeyValueStore.fromTaskRef(ref)
+          case mntReq =>
+            mountedRef.modify(_ + mntReq).void map \/.right
+        },
+        mntReq => mountedRef.modify(_ - mntReq).void
+      )
+
+      val store: MountConfigs ~> Task = KeyValueStore.fromTaskRef(configsRef)
 
       val mt: MEff ~> Task = NaturalTransformation.refl[Task] :+: store
 
@@ -79,7 +88,10 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
 
       val service = mount.service[Eff].toHttpService(liftMT[Task, ResponseT] compose eff)
 
-      f(service.run andThen (free.lift(_).into[Eff])).foldMap(eff)
+      val testSvc: TestSvc =
+        req => injectFT[Task, Eff] apply (service(req) flatMap (mountedRef.read strengthL _))
+
+      f(testSvc) foldMap eff
     }.unsafePerformSync
   }
 
@@ -105,12 +117,14 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
         !hasDot(d) ==> {
           runTest { service =>
             for {
-              _    <- M.mountFileSystem(d, StubFs, ConnectionUri("foo")).run.flatMap(orFailF)
-
-              resp <- service(Request(uri = pathUri(d)))
+              _    <- M.mountFileSystem(d, StubFs, ConnectionUri("foo"))
+                        .run.flatMap(orFailF)
+              r    <- service(Request(uri = pathUri(d)))
+              (res, _) = r
+              body <- lift(res.as[Json]).into[Eff]
             } yield {
-              resp.as[Json].unsafePerformSync must_== Json("stub" -> Json("connectionUri" := "foo"))
-              resp.status must_== Status.Ok
+              (body must_== Json("stub" -> Json("connectionUri" := "foo"))) and
+              (res.status must_== Ok)
             }
           }
         }
@@ -122,12 +136,14 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
 
         runTest { service =>
           for {
-            _    <- M.mountFileSystem(d, StubFs, ConnectionUri("foo")).run.flatMap(orFailF)
-
-            resp <- service(Request(uri = pathUri(d)))
+            _    <- M.mountFileSystem(d, StubFs, ConnectionUri("foo"))
+                      .run.flatMap(orFailF)
+            r    <- service(Request(uri = pathUri(d)))
+            (res, _) = r
+            body <- lift(res.as[Json]).into[Eff]
           } yield {
-            resp.as[Json].unsafePerformSync must_== Json("stub" -> Json("connectionUri" := "foo"))
-            resp.status must_== Status.Ok
+            (body must_== Json("stub" -> Json("connectionUri" := "foo"))) and
+            (res.status must_== Ok)
           }
         }
       }
@@ -141,10 +157,11 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
             for {
               _    <- M.mountView(f, cfg._1, cfg._2).run.flatMap(orFailF)
 
-              resp <- service(Request(uri = pathUri(f)))
+              r    <- service(Request(uri = pathUri(f)))
+              (res, _) = r
+              body <- lift(res.as[Json]).into[Eff]
             } yield {
-              resp.as[Json].unsafePerformSync must_== cfgStr
-              resp.status must_== Status.Ok
+              (body must_== cfgStr) and (res.status must_== Ok)
             }
           }
         }
@@ -153,9 +170,11 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
       "be 404 with missing mount (dir)" ! prop { d: APath =>
         runTest { service =>
           for {
-            resp <- service(Request(uri = pathUri(d)))
+            r   <- service(Request(uri = pathUri(d)))
+            (res, _) = r
+            err <- lift(res.as[ApiError]).into[Eff]
           } yield {
-            resp.as[ApiError].unsafePerformSync must beMountNotFoundError(d)
+            err must beMountNotFoundError(d)
           }
         }
       }
@@ -165,11 +184,13 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
           val dp = fileParent(fp) </> dir(fileName(fp).value)
 
           for {
-            _    <- M.mountFileSystem(dp, StubFs, ConnectionUri("foo")).run.flatMap(orFailF)
-
-            resp <- service(Request(uri = pathUri(fp)))
+            _   <- M.mountFileSystem(dp, StubFs, ConnectionUri("foo"))
+                     .run.flatMap(orFailF)
+            r   <- service(Request(uri = pathUri(fp)))
+            (res, _) = r
+            err <- lift(res.as[ApiError]).into[Eff]
           } yield {
-            resp.as[ApiError].unsafePerformSync must beMountNotFoundError(fp)
+            err must beMountNotFoundError(fp)
           }
         }
       }
@@ -188,21 +209,25 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
             val src = rootDir </> dir(srcHead) </> srcTail
             val dst = rootDir </> dir(dstHead) </> dstTail
             for {
-              _    <- M.mountFileSystem(src, StubFs, ConnectionUri("foo")).run.flatMap(orFailF)
+              _        <- M.mountFileSystem(src, StubFs, fooUri)
+                            .run.flatMap(orFailF)
 
-              resp <- service(Request(
-                method = MOVE,
-                uri = pathUri(src),
-                headers = Headers(destination(dst))))
+              r        <- service(Request(
+                            method = MOVE,
+                            uri = pathUri(src),
+                            headers = Headers(destination(dst))))
+
+              (res, mntd) = r
+              body     <- lift(res.as[String]).into[Eff]
 
               srcAfter <- M.lookup(src).run
               dstAfter <- M.lookup(dst).run
             } yield {
-              resp.as[String].unsafePerformSync must_== s"moved ${printPath(src)} to ${printPath(dst)}"
-              resp.status must_== Status.Ok
-
-              srcAfter must beNone
-              dstAfter must beSome(MountConfig.fileSystemConfig(StubFs, ConnectionUri("foo")))
+              (body must_== s"moved ${printPath(src)} to ${printPath(dst)}") and
+              (res.status must_== Ok)                                        and
+              (mntd must_== Set(MR.mountFileSystem(dst, StubFs, fooUri)))    and
+              (srcAfter must beNone)                                         and
+              (dstAfter must beSome(MountConfig.fileSystemConfig(StubFs, fooUri)))
             }
           }
         }
@@ -211,12 +236,16 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
       "be 404 with missing source" ! prop { (src: ADir, dst: ADir) =>
         runTest { service =>
           for {
-            resp <- service(Request(
-              method = MOVE,
-              uri = pathUri(src),
-              headers = Headers(destination(dst))))
+            r   <- service(Request(
+                     method = MOVE,
+                     uri = pathUri(src),
+                     headers = Headers(destination(dst))))
+
+            (res, mntd) = r
+            err <- lift(res.as[ApiError]).into[Eff]
           } yield {
-            resp.as[ApiError].unsafePerformSync must beApiErrorLike(pathNotFound(src))
+            (err must beApiErrorLike(pathNotFound(src))) and
+            (mntd must beEmpty)
           }
         }
       }
@@ -225,13 +254,18 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
         !hasDot(src) ==> {
           runTest { service =>
             for {
-              _    <- M.mountFileSystem(src, StubFs, ConnectionUri("foo")).run.flatMap(orFailF)
+              _   <- M.mountFileSystem(src, StubFs, fooUri)
+                       .run.flatMap(orFailF)
 
-              resp <- service(Request(
-                method = MOVE,
-                uri = pathUri(src)))
+              r   <- service(Request(
+                        method = MOVE,
+                        uri = pathUri(src)))
+
+              (res, mntd) = r
+              err <- lift(res.as[ApiError]).into[Eff]
             } yield {
-              resp.as[ApiError].unsafePerformSync must beHeaderMissingError("Destination")
+              (err must beHeaderMissingError("Destination")) and
+              (mntd must_== Set(MR.mountFileSystem(src, StubFs, fooUri)))
             }
           }
         }
@@ -241,16 +275,21 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
         !hasDot(src) ==> {
           runTest { service =>
             for {
-              _    <- M.mountFileSystem(src, StubFs, ConnectionUri("foo")).run.flatMap(orFailF)
+              _   <- M.mountFileSystem(src, StubFs, fooUri)
+                       .run.flatMap(orFailF)
 
-              resp <- service(Request(
-                method = MOVE,
-                uri = pathUri(src),
-                headers = Headers(destination(dst))))
+              r   <- service(Request(
+                       method = MOVE,
+                       uri = pathUri(src),
+                       headers = Headers(destination(dst))))
+
+              (res, mntd) = r
+              err <- lift(res.as[ApiError]).into[Eff]
             } yield {
-              resp.as[ApiError].unsafePerformSync must equal(ApiError.apiError(
+              (err must equal(ApiError.apiError(
                 Status.BadRequest withReason "Expected an absolute directory.",
-                "path" := dst))
+                "path" := dst))) and
+              (mntd must_== Set(MR.mountFileSystem(src, StubFs, fooUri)))
             }
           }
         }
@@ -260,16 +299,21 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
         !hasDot(src) ==> {
           runTest { service =>
             for {
-              _    <- M.mountFileSystem(src, StubFs, ConnectionUri("foo")).run.flatMap(orFailF)
+              _   <- M.mountFileSystem(src, StubFs, fooUri)
+                       .run.flatMap(orFailF)
 
-              resp <- service(Request(
-                method = MOVE,
-                uri = pathUri(src),
-                headers = Headers(destination(dst))))
+              r   <- service(Request(
+                       method = MOVE,
+                       uri = pathUri(src),
+                       headers = Headers(destination(dst))))
+
+              (res, mntd) = r
+              err <- lift(res.as[ApiError]).into[Eff]
             } yield {
-              resp.as[ApiError].unsafePerformSync must equal(ApiError.apiError(
+              (err must equal(ApiError.apiError(
                 Status.BadRequest withReason "Expected an absolute directory.",
-                "path" := dst))
+                "path" := dst))) and
+              (mntd must_== Set(MR.mountFileSystem(src, StubFs, fooUri)))
             }
           }
         }
@@ -283,28 +327,28 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
       import org.http4s.Method.PUT
 
       trait RequestBuilder {
-        def apply[B](parent: ADir, mount: RPath, body: B)(implicit B: EntityEncoder[B]): Request
+        def apply[B](parent: ADir, mount: RPath, body: B)(implicit B: EntityEncoder[B]): Free[Eff, Request]
       }
 
       def testBoth(test: RequestBuilder => Fragments) = {
         "POST" should {
           test(new RequestBuilder {
             def apply[B](parent: ADir, mount: RPath, body: B)(implicit B: EntityEncoder[B]) =
-              Request(
+              lift(Request(
                 method = POST,
                 uri = pathUri(parent),
                 headers = Headers(xFileName(mount)))
-              .withBody(body).unsafePerformSync
+              .withBody(body)).into[Eff]
             })
         }
 
         "PUT" should {
           test(new RequestBuilder {
             def apply[B](parent: ADir, mount: RPath, body: B)(implicit B: EntityEncoder[B]) =
-              Request(
+              lift(Request(
                 method = PUT,
                 uri = pathUri(parent </> mount))
-              .withBody(body).unsafePerformSync
+              .withBody(body)).into[Eff]
           })
         }
       }
@@ -314,14 +358,17 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
           !hasDot(parent </> fsDir) ==> {
             runTest { service =>
               for {
-                resp  <- service(reqBuilder(parent, fsDir, """{"stub": { "connectionUri": "foo" } }"""))
-
-                after <- M.lookup(parent </> fsDir).run
+                req   <- reqBuilder(parent, fsDir, """{"stub": { "connectionUri": "foo" } }""")
+                r     <- service(req)
+                (res, mntd) = r
+                body  <- lift(res.as[String]).into[Eff]
+                dst   =  parent </> fsDir
+                after <- M.lookup(dst).run
               } yield {
-                resp.as[String].unsafePerformSync must_== s"added ${printPath(parent </> fsDir)}"
-                resp.status must_== Status.Ok
-
-                after must beSome(MountConfig.fileSystemConfig(StubFs, ConnectionUri("foo")))
+                (body must_== s"added ${printPath(dst)}")                   and
+                (res.status must_== Ok)                                     and
+                (mntd must_== Set(MR.mountFileSystem(dst, StubFs, fooUri))) and
+                (after must beSome(MountConfig.fileSystemConfig(StubFs, fooUri)))
               }
             }
           }
@@ -330,18 +377,22 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
         "succeed with view path" ! prop { (parent: ADir, f: RFile) =>
           !hasDot(parent </> f) ==> {
             runTest { service =>
-              val cfg = viewConfig("select * from zips where pop < :cutoff", "cutoff" -> "1000")
-              val cfgStr = EncodeJson.of[MountConfig].encode(MountConfig.viewConfig(cfg))
+              val (expr, vars) = viewConfig("select * from zips where pop < :cutoff", "cutoff" -> "1000")
+              val cfgStr = EncodeJson.of[MountConfig].encode(MountConfig.viewConfig(expr, vars))
 
               for {
-                resp  <- service(reqBuilder(parent, f, cfgStr))
-
-                after <- M.lookup(parent </> f).run
+                req   <- reqBuilder(parent, f, cfgStr)
+                r     <- service(req)
+                (res, mntd) = r
+                body  <- lift(res.as[String]).into[Eff]
+                dst   =  parent </> f
+                after <- M.lookup(dst).run
               } yield {
-                resp.as[String].unsafePerformSync must_== s"added ${printPath(parent </> f)}"
-                resp.status must_== Status.Ok
-
-                after must beSome(MountConfig.viewConfig(cfg))
+                (body must_== s"added ${printPath(dst)}")         and
+                (res.status must_== Ok)                           and
+// TODO: This fails due to how we're bypassing Mounting for views, enable and fix.
+//              (mntd must_== Set(MR.mountView(dst, expr, vars))) and
+                (after must beSome(MountConfig.viewConfig(expr, vars)))
               }
             }
           }
@@ -350,24 +401,32 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
         "succeed with view under existing fs path" ! prop { (fs: ADir, viewSuffix: RFile) =>
           !hasDot(fs </> viewSuffix) ==> {
             runTest { service =>
-              val cfg = viewConfig("select * from zips where pop < :cutoff", "cutoff" -> "1000")
-              val cfgStr = EncodeJson.of[MountConfig].encode(MountConfig.viewConfig(cfg))
+              val (expr, vars) = viewConfig("select * from zips where pop < :cutoff", "cutoff" -> "1000")
+              val cfgStr = EncodeJson.of[MountConfig].encode(MountConfig.viewConfig(expr, vars))
 
               val view = fs </> viewSuffix
 
               for {
-                _         <- M.mountFileSystem(fs, StubFs, ConnectionUri("foo")).run.flatMap(orFailF)
+                _         <- M.mountFileSystem(fs, StubFs, fooUri)
+                               .run.flatMap(orFailF)
 
-                resp      <- service(reqBuilder(fs, viewSuffix, cfgStr))
+                req       <- reqBuilder(fs, viewSuffix, cfgStr)
+                r         <- service(req)
+                (res, mntd) = r
+                body      <- lift(res.as[String]).into[Eff]
 
                 afterFs   <- M.lookup(fs).run
                 afterView <- M.lookup(view).run
               } yield {
-                resp.as[String].unsafePerformSync must_== s"added ${printPath(view)}"
-                resp.status must_== Status.Ok
-
-                afterFs must beSome
-                afterView must beSome(MountConfig.viewConfig(cfg))
+                (body must_== s"added ${printPath(view)}") and
+                (res.status must_== Ok)                    and
+// TODO: This fails due to how we're bypassing Mounting for views, enable and fix.
+//              (mntd must_== Set(
+//                MR.mountFileSystem(fs, StubFs, fooUri),
+//                MR.mountView(view, expr, vars)
+//              ))                                         and
+                (afterFs must beSome)                      and
+                (afterView must beSome(MountConfig.viewConfig(expr, vars)))
               }
             }
           }
@@ -376,24 +435,30 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
         "succeed with view 'above' existing fs path" ! prop { (d: ADir, view: RFile, fsSuffix: RDir) =>
           !hasDot(d </> view) ==> {
             runTest { service =>
-              val fsCfg = ()
-
-              val cfg = viewConfig("select * from zips where pop < :cutoff", "cutoff" -> "1000")
-              val cfgStr = EncodeJson.of[MountConfig].encode(MountConfig.viewConfig(cfg))
+              val (expr, vars) = viewConfig("select * from zips where pop < :cutoff", "cutoff" -> "1000")
+              val cfgStr = EncodeJson.of[MountConfig].encode(MountConfig.viewConfig(expr, vars))
 
               val fs = d </> posixCodec.parseRelDir(posixCodec.printPath(view) + "/").flatMap(sandbox(currentDir, _)).get </> fsSuffix
 
               for {
-                _     <- M.mountFileSystem(fs,StubFs, ConnectionUri("foo")).run.flatMap(orFailF)
+                _     <- M.mountFileSystem(fs, StubFs, fooUri)
+                           .run.flatMap(orFailF)
 
-                resp  <- service(reqBuilder(d, view, cfgStr))
-
-                after <- M.lookup(d </> view).run
+                req   <- reqBuilder(d, view, cfgStr)
+                r     <- service(req)
+                (res, mntd) = r
+                body  <- lift(res.as[String]).into[Eff]
+                vdst  =  d </> view
+                after <- M.lookup(vdst).run
               } yield {
-                resp.as[String].unsafePerformSync must_== s"added ${printPath(d </> view)}"
-                resp.status must_== Status.Ok
-
-                after must beSome(MountConfig.viewConfig(cfg))
+                (body must_== s"added ${printPath(vdst)}") and
+                (res.status must_== Ok)                    and
+// TODO: This fails due to how we're bypassing Mounting for views, enable and fix.
+//              (mntd must_== Set(
+//                MR.mountFileSystem(fs, StubFs, fooUri),
+//                MR.mountView(vdst, expr, vars)
+//              ))                                         and
+                (after must beSome(MountConfig.viewConfig(expr, vars)))
               }
             }
           }
@@ -402,23 +467,24 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
         "be 409 with fs above existing fs path" ! prop { (d: ADir, fs: RDir, fsSuffix: RDir) =>
           (!identicalPath(fsSuffix, currentDir)) ==> {
             runTest { service =>
-              val cfg = (StubFs, ConnectionUri("foo"))
-
-              val cfgStr = EncodeJson.of[MountConfig].encode(MountConfig.fileSystemConfig(cfg))
-
+              val cfgStr = EncodeJson.of[MountConfig].encode(MountConfig.fileSystemConfig(StubFs, fooUri))
               val fs1 = d </> fs </> fsSuffix
 
               for {
-                _     <- M.mountFileSystem(fs1, cfg._1, cfg._2).run.flatMap(orFailF)
+                _     <- M.mountFileSystem(fs1, StubFs, fooUri)
+                           .run.flatMap(orFailF)
 
-                resp  <- service(reqBuilder(d, fs, cfgStr))
-
-                after <- M.lookup(d </> fs).run
+                req   <- reqBuilder(d, fs, cfgStr)
+                r     <- service(req)
+                (res, mntd) = r
+                jerr  <- lift(res.as[Json]).into[Eff]
+                dst   =  d </> fs
+                after <- M.lookup(dst).run
               } yield {
-                resp.as[Json].unsafePerformSync must_== Json("error" := s"cannot mount at ${printPath(d </> fs)} because existing mount below: ${printPath(fs1)}")
-                resp.status must_== Status.Conflict
-
-                after must beNone
+                (jerr must_== Json("error" := s"cannot mount at ${printPath(dst)} because existing mount below: ${printPath(fs1)}")) and
+                (res.status must_== Conflict)                               and
+                (mntd must_== Set(MR.mountFileSystem(fs1, StubFs, fooUri))) and
+                (after must beNone)
               }
             }
           }
@@ -426,14 +492,16 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
 
         "be 400 with fs config and file path in X-File-Name header" ! prop { (parent: ADir, fsFile: RFile) =>
           runTest { service =>
-            val cfg = (StubFs, ConnectionUri("foo"))
-
             for {
-              resp <- service(reqBuilder(parent, fsFile, """{ "stub": { "connectionUri": "foo" } }"""))
+              req <- reqBuilder(parent, fsFile, """{ "stub": { "connectionUri": "foo" } }""")
+              r   <- service(req)
+              (res, mntd) = r
+              err <- lift(res.as[ApiError]).into[Eff]
             } yield {
-              resp.as[ApiError].unsafePerformSync must beApiErrorWithMessage(
+              (err must beApiErrorWithMessage(
                 Status.BadRequest withReason "Incorrect path type.",
-                "path" := (parent </> fsFile))
+                "path" := (parent </> fsFile))) and
+              (mntd must beEmpty)
             }
           }
         }
@@ -444,11 +512,15 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
             val cfgStr = EncodeJson.of[MountConfig].encode(MountConfig.viewConfig(cfg))
 
             for {
-              resp <- service(reqBuilder(parent, viewDir, cfgStr))
+              req <- reqBuilder(parent, viewDir, cfgStr)
+              r   <- service(req)
+              (res, mntd) = r
+              err <- lift(res.as[ApiError]).into[Eff]
             } yield {
-              resp.as[ApiError].unsafePerformSync must beApiErrorWithMessage(
+              (err must beApiErrorWithMessage(
                 Status.BadRequest withReason "Incorrect path type.",
-                "path" := (parent </> viewDir))
+                "path" := (parent </> viewDir))) and
+              (mntd must beEmpty)
             }
           }
         }
@@ -460,10 +532,13 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
               val cfgStr = EncodeJson.of[MountConfig].encode(MountConfig.viewConfig(cfg))
 
               for {
-                resp <- service(reqBuilder(parent, f, cfgStr))
+                req <- reqBuilder(parent, f, cfgStr)
+                r   <- service(req)
+                (res, mntd) = r
+                err <- lift(res.as[ApiError]).into[Eff]
               } yield {
-                resp.as[ApiError].unsafePerformSync must
-                  beInvalidConfigError("There is no binding for the variable :cutoff")
+                (err must beInvalidConfigError("There is no binding for the variable :cutoff")) and
+                (mntd must beEmpty)
               }
             }
           }
@@ -473,10 +548,13 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
           !hasDot(parent </> f) ==> {
             runTest { service =>
               for {
-                resp <- service(reqBuilder(parent, f, "{"))
+                req <- reqBuilder(parent, f, "{")
+                r   <- service(req)
+                (res, mntd) = r
+                err <- lift(res.as[ApiError]).into[Eff]
               } yield {
-                resp.as[ApiError].unsafePerformSync must beApiErrorWithMessage(
-                  Status.BadRequest withReason "Malformed input.")
+                (err must beApiErrorWithMessage(BadRequest withReason "Malformed input.")) and
+                (mntd must beEmpty)
               }
             }
           }
@@ -486,9 +564,13 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
           !hasDot(parent </> d) ==> {
             runTest { service =>
               for {
-                resp <- service(reqBuilder(parent, d, """{ "stub": { "connectionUri": "invalid" } }"""))
+                req <- reqBuilder(parent, d, """{ "stub": { "connectionUri": "invalid" } }""")
+                r   <- service(req)
+                (res, mntd) = r
+                err <- lift(res.as[ApiError]).into[Eff]
               } yield {
-                resp.as[ApiError].unsafePerformSync must beInvalidConfigError("invalid connectionUri (simulated)")
+                (err must beInvalidConfigError("invalid connectionUri (simulated)")) and
+                (mntd must beEmpty)
               }
             }
           }
@@ -498,9 +580,13 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
           !hasDot(parent </> f) ==> {
             runTest { service =>
               for {
-                resp <- service(reqBuilder(parent, f, """{ "view": { "connectionUri": "foo://bar" } }"""))
+                req <- reqBuilder(parent, f, """{ "view": { "connectionUri": "foo://bar" } }""")
+                r   <- service(req)
+                (res, mntd) = r
+                err <- lift(res.as[ApiError]).into[Eff]
               } yield {
-                resp.as[ApiError].unsafePerformSync must beApiErrorWithMessage(Status.BadRequest)
+                (err must beApiErrorWithMessage(BadRequest)) and
+                (mntd must beEmpty)
               }
             }
           }
@@ -508,28 +594,32 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
       }
     }
 
-
     "POST" should {
       import org.http4s.Method.POST
 
       "be 409 with existing filesystem path" ! prop { (parent: ADir, fsDir: RDir) =>
         runTest { service =>
-          val previousCfg = (StubFs, ConnectionUri("bar"))
           val mntPath = parent </> fsDir
 
           for {
-            _    <- M.mountFileSystem(mntPath, previousCfg._1, previousCfg._2).run.flatMap(orFailF)
+            _     <- M.mountFileSystem(mntPath, StubFs, barUri)
+                       .run.flatMap(orFailF)
 
-            resp <- service(Request(
-                      method = POST,
-                      uri = pathUri(parent),
-                      headers = Headers(xFileName(fsDir)))
-                    .withBody("""{ "stub": { "connectionUri": "foo" } }""").unsafePerformSync)
+            req   <- lift(Request(
+                       method = POST,
+                       uri = pathUri(parent),
+                       headers = Headers(xFileName(fsDir)))
+                     .withBody("""{ "stub": { "connectionUri": "foo" } }""")).into[Eff]
+
+            r     <- service(req)
+            (res, mntd) = r
+            err   <- lift(res.as[ApiError]).into[Eff]
 
             after <- M.lookup(mntPath).run
           } yield {
-            resp.as[ApiError].unsafePerformSync must beApiErrorLike(pathExists(mntPath))
-            after must beSome(MountConfig.fileSystemConfig(previousCfg))
+            (err must beApiErrorLike(pathExists(mntPath)))                  and
+            (mntd must_== Set(MR.mountFileSystem(mntPath, StubFs, barUri))) and
+            (after must beSome(MountConfig.fileSystemConfig(StubFs, barUri)))
           }
         }
       }
@@ -538,12 +628,16 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
         !hasDot(parent) ==> {
           runTest { service =>
             for {
-              resp <- service(Request(
-                        method = POST,
-                        uri = pathUri(parent))
-                      .withBody("""{ "stub": { "connectionUri": "foo" } }""").unsafePerformSync)
+              req <- lift(Request(
+                       method = POST,
+                       uri = pathUri(parent))
+                     .withBody("""{ "stub": { "connectionUri": "foo" } }""")).into[Eff]
+              r   <- service(req)
+              (res, mntd) = r
+              err <- lift(res.as[ApiError]).into[Eff]
             } yield {
-              resp.as[ApiError].unsafePerformSync must beHeaderMissingError("X-File-Name")
+              (err must beHeaderMissingError("X-File-Name")) and
+              (mntd must beEmpty)
             }
           }
         }
@@ -556,23 +650,25 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
       "succeed with overwritten filesystem" ! prop { (fsDir: ADir) =>
         !hasDot(fsDir) ==> {
           runTest { service =>
-            val previousCfg = (StubFs, ConnectionUri("bar"))
-            val cfg = (StubFs, ConnectionUri("foo"))
-
             for {
-              _    <- M.mountFileSystem(fsDir, StubFs, ConnectionUri("foo")).run.flatMap(orFailF)
+              _     <- M.mountFileSystem(fsDir, StubFs, barUri)
+                         .run.flatMap(orFailF)
 
-              resp <- service(Request(
-                        method = PUT,
-                        uri = pathUri(fsDir))
-                      .withBody("""{ "stub": { "connectionUri": "foo" } }""").unsafePerformSync)
+              req   <- lift(Request(
+                         method = PUT,
+                         uri = pathUri(fsDir))
+                       .withBody("""{ "stub": { "connectionUri": "foo" } }""")).into[Eff]
+
+              r     <- service(req)
+              (res, mntd) = r
+              body  <- lift(res.as[String]).into[Eff]
 
               after <- M.lookup(fsDir).run
             } yield {
-              resp.as[String].unsafePerformSync must_== s"updated ${printPath(fsDir)}"
-              resp.status must_== Status.Ok
-
-              after must beSome(MountConfig.fileSystemConfig(cfg))
+              (body must_== s"updated ${printPath(fsDir)}")                 and
+              (res.status must_== Ok)                                       and
+              (mntd must_== Set(MR.mountFileSystem(fsDir, StubFs, fooUri))) and
+              (after must beSome(MountConfig.fileSystemConfig(StubFs, fooUri)))
             }
           }
         }
@@ -586,18 +682,21 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
         !hasDot(d) ==> {
           runTest { service =>
             for {
-              _     <- M.mountFileSystem(d, StubFs, ConnectionUri("foo")).run.flatMap(orFailF)
+              _     <- M.mountFileSystem(d, StubFs, ConnectionUri("foo"))
+                         .run.flatMap(orFailF)
 
-              resp  <- service(Request(
-                        method = DELETE,
-                        uri = pathUri(d)))
+              r     <- service(Request(
+                         method = DELETE,
+                         uri = pathUri(d)))
+              (res, mntd) = r
+              body  <- lift(res.as[String]).into[Eff]
 
               after <- M.lookup(d).run
             } yield {
-              resp.as[String].unsafePerformSync must_== s"deleted ${printPath(d)}"
-              resp.status must_== Status.Ok
-
-              after must beNone
+              (body must_== s"deleted ${printPath(d)}") and
+              (res.status must_== Ok)                   and
+              (mntd must beEmpty)                       and
+              (after must beNone)
             }
           }
         }
@@ -611,16 +710,18 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
             for {
               _     <- M.mountView(f, cfg._1, cfg._2).run.flatMap(orFailF)
 
-              resp  <- service(Request(
-                        method = DELETE,
-                        uri = pathUri(f)))
+              r     <- service(Request(
+                         method = DELETE,
+                         uri = pathUri(f)))
+              (res, mntd) = r
+              body  <- lift(res.as[String]).into[Eff]
 
               after <- M.lookup(f).run
             } yield {
-              resp.status must_== Status.Ok
-              resp.as[String].unsafePerformSync must_== s"deleted ${printPath(f)}"
-
-              after must beNone
+              (body must_== s"deleted ${printPath(f)}") and
+              (res.status must_== Ok)                   and
+              (mntd must beEmpty)                       and
+              (after must beNone)
             }
           }
         }
@@ -629,9 +730,12 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
       "be 404 with missing path" ! prop { p: APath =>
         runTest { service =>
           for {
-            resp <- service(Request(method = DELETE, uri = pathUri(p)))
+            r   <- service(Request(method = DELETE, uri = pathUri(p)))
+            (res, mntd) = r
+            err <- lift(res.as[ApiError]).into[Eff]
           } yield {
-            resp.as[ApiError].unsafePerformSync must beApiErrorLike(pathNotFound(p))
+            (err must beApiErrorLike(pathNotFound(p))) and
+            (mntd must beEmpty)
           }
         }
       }


### PR DESCRIPTION
Moving a filesystem mount was being done directly via the `MountConfigs` effect instead of using the `Mounting` effect. The result was that the mount configuration would be updated, but there would be no change in the actual mounted filesystems.

The fix was to revert back to using `Mounting#remount` to move the mount.

In order to expose the problem, the mount service specs were refactored to verify the state of the mounted filesystems as well as their configuration.