### PR TITLE
Separating product bucket

### DIFF
--- a/CHANGELOG/bugfix.md
+++ b/CHANGELOG/bugfix.md
@@ -1,0 +1,1 @@
+- move QScript projections to their own component so they can be used in static path processing, rather than trying to use a subset of Map.

--- a/core/src/main/scala/quasar/fs/QueryFile.scala
+++ b/core/src/main/scala/quasar/fs/QueryFile.scala
@@ -43,12 +43,13 @@ object QueryFile {
 
   val qscript = new Transform[Fix, QScriptInternal[Fix, ?]]
   val optimize = new Optimize[Fix]
-  val elide = scala.Predef.implicitly[ElideBuckets.Aux[Fix, QScriptInternal[Fix, ?]]]
+  val elide = scala.Predef.implicitly[ElideBuckets.Aux[Fix, QScriptInternal[Fix, ?], QScriptProject[Fix, ?]]]
+
 
   /** This is a stop-gap function that QScript-based backends should use until
     * LogicalPlan no longer needs to be exposed.
     */
-  val convertToQScript: Fix[LogicalPlan] => PlannerError \/ Fix[QScriptPure[Fix, ?]] =
+  val convertToQScript: Fix[LogicalPlan] => PlannerError \/ Fix[QScriptProject[Fix, ?]] =
     _.transCataM(qscript.lpToQScript).evalZero.map(
       _.transCata(elide.purify ⋙ optimize.applyAll))
 

--- a/core/src/main/scala/quasar/qscript/Diggable.scala
+++ b/core/src/main/scala/quasar/qscript/Diggable.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript
+
+import quasar.Predef._
+
+import scalaz._, Scalaz._
+import simulacrum.typeclass
+
+@typeclass trait Diggable[F[_]] {
+  type IT[G[_]]
+
+  // Int is number of buckets to skip
+  def digForBucket[G[_]](fg: F[IT[G]]):
+      // TODO: use matryoshka.instances.fixedpoint.Nat
+      StateT[Bucketing[IT, IT[G]] \/ ?, Int, F[IT[G]]]
+}
+
+object Diggable {
+  type Aux[T[_[_]], F[_]] = Diggable[F] { type IT[G[_]] = T[G] }
+
+  implicit def coproduct[T[_[_]], F[_], G[_]](
+    implicit FB: Diggable.Aux[T, F], GB: Diggable.Aux[T, G]):
+      Diggable.Aux[T, Coproduct[F, G, ?]] =
+    new Diggable[Coproduct[F, G, ?]] {
+      type IT[F[_]] = T[F]
+
+      def digForBucket[H[_]](fg: Coproduct[F, G, IT[H]]) =
+        fg.run.bitraverse(FB.digForBucket[H](_), GB.digForBucket[H](_)) ∘
+          (Coproduct(_))
+    }
+
+  implicit def const[T[_[_]], A]:
+      Diggable.Aux[T, Const[A, ?]] =
+    new Diggable[Const[A, ?]] {
+      type IT[F[_]] = T[F]
+
+      def digForBucket[G[_]](de: Const[A, IT[G]]) = StateT.stateT(de)
+    }
+}

--- a/core/src/main/scala/quasar/qscript/ProjectBucket.scala
+++ b/core/src/main/scala/quasar/qscript/ProjectBucket.scala
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript
+
+import quasar.Predef._
+import quasar.fp._
+
+import matryoshka._
+import monocle.macros.Lenses
+import scalaz._, Scalaz._
+
+/** Projections are technically dimensional (i.e., QScript) operations. However,
+  * to a filesystem, they are merely Map operations. So, we use these components
+  * while building the QScript plan and they are then used in static path
+  * processing, but they are replaced with equivalent MapFuncs before being
+  * processed by the filesystem.
+  */
+sealed abstract class ProjectBucket[T[_[_]], A] {
+  def src: A
+}
+
+@Lenses final case class BucketField[T[_[_]], A](
+  src: A,
+  value: FreeMap[T],
+  name: FreeMap[T])
+    extends ProjectBucket[T, A]
+
+@Lenses final case class BucketIndex[T[_[_]], A](
+  src: A,
+  value: FreeMap[T],
+  index: FreeMap[T])
+    extends ProjectBucket[T, A]
+
+object ProjectBucket {
+  implicit def equal[T[_[_]]: EqualT]: Delay[Equal, ProjectBucket[T, ?]] =
+    new Delay[Equal, ProjectBucket[T, ?]] {
+      def apply[A](eq: Equal[A]) =
+        Equal.equal {
+          case (BucketField(a1, v1, n1), BucketField(a2, v2, n2)) =>
+            eq.equal(a1, a2) && v1 ≟ v2 && n1 ≟ n2
+          case (BucketIndex(a1, v1, i1), BucketIndex(a2, v2, i2)) =>
+            eq.equal(a1, a2) && v1 ≟ v2 && i1 ≟ i2
+          case (_, _) => false
+        }
+    }
+
+  implicit def traverse[T[_[_]]]: Traverse[ProjectBucket[T, ?]] =
+    new Traverse[ProjectBucket[T, ?]] {
+      def traverseImpl[G[_], A, B](
+        fa: ProjectBucket[T, A])(
+        f: A => G[B])(
+        implicit G: Applicative[G]):
+          G[ProjectBucket[T, B]] = fa match {
+        case BucketField(src, values, name) =>
+          f(src) ∘ (BucketField(_, values, name))
+        case BucketIndex(src, values, index) =>
+          f(src) ∘ (BucketIndex(_, values, index))
+      }
+    }
+
+  implicit def show[T[_[_]]: ShowT]: Delay[Show, ProjectBucket[T, ?]] =
+    new Delay[Show, ProjectBucket[T, ?]] {
+      def apply[A](sh: Show[A]): Show[ProjectBucket[T, A]] =
+        Show.show {
+          case BucketField(a, v, n) => Cord("BucketField(") ++
+            sh.show(a) ++ Cord(",") ++
+            v.show ++ Cord(",") ++
+            n.show ++ Cord(")")
+          case BucketIndex(a, v, i) => Cord("BucketIndex(") ++
+            sh.show(a) ++ Cord(",") ++
+            v.show ++ Cord(",") ++
+            i.show ++ Cord(")")
+        }
+    }
+
+  implicit def mergeable[T[_[_]]: Corecursive: EqualT]:
+      Mergeable.Aux[T, ProjectBucket[T, Unit]] =
+    new Mergeable[ProjectBucket[T, Unit]] {
+      type IT[F[_]] = T[F]
+
+      def mergeSrcs(
+        left: FreeMap[IT],
+        right: FreeMap[IT],
+        p1: ProjectBucket[IT, Unit],
+        p2: ProjectBucket[IT, Unit]) =
+        OptionT(state((p1 ≟ p2).option(SrcMerge(p1, left, right))))
+    }
+
+  implicit def diggable[T[_[_]]: Corecursive]:
+      Diggable.Aux[T, ProjectBucket[T, ?]] =
+    new Diggable[ProjectBucket[T, ?]] {
+      implicit val PB =
+        scala.Predef.implicitly[ProjectBucket[T, ?] :<: Bucketing[T, ?]]
+
+      type IT[G[_]] = T[G]
+
+      def digForBucket[G[_]](fg: ProjectBucket[T, IT[G]]) =
+        StateT(s => if (s ≟ 0) PB.inj(fg).left else ((s - 1, fg)).right)
+    }
+
+  implicit def bucketable[T[_[_]]: Corecursive]:
+      Bucketable.Aux[T, ProjectBucket[T, ?]] =
+    new Bucketable[ProjectBucket[T, ?]] {
+      implicit val PB =
+        scala.Predef.implicitly[ProjectBucket[T, ?] :<: Bucketing[T, ?]]
+
+      type IT[G[_]] = T[G]
+
+      def applyBucket[G[_]: Functor](
+        ft: ProjectBucket[IT, IT[G]], inner: IT[G])(
+        f: (IT[G],
+            IT[G],
+            SrcMerge[ThetaJoin[IT, IT[G]], FreeMap[IT]] =>
+                (IT[G], FreeMap[IT], FreeMap[IT])) =>
+              QSState[(IT[G], FreeMap[IT], FreeMap[IT])])(
+        implicit TJ: ThetaJoin[IT, ?] :<: G) =
+        ft match {
+          case BucketField(src, _, name) =>
+            f(
+              src,
+              inner,
+              { case SrcMerge(src, mfl, mfr) =>
+                (TJ.inj(src).embed, rebase(name, mfl), mfr)
+              })
+          case BucketIndex(src, _, index) =>
+            f(
+              src,
+              inner,
+              { case SrcMerge(src, mfl, mfr) =>
+                (TJ.inj(src).embed, rebase(index, mfl), mfr)
+              })
+        }
+    }
+}

--- a/core/src/main/scala/quasar/qscript/ThetaJoin.scala
+++ b/core/src/main/scala/quasar/qscript/ThetaJoin.scala
@@ -84,15 +84,11 @@ object ThetaJoin {
         right: FreeMap[IT],
         p1: ThetaJoin[IT, Unit],
         p2: ThetaJoin[IT, Unit]) =
-        OptionT(state(
-          if (p1 ≟ p2)
-            SrcMerge[ThetaJoin[IT, Unit], FreeMap[IT]](p1, left, right).some
-          else
-            None))
+        OptionT(state((p1 ≟ p2).option(SrcMerge(p1, left, right))))
     }
 
-  implicit def bucketable[T[_[_]]]: Bucketable.Aux[T, ThetaJoin[T, ?]] =
-    new Bucketable[ThetaJoin[T, ?]] {
+  implicit def diggable[T[_[_]]]: Diggable.Aux[T, ThetaJoin[T, ?]] =
+    new Diggable[ThetaJoin[T, ?]] {
       type IT[G[_]] = T[G]
 
       def digForBucket[G[_]](tj: ThetaJoin[T, IT[G]]) = IndexedStateT.stateT(tj)

--- a/core/src/main/scala/quasar/qscript/package.scala
+++ b/core/src/main/scala/quasar/qscript/package.scala
@@ -17,6 +17,8 @@
 package quasar
 
 import quasar.Predef._
+import quasar.Planner._
+import quasar.namegen._
 
 import scala.Predef.implicitly
 
@@ -40,8 +42,11 @@ package object qscript {
     * structure, and it contains no Read or EquiJoin.
     */
   type QScriptPure[T[_[_]], A] = Coproduct[ThetaJoin[T, ?], QScriptPrim[T, ?], A]
+  type QScriptProject[T[_[_]], A] = Coproduct[ProjectBucket[T, ?], QScriptPure[T, ?], A]
 
-  type QScriptInternal[T[_[_]], A] = Coproduct[QScriptBucket[T, ?], QScriptPure[T, ?], A]
+  type Bucketing[T[_[_]], A] = Coproduct[QScriptBucket[T, ?], ProjectBucket[T, ?], A]
+
+  type QScriptInternal[T[_[_]], A] = Coproduct[QScriptBucket[T, ?], QScriptProject[T, ?], A]
 
   /** These nodes exist in all QScript structures that a backend sees.
     */
@@ -79,6 +84,8 @@ package object qscript {
   type FreeQS[T[_[_]]] = FreeUnit[QScriptInternal[T, ?]]
 
   type JoinFunc[T[_[_]]] = Free[MapFunc[T, ?], JoinSide]
+
+  type QSState[A] = StateT[PlannerError \/ ?, NameGen, A]
 
   def UnitF[T[_[_]]] = ().point[Free[MapFunc[T, ?], ?]]
 

--- a/foundation/src/main/scala/quasar/fp/free/package.scala
+++ b/foundation/src/main/scala/quasar/fp/free/package.scala
@@ -52,13 +52,19 @@ package object free {
   def injectFT[F[_], S[_]](implicit S: F :<: S): F ~> Free[S, ?] =
     liftFT[S] compose injectNT[F, S]
 
-  /** Given `F[_]` and `G[_]` such that `F :<: G`, lifts a natural transformation
-    * `F ~> F` to `G ~> G`.
+  /** Given `F[_]` and `G[_]` such that both `:<: H`, lifts a natural
+    * transformation `F ~> G` to `H ~> H`.
     */
-  def injectedNT[F[_], G[_]](f: F ~> F)(implicit G: F :<: G): G ~> G =
-    new (G ~> G) {
-      def apply[A](ga: G[A]) = G.prj(ga).fold(ga)(fa => G.inj(f(fa)))
+  object injectedNT {
+    def apply[H[_]] = new Aux[H]
+
+    final class Aux[H[_]] {
+      def apply[F[_], G[_]](f: F ~> G)(implicit F: F :<: H, G: G :<: H): H ~> H =
+        new (H ~> H) {
+          def apply[A](ga: H[A]) = F.prj(ga).fold(ga)(fa => G.inj(f(fa)))
+        }
     }
+  }
 
   /** `Free#liftF` as a natural transformation */
   def liftFT[S[_]]: S ~> Free[S, ?] =


### PR DESCRIPTION
This is the setup for the Read rewrite pass. It extracts projections from QScriptBucket and moves Map from SourcedPathable to QScriptCore (since Map was only Pathable in the case where it consisted of only projections, which is now handled by explicit projection nodes). It also adds a `simplifyProjections` pass which converts any projection nodes into Map nodes (this is what `elideBuckets` did with projection nodes, but now we keep them around after eliding buckets for the static path handling).