### PR TITLE
Publish foundation's test artifact

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- Publish the foundation project's test artifacts for access to QuasarSpecification

--- a/build.sbt
+++ b/build.sbt
@@ -180,7 +180,9 @@ lazy val foundation = project
   .settings(name := "quasar-foundation-internal")
   .settings(oneJarSettings: _*)
   .settings(publishSettings: _*)
-  .settings(libraryDependencies ++= Dependencies.core)
+  .settings(
+    libraryDependencies ++= Dependencies.core,
+    publishArtifact in (Test, packageBin) := true)
   .enablePlugins(AutomateHeaderPlugin)
 
 lazy val ejson = project


### PR DESCRIPTION
Otherwise downstream dependencies that make use of quasar tests cannot
access QuasarSpecification.