### PR TITLE
SD-1871 Mounting HavingPrefix

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,4 @@
+- A handful of refactorings to Mounting
+  - Rename Lookup -> LookupConfig
+  - Add a HavingPrefix term
+  - Use failure effects in Mounting.Ops

--- a/core/src/main/scala/quasar/fs/mount/MountType.scala
+++ b/core/src/main/scala/quasar/fs/mount/MountType.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.fs.mount
+
+import quasar.Predef._
+import quasar.SKI._
+import quasar.fs.FileSystemType
+
+import monocle.Prism
+import scalaz._, Scalaz._
+
+sealed abstract class MountType {
+  import MountType._
+
+  def fold[X](fs: FileSystemType => X, v: => X): X =
+    this match {
+      case FileSystemMount(t) => fs(t)
+      case ViewMount          => v
+    }
+
+  override def toString: String =
+    this.shows
+}
+
+object MountType {
+  final case class FileSystemMount(fsType: FileSystemType) extends MountType
+  case object ViewMount extends MountType
+
+  val fileSystemMount: Prism[MountType, FileSystemType] =
+    Prism.partial[MountType, FileSystemType] {
+      case FileSystemMount(fs) => fs
+    } (FileSystemMount)
+
+  val viewMount: Prism[MountType, Unit] =
+    Prism.partial[MountType, Unit] {
+      case ViewMount => ()
+    } (κ(ViewMount))
+
+  implicit val order: Order[MountType] =
+    Order.orderBy(mt => (viewMount.isMatching(mt), fileSystemMount.getOption(mt)))
+
+  implicit val show: Show[MountType] =
+    Show.shows(_.fold(t => s"FileSystemMount(${t.shows})", "ViewMount"))
+}

--- a/core/src/main/scala/quasar/fs/mount/Mounter.scala
+++ b/core/src/main/scala/quasar/fs/mount/Mounter.scala
@@ -75,7 +75,7 @@ object Mounter {
             case FileSystemConfig(tpe, _) => MountType.fileSystemMount(tpe)
           }.run
 
-        case Lookup(path) =>
+        case LookupConfig(path) =>
           mountConfigs.get(path).run
 
         case MountView(loc, query, vars) =>

--- a/core/src/main/scala/quasar/fs/mount/Mounter.scala
+++ b/core/src/main/scala/quasar/fs/mount/Mounter.scala
@@ -71,9 +71,10 @@ object Mounter {
       def apply[A](ma: Mounting[A]) = ma match {
         case LookupType(path) =>
           mountConfigs.get(path).map {
-            case ViewConfig(_, _) => ViewType.left
-            case FileSystemConfig(tpe, _) => tpe.right
+            case ViewConfig(_, _)         => MountType.viewMount()
+            case FileSystemConfig(tpe, _) => MountType.fileSystemMount(tpe)
           }.run
+
         case Lookup(path) =>
           mountConfigs.get(path).run
 

--- a/core/src/main/scala/quasar/fs/mount/Mounter.scala
+++ b/core/src/main/scala/quasar/fs/mount/Mounter.scala
@@ -22,7 +22,7 @@ import quasar.fs._
 import quasar.fp._, free._
 
 import pathy.Path._
-import scalaz.{:+: => _, _}, Scalaz._
+import scalaz._, Scalaz._
 
 object Mounter {
   import Mounting._, MountConfig._
@@ -67,13 +67,25 @@ object Mounter {
       failIfExisting *> mount0(req) *> putOrUnmount
     }
 
+    def lookupType(p: APath): OptionT[FreeS, MountType] =
+      mountConfigs.get(p).map {
+        case ViewConfig(_, _)         => MountType.viewMount()
+        case FileSystemConfig(tpe, _) => MountType.fileSystemMount(tpe)
+      }
+
     new (Mounting ~> FreeS) {
       def apply[A](ma: Mounting[A]) = ma match {
+        case HavingPrefix(dir) =>
+          mountConfigs.keys flatMap { paths =>
+            paths.foldLeftM(Map[APath, MountType]())((m, p) =>
+              if (((dir: APath) =/= p) && p.relativeTo(dir).isDefined)
+                lookupType(p).map(m.updated(p, _)).getOrElse(m)
+              else
+                m.point[FreeS])
+          }
+
         case LookupType(path) =>
-          mountConfigs.get(path).map {
-            case ViewConfig(_, _)         => MountType.viewMount()
-            case FileSystemConfig(tpe, _) => MountType.fileSystemMount(tpe)
-          }.run
+          lookupType(path).run
 
         case LookupConfig(path) =>
           mountConfigs.get(path).run

--- a/core/src/main/scala/quasar/fs/mount/Mounting.scala
+++ b/core/src/main/scala/quasar/fs/mount/Mounting.scala
@@ -49,6 +49,13 @@ sealed trait Mounting[A]
 
 object Mounting {
 
+  /** Provides for accessing many mounts at once, which allows certain
+    * operations (like determining which paths in a directory refer to
+    * mounts) to be implemented more efficiently.
+    */
+  final case class HavingPrefix(dir: ADir)
+    extends Mounting[Map[APath, MountType]]
+
   final case class LookupType(path: APath)
     extends Mounting[Option[MountType]]
 
@@ -81,6 +88,10 @@ object Mounting {
     extends LiftedOps[Mounting, S] {
 
     import MountConfig._
+
+    /** Returns mounts located at a path having the given prefix. */
+    def havingPrefix(dir: ADir): F[Map[APath, MountType]] =
+      lift(HavingPrefix(dir))
 
     /** Returns the mount configuration if the given path represents a mount. */
     def lookupConfig(path: APath): OptionT[F, MountConfig] =

--- a/core/src/main/scala/quasar/fs/mount/Mounting.scala
+++ b/core/src/main/scala/quasar/fs/mount/Mounting.scala
@@ -33,10 +33,8 @@ sealed trait Mounting[A]
 
 object Mounting {
 
-  final case object ViewType
-
   final case class LookupType(path: APath)
-    extends Mounting[Option[ViewType.type \/ FileSystemType]]
+    extends Mounting[Option[MountType]]
 
   final case class Lookup(path: APath)
     extends Mounting[Option[MountConfig]]
@@ -70,7 +68,7 @@ object Mounting {
 
     type M[A] = EitherT[F, MountingError, A]
 
-    def lookupType(path: APath): OptionT[F, ViewType.type \/ FileSystemType] =
+    def lookupType(path: APath): OptionT[F, MountType] =
       OptionT(lift(LookupType(path)))
 
     /** Returns the mount configuration for the given mount path or nothing

--- a/core/src/main/scala/quasar/fs/mount/package.scala
+++ b/core/src/main/scala/quasar/fs/mount/package.scala
@@ -16,19 +16,31 @@
 
 package quasar.fs
 
-import quasar.Predef.Map
+import quasar.Predef.{Map, Vector}
 import quasar.effect._
-import quasar.fp.{TaskRef}
+import quasar.fp.TaskRef
 import quasar.fp.free, free._
 
-import scala.collection.immutable.Vector
-
 import monocle.Lens
-import scalaz.{Lens => _, _}
+import scalaz.{Lens => _, Failure => _, _}
 import scalaz.concurrent.Task
 
 package object mount {
   type MntErrT[F[_], A] = EitherT[F, MountingError, A]
+
+  type MountingFailure[A] = Failure[MountingError, A]
+
+  object MountingFailure {
+    def Ops[S[_]](implicit S: MountingFailure :<: S) =
+      Failure.Ops[MountingError, S]
+  }
+
+  type PathMismatchFailure[A] = Failure[Mounting.PathTypeMismatch, A]
+
+  object PathMismatchFailure {
+    def Ops[S[_]](implicit S: PathMismatchFailure :<: S) =
+      Failure.Ops[Mounting.PathTypeMismatch, S]
+  }
 
   type MountConfigs[A] = KeyValueStore[APath, MountConfig, A]
 

--- a/core/src/test/scala/quasar/fs/mount/MountTypeArbitrary.scala
+++ b/core/src/test/scala/quasar/fs/mount/MountTypeArbitrary.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.fs.mount
+
+import quasar.fs._, FileSystemTypeArbitrary._
+
+import org.scalacheck.{Arbitrary, Gen}
+
+trait MountTypeArbitrary {
+  import MountType._
+
+  implicit val mountTypeArbitrary: Arbitrary[MountType] =
+    Arbitrary(Gen.oneOf(
+      Gen.const(viewMount()),
+      Arbitrary.arbitrary[FileSystemType] map (fileSystemMount(_))))
+}
+
+object MountTypeArbitrary extends MountTypeArbitrary

--- a/core/src/test/scala/quasar/fs/mount/MountTypeSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/MountTypeSpec.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.fs.mount
+
+import org.specs2.scalaz.Spec
+import scalaz.scalacheck.ScalazProperties._
+
+final class MountTypeSpec extends Spec {
+  import MountTypeArbitrary._
+  checkAll(order.laws[MountType])
+}

--- a/core/src/test/scala/quasar/fs/mount/MounterSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/MounterSpec.scala
@@ -22,13 +22,15 @@ import quasar.fp._, free._
 import quasar.fs.APath
 
 import pathy.Path._
-import scalaz._, Scalaz._
+import scalaz.{Failure => _, _}, Scalaz._
 import scalaz.concurrent.Task
 
-class MounterSpec extends MountingSpec[Mounting] {
+class MounterSpec extends MountingSpec[MounterSpec.Eff] {
   import MountConfig._, MountingError._, MountRequest._
+  import Mounting.PathTypeMismatch
 
-  type MEff[A] = Coproduct[Task, MountConfigs, A]
+  type MEff0[A] = Coproduct[MountConfigs, MounterSpec.Eff0, A]
+  type MEff[A]  = Coproduct[Task, MEff0, A]
 
   val invalidUri = ConnectionUri(uriA.value + "INVALID")
   val invalidCfg = fileSystemConfig(dbType, invalidUri)
@@ -45,13 +47,19 @@ class MounterSpec extends MountingSpec[Mounting] {
     val mm = Mounter[Task, MEff](doMount.andThen(_.point[Task]), κ(Task.now(())))
     val cfgRef = TaskRef(Map.empty[APath, MountConfig]).unsafePerformSync
 
+    val interpEff =
+      mm :+: injectFT[MountingFailure, MEff] :+: injectFT[PathMismatchFailure, MEff]
+
     val interpMnts: MountConfigs ~> Task =
       KeyValueStore.fromTaskRef(cfgRef)
 
-    val interpEff: MEff ~> Task =
-      NaturalTransformation.refl[Task] :+: interpMnts
+    val interpMEff: MEff ~> Task =
+      reflNT[Task]                                   :+:
+      interpMnts                                     :+:
+      Failure.toRuntimeError[Task, MountingError]    :+:
+      Failure.toRuntimeError[Task, PathTypeMismatch]
 
-    free.foldMapNT(interpEff) compose mm
+    free.foldMapNT(interpMEff) compose interpEff
   }
 
   "Handling mounts" should {
@@ -59,9 +67,14 @@ class MounterSpec extends MountingSpec[Mounting] {
       val loc = rootDir </> dir("fs")
       val cfg = MountConfig.fileSystemConfig(dbType, invalidUri)
 
-      mnt.mountFileSystem(loc, dbType, invalidUri)
-        .run.tuple(mnt.lookup(loc).run)
+      mntErr.attempt(mnt.mountFileSystem(loc, dbType, invalidUri))
+        .tuple(mnt.lookup(loc).run)
         .map(_ must_== ((MountingError.invalidConfig(cfg, "invalid URI".wrapNel).left, None)))
     }
   }
+}
+
+object MounterSpec {
+  type Eff0[A] = Coproduct[MountingFailure, PathMismatchFailure, A]
+  type Eff[A]  = Coproduct[Mounting, Eff0, A]
 }

--- a/core/src/test/scala/quasar/fs/mount/MounterSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/MounterSpec.scala
@@ -68,7 +68,7 @@ class MounterSpec extends MountingSpec[MounterSpec.Eff] {
       val cfg = MountConfig.fileSystemConfig(dbType, invalidUri)
 
       mntErr.attempt(mnt.mountFileSystem(loc, dbType, invalidUri))
-        .tuple(mnt.lookup(loc).run)
+        .tuple(mnt.lookupConfig(loc).run)
         .map(_ must_== ((MountingError.invalidConfig(cfg, "invalid URI".wrapNel).left, None)))
     }
   }

--- a/foundation/src/main/scala/quasar/fp/package.scala
+++ b/foundation/src/main/scala/quasar/fp/package.scala
@@ -429,6 +429,9 @@ package object fp
     */
   def ignore[A](a: A): Unit = ()
 
+  def reflNT[F[_]]: F ~> F =
+    NaturalTransformation.refl[F]
+
   /** `liftM` as a natural transformation
     *
     * TODO: PR to scalaz

--- a/repl/src/main/scala/quasar/repl/Repl.scala
+++ b/repl/src/main/scala/quasar/repl/Repl.scala
@@ -227,10 +227,7 @@ object Repl {
   def mountType[S[_]](path: APath)(implicit
     M: Mounting.Ops[S]
   ): Free[S, Option[String]] =
-    M.lookup(path).map {
-      case MountConfig.ViewConfig(_, _)                         => "view"
-      case MountConfig.FileSystemConfig(FileSystemType(typ), _) => typ
-    }.run
+    M.lookupType(path).map(_.fold(_.shows, "view")).run
 
   def printLog[S[_]](debugLevel: DebugLevel, log: Vector[PhaseResult])(implicit
     P: ConsoleIO.Ops[S]

--- a/web/src/main/scala/quasar/api/package.scala
+++ b/web/src/main/scala/quasar/api/package.scala
@@ -42,6 +42,8 @@ package object api {
   type ResponseIOT[F[_], A] = EitherT[F, Task[Response], A]
   type ResponseOr[A]        = ResponseT[Task, A]
 
+  type ApiErrT[F[_], A] = EitherT[F, ApiError, A]
+
   /** Interpret a `Failure` effect into `ResponseOr` given evidence the
     * failure type can be converted to a `QResponse`.
     */

--- a/web/src/main/scala/quasar/api/services/RestApi.scala
+++ b/web/src/main/scala/quasar/api/services/RestApi.scala
@@ -42,9 +42,11 @@ object RestApi {
         S1: ReadFile :<: S,
         S2: WriteFile :<: S,
         S3: ManageFile :<: S,
-        S4: Mounting :<: S,
-        S5: QueryFile :<: S,
-        S6: FileSystemFailure :<: S
+        S4: QueryFile :<: S,
+        S5: FileSystemFailure :<: S,
+        S6: Mounting :<: S,
+        S7: MountingFailure :<: S,
+        S8: PathMismatchFailure :<: S
       ): Map[String, QHttpService[S]] =
     ListMap(
       "/compile/fs"  -> query.compile.service[S],

--- a/web/src/main/scala/quasar/api/services/data.scala
+++ b/web/src/main/scala/quasar/api/services/data.scala
@@ -145,7 +145,7 @@ object data {
       persistErrors: FreeFS[Vector[FileSystemError]]
     ): Free[S, QResponse[S]] =
       decodeErrors.toList.toNel
-        .map(errs => respond_[S, ApiError, S](ApiError.apiError(
+        .map(errs => respond_[S, ApiError](ApiError.apiError(
           BadRequest withReason "Malformed upload data.",
           "errors" := errs.map(_.shows))))
         .getOrElse(persistErrors.fold(_.toResponse[S], errs =>

--- a/web/src/main/scala/quasar/api/services/metadata.scala
+++ b/web/src/main/scala/quasar/api/services/metadata.scala
@@ -66,7 +66,7 @@ object metadata {
 
     def mkNode(parent: ADir, name: PathSegment): Q.M[FsNode] =
       M.lookupType(parent </> name.fold(dir1, file1)).run
-        .map(mntType => FsNode(name, mntType.map(_.fold(κ("view"), _.value))))
+        .map(mntType => FsNode(name, mntType.map(_.fold(_.value, "view"))))
         .liftM[FileSystemErrT]
 
     def dirMetadata(d: ADir): Free[S, QResponse[S]] = respond(

--- a/web/src/main/scala/quasar/api/services/mount.scala
+++ b/web/src/main/scala/quasar/api/services/mount.scala
@@ -46,7 +46,7 @@ object mount {
           NotFound withReason "Mount point not found.",
           s"There is no mount point at ${printPath(path)}",
           "path" := path)
-        respondT(M.lookup(path).toRight(err))
+        respondT(M.lookupConfig(path).toRight(err))
 
       case req @ MOVE -> AsPath(src) =>
         respondT(requiredHeader(Destination, req).map(_.value).fold(
@@ -120,7 +120,7 @@ object mount {
                    parseErrorMsg).left,
                  (msg, _) => ApiError.fromMsg_(
                    BadRequest, msg).left))
-      exists <- M.lookup(path).isDefined.liftM[ApiErrT]
+      exists <- M.lookupType(path).isDefined.liftM[ApiErrT]
       mnt    =  if (replaceIfExists && exists) M.replace(path, bConf)
                 else M.mount(path, bConf)
       _      <- mnt.liftM[ApiErrT]

--- a/web/src/main/scala/quasar/api/services/mount.scala
+++ b/web/src/main/scala/quasar/api/services/mount.scala
@@ -17,7 +17,7 @@
 package quasar.api.services
 
 import quasar.Predef._
-import quasar.api._, ToApiError.ops._
+import quasar.api._
 import quasar.fp._
 import quasar.fs.{AbsPath, APath, sandboxAbs}
 import quasar.fs.mount._
@@ -36,7 +36,9 @@ object mount {
   def service[S[_]](
     implicit
     M: Mounting.Ops[S],
-    S0: Task :<: S
+    S0: Task :<: S,
+    S1: MountingFailure :<: S,
+    S2: PathMismatchFailure :<: S
   ): QHttpService[S] =
     QHttpService {
       case GET -> AsPath(path) =>
@@ -44,36 +46,36 @@ object mount {
           NotFound withReason "Mount point not found.",
           s"There is no mount point at ${printPath(path)}",
           "path" := path)
-        respond(M.lookup(path).toRight(err).run)
+        respondT(M.lookup(path).toRight(err))
 
       case req @ MOVE -> AsPath(src) =>
-        respond(requiredHeader(Destination, req).map(_.value).fold(
-          err => EitherT.leftU[String](err.point[Free[S, ?]]),
+        respondT(requiredHeader(Destination, req).map(_.value).fold(
+          _.raiseError[ApiErrT[M.F, ?], String],
           dst => refineType(src).fold(
             srcDir  => move[S, Dir](srcDir,  dst, UriPathCodec.parseAbsDir,  "directory"),
-            srcFile => move[S, File](srcFile, dst, UriPathCodec.parseAbsFile, "file"))).run)
+            srcFile => move[S, File](srcFile, dst, UriPathCodec.parseAbsFile, "file"))))
 
-      case req @ POST -> AsDirPath(parent) => respond((for {
-        hdr <- EitherT.fromDisjunction[M.F](requiredHeader(XFileName, req))
-        fn  =  hdr.value
-        dst <- EitherT.fromDisjunction[M.F](
-                (UriPathCodec.parseRelDir(fn) orElse UriPathCodec.parseRelFile(fn))
-                  .flatMap(sandbox(currentDir, _))
-                  .map(parent </> _)
-                  .toRightDisjunction(ApiError.apiError(
-                    BadRequest withReason "Filename must be a relative path.",
-                    "fileName" := fn)))
-        _   <- mount[S](dst, req, replaceIfExists = false)
-      } yield s"added ${printPath(dst)}").run)
+      case req @ POST -> AsDirPath(parent) =>
+        respondT(for {
+          hdr <- EitherT.fromDisjunction[M.F](requiredHeader(XFileName, req))
+          fn  =  hdr.value
+          dst <- EitherT.fromDisjunction[M.F](
+                  (UriPathCodec.parseRelDir(fn) orElse UriPathCodec.parseRelFile(fn))
+                    .flatMap(sandbox(currentDir, _))
+                    .map(parent </> _)
+                    .toRightDisjunction(ApiError.apiError(
+                      BadRequest withReason "Filename must be a relative path.",
+                      "fileName" := fn)))
+          _   <- mount[S](dst, req, replaceIfExists = false)
+        } yield s"added ${printPath(dst)}")
 
       case req @ PUT -> AsPath(path) =>
-        respond(
-          mount[S](path, req, replaceIfExists = true)
-            .map(upd => s"${upd ? "updated" | "added"} ${printPath(path)}")
-            .run)
+        respondT(mount[S](path, req, replaceIfExists = true) map { upd =>
+          s"${upd ? "updated" | "added"} ${printPath(path)}"
+        })
 
       case DELETE -> AsPath(p) =>
-        respond(M.unmount(p).as(s"deleted ${printPath(p)}").run)
+        respond(M.unmount(p).as(s"deleted ${printPath(p)}"))
     }
 
   ////
@@ -84,16 +86,18 @@ object mount {
     parse: String => Option[Path[Abs, T, Unsandboxed]],
     typeStr: String
   )(implicit
-    M: Mounting.Ops[S]
+    M: Mounting.Ops[S],
+    S0: MountingFailure :<: S,
+    S1: PathMismatchFailure :<: S
   ): EitherT[Free[S, ?], ApiError, String] =
     parse(dstStr).map(sandboxAbs).cata(dst =>
       M.remount[T](src, dst)
         .as(s"moved ${printPath(src)} to ${printPath(dst)}")
-        .leftMap(_.toApiError),
+        .liftM[ApiErrT],
       ApiError.apiError(
         BadRequest withReason s"Expected an absolute $typeStr.",
         "path" := transcode(UriPathCodec, posixCodec)(dstStr)
-      ).raiseError[EitherT[M.F, ApiError, ?], String])
+      ).raiseError[ApiErrT[Free[S, ?], ?], String])
 
   private def mount[S[_]](
     path: APath,
@@ -101,25 +105,24 @@ object mount {
     replaceIfExists: Boolean
   )(implicit
     M: Mounting.Ops[S],
-    S0: Task :<: S
-  ): EitherT[Free[S, ?], ApiError, Boolean] = {
-    type FreeS[A] = Free[S, A]
-
+    S0: Task :<: S,
+    S1: MountingFailure :<: S,
+    S2: PathMismatchFailure :<: S
+  ): EitherT[Free[S, ?], ApiError, Boolean] =
     for {
-      body  <- EitherT.right(free.injectFT[Task, S].apply(
-                 EntityDecoder.decodeString(req)): FreeS[String])
-      bConf <- EitherT.fromDisjunction[FreeS](Parse.decodeWith(
-                  body,
-                  (_: MountConfig).right[ApiError],
-                  parseErrorMsg => ApiError.fromMsg_(
-                    BadRequest withReason "Malformed input.",
-                    parseErrorMsg).left,
-                  (msg, _) => ApiError.fromMsg_(
-                    BadRequest, msg).left))
-      exists <- EitherT.right(M.lookup(path).isDefined)
-      mnt    = if (replaceIfExists && exists) M.replace(path, bConf) else M.mount(path, bConf)
-      r      <- mnt.leftMap(_.toApiError)
-      _      <- EitherT.fromDisjunction[FreeS](r.leftMap(_.toApiError))
+      body  <- free.lift(EntityDecoder.decodeString(req))
+                 .into[S].liftM[ApiErrT]
+      bConf <- EitherT.fromDisjunction[Free[S, ?]](Parse.decodeWith(
+                 body,
+                 (_: MountConfig).right[ApiError],
+                 parseErrorMsg => ApiError.fromMsg_(
+                   BadRequest withReason "Malformed input.",
+                   parseErrorMsg).left,
+                 (msg, _) => ApiError.fromMsg_(
+                   BadRequest, msg).left))
+      exists <- M.lookup(path).isDefined.liftM[ApiErrT]
+      mnt    =  if (replaceIfExists && exists) M.replace(path, bConf)
+                else M.mount(path, bConf)
+      _      <- mnt.liftM[ApiErrT]
     } yield exists
-  }
 }

--- a/web/src/test/scala/quasar/api/services/MountServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/MountServiceSpec.scala
@@ -218,8 +218,8 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
               (res, mntd) = r
               body     <- lift(res.as[String]).into[Eff]
 
-              srcAfter <- M.lookup(src).run
-              dstAfter <- M.lookup(dst).run
+              srcAfter <- M.lookupConfig(src).run
+              dstAfter <- M.lookupConfig(dst).run
             } yield {
               (body must_== s"moved ${printPath(src)} to ${printPath(dst)}") and
               (res.status must_== Ok)                                        and
@@ -358,7 +358,7 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
                 (res, mntd) = r
                 body  <- lift(res.as[String]).into[Eff]
                 dst   =  parent </> fsDir
-                after <- M.lookup(dst).run
+                after <- M.lookupConfig(dst).run
               } yield {
                 (body must_== s"added ${printPath(dst)}")                   and
                 (res.status must_== Ok)                                     and
@@ -381,7 +381,7 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
                 (res, mntd) = r
                 body  <- lift(res.as[String]).into[Eff]
                 dst   =  parent </> f
-                after <- M.lookup(dst).run
+                after <- M.lookupConfig(dst).run
               } yield {
                 (body must_== s"added ${printPath(dst)}")         and
                 (res.status must_== Ok)                           and
@@ -408,8 +408,8 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
                 (res, mntd) = r
                 body      <- lift(res.as[String]).into[Eff]
 
-                afterFs   <- M.lookup(fs).run
-                afterView <- M.lookup(view).run
+                afterFs   <- M.lookupConfig(fs).run
+                afterView <- M.lookupConfig(view).run
               } yield {
                 (body must_== s"added ${printPath(view)}") and
                 (res.status must_== Ok)                    and
@@ -440,7 +440,7 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
                 (res, mntd) = r
                 body  <- lift(res.as[String]).into[Eff]
                 vdst  =  d </> view
-                after <- M.lookup(vdst).run
+                after <- M.lookupConfig(vdst).run
               } yield {
                 (body must_== s"added ${printPath(vdst)}") and
                 (res.status must_== Ok)                    and
@@ -468,7 +468,7 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
                 (res, mntd) = r
                 jerr  <- lift(res.as[Json]).into[Eff]
                 dst   =  d </> fs
-                after <- M.lookup(dst).run
+                after <- M.lookupConfig(dst).run
               } yield {
                 (jerr must_== Json("error" := s"cannot mount at ${printPath(dst)} because existing mount below: ${printPath(fs1)}")) and
                 (res.status must_== Conflict)                               and
@@ -584,7 +584,7 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
             (res, mntd) = r
             err   <- lift(res.as[ApiError]).into[Eff]
 
-            after <- M.lookup(mntPath).run
+            after <- M.lookupConfig(mntPath).run
           } yield {
             (err must beApiErrorLike(pathExists(mntPath)))                  and
             (mntd must_== Set(MR.mountFileSystem(mntPath, StubFs, barUri))) and
@@ -631,7 +631,7 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
               (res, mntd) = r
               body  <- lift(res.as[String]).into[Eff]
 
-              after <- M.lookup(fsDir).run
+              after <- M.lookupConfig(fsDir).run
             } yield {
               (body must_== s"updated ${printPath(fsDir)}")                 and
               (res.status must_== Ok)                                       and
@@ -658,7 +658,7 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
               (res, mntd) = r
               body  <- lift(res.as[String]).into[Eff]
 
-              after <- M.lookup(d).run
+              after <- M.lookupConfig(d).run
             } yield {
               (body must_== s"deleted ${printPath(d)}") and
               (res.status must_== Ok)                   and
@@ -683,7 +683,7 @@ class MountServiceSpec extends Specification with ScalaCheck with Http4s with Pa
               (res, mntd) = r
               body  <- lift(res.as[String]).into[Eff]
 
-              after <- M.lookup(f).run
+              after <- M.lookupConfig(f).run
             } yield {
               (body must_== s"deleted ${printPath(f)}") and
               (res.status must_== Ok)                   and


### PR DESCRIPTION
Adds two new terms to `Mounting`: `Move` and `HavingPrefix`. The former is an optimization to allow us not to have to unmount/remount a mount just to change location. `HavingPrefix` exists as a primitive to allow discovering many mounts at once. This allows us to implement the `/metadata/fs` endpoint much more efficiently.

Both also are needed for the next phase, which is to rewrite the view mounter in terms of the `Mounting` algebra so it can use different implementations.

While I was in there, I also got rid of `EitherT` in `Mounting.Ops` in favor of `Failure` effects, which makes them a bit nicer to use in many cases (@mossprescott you may find this interesting).