### PR TITLE
Consistently apply type-checks around view interpretation

### DIFF
--- a/CHANGELOG/bugfix.md
+++ b/CHANGELOG/bugfix.md
@@ -1,0 +1,1 @@
+- [SD-1869] fix for reading from views containing certain queries including most joins

--- a/it/src/test/scala/quasar/ViewReadQueryRegressionSpec.scala
+++ b/it/src/test/scala/quasar/ViewReadQueryRegressionSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar
+
+import quasar.Predef._
+import quasar.effect._
+import quasar.fp.TaskRef
+import quasar.fp.free, free._
+import quasar.fs.{ADir, APath, /*FileSystemError, FileSystemErrT,*/ ReadFile}
+import quasar.fs.mount._
+import quasar.regression._
+import quasar.sql.Sql
+
+import matryoshka.{Fix}
+import pathy.Path._
+import scalaz.{:+: => _, _}, Scalaz._
+import scalaz.concurrent.Task
+import scalaz.stream.Process
+
+class ViewReadQueryRegressionSpec
+  extends QueryRegressionTest[FileSystemIO](QueryRegressionTest.externalFS.map(_.take(1))) {
+
+  val suiteName = "View Reads"
+
+  type ViewFS0[A] = Coproduct[MonotonicSeq, FileSystemIO, A]
+  type ViewFS1[A] = Coproduct[ViewState, ViewFS0, A]
+  type ViewFS[A]  = Coproduct[MountConfigs, ViewFS1, A]
+
+  val viewState: Task[KeyValueStore[ReadFile.ReadHandle, ResultSet, ?] ~> Task] =
+    TaskRef(Map.empty[ReadFile.ReadHandle, ResultSet])
+      .map(KeyValueStore.fromTaskRef)
+
+  def mntConfigs(path: APath, expr: Fix[Sql], vars: Variables): Task[MountConfigs ~> Task] =
+    TaskRef(Map[APath, MountConfig](path -> MountConfig.viewConfig(expr, vars)))
+      .map(KeyValueStore.fromTaskRef)
+
+  val seq = TaskRef(0L).map(MonotonicSeq.fromTaskRef)
+
+  val RF = ReadFile.Ops[ReadFile]
+
+  def queryResults(expr: Fix[Sql], vars: Variables, basePath: ADir) = {
+    val path = basePath </> file("view")
+
+    val prg: Process[RF.unsafe.M, Data] = RF.scanAll(path)
+
+    val interp = mntConfigs(path, expr, vars).flatMap(interpViews).unsafePerformSync
+
+    def t: RF.unsafe.M ~> qfTransforms.CompExecM =
+      new (RF.unsafe.M ~> qfTransforms.CompExecM) {
+        def apply[A](fa: RF.unsafe.M[A]): qfTransforms.CompExecM[A] = {
+          val u: ReadFile ~> Free[FileSystemIO, ?] =
+            mapSNT(interp) compose view.readFile[ViewFS]
+
+          EitherT(EitherT.right(WriterT.put(fa.run.flatMapSuspension(u))(Vector.empty)))
+        }
+      }
+
+    prg.translate(t)
+  }
+
+  def interpViews(mntCfgs: MountConfigs ~> Task): Task[ViewFS ~> FileSystemIO] =
+    (viewState |@| seq)((v, s) =>
+      (injectNT[Task, FileSystemIO] compose mntCfgs) :+:
+      (injectNT[Task, FileSystemIO] compose v) :+:
+      (injectNT[Task, FileSystemIO] compose s) :+:
+      NaturalTransformation.refl[FileSystemIO])
+}


### PR DESCRIPTION
See SD-1869

Run all regression test queries as if the query was mounted as a view, by interpreting `ReadFile.scanAll`. This turned up a number of queries that were affected by the rewriting:
- some simply had their results nested under `value`
- some joins returned no results (as observed in SD-1869)
- some joins led to endless map-reduce

The fix is to be more consistent about how and when type-checks are applied the LogicalPlan:
- queries submitted via `QueryFile.EvaluatePlan` and `.ExecutePlan` will already be "prepared" with type-checking (as before)
- that type-checking is now stripped by `ViewMounter` before view queries are expanded, and then the expanded LP is re-prepared
- to that end, more of the LP transformation steps are now exposed in quasar package obj
- this also allows for more clarity about when it's necessary to "refine" an LP to a constant, which also cleaned up a TODO