### PR TITLE
Newlines in tests.

### DIFF
--- a/core/src/test/scala/quasar/codec.scala
+++ b/core/src/test/scala/quasar/codec.scala
@@ -78,7 +78,7 @@ class DataCodecSpecs extends quasar.QuasarSpecification with ScalaCheck with Dis
       "encode NA"        in { DataCodec.render(Data.NA) must beRightDisjunction("""{ "$na": null }""") }
     }
 
-    "round-trip" ! prop { (data: Data) =>
+    "round-trip" >> prop { (data: Data) =>
       representable(data) ==> {
         DataCodec.render(data).flatMap(DataCodec.parse) must beRightDisjunction(data)
       }
@@ -156,7 +156,7 @@ class DataCodecSpecs extends quasar.QuasarSpecification with ScalaCheck with Dis
       "encode NA"        in { DataCodec.render(Data.NA) must beRightDisjunction("null") }
     }
 
-    "round-trip" ! prop { (data: Data) =>
+    "round-trip" >> prop { (data: Data) =>
       representable(data) ==> {
         DataCodec.render(data).flatMap(DataCodec.parse) must beRightDisjunction(data)
       }
@@ -209,7 +209,7 @@ class DataCodecSpecs extends quasar.QuasarSpecification with ScalaCheck with Dis
   }
 
   "Error messages" should {
-    "UnrepresentableDataError" ! prop { any: Data =>
+    "UnrepresentableDataError" >> prop { any: Data =>
       UnrepresentableDataError(any).message must_= ("not representable: " + any)
     }
     "UnescapedKeyError" in {

--- a/core/src/test/scala/quasar/fs/ManageFileSpec.scala
+++ b/core/src/test/scala/quasar/fs/ManageFileSpec.scala
@@ -29,7 +29,7 @@ class ManageFileSpec extends quasar.QuasarSpecification with ScalaCheck with Fil
 
   "ManageFile" should {
     "renameFile" >> {
-      "moves the existing file to a new name in the same directory" ! prop {
+      "moves the existing file to a new name in the same directory" >> prop {
         (s: SingleFileMemState, name: String) => {
           val rename =
             manage.renameFile(s.file, name).liftM[Process]

--- a/core/src/test/scala/quasar/fs/QueryFileSpec.scala
+++ b/core/src/test/scala/quasar/fs/QueryFileSpec.scala
@@ -42,7 +42,7 @@ class QueryFileSpec
 
   "QueryFile" should {
     "descendantFiles" >> {
-      "returns all descendants of the given directory" ! prop {
+      "returns all descendants of the given directory" >> prop {
         (target: ADir, descendants: NonEmptyList[RFile], others: List[AFile]) =>
           val data = Vector(Data.Str("foo"))
           val outsideOfTarget = others.filterNot(_.relativeTo(target).isDefined)
@@ -56,24 +56,24 @@ class QueryFileSpec
       }.setArbitrary2(nonEmptyListSmallerThan(10)).setArbitrary3(listSmallerThan(5))
         .set(workers = java.lang.Runtime.getRuntime.availableProcessors)
 
-      "returns not found when dir does not exist" ! prop { d: ADir => (d =/= rootDir) ==> {
+      "returns not found when dir does not exist" >> prop { d: ADir => (d =/= rootDir) ==> {
         Mem.interpret(query.descendantFiles(d)).eval(emptyMem)
           .toEither must beLeft(pathErr(pathNotFound(d)))
       }}
     }
 
     "fileExists" >> {
-      "return true when file exists" ! prop { s: SingleFileMemState =>
+      "return true when file exists" >> prop { s: SingleFileMemState =>
         Mem.interpret(query.fileExists(s.file)).eval(s.state) ==== true
       }
 
-      "return false when file doesn't exist" ! prop { (absentFile: AFile, s: SingleFileMemState) =>
+      "return false when file doesn't exist" >> prop { (absentFile: AFile, s: SingleFileMemState) =>
         absentFile ≠ s.file ==> {
           Mem.interpret(query.fileExists(absentFile)).eval(s.state) ==== false
         }
       }
 
-      "return false when dir exists with same name as file" ! prop { (f: AFile, data: Vector[Data]) =>
+      "return false when dir exists with same name as file" >> prop { (f: AFile, data: Vector[Data]) =>
         val n = fileName(f)
         val fd = parentDir(f).get </> dir(n.value) </> file("different.txt")
 
@@ -82,7 +82,7 @@ class QueryFileSpec
     }
 
     "evaluate" >> {
-      "streams the results of evaluating the logical plan" ! prop { s: SingleFileMemState =>
+      "streams the results of evaluating the logical plan" >> prop { s: SingleFileMemState =>
         val query = LogicalPlan.Read(s.file)
         val state = s.state.copy(queryResps = Map(query -> s.contents))
         val result = MemTask.runLog[FileSystemError, PhaseResults, Data](evaluate(query)).run.run.eval(state)
@@ -91,7 +91,7 @@ class QueryFileSpec
     }
 
     "enumerate" >> {
-      "streams results until an empty vector is received" ! prop {
+      "streams results until an empty vector is received" >> prop {
         s: SingleFileMemState =>
 
         val query = LogicalPlan.Read(s.file)
@@ -103,7 +103,7 @@ class QueryFileSpec
           .leftMap(_.resultMap) ==== ((Map.empty, \/.right(s.contents)))
       }
 
-      "closes result handle when terminated early" ! prop {
+      "closes result handle when terminated early" >> prop {
         s: SingleFileMemState =>
 
         val n = s.contents.length / 2

--- a/core/src/test/scala/quasar/fs/ReadFileSpec.scala
+++ b/core/src/test/scala/quasar/fs/ReadFileSpec.scala
@@ -28,7 +28,7 @@ class ReadFileSpec extends quasar.QuasarSpecification with ScalaCheck with FileS
   import DataArbitrary._, FileSystemError._, PathError._
 
   "ReadFile" should {
-    "scan should read data until an empty vector is received" ! prop {
+    "scan should read data until an empty vector is received" >> prop {
       (f: AFile, xs: Vector[Data]) =>
 
       val p = write.append(f, xs.toProcess).drain ++ read.scanAll(f)
@@ -36,7 +36,7 @@ class ReadFileSpec extends quasar.QuasarSpecification with ScalaCheck with FileS
       MemTask.runLogEmpty(p).unsafePerformSync must_=== \/-(xs)
     }
 
-    "scan should automatically close the read handle when terminated early" ! prop {
+    "scan should automatically close the read handle when terminated early" >> prop {
       (f: AFile, xs: Vector[Data]) => xs.nonEmpty ==> {
         val n = xs.length / 2
         val p = write.append(f, xs.toProcess).drain ++ read.scanAll(f).take(n)
@@ -46,7 +46,7 @@ class ReadFileSpec extends quasar.QuasarSpecification with ScalaCheck with FileS
       }
     }
 
-    "scan should automatically close the read handle on failure" ! prop {
+    "scan should automatically close the read handle on failure" >> prop {
       (f: AFile, xs: Vector[Data]) => xs.nonEmpty ==> {
         val reads = List(xs.right, pathErr(pathNotFound(f)).left)
 

--- a/core/src/test/scala/quasar/fs/SandboxedPathySpec.scala
+++ b/core/src/test/scala/quasar/fs/SandboxedPathySpec.scala
@@ -29,11 +29,11 @@ import scalaz._, Scalaz._
 class SandboxedPathySpec extends quasar.QuasarSpecification with DisjunctionMatchers with ScalaCheck {
 
   "rootSubPath" should {
-    "returns the correct sub path" ! prop { (d: ADir, p: RPath) =>
+    "returns the correct sub path" >> prop { (d: ADir, p: RPath) =>
       refineType(rootSubPath(depth(d), d </> p)) ==== d.left
     }
 
-    "return the path if the index is too long or the same" ! prop { (d: ADir, i: Int) =>
+    "return the path if the index is too long or the same" >> prop { (d: ADir, i: Int) =>
       (i > 0 && (i.toLong + depth(d)) < Int.MaxValue) ==> {
         refineType(rootSubPath(depth(d) + i, d)) ==== d.left
       }
@@ -41,13 +41,13 @@ class SandboxedPathySpec extends quasar.QuasarSpecification with DisjunctionMatc
   }
 
   "largestCommonPathFromRoot" should {
-    "completely different APaths should return rootDir" ! prop { (a: APath, b: APath) =>
+    "completely different APaths should return rootDir" >> prop { (a: APath, b: APath) =>
       segAt(0, a) =/= segAt(0, b) ==> {
         refineType(largestCommonPathFromRoot(a, b)) ==== rootDir.left
       }
     }
 
-    "return common path" ! prop { (a: ADir, b: RPath, c: RPath) =>
+    "return common path" >> prop { (a: ADir, b: RPath, c: RPath) =>
       segAt(0, b) =/= segAt(0, c) ==> {
         refineType(largestCommonPathFromRoot(a </> b, a </> c)) ==== a.left
       }
@@ -55,7 +55,7 @@ class SandboxedPathySpec extends quasar.QuasarSpecification with DisjunctionMatc
   }
 
   "segAt" should {
-    "segment at specified index" ! prop { (d: ADir, dirName: String, p: RPath) =>
+    "segment at specified index" >> prop { (d: ADir, dirName: String, p: RPath) =>
       segAt(depth(d), d </> dir(dirName) </> p) ==== DirName(dirName).left.some
     }
   }

--- a/core/src/test/scala/quasar/fs/mount/MountsSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/MountsSpec.scala
@@ -27,11 +27,11 @@ import scalaz.std.list._
 class MountsSpec extends quasar.QuasarSpecification with ScalaCheck with DisjunctionMatchers {
   "Mounts" should {
     "adding entries" >> {
-      "fails when dir is a prefix of existing" ! prop { mnt: AbsDir[Sandboxed] =>
+      "fails when dir is a prefix of existing" >> prop { mnt: AbsDir[Sandboxed] =>
         Mounts.singleton(mnt </> dir("c1"), 1).add(mnt, 2) must beLeftDisjunction
       }
 
-      "fails when dir is prefixed by existing" ! prop { mnt: AbsDir[Sandboxed] =>
+      "fails when dir is prefixed by existing" >> prop { mnt: AbsDir[Sandboxed] =>
         Mounts.singleton(mnt, 1).add(mnt </> dir("c2"), 2) must beLeftDisjunction
       }
 
@@ -42,7 +42,7 @@ class MountsSpec extends quasar.QuasarSpecification with ScalaCheck with Disjunc
         Mounts.fromFoldable(List((mnt1, 1), (mnt2, 2))) must beRightDisjunction
       }
 
-      "succeeds when replacing value at existing" ! prop { mnt: AbsDir[Sandboxed] =>
+      "succeeds when replacing value at existing" >> prop { mnt: AbsDir[Sandboxed] =>
         Mounts.singleton(mnt, 1)
           .add(mnt, 2)
           .toOption

--- a/core/src/test/scala/quasar/fs/mount/ViewFSSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/ViewFSSpec.scala
@@ -432,7 +432,7 @@ class ViewFSSpec extends quasar.QuasarSpecification with ScalaCheck with TreeMat
     def twoNodes(aDir: ADir) =
       Map(aDir -> Set[PathSegment](FileName("afile").right, DirName("adir").left))
 
-    "preserve files and dirs in the presence of non-conflicting views" ! prop { (aDir: ADir) =>
+    "preserve files and dirs in the presence of non-conflicting views" >> prop { (aDir: ADir) =>
       val expr = parseExpr("select * from zips")
 
       val views = Map(
@@ -451,7 +451,7 @@ class ViewFSSpec extends quasar.QuasarSpecification with ScalaCheck with TreeMat
           DirName("views").left)))
     }
 
-    "overlay files and dirs with conflicting paths" ! prop { (aDir: ADir) =>
+    "overlay files and dirs with conflicting paths" >> prop { (aDir: ADir) =>
       val expr = parseExpr("select * from zips")
 
       val views = Map(
@@ -468,7 +468,7 @@ class ViewFSSpec extends quasar.QuasarSpecification with ScalaCheck with TreeMat
           DirName("adir").left)))  // no conflict with same dir
     }
 
-    "preserve empty dir result" ! prop { (aDir: ADir) =>
+    "preserve empty dir result" >> prop { (aDir: ADir) =>
       val views = Map[AFile, Fix[Sql]]()
 
       val f = query.ls(aDir).run
@@ -479,7 +479,7 @@ class ViewFSSpec extends quasar.QuasarSpecification with ScalaCheck with TreeMat
         \/-(Set()))
     }
 
-    "preserve error for non-existent dir" ! prop { (aDir: ADir) =>
+    "preserve error for non-existent dir" >> prop { (aDir: ADir) =>
       (aDir =/= rootDir) ==> {
         val views = Map[AFile, Fix[Sql]]()
 
@@ -505,7 +505,7 @@ class ViewFSSpec extends quasar.QuasarSpecification with ScalaCheck with TreeMat
   }
 
   "QueryFile.fileExists" should {
-    "behave as underlying interpreter" ! prop { file: AFile =>
+    "behave as underlying interpreter" >> prop { file: AFile =>
       val program = query.fileExists(file)
 
       val ops = traceInterp(program, Map())._1
@@ -520,7 +520,7 @@ class ViewFSSpec extends quasar.QuasarSpecification with ScalaCheck with TreeMat
       hasFile and noFile
     }
 
-    "return true if there is a view at that path" ! prop { (file: AFile, expr: Fix[Sql]) =>
+    "return true if there is a view at that path" >> prop { (file: AFile, expr: Fix[Sql]) =>
       val views = Map(file -> expr)
 
       val program = query.fileExists(file)

--- a/core/src/test/scala/quasar/fs/mount/ViewMounterSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/ViewMounterSpec.scala
@@ -253,14 +253,14 @@ class ViewMounterSpec extends quasar.QuasarSpecification with ScalaCheck with Tr
   }
 
   "ls" >> {
-    "be empty" ! prop { (dir: ADir) =>
+    "be empty" >> prop { (dir: ADir) =>
       val vs = Map[APath, MountConfig]()
 
       eval(vs)(ViewMounter.ls[MountConfigs](dir))
         ._2 must beEmpty
     }
 
-    "list view under its parent dir" ! prop { (path: AFile) =>
+    "list view under its parent dir" >> prop { (path: AFile) =>
       val vs = Map[APath, MountConfig](
         path -> MountConfig.viewConfig(viewConfig("select * from `/foo`")))
 
@@ -268,7 +268,7 @@ class ViewMounterSpec extends quasar.QuasarSpecification with ScalaCheck with Tr
         ._2 must_=== Set[PathSegment](fileName(path).right)
     }
 
-    "list view parent under grand-parent dir" ! prop { (dir: ADir) =>
+    "list view parent under grand-parent dir" >> prop { (dir: ADir) =>
       (dir ≠ rootDir) ==> {
         val parent = parentDir(dir).get
         val vs = Map[APath, MountConfig](

--- a/core/src/test/scala/quasar/sql/SqlParserSpec.scala
+++ b/core/src/test/scala/quasar/sql/SqlParserSpec.scala
@@ -549,7 +549,7 @@ class SQLParserSpec extends quasar.QuasarSpecification with ScalaCheck with Disj
       }.pendingUntilFixed("SD-1536")
     }
 
-    "round-trip to SQL and back" ! prop { (node: Fix[Sql]) =>
+    "round-trip to SQL and back" >> prop { (node: Fix[Sql]) =>
       val parsed = parse(pprint(node))
 
       parsed.fold(

--- a/core/src/test/scala/quasar/std/AggLibSpec.scala
+++ b/core/src/test/scala/quasar/std/AggLibSpec.scala
@@ -32,7 +32,7 @@ class AggLibSpec extends quasar.QuasarSpecification with ScalaCheck with Validat
   import AggLib._
 
   "Arbitrary" should {
-    "type a nonempty constant set to the constant first value" ! prop { xs: NonEmptyList[Data] =>
+    "type a nonempty constant set to the constant first value" >> prop { xs: NonEmptyList[Data] =>
       Arbitrary.tpe(Func.Input1(Type.Const(Data.Set(xs.list.toList)))) must beSuccessful(Type.Const(xs.head))
     }
 
@@ -42,18 +42,18 @@ class AggLibSpec extends quasar.QuasarSpecification with ScalaCheck with Validat
   }
 
   "Avg" should {
-    "type a constant Int set to the constant average of values" ! prop { n: BigInt =>
+    "type a constant Int set to the constant average of values" >> prop { n: BigInt =>
       val s = Data.Set(List(Data.Int(n), Data.Int(n + 2)))
       Avg.tpe(Func.Input1(Type.Const(s))) must beSuccessful(Type.Const(Data.Dec(BigDecimal(n + 1))))
     }
 
-    "type a constant Dec set to the constant average of values" ! prop { n0: Double =>
+    "type a constant Dec set to the constant average of values" >> prop { n0: Double =>
       val n = BigDecimal(n0)
       val s = Data.Set(List(Data.Dec(n), Data.Dec(n / 2.0)))
       Avg.tpe(Func.Input1(Type.Const(s))) must beSuccessful(Type.Const(Data.Dec(n * 0.75)))
     }
 
-    "type a constant Interval set to the constant average of values" ! prop { n: Int =>
+    "type a constant Interval set to the constant average of values" >> prop { n: Int =>
       val dur = Duration.ofMillis(n.toLong)
       val s = Data.Set(List(Data.Interval(dur), Data.Interval(dur.plusMillis(2))))
       Avg.tpe(Func.Input1(Type.Const(s))) must beSuccessful(Type.Const(Data.Dec(n.toLong + 1)))
@@ -65,13 +65,13 @@ class AggLibSpec extends quasar.QuasarSpecification with ScalaCheck with Validat
   }
 
   "Count" should {
-    "type a constant set as the constant length" ! prop { xs: List[Int] =>
+    "type a constant set as the constant length" >> prop { xs: List[Int] =>
       Count.tpe(Func.Input1(Type.Const(Data.Set(xs.map(Data.Int(_)))))) must beSuccessful(Type.Const(Data.Int(xs.length)))
     }
   }
 
   "Max" should {
-    "type a constant set as the constant max value" ! prop { xs: NonEmptyList[Int] =>
+    "type a constant set as the constant max value" >> prop { xs: NonEmptyList[Int] =>
       Max.tpe(Func.Input1(Type.Const(Data.Set(xs.list.toList.map(Data.Int(_)))))) must
         beSuccessful(Type.Const(Data.Int(xs.maximum1)))
     }
@@ -82,7 +82,7 @@ class AggLibSpec extends quasar.QuasarSpecification with ScalaCheck with Validat
   }
 
   "Min" should {
-    "type a constant set as the constant min value" ! prop { xs: NonEmptyList[Int] =>
+    "type a constant set as the constant min value" >> prop { xs: NonEmptyList[Int] =>
       Min.tpe(Func.Input1(Type.Const(Data.Set(xs.list.toList.map(Data.Int(_)))))) must
         beSuccessful(Type.Const(Data.Int(xs.minimum1)))
     }
@@ -93,18 +93,18 @@ class AggLibSpec extends quasar.QuasarSpecification with ScalaCheck with Validat
   }
 
   "Sum" should {
-    "type a constant Int set to the constant Int sum of values" ! prop { xs: NonEmptyList[BigInt] =>
+    "type a constant Int set to the constant Int sum of values" >> prop { xs: NonEmptyList[BigInt] =>
       val s = Data.Set(xs.list.toList map (Data.Int(_)))
       Sum.tpe(Func.Input1(Type.Const(s))) must beSuccessful(Type.Const(Data.Int(xs.list.toList.sum)))
     }
 
-    "type a constant Dec set to the constant Dec sum of values" ! prop { xs: NonEmptyList[Double] =>
+    "type a constant Dec set to the constant Dec sum of values" >> prop { xs: NonEmptyList[Double] =>
       val ys = xs.list.toList map (BigDecimal(_))
       val s = Data.Set(ys map (Data.Dec(_)))
       Sum.tpe(Func.Input1(Type.Const(s))) must beSuccessful(Type.Const(Data.Dec(ys.sum)))
     }
 
-    "type a constant Interval set to the constant Interval sum of values" ! prop { xs: NonEmptyList[Int] =>
+    "type a constant Interval set to the constant Interval sum of values" >> prop { xs: NonEmptyList[Int] =>
       val milliss = xs.list.toList map (_.toLong)
       val s = Data.Set(milliss map (n => Data.Interval(Duration.ofMillis(n))))
       Sum.tpe(Func.Input1(Type.Const(s))) must beSuccessful(Type.Const(Data.Interval(Duration.ofMillis(milliss.sum))))

--- a/core/src/test/scala/quasar/std/math.scala
+++ b/core/src/test/scala/quasar/std/math.scala
@@ -85,12 +85,12 @@ class MathSpec extends quasar.QuasarSpecification with ScalaCheck with TypeArbit
         beSome(FreeF[Fix[LogicalPlan]]('x))
     }
 
-    "eliminate multiply by dec zero (on the right)" ! prop { (c : Const) =>
+    "eliminate multiply by dec zero (on the right)" >> prop { (c : Const) =>
       val expr = Multiply.tpe(Func.Input2(c, Const(Dec(0.0))))
       expr should beSuccessful(TZero())
     }
 
-    "eliminate multiply by zero (on the left)" ! prop { (c : Const) =>
+    "eliminate multiply by zero (on the left)" >> prop { (c : Const) =>
       val expr = Multiply.tpe(Func.Input2(TZero(), c))
       expr should beSuccessful(TZero())
     }
@@ -155,16 +155,16 @@ class MathSpec extends quasar.QuasarSpecification with ScalaCheck with TypeArbit
       expr must beFailing
     }
 
-    "typecheck number raised to 0th power" ! prop { (t: Type) =>
+    "typecheck number raised to 0th power" >> prop { (t: Type) =>
       Power.tpe(Func.Input2(t, TZero())) should beSuccessful(TOne())
     }.setArbitrary(arbitraryNumeric)
 
-    "typecheck 0 raised to any (non-zero) power" ! prop { (t: Type) =>
+    "typecheck 0 raised to any (non-zero) power" >> prop { (t: Type) =>
       (t != TZero()) ==>
         (Power.tpe(Func.Input2(TZero(), t)) should beSuccessful(TZero()))
     }.setArbitrary(arbitraryNumeric)
 
-    "typecheck any number raised to 1st power" ! prop { (t: Type) =>
+    "typecheck any number raised to 1st power" >> prop { (t: Type) =>
       Power.tpe(Func.Input2(t, TOne())) should beSuccessful(t)
     }.setArbitrary(arbitraryNumeric)
 

--- a/core/src/test/scala/quasar/std/relations.scala
+++ b/core/src/test/scala/quasar/std/relations.scala
@@ -38,7 +38,7 @@ class RelationsSpec extends quasar.QuasarSpecification with ScalaCheck with Type
 
   "RelationsLib" should {
 
-    "type eq with matching arguments" ! prop { (t : Type) =>
+    "type eq with matching arguments" >> prop { (t : Type) =>
       val expr = Eq.tpe(Func.Input2(t, t))
       t match {
         case Const(_) => expr should beSuccessful(Const(Bool(true)))
@@ -61,12 +61,12 @@ class RelationsSpec extends quasar.QuasarSpecification with ScalaCheck with Type
       expr should beSuccessful(Const(Bool(false)))
     }
 
-    "type Eq with Top" ! prop { (t : Type) =>
+    "type Eq with Top" >> prop { (t : Type) =>
       Eq.tpe(Func.Input2(Type.Top, t)) should beSuccessful(Type.Bool)
       Eq.tpe(Func.Input2(t, Type.Top)) should beSuccessful(Type.Bool)
     }
 
-    "type Neq with Top" ! prop { (t : Type) =>
+    "type Neq with Top" >> prop { (t : Type) =>
       Neq.tpe(Func.Input2(Type.Top, t)) should beSuccessful(Type.Bool)
       Neq.tpe(Func.Input2(t, Type.Top)) should beSuccessful(Type.Bool)
     }
@@ -78,12 +78,12 @@ class RelationsSpec extends quasar.QuasarSpecification with ScalaCheck with Type
 
     // TODO: similar for the rest of the simple relations
 
-    "fold cond with true" ! prop { (t1 : Type, t2 : Type) =>
+    "fold cond with true" >> prop { (t1 : Type, t2 : Type) =>
       val expr = Cond.tpe(Func.Input3(Const(Bool(true)), t1, t2))
       expr must beSuccessful(t1)
     }
 
-    "fold cond with false" ! prop { (t1 : Type, t2 : Type) =>
+    "fold cond with false" >> prop { (t1 : Type, t2 : Type) =>
       val expr = Cond.tpe(Func.Input3(Const(Bool(false)), t1, t2))
       expr must beSuccessful(t2)
     }
@@ -93,12 +93,12 @@ class RelationsSpec extends quasar.QuasarSpecification with ScalaCheck with Type
       expr must beSuccessful(Type.Int)
     }
 
-    "find lub for cond with arbitrary args" ! prop { (t1 : Type, t2 : Type) =>
+    "find lub for cond with arbitrary args" >> prop { (t1 : Type, t2 : Type) =>
       val expr = Cond.tpe(Func.Input3(Type.Bool, t1, t2))
       expr must beSuccessful(Type.lub(t1, t2))
     }
 
-    "fold coalesce with right null type" ! prop { (t1 : Type) =>
+    "fold coalesce with right null type" >> prop { (t1 : Type) =>
       val expr = Coalesce.tpe(Func.Input2(t1, Type.Null))
       expr must beSuccessful(t1 match {
         case Const(Null) => Type.Null
@@ -106,12 +106,12 @@ class RelationsSpec extends quasar.QuasarSpecification with ScalaCheck with Type
       })
     }
 
-    "fold coalesce with left null type" ! prop { (t2 : Type) =>
+    "fold coalesce with left null type" >> prop { (t2 : Type) =>
       val expr = Coalesce.tpe(Func.Input2(Type.Null, t2))
       expr must beSuccessful(t2)
     }
 
-    "fold coalesce with right null value" ! prop { (t1 : Type) =>
+    "fold coalesce with right null value" >> prop { (t1 : Type) =>
       val expr = Coalesce.tpe(Func.Input2(t1, Const(Null)))
       expr must beSuccessful(t1 match {
         case Type.Null => Const(Null)
@@ -119,12 +119,12 @@ class RelationsSpec extends quasar.QuasarSpecification with ScalaCheck with Type
       })
     }
 
-    "fold coalesce with left null value" ! prop { (t2 : Type) =>
+    "fold coalesce with left null value" >> prop { (t2 : Type) =>
       val expr = Coalesce.tpe(Func.Input2(Const(Null), t2))
       expr must beSuccessful(t2)
     }
 
-    "fold coalesce with left value" ! prop { (t2 : Type) =>
+    "fold coalesce with left value" >> prop { (t2 : Type) =>
       val expr = Coalesce.tpe(Func.Input2(Const(Int(3)), t2))
       expr must beSuccessful(Const(Int(3)))
     }
@@ -134,7 +134,7 @@ class RelationsSpec extends quasar.QuasarSpecification with ScalaCheck with Type
       expr must beSuccessful(Type.Int)
     }
 
-    "find lub for coalesce with arbitrary args" ! prop { (t1: Type, t2: Type) =>
+    "find lub for coalesce with arbitrary args" >> prop { (t1: Type, t2: Type) =>
       val expr = Coalesce.tpe(Func.Input2(t1, t2))
       if (t1 == Type.Null || t1 == Const(Null))
         expr must beSuccessful(t2)

--- a/core/src/test/scala/quasar/std/set.scala
+++ b/core/src/test/scala/quasar/std/set.scala
@@ -66,7 +66,7 @@ class SetSpec extends quasar.QuasarSpecification with ScalaCheck with TypeArbitr
       expr should beSuccessful(Type.Const(Data.Set(Nil)))
     }
 
-    "maintain first type for constantly" ! prop { (t1 : Type, t2 : Type) =>
+    "maintain first type for constantly" >> prop { (t1 : Type, t2 : Type) =>
       val expr = Constantly.tpe(Func.Input2(t1, t2))
       (t1, t2) match {
         case (Const(r), Const(Data.Set(l))) =>

--- a/core/src/test/scala/quasar/std/structural.scala
+++ b/core/src/test/scala/quasar/std/structural.scala
@@ -37,37 +37,37 @@ class StructuralSpecs extends quasar.QuasarSpecification with ScalaCheck with Va
     // else is known about it.
     val unknown = AnyArray ⨿ Str
 
-    "type combination of arbitrary strs as str" ! prop { (st1: Type, st2: Type) =>
+    "type combination of arbitrary strs as str" >> prop { (st1: Type, st2: Type) =>
       ConcatOp.tpe(Func.Input2(st1, st2)).map(Str contains _) must beSuccessful(true)
       ConcatOp.tpe(Func.Input2(st2, st1)).map(Str contains _) must beSuccessful(true)
     }.setArbitrary1(arbStrType).setArbitrary2(arbStrType)
 
-    "type arbitrary str || unknown as Str" ! prop { (st: Type) =>
+    "type arbitrary str || unknown as Str" >> prop { (st: Type) =>
       ConcatOp.tpe(Func.Input2(st, unknown)) must beSuccessful(Str)
       ConcatOp.tpe(Func.Input2(unknown, st)) must beSuccessful(Str)
     }.setArbitrary(arbStrType)
 
-    "fold constant Strings" ! prop { (s1: String, s2: String) =>
+    "fold constant Strings" >> prop { (s1: String, s2: String) =>
       ConcatOp.tpe(Func.Input2(Const(Data.Str(s1)), Const(Data.Str(s2)))) must
         beSuccessful(Const(Data.Str(s1 + s2)))
     }
 
-    "type combination of arbitrary arrays as array" ! prop { (at1: Type, at2: Type) =>
+    "type combination of arbitrary arrays as array" >> prop { (at1: Type, at2: Type) =>
       ConcatOp.tpe(Func.Input2(at1, at2)).map(_.arrayLike) must beSuccessful(true)
       ConcatOp.tpe(Func.Input2(at2, at1)).map(_.arrayLike) must beSuccessful(true)
     }.setArbitrary1(arbArrayType).setArbitrary2(arbArrayType)
 
-    "type arbitrary array || unknown as array" ! prop { (at: Type) =>
+    "type arbitrary array || unknown as array" >> prop { (at: Type) =>
       ConcatOp.tpe(Func.Input2(at, unknown)).map(_.arrayLike) must beSuccessful(true)
       ConcatOp.tpe(Func.Input2(unknown, at)).map(_.arrayLike) must beSuccessful(true)
     }.setArbitrary(arbArrayType)
 
-    "fold constant arrays" ! prop { (ds1: List[Data], ds2: List[Data]) =>
+    "fold constant arrays" >> prop { (ds1: List[Data], ds2: List[Data]) =>
       ConcatOp.tpe(Func.Input2(Const(Data.Arr(ds1)), Const(Data.Arr(ds2)))) must
         beSuccessful(Const(Data.Arr(ds1 ++ ds2)))
     }
 
-    "fail with mixed Str and array args" ! prop { (st: Type, at: Type) =>
+    "fail with mixed Str and array args" >> prop { (st: Type, at: Type) =>
       ConcatOp.tpe(Func.Input2(st, at)) must beFailing
       ConcatOp.tpe(Func.Input2(at, st)) must beFailing
     }.setArbitrary1(arbStrType).setArbitrary2(arbArrayType)
@@ -78,7 +78,7 @@ class StructuralSpecs extends quasar.QuasarSpecification with ScalaCheck with Va
   }
 
   "FlattenMap" should {
-    "only accept maps" ! prop { (nonMap: Type) =>
+    "only accept maps" >> prop { (nonMap: Type) =>
       FlattenMap.tpe(Func.Input1(nonMap)) must beFailing
     }.setArbitrary(arbArrayType)
 
@@ -92,7 +92,7 @@ class StructuralSpecs extends quasar.QuasarSpecification with ScalaCheck with Va
   }
 
   "FlattenMapKeys" should {
-    "only accept maps" ! prop { (nonMap: Type) =>
+    "only accept maps" >> prop { (nonMap: Type) =>
       FlattenMapKeys.tpe(Func.Input1(nonMap)) must beFailing
     }.setArbitrary(arbArrayType)
 
@@ -106,7 +106,7 @@ class StructuralSpecs extends quasar.QuasarSpecification with ScalaCheck with Va
   }
 
   "FlattenArray" should {
-    "only accept arrays" ! prop { (nonArr: Type) =>
+    "only accept arrays" >> prop { (nonArr: Type) =>
       FlattenArray.tpe(Func.Input1(nonArr)) must beFailing
     }.setArbitrary(arbStrType)
 
@@ -120,7 +120,7 @@ class StructuralSpecs extends quasar.QuasarSpecification with ScalaCheck with Va
   }
 
   "FlattenArrayIndices" should {
-    "only accept arrays" ! prop { (nonArr: Type) =>
+    "only accept arrays" >> prop { (nonArr: Type) =>
       FlattenArrayIndices.tpe(Func.Input1(nonArr)) must beFailing
     }.setArbitrary(arbStrType)
 
@@ -133,13 +133,13 @@ class StructuralSpecs extends quasar.QuasarSpecification with ScalaCheck with Va
         beSuccessful(List(FlexArr(0, None, Top)))
     }
 
-    "only untype from ints" ! prop { (nonInt: Type) =>
+    "only untype from ints" >> prop { (nonInt: Type) =>
       FlattenArrayIndices.untpe(nonInt).map(_.unsized) must beFailing
     }.setArbitrary(arbStrType)
   }
 
   "ShiftMap" should {
-    "only accept maps" ! prop { (nonMap: Type) =>
+    "only accept maps" >> prop { (nonMap: Type) =>
       ShiftMap.tpe(Func.Input1(nonMap)) must beFailing
     }.setArbitrary(arbArrayType)
 
@@ -153,7 +153,7 @@ class StructuralSpecs extends quasar.QuasarSpecification with ScalaCheck with Va
   }
 
   "ShiftMapKeys" should {
-    "only accept maps" ! prop { (nonMap: Type) =>
+    "only accept maps" >> prop { (nonMap: Type) =>
       ShiftMapKeys.tpe(Func.Input1(nonMap)) must beFailing
     }.setArbitrary(arbArrayType)
 
@@ -167,7 +167,7 @@ class StructuralSpecs extends quasar.QuasarSpecification with ScalaCheck with Va
   }
 
   "ShiftArray" should {
-    "only accept arrays" ! prop { (nonArr: Type) =>
+    "only accept arrays" >> prop { (nonArr: Type) =>
       ShiftArray.tpe(Func.Input1(nonArr)) must beFailing
     }.setArbitrary(arbStrType)
 
@@ -181,7 +181,7 @@ class StructuralSpecs extends quasar.QuasarSpecification with ScalaCheck with Va
   }
 
   "ShiftArrayIndices" should {
-    "only accept arrays" ! prop { (nonArr: Type) =>
+    "only accept arrays" >> prop { (nonArr: Type) =>
       ShiftArrayIndices.tpe(Func.Input1(nonArr)) must beFailing
     }.setArbitrary(arbStrType)
 
@@ -194,7 +194,7 @@ class StructuralSpecs extends quasar.QuasarSpecification with ScalaCheck with Va
         beSuccessful(List(FlexArr(0, None, Top)))
     }
 
-    "only untype from ints" ! prop { (nonInt: Type) =>
+    "only untype from ints" >> prop { (nonInt: Type) =>
       ShiftArrayIndices.untpe(nonInt).map(_.unsized) must beFailing
     }.setArbitrary(arbStrType)
   }

--- a/core/src/test/scala/quasar/types.scala
+++ b/core/src/test/scala/quasar/types.scala
@@ -95,19 +95,19 @@ class TypesSpec extends quasar.QuasarSpecification with ScalaCheck with Validati
     }
 
     // Properties:
-    "succeed with same arbitrary type" ! prop { (t: Type) =>
+    "succeed with same arbitrary type" >> prop { (t: Type) =>
       typecheck(t, t).toOption should beSome
     }
 
-    "succeed with Top/arbitrary type" ! prop { (t: Type) =>
+    "succeed with Top/arbitrary type" >> prop { (t: Type) =>
       typecheck(Top, t).toOption should beSome
     }
 
-    "succeed with widening of product" ! prop { (t1: Type, t2: Type) =>
+    "succeed with widening of product" >> prop { (t1: Type, t2: Type) =>
       typecheck(t1, t1 ⨯ t2).toOption should beSome
     }.setArbitrary1(arbitrarySimpleType).setArbitrary2(arbitrarySimpleType)
 
-    "fail with narrowing to product" ! prop { (t1: Type, t2: Type) =>
+    "fail with narrowing to product" >> prop { (t1: Type, t2: Type) =>
       // Note: using only non-product/coproduct input types here because otherwise this test
       // rejects many large inputs and the test is very slow.
       typecheck(t2, t1).isFailure ==> {
@@ -115,11 +115,11 @@ class TypesSpec extends quasar.QuasarSpecification with ScalaCheck with Validati
       }
     }.setArbitrary1(arbitraryNonnestedType).setArbitrary2(arbitraryNonnestedType)
 
-    "succeed with widening to coproduct" ! prop { (t1: Type, t2: Type) =>
+    "succeed with widening to coproduct" >> prop { (t1: Type, t2: Type) =>
       typecheck(t1 ⨿ t2, t1).toOption should beSome
     }.setArbitrary1(arbitrarySimpleType).setArbitrary2(arbitrarySimpleType)
 
-    "fail with narrowing from coproduct" ! prop { (t1: Type, t2: Type) =>
+    "fail with narrowing from coproduct" >> prop { (t1: Type, t2: Type) =>
       // Note: using only non-product/coproduct input types here because otherwise this test
       // rejects many large inputs and the test is very slow.
       typecheck(t1, t2).isFailure ==> {
@@ -127,43 +127,43 @@ class TypesSpec extends quasar.QuasarSpecification with ScalaCheck with Validati
       }
     }.setArbitrary1(arbitraryNonnestedType).setArbitrary2(arbitraryNonnestedType)
 
-    "match under Obj with matching field name" ! prop { (t1: Type, t2: Type) =>
+    "match under Obj with matching field name" >> prop { (t1: Type, t2: Type) =>
       typecheck(Obj(Map("a" -> t1), None), Obj(Map("a" -> t2), None)) must
         beEqualIfSuccess(typecheck(t1, t2))
     }
 
-    "fail under Obj with non-matching field name and arbitrary types" ! prop { (t1: Type, t2: Type) =>
+    "fail under Obj with non-matching field name and arbitrary types" >> prop { (t1: Type, t2: Type) =>
       typecheck(Obj(Map("a" -> t1), None), Obj(Map("b" -> t2), None)).toOption should beNone
     }
 
-    "match unknowns under Obj" ! prop { (t1: Type, t2: Type) =>
+    "match unknowns under Obj" >> prop { (t1: Type, t2: Type) =>
       typecheck(Obj(Map(), Some(t1)), Obj(Map(), Some(t2))) must
         beEqualIfSuccess(typecheck(t1, t2))
     }
 
-    "match under unknown/known Objs" ! prop { (t1: Type, t2: Type) =>
+    "match under unknown/known Objs" >> prop { (t1: Type, t2: Type) =>
       typecheck(Obj(Map(), Some(t1)), Obj(Map("a" -> t2), None)) must
         beEqualIfSuccess(typecheck(t1, t2))
     }
 
-    "match under Arr with matching index" ! prop { (t1: Type, t2: Type) =>
+    "match under Arr with matching index" >> prop { (t1: Type, t2: Type) =>
       typecheck(Arr(List(t1)), Arr(List(t2))) must
         beEqualIfSuccess(typecheck(t1, t2))
     }
 
-    "match under FlexArr" ! prop { (t1: Type, t2: Type) =>
+    "match under FlexArr" >> prop { (t1: Type, t2: Type) =>
       typecheck(FlexArr(0, None, t1), FlexArr(0, None, t2)) must
         beEqualIfSuccess(typecheck(t1, t2))
     }
 
-    "match under FlexArr/Arr" ! prop { (t1: Type, t2: Type) =>
+    "match under FlexArr/Arr" >> prop { (t1: Type, t2: Type) =>
       typecheck(FlexArr(0, None, t1), Arr(List(t2))) must
         beEqualIfSuccess(typecheck(t1, t2))
     }
   }
 
   "objectField" should {
-    "reject arbitrary simple type" ! prop { (t: Type) =>
+    "reject arbitrary simple type" >> prop { (t: Type) =>
       t.objectField(const("a")).toOption should beNone
     }.setArbitrary(arbitrarySimpleType)
 
@@ -226,11 +226,11 @@ class TypesSpec extends quasar.QuasarSpecification with ScalaCheck with Validati
   }
 
   "children" should {
-    "be Nil for arbitrary simple type" ! prop { (t: Type) =>
+    "be Nil for arbitrary simple type" >> prop { (t: Type) =>
       children(t) should_== Nil
     }.setArbitrary(arbitraryTerminal)
 
-    "be list of one for arbitrary const type" ! prop { (t: Type) =>
+    "be list of one for arbitrary const type" >> prop { (t: Type) =>
       children(t).length should_== 1
     }.setArbitrary(arbitraryConst)
 
@@ -293,7 +293,7 @@ class TypesSpec extends quasar.QuasarSpecification with ScalaCheck with Validati
   "mapUp" should {
     val idp: PartialFunction[Type, Type] = { case t => t }
 
-    "preserve arbitrary types" ! prop { (t: Type) =>
+    "preserve arbitrary types" >> prop { (t: Type) =>
       mapUp(t)(idp) should_== t
     }
 
@@ -329,7 +329,7 @@ class TypesSpec extends quasar.QuasarSpecification with ScalaCheck with Validati
   "mapUpM" should {
     import scalaz.Id._
 
-    "preserve arbitrary types" ! prop { (t: Type) =>
+    "preserve arbitrary types" >> prop { (t: Type) =>
       mapUpM[Id](t)(ι) should_== t
     }
 
@@ -385,7 +385,7 @@ class TypesSpec extends quasar.QuasarSpecification with ScalaCheck with Validati
   }
 
   "product" should {
-    "have order-independent equality for arbitrary types" ! prop { (t1: Type, t2: Type) =>
+    "have order-independent equality for arbitrary types" >> prop { (t1: Type, t2: Type) =>
       (t1 ⨯ t2) must_= (t2 ⨯ t1)
     }
   }
@@ -395,7 +395,7 @@ class TypesSpec extends quasar.QuasarSpecification with ScalaCheck with Validati
       (Int ⨿ Str) must_= (Str ⨿ Int)
     }
 
-    "have order-independent equality for arbitrary types" ! prop { (t1: Type, t2: Type) =>
+    "have order-independent equality for arbitrary types" >> prop { (t1: Type, t2: Type) =>
       (t1 ⨿ t2) must_= (t2 ⨿ t1)
     }
 
@@ -437,7 +437,7 @@ class TypesSpec extends quasar.QuasarSpecification with ScalaCheck with Validati
 
   "type" should {
     // Properties:
-    "have t == t for arbitrary type" ! prop { (t: Type) =>
+    "have t == t for arbitrary type" >> prop { (t: Type) =>
       t must_= t
     }
 
@@ -483,28 +483,28 @@ class TypesSpec extends quasar.QuasarSpecification with ScalaCheck with Validati
 
 
     // Properties for product:
-    "simplify t ⨯ t to t" ! prop { (t: Type) =>
+    "simplify t ⨯ t to t" >> prop { (t: Type) =>
       simplify(t ⨯ t) must_= simplify(t)
     }
 
-    "simplify Top ⨯ t to t" ! prop { (t: Type) =>
+    "simplify Top ⨯ t to t" >> prop { (t: Type) =>
       simplify(Top ⨯ t) must_= simplify(t)
     }
 
-    "simplify Bottom ⨯ t to Bottom" ! prop { (t: Type) =>
+    "simplify Bottom ⨯ t to Bottom" >> prop { (t: Type) =>
       simplify(Bottom ⨯ t) must_= Bottom
     }
 
     // Properties for coproduct:
-    "simplify t ⨿ t to t" ! prop { (t: Type) =>
+    "simplify t ⨿ t to t" >> prop { (t: Type) =>
       simplify(t ⨿ t) must_= simplify(t)
     }
 
-    "simplify Top ⨿ t to Top" ! prop { (t: Type) =>
+    "simplify Top ⨿ t to Top" >> prop { (t: Type) =>
       simplify(Top ⨿ t) must_= Top
     }
 
-    "simplify Bottom ⨿ t to t" ! prop { (t: Type) =>
+    "simplify Bottom ⨿ t to t" >> prop { (t: Type) =>
       simplify(Bottom ⨿ t) must_= simplify(t)
     }
 
@@ -570,35 +570,35 @@ class TypesSpec extends quasar.QuasarSpecification with ScalaCheck with Validati
       glb(Str, Const(Data.Str("a"))) should_== Const(Data.Str("a"))
     }
 
-    "lub with Top" ! prop { (t: Type) =>
+    "lub with Top" >> prop { (t: Type) =>
       lub(t, Top) should_== Top
     }
 
-    "lub with Bottom" ! prop { (t: Type) =>
+    "lub with Bottom" >> prop { (t: Type) =>
       lub(t, Bottom) should_== t
     }
 
-    "lub symmetric for nonnested" ! prop { (t1: Type, t2: Type) =>
+    "lub symmetric for nonnested" >> prop { (t1: Type, t2: Type) =>
       lub(t1, t2) should_== lub(t2, t1)
     }.setArbitrary1(arbitraryNonnestedType).setArbitrary2(arbitraryNonnestedType)
 
-    "lub symmetric" ! prop { (t1: Type, t2: Type) =>
+    "lub symmetric" >> prop { (t1: Type, t2: Type) =>
       lub(t1, t2) should_== lub(t2, t1)
     }
 
-    "glb with Top" ! prop { (t: Type) =>
+    "glb with Top" >> prop { (t: Type) =>
       glb(t, Top) should_== t
     }
 
-    "glb with Bottom" ! prop { (t: Type) =>
+    "glb with Bottom" >> prop { (t: Type) =>
       glb(t, Bottom) should_== Bottom
     }
 
-    "glb symmetric for non-nested" ! prop { (t1: Type, t2: Type) =>
+    "glb symmetric for non-nested" >> prop { (t1: Type, t2: Type) =>
       glb(t1, t2) should_== glb(t2, t1)
     }.setArbitrary1(arbitraryNonnestedType).setArbitrary2(arbitraryNonnestedType)
 
-    "glb symmetric" ! prop { (t1: Type, t2: Type) =>
+    "glb symmetric" >> prop { (t1: Type, t2: Type) =>
       glb(t1, t2) should_== glb(t2, t1)
     }
 
@@ -648,11 +648,11 @@ class TypesSpec extends quasar.QuasarSpecification with ScalaCheck with Validati
   }
 
   "arrayElem" should {
-    "fail for non-array type" ! prop { (t: Type) =>
+    "fail for non-array type" >> prop { (t: Type) =>
       t.arrayElem(Const(Data.Int(0))) should beFailing//WithClass[TypeError]
     }.setArbitrary(arbitrarySimpleType)
 
-    "fail for non-int index"  ! prop { (t: Type) =>
+    "fail for non-int index"  >> prop { (t: Type) =>
       // TODO: this occasionally get stuck... maybe lub() is diverging?
       lub(t, Int) != Int ==> {
         val arr = Const(Data.Arr(Nil))
@@ -733,7 +733,7 @@ class TypesSpec extends quasar.QuasarSpecification with ScalaCheck with Validati
       (typJson(Id)        must_= jString("Id"))
     }
 
-    "encode constant types as their data encoding" ! prop { data: Data =>
+    "encode constant types as their data encoding" >> prop { data: Data =>
       val exp = DataCodec.Precise.encode(data)
       exp.isRight ==> {
         (Right(typJson(Const(data))): scala.Either[DataEncodingError, Json]) must_===
@@ -741,11 +741,11 @@ class TypesSpec extends quasar.QuasarSpecification with ScalaCheck with Validati
       }
     }
 
-    "encode arrays as an array of types" ! prop { types: List[Type] =>
+    "encode arrays as an array of types" >> prop { types: List[Type] =>
       typJson(Arr(types)) must_= Json("Array" := types)
     }
 
-    "encode flex arrays as components" ! prop { (min: Int, max: Option[Int], mbr: Type) =>
+    "encode flex arrays as components" >> prop { (min: Int, max: Option[Int], mbr: Type) =>
       typJson(FlexArr(min, max, mbr)) must_=
         Json("FlexArr" := (
           ("minSize" := min)  ->:
@@ -754,7 +754,7 @@ class TypesSpec extends quasar.QuasarSpecification with ScalaCheck with Validati
           jEmptyObject))
     }
 
-    "encode objects" ! prop { (assocs: Map[String, Type], unks: Option[Type]) =>
+    "encode objects" >> prop { (assocs: Map[String, Type], unks: Option[Type]) =>
       typJson(Obj(assocs, unks)) must_=
         Json("Obj" := (
           ("associations" := assocs) ->:
@@ -762,7 +762,7 @@ class TypesSpec extends quasar.QuasarSpecification with ScalaCheck with Validati
           jEmptyObject))
     }
 
-    "encode coproducts as an array of types" ! prop { (t1: Type, t2: Type, ts: List[Type]) =>
+    "encode coproducts as an array of types" >> prop { (t1: Type, t2: Type, ts: List[Type]) =>
       val coprod = ts.foldLeft(Coproduct(t1, t2))(Coproduct(_, _))
       typJson(coprod) must_= Json("Coproduct" := coprod.flatten)
     }

--- a/ejson/src/test/scala/quasar/ejson/Z85.scala
+++ b/ejson/src/test/scala/quasar/ejson/Z85.scala
@@ -49,7 +49,7 @@ class Z85Specs extends quasar.QuasarSpecification with Discipline {
   }
 
   "decode >>> encode" should {
-    "be identity, modulo padding" ! prop { (b: ByteVector) =>
+    "be identity, modulo padding" >> prop { (b: ByteVector) =>
       decode(encode(b)) must beSome(padBV(b))
     }
   }

--- a/it/src/test/scala/quasar/fs/ManageFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/ManageFilesSpec.scala
@@ -259,7 +259,7 @@ class ManageFilesSpec extends FileSystemTest[FileSystem](
         runLogT(run, p).runEither must beRight(anotherDoc)
       }
 
-      "temp file should be generated in hint directory" ! prop { rdir: RDir =>
+      "temp file should be generated in hint directory" >> prop { rdir: RDir =>
         val hintDir = managePrefix </> rdir
 
         runT(run)(manage.tempFile(hintDir))
@@ -267,7 +267,7 @@ class ManageFilesSpec extends FileSystemTest[FileSystem](
           .runEither must beRight(beSome[RFile])
       }
 
-      "temp file should be generated in parent of hint file" ! prop { rfile: RFile =>
+      "temp file should be generated in parent of hint file" >> prop { rfile: RFile =>
         val hintFile = managePrefix </> rfile
         val hintDir  = fileParent(hintFile)
 

--- a/it/src/test/scala/quasar/fs/ReadFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/ReadFilesSpec.scala
@@ -120,7 +120,7 @@ class ReadFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT) w
         r.runEither must beRight((xs: scala.collection.IndexedSeq[Data]) => xs must beEmpty)
       }
 
-      "scan with offset k > 0 and no limit skips first k data" ! prop { k: Int Refined RPositive =>
+      "scan with offset k > 0 and no limit skips first k data" >> prop { k: Int Refined RPositive =>
         val r = runLogT(run, read.scan(smallFile.file, widenPositive(k), None))
         val d = smallFile.data.zip(EStream.iterate(0)(_ + 1))
                   .dropWhile(_._2 < k.get).map(_._1)
@@ -128,14 +128,14 @@ class ReadFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT) w
         r.runEither must beRight(d.toList)
       }.set(minTestsOk = 10)
 
-      "scan with offset zero and limit j stops after j data" ! prop { j: Int Refined Interval.Open[W.`1`.T, SmallFileSize] =>
+      "scan with offset zero and limit j stops after j data" >> prop { j: Int Refined Interval.Open[W.`1`.T, SmallFileSize] =>
         val limit = Positive(j.get.toLong).get // Not ideal, but simplest solution for now
         val r = runLogT(run, read.scan(smallFile.file, 0L, Some(limit)))
 
         r.runEither must beRight(smallFile.data.take(j.get).toList)
       }.set(minTestsOk = 10)
 
-      "scan with offset k and limit j takes j data, starting from k" ! Prop.forAll(
+      "scan with offset k and limit j takes j data, starting from k" >> Prop.forAll(
         chooseRefinedNum[Refined, Int, RPositive](1, 200),
         chooseRefinedNum[Refined, Int, NonNegative](0, 200)
       ) { (j: Int Refined RPositive, k: Int Refined NonNegative) =>
@@ -147,7 +147,7 @@ class ReadFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT) w
         r.runEither must beRight(d.toList)
       }.set(minTestsOk = 5)
 
-      "scan with offset zero and limit j, where j > |file|, stops at end of file" ! prop { j: Int Refined Greater[SmallFileSize] =>
+      "scan with offset zero and limit j, where j > |file|, stops at end of file" >> prop { j: Int Refined Greater[SmallFileSize] =>
           val limit = Some(Positive(j.get.toLong).get) // Not ideal, but simplest solution for now
           val r = runLogT(run, read.scan(smallFile.file, 0L, limit))
 

--- a/it/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
@@ -99,7 +99,7 @@ class MongoDbFileSystemSpec
         val invalidData = testPrefix.map(_ </> dir("invaliddata"))
                             .liftM[FileSystemErrT]
 
-        "fail with `InvalidData` when attempting to save non-documents" ! prop {
+        "fail with `InvalidData` when attempting to save non-documents" >> prop {
           (data: Data, fname: Int) => isNotObj(data) ==> {
             val path = invalidData map (_ </> file(fname.toHexString))
 

--- a/it/src/test/scala/quasar/regression/PredicateSpec.scala
+++ b/it/src/test/scala/quasar/regression/PredicateSpec.scala
@@ -55,12 +55,12 @@ class PredicateSpec extends quasar.QuasarSpecification with ScalaCheck {
   "containsAtLeast" should {
     val pred = ContainsAtLeast
 
-    "match exact result with no dupes" ! prop { (a: Vector[Json]) =>
+    "match exact result with no dupes" >> prop { (a: Vector[Json]) =>
       val expected = a.distinct
       run(pred, expected, expected) must beLike { case Success(_, _) => ok }
     }
 
-    "match shuffled result with no dupes" ! prop { (a: Vector[Json]) =>
+    "match shuffled result with no dupes" >> prop { (a: Vector[Json]) =>
       val expected = a.distinct
       val shuffled = shuffle(expected).unsafePerformSync
 
@@ -69,7 +69,7 @@ class PredicateSpec extends quasar.QuasarSpecification with ScalaCheck {
       }
     }
 
-    "reject shuffled fields" ! prop { (json: List[Json]) =>
+    "reject shuffled fields" >> prop { (json: List[Json]) =>
       val pairs = json.zipWithIndex.map { case (js, x) => x.toString -> js}
       val shuffledPairs = shuffle(pairs).unsafePerformSync
 
@@ -81,14 +81,14 @@ class PredicateSpec extends quasar.QuasarSpecification with ScalaCheck {
       }
     }
 
-    "fail if the process fails" ! prop { (a: Vector[Json], b: Vector[Json], c: Vector[Json]) =>
+    "fail if the process fails" >> prop { (a: Vector[Json], b: Vector[Json], c: Vector[Json]) =>
       val expected = (a ++ b).distinct
       val partialResult = shuffle(a ++ c).unsafePerformSync
 
       pred(expected, partial(partialResult)).unsafePerformSyncAttempt.toOption must beNone
     }
 
-    "match with any additional (no dupes)" ! prop { (a: Vector[Json], b: Vector[Json]) =>
+    "match with any additional (no dupes)" >> prop { (a: Vector[Json], b: Vector[Json]) =>
       val expected = a.distinct
       val result = shuffle(a ++ b).unsafePerformSync
 
@@ -97,7 +97,7 @@ class PredicateSpec extends quasar.QuasarSpecification with ScalaCheck {
       }
     }
 
-    "reject with any missing (no dupes)" ! prop { (a: Vector[Json], b: Vector[Json]) =>
+    "reject with any missing (no dupes)" >> prop { (a: Vector[Json], b: Vector[Json]) =>
       val expected = (a ++ b).distinct
       val result0 = a.distinct
 
@@ -114,12 +114,12 @@ class PredicateSpec extends quasar.QuasarSpecification with ScalaCheck {
   "containsExactly" should {
     val pred = ContainsExactly
 
-    "match exact result with no dupes" ! prop { (a: Vector[Json]) =>
+    "match exact result with no dupes" >> prop { (a: Vector[Json]) =>
       val expected = a.distinct
       run(pred, expected, expected) must beLike { case Success(_, _) => ok }
     }
 
-    "match shuffled result with no dupes" ! prop { (a: Vector[Json]) =>
+    "match shuffled result with no dupes" >> prop { (a: Vector[Json]) =>
       val expected = a.distinct
       val shuffled = shuffle(expected).unsafePerformSync
 
@@ -128,7 +128,7 @@ class PredicateSpec extends quasar.QuasarSpecification with ScalaCheck {
       }
     }
 
-    "reject shuffled fields" ! prop { (json: List[Json]) =>
+    "reject shuffled fields" >> prop { (json: List[Json]) =>
       val pairs = json.zipWithIndex.map { case (js, x) => x.toString -> js}
       val shuffledPairs = shuffle(pairs).unsafePerformSync
 
@@ -140,7 +140,7 @@ class PredicateSpec extends quasar.QuasarSpecification with ScalaCheck {
       }
     }
 
-    "fail if the process fails" ! prop { (a: Vector[Json], b: Vector[Json]) =>
+    "fail if the process fails" >> prop { (a: Vector[Json], b: Vector[Json]) =>
       val expected = (a ++ b).distinct
       val result0 = a.distinct
 
@@ -151,7 +151,7 @@ class PredicateSpec extends quasar.QuasarSpecification with ScalaCheck {
       }
     }
 
-    "reject with any additional (no dupes)" ! prop { (a: Vector[Json], b: Vector[Json]) =>
+    "reject with any additional (no dupes)" >> prop { (a: Vector[Json], b: Vector[Json]) =>
       val expected = a.distinct
       val result0 = (a ++ b).distinct
 
@@ -164,7 +164,7 @@ class PredicateSpec extends quasar.QuasarSpecification with ScalaCheck {
       }
     }
 
-    "reject with any missing (no dupes)" ! prop { (a: Vector[Json], b: Vector[Json]) =>
+    "reject with any missing (no dupes)" >> prop { (a: Vector[Json], b: Vector[Json]) =>
       val expected = (a ++ b).distinct
       val result0 = a.distinct
 
@@ -181,11 +181,11 @@ class PredicateSpec extends quasar.QuasarSpecification with ScalaCheck {
   "equalsExactly" should {
     val pred = EqualsExactly
 
-    "match exact result" ! prop { (expected: Vector[Json]) =>
+    "match exact result" >> prop { (expected: Vector[Json]) =>
       run(pred, expected, expected) must beLike { case Success(_, _) => ok }
     }
 
-    "reject shuffled result" ! prop { (expected: Vector[Json]) =>
+    "reject shuffled result" >> prop { (expected: Vector[Json]) =>
       val shuffled = shuffle(expected).unsafePerformSync
 
       shuffled != expected ==> {
@@ -193,7 +193,7 @@ class PredicateSpec extends quasar.QuasarSpecification with ScalaCheck {
       }
     }
 
-    "reject shuffled fields" ! prop { (json: List[Json]) =>
+    "reject shuffled fields" >> prop { (json: List[Json]) =>
       val pairs = json.zipWithIndex.map { case (js, x) => x.toString -> js}
       val shuffledPairs = shuffle(pairs).unsafePerformSync
 
@@ -205,14 +205,14 @@ class PredicateSpec extends quasar.QuasarSpecification with ScalaCheck {
       }
     }
 
-    "fail if the process fails" ! prop { (a: Vector[Json], b: Vector[Json]) =>
+    "fail if the process fails" >> prop { (a: Vector[Json], b: Vector[Json]) =>
       val expected = a ++ b
       val partialResult = a
 
       pred(expected, partial(partialResult)).unsafePerformSyncAttempt.toOption must beNone
     }
 
-    "reject with any additional" ! prop { (a: Vector[Json], b: Vector[Json], c: Vector[Json]) =>
+    "reject with any additional" >> prop { (a: Vector[Json], b: Vector[Json], c: Vector[Json]) =>
       (b.nonEmpty) ==> {
         val expected = a ++ c
         val result = a ++ b ++ c
@@ -225,7 +225,7 @@ class PredicateSpec extends quasar.QuasarSpecification with ScalaCheck {
       }
     }
 
-    "reject with any missing" ! prop { (a: Vector[Json], b: Vector[Json], c: Vector[Json]) =>
+    "reject with any missing" >> prop { (a: Vector[Json], b: Vector[Json], c: Vector[Json]) =>
       (b.nonEmpty) ==> {
         val expected = a ++ b ++ c
         val result = a ++ c
@@ -242,11 +242,11 @@ class PredicateSpec extends quasar.QuasarSpecification with ScalaCheck {
   "equalsInitial" should {
     val pred = EqualsInitial
 
-    "match exact result" ! prop { (expected: Vector[Json]) =>
+    "match exact result" >> prop { (expected: Vector[Json]) =>
       run(pred, expected, expected) must beLike { case Success(_, _) => ok }
     }
 
-    "reject shuffled result" ! prop { (expected: Vector[Json]) =>
+    "reject shuffled result" >> prop { (expected: Vector[Json]) =>
       val shuffled = shuffle(expected).unsafePerformSync
 
       shuffled != expected ==> {
@@ -254,7 +254,7 @@ class PredicateSpec extends quasar.QuasarSpecification with ScalaCheck {
       }
     }
 
-    "reject shuffled fields" ! prop { (json: List[Json]) =>
+    "reject shuffled fields" >> prop { (json: List[Json]) =>
       val pairs = json.zipWithIndex.map { case (js, x) => x.toString -> js}
       val shuffledPairs = shuffle(pairs).unsafePerformSync
 
@@ -266,21 +266,21 @@ class PredicateSpec extends quasar.QuasarSpecification with ScalaCheck {
       }
     }
 
-    "fail if the process fails" ! prop { (a: Vector[Json], b: Vector[Json]) =>
+    "fail if the process fails" >> prop { (a: Vector[Json], b: Vector[Json]) =>
       val expected = a ++ b
       val partialResult = partial(a)
 
       pred(expected, partialResult).unsafePerformSyncAttempt.toOption must beNone
     }
 
-    "match with any following" ! prop { (a: Vector[Json], b: Vector[Json]) =>
+    "match with any following" >> prop { (a: Vector[Json], b: Vector[Json]) =>
       val expected = a
       val result = a ++ b
 
       run(pred, expected, result) must beLike { case Success(_, _) => ok }
     }
 
-    "reject with any leading" ! prop { (a: Vector[Json], b: Vector[Json], c: Vector[Json]) =>
+    "reject with any leading" >> prop { (a: Vector[Json], b: Vector[Json], c: Vector[Json]) =>
       val expected = b
       val result = a ++ b ++ c
       (a.nonEmpty && b.nonEmpty && result.take(b.length) != b) ==> {
@@ -292,12 +292,12 @@ class PredicateSpec extends quasar.QuasarSpecification with ScalaCheck {
   "doesNotContain" should {
     val pred = DoesNotContain
 
-    "reject exact result with no dupes" ! prop { (a: Vector[Json]) =>
+    "reject exact result with no dupes" >> prop { (a: Vector[Json]) =>
       val expected = a.distinct
       run(pred, expected, expected) must beLike { case Failure(_, _, _, _) => ok }
     }
 
-    "reject shuffled result with no dupes" ! prop { (a: Vector[Json]) =>
+    "reject shuffled result with no dupes" >> prop { (a: Vector[Json]) =>
       val expected = a.distinct
       val shuffled = shuffle(expected).unsafePerformSync
 
@@ -306,7 +306,7 @@ class PredicateSpec extends quasar.QuasarSpecification with ScalaCheck {
       }
     }
 
-    "reject shuffled fields" ! prop { (json: List[Json]) =>
+    "reject shuffled fields" >> prop { (json: List[Json]) =>
       val pairs = json.zipWithIndex.map { case (js, x) => x.toString -> js}
       val shuffledPairs = shuffle(pairs).unsafePerformSync
 
@@ -318,13 +318,13 @@ class PredicateSpec extends quasar.QuasarSpecification with ScalaCheck {
       }
     }
 
-    "fail if the process fails" ! prop { (result: Vector[Json], expected: Vector[Json]) =>
+    "fail if the process fails" >> prop { (result: Vector[Json], expected: Vector[Json]) =>
       (result.toSet intersect expected.toSet).isEmpty ==> {
         pred(expected, partial(result)).unsafePerformSyncAttempt.toOption must beNone
       }
     }.set(maxSize = 10)
 
-    "reject any subset" ! prop { (a: Vector[Json], b: Vector[Json], c: Vector[Json]) =>
+    "reject any subset" >> prop { (a: Vector[Json], b: Vector[Json], c: Vector[Json]) =>
       b.nonEmpty ==> {
         val expected = shuffle(b ++ c).unsafePerformSync
         val result = shuffle(a ++ b).unsafePerformSync
@@ -333,7 +333,7 @@ class PredicateSpec extends quasar.QuasarSpecification with ScalaCheck {
       }
     }
 
-    "match any disjoint values" ! prop { (result: Vector[Json], expected: Vector[Json]) =>
+    "match any disjoint values" >> prop { (result: Vector[Json], expected: Vector[Json]) =>
       (result.toSet intersect expected.toSet).isEmpty ==> {
         val values: Process[Task, Json] = Process.emitAll(result)
 

--- a/main/src/test/scala/quasar/config/CoreConfigSpec.scala
+++ b/main/src/test/scala/quasar/config/CoreConfigSpec.scala
@@ -54,7 +54,7 @@ class CoreConfigSpec extends ConfigSpec[CoreConfig] with ScalaCheck {
   }
 
   "encoding" should {
-    "round-trip any well-formed config" ! prop { (cfg: CoreConfig) =>
+    "round-trip any well-formed config" >> prop { (cfg: CoreConfig) =>
       val json = CoreConfig.codec.encode(cfg)
       val cfg2 = CoreConfig.codec.decode(json.hcursor)
       cfg2.result must beRight(cfg)

--- a/main/src/test/scala/quasar/main/prettify.scala
+++ b/main/src/test/scala/quasar/main/prettify.scala
@@ -226,7 +226,7 @@ class PrettifySpecs extends quasar.QuasarSpecification with ScalaCheck with Disj
       case _              => true
     }
 
-    "round-trip all representable values" ! prop { (data: Data) =>
+    "round-trip all representable values" >> prop { (data: Data) =>
       representable(data) ==> {
         val r = render(data).value
         parse(r) must beSome(data)
@@ -239,7 +239,7 @@ class PrettifySpecs extends quasar.QuasarSpecification with ScalaCheck with Disj
       case _ => true
     }
 
-    "round-trip all flat rendered values that aren't \"\"" ! prop { (data: Data) =>
+    "round-trip all flat rendered values that aren't \"\"" >> prop { (data: Data) =>
       val r = render(data).value
       (isFlat(data) && r != "") ==> {
         parse(r).map(render(_).value) must beSome(r)

--- a/mongodb/src/test/scala/quasar/physical/mongodb/bson.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/bson.scala
@@ -49,7 +49,7 @@ class BsonSpecs extends quasar.QuasarSpecification with ScalaCheck {
 
     import BsonGen._
 
-    "be (fully) isomorphic for representable types" ! prop { (bson: Bson) =>
+    "be (fully) isomorphic for representable types" >> prop { (bson: Bson) =>
       val representable = bson match {
         case JavaScript(_)         => false
         case JavaScriptScope(_, _) => false
@@ -65,7 +65,7 @@ class BsonSpecs extends quasar.QuasarSpecification with ScalaCheck {
         fromRepr(wrapped.repr) must_== Doc(ListMap("value" -> Undefined))
     }.setGen(simpleGen)
 
-    "be 'semi' isomorphic for all types" ! prop { (bson: Bson) =>
+    "be 'semi' isomorphic for all types" >> prop { (bson: Bson) =>
       val wrapped = Doc(ListMap("value" -> bson)).repr
 
       // (fromRepr >=> repr >=> fromRepr) == fromRepr
@@ -76,7 +76,7 @@ class BsonSpecs extends quasar.QuasarSpecification with ScalaCheck {
   "toJs" should {
     import BsonGen._
 
-    "correspond to Data.toJs where toData is defined" ! prop { (bson: Bson) =>
+    "correspond to Data.toJs where toData is defined" >> prop { (bson: Bson) =>
       val data = BsonCodec.toData(bson)
       (data != Data.NA && !data.isInstanceOf[Data.Set]) ==> {
         data match {

--- a/mongodb/src/test/scala/quasar/physical/mongodb/bsoncodec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/bsoncodec.scala
@@ -43,7 +43,7 @@ class BsonCodecSpecs extends quasar.QuasarSpecification with ScalaCheck with Dis
       fromData(Data.Id("invalid")) must beLeftDisjunction
     }
 
-    "be isomorphic for preserved values" ! prop { (data: Data) =>
+    "be isomorphic for preserved values" >> prop { (data: Data) =>
       // (fromData >=> toData) == identity, except for values that are known not to be preserved
 
       import Data._
@@ -64,7 +64,7 @@ class BsonCodecSpecs extends quasar.QuasarSpecification with ScalaCheck with Dis
       }
     }
 
-    "be 'semi'-isomorphic for all Bson values" ! prop { (bson: Bson) =>
+    "be 'semi'-isomorphic for all Bson values" >> prop { (bson: Bson) =>
       // (toData >=> fromData >=> toData) == toData
 
       val data = toData(bson)
@@ -77,7 +77,7 @@ class BsonCodecSpecs extends quasar.QuasarSpecification with ScalaCheck with Dis
       toData(Bson.MinKey) must_== Data.NA
     }
 
-    "be 'semi'-isomorphic for all Data values" ! prop { (data: Data) =>
+    "be 'semi'-isomorphic for all Data values" >> prop { (data: Data) =>
       // (fromData >=> toData >=> fromData) == fromData
       // Which is to say, every Bson value that results from conversion
       // can be converted to Data and back to Bson, recovering the same
@@ -89,7 +89,7 @@ class BsonCodecSpecs extends quasar.QuasarSpecification with ScalaCheck with Dis
     }
   }
 
-  "round trip to repr (all Data types)" ! prop { (data: Data) =>
+  "round trip to repr (all Data types)" >> prop { (data: Data) =>
       val v = fromData(data)
       v.isRight ==> {
         val wrapped = v.map(bson => Bson.Doc(ListMap("value" -> bson)))

--- a/mongodb/src/test/scala/quasar/physical/mongodb/collection.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/collection.scala
@@ -128,7 +128,7 @@ class CollectionSpec extends quasar.QuasarSpecification with ScalaCheck with Dis
         beRightDisjunction
     }
 
-    "never emit an invalid db name" ! prop { (db: SpecialStr, c: SpecialStr) =>
+    "never emit an invalid db name" >> prop { (db: SpecialStr, c: SpecialStr) =>
       val f = rootDir </> dir(db.str) </> file(c.str)
       val notTooLong = posixCodec.printPath(f).length < 30
       // NB: as long as the path is not too long, it should convert to something that's legal
@@ -141,7 +141,7 @@ class CollectionSpec extends quasar.QuasarSpecification with ScalaCheck with Dis
       }
     }.set(maxSize = 5)
 
-    "round-trip" ! prop { f: AbsFileOf[SpecialStr] =>
+    "round-trip" >> prop { f: AbsFileOf[SpecialStr] =>
       // NB: the path might be too long to convert
       val r = Collection.fromFile(f.path)
       (r.isRight) ==> {
@@ -224,7 +224,7 @@ class CollectionSpec extends quasar.QuasarSpecification with ScalaCheck with Dis
     }
   }
 
-  "dbName <-> dirName are inverses" ! prop { db: SpecialStr =>
+  "dbName <-> dirName are inverses" >> prop { db: SpecialStr =>
     val name = Collection.dbNameFromPath(rootDir </> dir(db.str))
     // NB: can fail if the path has enough multi-byte chars to exceed 64 bytes
     name.isRight ==> {

--- a/mongodb/src/test/scala/quasar/physical/mongodb/pipeline.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/pipeline.scala
@@ -128,13 +128,13 @@ class PipelineSpec extends quasar.QuasarSpecification with ScalaCheck with ArbBs
   }) }
 
   "Project.id" should {
-    "be idempotent" ! prop { (p: $Project[Unit]) =>
+    "be idempotent" >> prop { (p: $Project[Unit]) =>
       p.id must_== p.id.id
     }
   }
 
   "Project.get" should {
-    "retrieve whatever value it was set to" ! prop { (p: $Project[Unit], f: BsonField) =>
+    "retrieve whatever value it was set to" >> prop { (p: $Project[Unit], f: BsonField) =>
       val One = $literal(Bson.Int32(1))
 
       p.set(f, \/-(One)).get(DocVar.ROOT(f)) must (beSome(\/-(One)))
@@ -142,13 +142,13 @@ class PipelineSpec extends quasar.QuasarSpecification with ScalaCheck with ArbBs
   }
 
   "Project.setAll" should {
-    "actually set all" ! prop { (p: $Project[Unit]) =>
+    "actually set all" >> prop { (p: $Project[Unit]) =>
       p.setAll(p.getAll.map(t => t._1 -> \/-(t._2))) must_== p
     }.pendingUntilFixed("result could have `_id -> _id` inserted without changing semantics")
   }
 
   "Project.deleteAll" should {
-    "return empty when everything is deleted" ! prop { (p: $Project[Unit]) =>
+    "return empty when everything is deleted" >> prop { (p: $Project[Unit]) =>
       p.deleteAll(p.getAll.map(_._1)) must_== p.empty
     }
   }

--- a/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -3387,7 +3387,7 @@ class PlannerSpec extends quasar.QuasarSpecification with ScalaCheck with Compil
 
     args.report(showtimes = true)
 
-    "plan multiple reducing projections (all, distinct, orderBy)" ! Prop.forAll(select(distinct, maybeReducingExpr, Gen.option(filter), Gen.option(groupBySeveral), orderBySeveral)) { q =>
+    "plan multiple reducing projections (all, distinct, orderBy)" >> Prop.forAll(select(distinct, maybeReducingExpr, Gen.option(filter), Gen.option(groupBySeveral), orderBySeveral)) { q =>
       plan(q.value) must beRight.which { fop =>
         val wf = fop.op
         noConsecutiveProjectOps(wf)
@@ -3420,7 +3420,7 @@ class PlannerSpec extends quasar.QuasarSpecification with ScalaCheck with Compil
       }
     }
 
-    "plan multiple reducing projections (all, distinct)" ! Prop.forAll(select(distinct, maybeReducingExpr, Gen.option(filter), Gen.option(groupBySeveral), noOrderBy)) { q =>
+    "plan multiple reducing projections (all, distinct)" >> Prop.forAll(select(distinct, maybeReducingExpr, Gen.option(filter), Gen.option(groupBySeveral), noOrderBy)) { q =>
       plan(q.value) must beRight.which { fop =>
         val wf = fop.op
         noConsecutiveProjectOps(wf)
@@ -3435,7 +3435,7 @@ class PlannerSpec extends quasar.QuasarSpecification with ScalaCheck with Compil
       }
     }.set(maxSize = 10)
 
-    "plan multiple reducing projections (all)" ! Prop.forAll(select(notDistinct, maybeReducingExpr, Gen.option(filter), Gen.option(groupBySeveral), noOrderBy)) { q =>
+    "plan multiple reducing projections (all)" >> Prop.forAll(select(notDistinct, maybeReducingExpr, Gen.option(filter), Gen.option(groupBySeveral), noOrderBy)) { q =>
       plan(q.value) must beRight.which { fop =>
         val wf = fop.op
         noConsecutiveProjectOps(wf)
@@ -3451,7 +3451,7 @@ class PlannerSpec extends quasar.QuasarSpecification with ScalaCheck with Compil
     }.set(maxSize = 10)
 
     // NB: tighter constraint because we know there's no filter.
-    "plan multiple reducing projections (no filter)" ! Prop.forAll(select(notDistinct, maybeReducingExpr, noFilter, Gen.option(groupBySeveral), noOrderBy)) { q =>
+    "plan multiple reducing projections (no filter)" >> Prop.forAll(select(notDistinct, maybeReducingExpr, noFilter, Gen.option(groupBySeveral), noOrderBy)) { q =>
       plan(q.value) must beRight.which { fop =>
         val wf = fop.op
         noConsecutiveProjectOps(wf)

--- a/web/src/test/scala/quasar/api/AsPathSpec.scala
+++ b/web/src/test/scala/quasar/api/AsPathSpec.scala
@@ -28,13 +28,13 @@ import org.http4s.dsl.{Path => HPath}
 class AsPathSpec extends quasar.QuasarSpecification with ScalaCheck with PathUtils {
   "AsPath" should {
     "decode any Path we can throw at it" >> {
-      "AbsFile" ! prop { file: AFile =>
+      "AbsFile" >> prop { file: AFile =>
         !hasDot(file) ==> {
           val httpPath = HPath(UriPathCodec.printPath(file))
           AsFilePath.unapply(httpPath) must_== Some(file)
         }
       }
-      "AbsDir" ! prop { dir : ADir =>
+      "AbsDir" >> prop { dir : ADir =>
         !hasDot(dir) ==> {
           val httpPath = HPath(UriPathCodec.printPath(dir))
           AsDirPath.unapply(httpPath) must_== Some(dir)

--- a/web/src/test/scala/quasar/api/UriPathCodecSpec.scala
+++ b/web/src/test/scala/quasar/api/UriPathCodecSpec.scala
@@ -31,16 +31,16 @@ class UriPathCodecSpec extends quasar.QuasarSpecification with ScalaCheck {
   "UriPathCodec" should {
     val codec = UriPathCodec
     "print and parse again should produce same Path" >> {
-      "absolute file" ! prop { path: AFile =>
+      "absolute file" >> prop { path: AFile =>
         codec.parseAbsFile(codec.printPath(path)) must_== Some(path)
       }
-      "relative file" ! prop { path: RFile =>
+      "relative file" >> prop { path: RFile =>
         codec.parseRelFile(codec.printPath(path)) must_== Some(path)
       }
-      "absolute dir" ! prop { path: ADir =>
+      "absolute dir" >> prop { path: ADir =>
         codec.parseAbsDir(codec.printPath(path)) must_== Some(path)
       }
-      "relative dir" ! prop { path: RDir =>
+      "relative dir" >> prop { path: RDir =>
         codec.parseRelDir(codec.printPath(path)) must_== Some(path)
       }
     }

--- a/web/src/test/scala/quasar/api/services/MetadataServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/MetadataServiceSpec.scala
@@ -72,17 +72,17 @@ class MetadataServiceSpec extends quasar.QuasarSpecification with ScalaCheck wit
   "Metadata Service" should {
     "respond with NotFound" >> {
       // TODO: escaped paths do not survive being embedded in error messages
-      "if directory does not exist" ! prop { dir: ADir => (dir != rootDir) ==> {
+      "if directory does not exist" >> prop { dir: ADir => (dir != rootDir) ==> {
         val response = service(InMemState.empty, Map())(Request(uri = pathUri(dir))).unsafePerformSync
         response.as[ApiError].unsafePerformSync must beApiErrorLike(pathNotFound(dir))
       }}
 
-      "file does not exist" ! prop { file: AFile =>
+      "file does not exist" >> prop { file: AFile =>
         val response = service(InMemState.empty, Map())(Request(uri = pathUri(file))).unsafePerformSync
         response.as[ApiError].unsafePerformSync must beApiErrorLike(pathNotFound(file))
       }
 
-      "if file with same name as existing directory (without trailing slash)" ! prop { s: SingleFileMemState =>
+      "if file with same name as existing directory (without trailing slash)" >> prop { s: SingleFileMemState =>
         depth(s.file) > 1 ==> {
           val parent = fileParent(s.file)
           // .get here is because we know thanks to the property guard, that the parent directory has a name
@@ -99,14 +99,14 @@ class MetadataServiceSpec extends quasar.QuasarSpecification with ScalaCheck wit
           .as[Json].unsafePerformSync must_== Json("children" := List[FsNode]())
       }
 
-      "and list of children for existing nonempty directory" ! prop { s: NonEmptyDir =>
+      "and list of children for existing nonempty directory" >> prop { s: NonEmptyDir =>
         val childNodes = s.ls.map(FsNode(_, None))
 
         service(s.state, Map())(Request(uri = pathUri(s.dir)))
           .as[Json].unsafePerformSync must_== Json("children" := childNodes.sorted)
       }.set(minTestsOk = 10)  // NB: this test is slow because NonEmptyDir instances are still relatively large
 
-      "and mounts when any children happen to be mount points" ! prop { (
+      "and mounts when any children happen to be mount points" >> prop { (
         fName: FileName,
         dName: DirName,
         mName: DirName,
@@ -133,7 +133,7 @@ class MetadataServiceSpec extends quasar.QuasarSpecification with ScalaCheck wit
           ).sorted)
       }}
 
-      "and empty object for existing file" ! prop { s: SingleFileMemState =>
+      "and empty object for existing file" >> prop { s: SingleFileMemState =>
         service(s.state, Map())(Request(uri = pathUri(s.file)))
           .as[Json].unsafePerformSync must_=== Json.obj()
       }

--- a/web/src/test/scala/quasar/api/services/MountServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/MountServiceSpec.scala
@@ -113,7 +113,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
 
   "Mount Service" should {
     "GET" should {
-      "succeed with correct filesystem path" ! prop { d: ADir =>
+      "succeed with correct filesystem path" >> prop { d: ADir =>
         !hasDot(d) ==> {
           runTest { service =>
             for {
@@ -146,7 +146,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
         }
       }
 
-      "succeed with correct view path" ! prop { f: AFile =>
+      "succeed with correct view path" >> prop { f: AFile =>
         !hasDot(f) ==> {
           runTest { service =>
             val cfg = viewConfig("select * from zips where pop > :cutoff", "cutoff" -> "1000")
@@ -165,7 +165,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
         }
       }
 
-      "be 404 with missing mount (dir)" ! prop { d: APath =>
+      "be 404 with missing mount (dir)" >> prop { d: APath =>
         runTest { service =>
           for {
             r   <- service(Request(uri = pathUri(d)))
@@ -177,7 +177,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
         }
       }
 
-      "be 404 with path type mismatch" ! prop { fp: AFile =>
+      "be 404 with path type mismatch" >> prop { fp: AFile =>
         runTest { service =>
           val dp = fileParent(fp) </> dir(fileName(fp).value)
 
@@ -198,7 +198,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
 
       def destination(p: pathy.Path[_, _, Sandboxed]) = Header(Destination.name.value, UriPathCodec.printPath(p))
 
-      "succeed with filesystem mount" ! prop { (srcHead: String, srcTail: RDir, dstHead: String, dstTail: RDir) =>
+      "succeed with filesystem mount" >> prop { (srcHead: String, srcTail: RDir, dstHead: String, dstTail: RDir) =>
         // NB: distinct first segments means no possible conflict, but doesn't
         // hit every possible scenario.
         (srcHead != "" && dstHead != "" && srcHead != dstHead && !hasDot(rootDir </> dir(srcHead) </> srcTail)) ==> {
@@ -229,7 +229,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
         }
       }
 
-      "be 404 with missing source" ! prop { (src: ADir, dst: ADir) =>
+      "be 404 with missing source" >> prop { (src: ADir, dst: ADir) =>
         runTest { service =>
           for {
             r   <- service(Request(
@@ -246,7 +246,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
         }
       }
 
-      "be 400 with no specified Destination" ! prop { (src: ADir) =>
+      "be 400 with no specified Destination" >> prop { (src: ADir) =>
         !hasDot(src) ==> {
           runTest { service =>
             for {
@@ -266,7 +266,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
         }
       }
 
-      "be 400 with relative path destination" ! prop { (src: ADir, dst: RDir) =>
+      "be 400 with relative path destination" >> prop { (src: ADir, dst: RDir) =>
         !hasDot(src) ==> {
           runTest { service =>
             for {
@@ -289,7 +289,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
         }
       }
 
-      "be 400 with non-directory path destination" ! prop { (src: ADir, dst: AFile) =>
+      "be 400 with non-directory path destination" >> prop { (src: ADir, dst: AFile) =>
         !hasDot(src) ==> {
           runTest { service =>
             for {
@@ -347,7 +347,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
       }
 
       testBoth { reqBuilder =>
-        "succeed with filesystem path" ! prop { (parent: ADir, fsDir: RDir) =>
+        "succeed with filesystem path" >> prop { (parent: ADir, fsDir: RDir) =>
           !hasDot(parent </> fsDir) ==> {
             runTest { service =>
               for {
@@ -367,7 +367,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
           }
         }
 
-        "succeed with view path" ! prop { (parent: ADir, f: RFile) =>
+        "succeed with view path" >> prop { (parent: ADir, f: RFile) =>
           !hasDot(parent </> f) ==> {
             runTest { service =>
               val (expr, vars) = viewConfig("select * from zips where pop < :cutoff", "cutoff" -> "1000")
@@ -390,7 +390,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
           }
         }
 
-        "succeed with view under existing fs path" ! prop { (fs: ADir, viewSuffix: RFile) =>
+        "succeed with view under existing fs path" >> prop { (fs: ADir, viewSuffix: RFile) =>
           !hasDot(fs </> viewSuffix) ==> {
             runTest { service =>
               val (expr, vars) = viewConfig("select * from zips where pop < :cutoff", "cutoff" -> "1000")
@@ -422,7 +422,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
           }
         }
 
-        "succeed with view 'above' existing fs path" ! prop { (d: ADir, view: RFile, fsSuffix: RDir) =>
+        "succeed with view 'above' existing fs path" >> prop { (d: ADir, view: RFile, fsSuffix: RDir) =>
           !hasDot(d </> view) ==> {
             runTest { service =>
               val (expr, vars) = viewConfig("select * from zips where pop < :cutoff", "cutoff" -> "1000")
@@ -452,7 +452,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
           }
         }
 
-        "be 409 with fs above existing fs path" ! prop { (d: ADir, fs: RDir, fsSuffix: RDir) =>
+        "be 409 with fs above existing fs path" >> prop { (d: ADir, fs: RDir, fsSuffix: RDir) =>
           (!identicalPath(fsSuffix, currentDir)) ==> {
             runTest { service =>
               val cfgStr = EncodeJson.of[MountConfig].encode(MountConfig.fileSystemConfig(StubFs, fooUri))
@@ -477,7 +477,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
           }
         }.pendingUntilFixed("test harness does not yet detect conflicts")
 
-        "be 400 with fs config and file path in X-File-Name header" ! prop { (parent: ADir, fsFile: RFile) =>
+        "be 400 with fs config and file path in X-File-Name header" >> prop { (parent: ADir, fsFile: RFile) =>
           runTest { service =>
             for {
               req <- reqBuilder(parent, fsFile, """{ "stub": { "connectionUri": "foo" } }""")
@@ -493,7 +493,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
           }
         }
 
-        "be 400 with view config and dir path in X-File-Name header" ! prop { (parent: ADir, viewDir: RDir) =>
+        "be 400 with view config and dir path in X-File-Name header" >> prop { (parent: ADir, viewDir: RDir) =>
           runTest { service =>
             val cfg = viewConfig("select * from zips where pop < :cutoff", "cutoff" -> "1000")
             val cfgStr = EncodeJson.of[MountConfig].encode(MountConfig.viewConfig(cfg))
@@ -512,7 +512,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
           }
         }
 
-        "be 400 with invalid JSON" ! prop { (parent: ADir, f: RFile) =>
+        "be 400 with invalid JSON" >> prop { (parent: ADir, f: RFile) =>
           !hasDot(parent </> f) ==> {
             runTest { service =>
               for {
@@ -528,7 +528,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
           }
         }
 
-        "be 400 with invalid connection uri" ! prop { (parent: ADir, d: RDir) =>
+        "be 400 with invalid connection uri" >> prop { (parent: ADir, d: RDir) =>
           !hasDot(parent </> d) ==> {
             runTest { service =>
               for {
@@ -544,7 +544,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
           }
         }
 
-        "be 400 with invalid view URI" ! prop { (parent: ADir, f: RFile) =>
+        "be 400 with invalid view URI" >> prop { (parent: ADir, f: RFile) =>
           !hasDot(parent </> f) ==> {
             runTest { service =>
               for {
@@ -565,7 +565,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
     "POST" should {
       import org.http4s.Method.POST
 
-      "be 409 with existing filesystem path" ! prop { (parent: ADir, fsDir: RDir) =>
+      "be 409 with existing filesystem path" >> prop { (parent: ADir, fsDir: RDir) =>
         runTest { service =>
           val mntPath = parent </> fsDir
 
@@ -591,7 +591,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
         }
       }
 
-      "be 400 with missing X-File-Name header" ! prop { (parent: ADir) =>
+      "be 400 with missing X-File-Name header" >> prop { (parent: ADir) =>
         !hasDot(parent) ==> {
           runTest { service =>
             for {
@@ -614,7 +614,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
     "PUT" should {
       import org.http4s.Method.PUT
 
-      "succeed with overwritten filesystem" ! prop { (fsDir: ADir) =>
+      "succeed with overwritten filesystem" >> prop { (fsDir: ADir) =>
         !hasDot(fsDir) ==> {
           runTest { service =>
             for {
@@ -644,7 +644,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
     "DELETE" should {
       import org.http4s.Method.DELETE
 
-      "succeed with filesystem path" ! prop { (d: ADir) =>
+      "succeed with filesystem path" >> prop { (d: ADir) =>
         !hasDot(d) ==> {
           runTest { service =>
             for {
@@ -667,7 +667,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
         }
       }
 
-      "succeed with view path" ! prop { (f: AFile) =>
+      "succeed with view path" >> prop { (f: AFile) =>
         !hasDot(f) ==> {
           runTest { service =>
             val cfg = viewConfig("select * from zips where pop > :cutoff", "cutoff" -> "1000")
@@ -692,7 +692,7 @@ class MountServiceSpec extends quasar.QuasarSpecification with ScalaCheck with H
         }
       }
 
-      "be 404 with missing path" ! prop { p: APath =>
+      "be 404 with missing path" >> prop { p: APath =>
         runTest { service =>
           for {
             r   <- service(Request(method = DELETE, uri = pathUri(p)))

--- a/web/src/test/scala/quasar/api/services/query/CompileServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/query/CompileServiceSpec.scala
@@ -32,7 +32,7 @@ class CompileServiceSpec extends quasar.QuasarSpecification with FileSystemFixtu
 
   "Compile" should {
 
-    "plan simple query" ! prop { filesystem: SingleFileMemState =>
+    "plan simple query" >> prop { filesystem: SingleFileMemState =>
       // Representation of the directory as a string without the leading slash
       val pathString = printPath(filesystem.file).drop(1)
       get[AJson](compileService)(
@@ -46,7 +46,7 @@ class CompileServiceSpec extends quasar.QuasarSpecification with FileSystemFixtu
       )
     }
 
-    "plan query with var" ! prop { (filesystem: SingleFileMemState, varName: AlphaCharacters, var_ : Int) =>
+    "plan query with var" >> prop { (filesystem: SingleFileMemState, varName: AlphaCharacters, var_ : Int) =>
       val pathString = printPath(filesystem.file).drop(1)
       val query = selectAllWithVar(file1(filesystem.filename),varName.value)
       get[AJson](compileService)(

--- a/web/src/test/scala/quasar/api/services/query/QueryServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/query/QueryServiceSpec.scala
@@ -48,7 +48,7 @@ class QueryServiceSpec extends quasar.QuasarSpecification with FileSystemFixture
 
     testBoth { service =>
       "GET" >> {
-        "be 404 for missing directory" ! prop { (dir: ADir, file: AFile) =>
+        "be 404 for missing directory" >> prop { (dir: ADir, file: AFile) =>
           get(service)(
             path = dir,
             query = Some(Query(selectAll(file))),
@@ -58,7 +58,7 @@ class QueryServiceSpec extends quasar.QuasarSpecification with FileSystemFixture
           )
         }.pendingUntilFixed("SD-773")
 
-        "be 400 for missing query" ! prop { filesystem: SingleFileMemState =>
+        "be 400 for missing query" >> prop { filesystem: SingleFileMemState =>
           get(service)(
             path = filesystem.parent,
             query = None,
@@ -69,7 +69,7 @@ class QueryServiceSpec extends quasar.QuasarSpecification with FileSystemFixture
           )
         }
 
-        "be 400 for query error" ! prop { filesystem: SingleFileMemState =>
+        "be 400 for query error" >> prop { filesystem: SingleFileMemState =>
           get(service)(
             path = filesystem.parent,
             query = Some(Query("select date where")),
@@ -86,7 +86,7 @@ class QueryServiceSpec extends quasar.QuasarSpecification with FileSystemFixture
             case _ => None
           }
 
-        "be 400 for bad path (file instead of dir)" ! prop { filesystem: SingleFileMemState =>
+        "be 400 for bad path (file instead of dir)" >> prop { filesystem: SingleFileMemState =>
           filesystem.parent =/= rootDir ==> {
 
             val parentAsFile = asFile(filesystem.parent).get

--- a/web/src/test/scala/quasar/api/zip.scala
+++ b/web/src/test/scala/quasar/api/zip.scala
@@ -93,7 +93,7 @@ class ZipSpecs extends quasar.QuasarSpecification with ScalaCheck with ScalazMat
       unzip(read)(p)
     }
 
-    "zip files of constant bytes" ! prop { (filesAndSize: Map[RelFile[Sandboxed], Positive], byte: Byte) =>
+    "zip files of constant bytes" >> prop { (filesAndSize: Map[RelFile[Sandboxed], Positive], byte: Byte) =>
       def byteStream(size: Positive): Process[Task, ByteVector] =
         Process.emit(ByteVector.view(Array.fill(size.toInt)(byte)))
       val bytesMapping = filesAndSize.mapValues(byteStream)
@@ -101,7 +101,7 @@ class ZipSpecs extends quasar.QuasarSpecification with ScalaCheck with ScalazMat
       counts(z).unsafePerformSync must_== filesAndSize.toList
     }.set(minTestsOk = 10) // This test is relatively slow
 
-    "zip files of random bytes" ! prop { filesAndSize: Map[RelFile[Sandboxed], Positive] =>
+    "zip files of random bytes" >> prop { filesAndSize: Map[RelFile[Sandboxed], Positive] =>
       def byteStream(size: Positive): Process[Task, ByteVector] =
         Process.emit(ByteVector.view(Array.fill(size.toInt)(rand.nextInt.toByte)))
       val bytesMapping = filesAndSize.mapValues(byteStream)
@@ -137,7 +137,7 @@ class ZipSpecs extends quasar.QuasarSpecification with ScalaCheck with ScalazMat
       z.map(_.size).sum.runLog.unsafePerformSync(0) must beBetween(MinExpectedSize, MaxExpectedSize)
     }
 
-    "read twice without conflict" ! prop { filesAndSize: Map[RelFile[Sandboxed], Positive] =>
+    "read twice without conflict" >> prop { filesAndSize: Map[RelFile[Sandboxed], Positive] =>
       def byteStream(size: Positive): Process[Task, ByteVector] =
         Process.emit(ByteVector.view(Array.fill(size.toInt)(rand.nextInt.toByte)))
       val bytesMapping = filesAndSize.mapValues(byteStream)


### PR DESCRIPTION
I may be missing something fundamental but when analyzing test
failures I find this sort of presentation...
```
  [info]
  [info] containsAtLeast should
  [info]   + match exact result with no dupes  + match shuffled result with no dupes  + reject shuffled fields  + fail if the process fails  + match with any additional (no dupes)  + reject with any missing (no dupes)containsExactly should
  [info]   + match exact result with no dupes  + match shuffled result with no dupes  + reject shuffled fields  + fail if the process fails  + reject with any additional (no dupes)  + reject with any missing (no dupes)equalsExactly should
  [info]   + match exact result  + reject shuffled result  + reject shuffled fields  + fail if the process fails  + reject with any additional  + reject with any missingequalsInitial should
  [info]   + match exact result  + reject shuffled result  + reject shuffled fields  + fail if the process fails  + match with any following  + reject with any leadingdoesNotContain should
  [info]   + reject exact result with no dupes  + reject shuffled result with no dupes  + reject shuffled fields  + fail if the process fails  + reject any subset  + match any disjoint values
```

...quite a bit less readable than this sort.

```
  [info] containsAtLeast should
  [info]   + match exact result with no dupes
  [info]   + match shuffled result with no dupes
  [info]   + reject shuffled fields
  [info]   + fail if the process fails
  [info]   + match with any additional (no dupes)
  [info]   + reject with any missing (no dupes)
  [info] containsExactly should
  [info]   + match exact result with no dupes
  [info]   + match shuffled result with no dupes
  [info]   + reject shuffled fields
  [info]   + fail if the process fails
  [info]   + reject with any additional (no dupes)
  [info]   + reject with any missing (no dupes)
  [info] equalsExactly should
  [info]   + match exact result
  [info]   + reject shuffled result
  [info]   + reject shuffled fields
  [info]   + fail if the process fails
  [info]   + reject with any additional
  [info]   + reject with any missing
  [info] equalsInitial should
  [info]   + match exact result
  [info]   + reject shuffled result
  [info]   + reject shuffled fields
  [info]   + fail if the process fails
  [info]   + match with any following
  [info]   + reject with any leading
  [info] doesNotContain should
  [info]   + reject exact result with no dupes
  [info]   + reject shuffled result with no dupes
  [info]   + reject shuffled fields
  [info]   + fail if the process fails
  [info]   + reject any subset
  [info]   + match any disjoint values
```