### PR TITLE
[SD-1833] Fix an issue where attempting to replace a view mount would fail

### DIFF
--- a/CHANGELOG/bugfix.md
+++ b/CHANGELOG/bugfix.md
@@ -1,0 +1,1 @@
+- [SD-1833] Fix an issue where attempting to replace a view mount would fail

--- a/core/src/main/scala/quasar/fs/mount/EvaluatorMounter.scala
+++ b/core/src/main/scala/quasar/fs/mount/EvaluatorMounter.scala
@@ -49,8 +49,7 @@ final class EvaluatorMounter[F[_], S[_]](
       (req: MountRequest)
       (implicit T0: F :<: T,
                 T1: fsMounter.MountedFs :<: T,
-                T2: MountConfigs :<: T,
-                T3: EvalFSRef :<: T)
+                T2: EvalFSRef :<: T)
       : Free[T, MountingError \/ Unit] = {
 
     type EvalM[A]    = Free[T, A]
@@ -59,7 +58,7 @@ final class EvaluatorMounter[F[_], S[_]](
     val handleMount: EvalErrM[Unit] =
       EitherT(req match {
         case MountView(f, qry, vars) =>
-          ViewMounter.mount[T](f, qry, vars)
+          ViewMounter.validate(f, qry, vars).point[Free[T, ?]]
 
         case MountFileSystem(d, typ, uri) =>
           fsMounter.mount[T](d, typ, uri)
@@ -72,14 +71,13 @@ final class EvaluatorMounter[F[_], S[_]](
       (req: MountRequest)
       (implicit T0: F :<: T,
                 T1: fsMounter.MountedFs :<: T,
-                T2: EvalFSRef :<: T,
-                T3: MountConfigs :<: T)
+                T2: EvalFSRef :<: T)
       : Free[T, Unit] = {
 
     val handleUnmount: Free[T, Unit] =
       req match {
         case MountView(f, _, _) =>
-          ViewMounter.unmount[T](f)
+          ().point[Free[T, ?]]
 
         case MountFileSystem(d, _, _) =>
           fsMounter.unmount[T](d)

--- a/core/src/main/scala/quasar/fs/mount/view.scala
+++ b/core/src/main/scala/quasar/fs/mount/view.scala
@@ -201,9 +201,9 @@ object view {
             refineType(path).fold(
               d => viewPaths
                 .foldMap(f => f.relativeTo(d).map(κ(f)).toList)
-                .foldMap(ViewMounter.unmount[S])
+                .foldMap(ViewMounter.delete[S])
                 *> delete,
-              f => viewPaths.contains(f) ? ViewMounter.unmount[S](f).map(_.right[FileSystemError]) | delete)
+              f => viewPaths.contains(f) ? ViewMounter.delete[S](f).map(_.right[FileSystemError]) | delete)
           }
 
         case TempFile(nearTo) =>

--- a/core/src/test/scala/quasar/fs/mount/ViewMounterSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/ViewMounterSpec.scala
@@ -86,14 +86,14 @@ class ViewMounterSpec extends mutable.Specification with ScalaCheck with TreeMat
     }
   }
 
-  "unmounting views" >> {
-    "removes plan from mounted views" >> {
+  "deleting views" >> {
+    "removes view config at given location" >> {
       val f  = rootDir </> dir("mnt") </> file("foo")
 
       eval(
         Map(f -> MountConfig.viewConfig(viewConfig("select * from zips")))
         )(
-        ViewMounter.unmount[MountConfigs](f)
+        ViewMounter.delete[MountConfigs](f)
         )._1 must beEmpty
     }
   }

--- a/main/src/main/scala/quasar/main/package.scala
+++ b/main/src/main/scala/quasar/main/package.scala
@@ -209,8 +209,7 @@ package object main {
   /** Effect required by the core Quasar services */
   type CoreEff0[A] = Coproduct[Mounting, FileSystem, A]
   type CoreEff1[A] = Coproduct[FileSystemFailure, CoreEff0, A]
-  type CoreEff2[A] = Coproduct[MountConfigs, CoreEff1, A]
-  type CoreEff[A]  = Coproduct[Task, CoreEff2, A]
+  type CoreEff[A]  = Coproduct[Task, CoreEff1, A]
   type CoreEffM[A] = Free[CoreEff, A]
 
   // TODO: Accept an initial set of mounts?
@@ -244,7 +243,6 @@ package object main {
           free.foldMapNT(mnt) compose mounter
 
         liftTask                                :+:
-        injectFT[MountConfigs, CfgsErrsIO]      :+:
         injectFT[FileSystemFailure, CfgsErrsIO] :+:
         mounting                                :+:
         (translateFsErrs compose FsEff.evalFSFromRef(evalFsRef, f))

--- a/web/src/main/scala/quasar/api/services/RestApi.scala
+++ b/web/src/main/scala/quasar/api/services/RestApi.scala
@@ -44,8 +44,7 @@ object RestApi {
         S3: ManageFile :<: S,
         S4: Mounting :<: S,
         S5: QueryFile :<: S,
-        S6: FileSystemFailure :<: S,
-        S7: MountConfigs :<: S
+        S6: FileSystemFailure :<: S
       ): Map[String, QHttpService[S]] =
     ListMap(
       "/compile/fs"  -> query.compile.service[S],


### PR DESCRIPTION
The fix reverts all of the mount service changes made in

8c1eff6614cfe055ee1039ace88369773308e355
f6e846d0c299d7eaaae0c17a4614db33e3c3583b

the problem stemmed from `ViewMounter.mount` being used in
`EvaluatorMounter`. `EvaluatorMounter.mount/unmount` exist to
handle `MountRequests` issued by `Mounter`. If requests are
handled successfully, then `Mounter` updates the mount configuration
appropriately.

When `ViewMounter.mount` began modifying mount configuration itself
this began to cause conflicts as `Mounter` would end up calling
`EvaluatorMounter.mount`, which handed off to `ViewMounter.mount`
which ended up modifying configuration. When control returned to
`Mounter`, it would find the configuration had changed and abort
the mount.

The fix was to only perform validation on the candidate view mount
in `EvaluatorMounter` rather than modifying the configuration directly.