### PR TITLE
Various fixes to help filesystem authors.

### DIFF
--- a/CHANGELOG/bugfix.md
+++ b/CHANGELOG/bugfix.md
@@ -1,0 +1,4 @@
+- Eliminate the `DeadEnd` `Empty` case from QScript.
+- Make `Read` not a functor
+- Generalize `FreeQS` to include any QScript component.
+- Track `LeftShift` provenance properly.

--- a/core/src/main/scala/quasar/qscript/DeadEnd.scala
+++ b/core/src/main/scala/quasar/qscript/DeadEnd.scala
@@ -24,7 +24,6 @@ sealed abstract class DeadEnd
   * in the structure a backend sees, it represents the mount point.
   */
 final case object Root extends DeadEnd
-final case object Empty extends DeadEnd
 
 object DeadEnd {
   implicit def equal: Equal[DeadEnd] = Equal.equalRef

--- a/core/src/main/scala/quasar/qscript/MapFunc.scala
+++ b/core/src/main/scala/quasar/qscript/MapFunc.scala
@@ -229,6 +229,8 @@ object MapFunc {
         case MakeArray(a1) => f(a1) ∘ (MakeArray(_))
         case DupArrayIndices(a1) => f(a1) ∘ (DupArrayIndices(_))
         case DupMapKeys(a1) => f(a1) ∘ (DupMapKeys(_))
+        case ZipArrayIndices(a1) => f(a1) ∘ (ZipArrayIndices(_))
+        case ZipMapKeys(a1) => f(a1) ∘ (ZipMapKeys(_))
 
         // binary
         case Extract(a1, a2) => (f(a1) ⊛ f(a2))(Extract(_, _))
@@ -293,6 +295,8 @@ object MapFunc {
         case (MakeArray(a1), MakeArray(b1)) => in.equal(a1, b1)
         case (DupArrayIndices(a1), DupArrayIndices(b1)) => in.equal(a1, b1)
         case (DupMapKeys(a1), DupMapKeys(b1)) => in.equal(a1, b1)
+        case (ZipArrayIndices(a1), ZipArrayIndices(b1)) => in.equal(a1, b1)
+        case (ZipMapKeys(a1), ZipMapKeys(b1)) => in.equal(a1, b1)
 
         case (Extract(a1, a2), Extract(b1, b2)) => in.equal(a1, b1) && in.equal(a2, b2)
         case (Add(a1, a2), Add(b1, b2)) => in.equal(a1, b1) && in.equal(a2, b2)
@@ -358,6 +362,8 @@ object MapFunc {
         case MakeArray(a1) => Cord("MakeArray(") ++ sh.show(a1) ++ Cord(")")
         case DupArrayIndices(a1) => Cord("DupArrayIndices(") ++ sh.show(a1) ++ Cord(")")
         case DupMapKeys(a1) => Cord("DupMapKeys(") ++ sh.show(a1) ++ Cord(")")
+        case ZipArrayIndices(a1) => Cord("ZipArrayIndices(") ++ sh.show(a1) ++ Cord(")")
+        case ZipMapKeys(a1) => Cord("ZipMapKeys(") ++ sh.show(a1) ++ Cord(")")
 
         // binary
         case Extract(a1, a2) => Cord("Extract(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
@@ -529,6 +535,8 @@ object MapFuncs {
   // helpers & QScript-specific
   @Lenses final case class DupMapKeys[T[_[_]], A](a1: A) extends Unary[T, A]
   @Lenses final case class DupArrayIndices[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ZipMapKeys[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ZipArrayIndices[T[_[_]], A](a1: A) extends Unary[T, A]
   @Lenses final case class Range[T[_[_]], A](a1: A, a2: A) extends Binary[T, A]
 
   @Lenses final case class Guard[T[_[_]], A](a1: A, pattern: Type, a2: A, a3: A)

--- a/core/src/main/scala/quasar/qscript/Mergeable.scala
+++ b/core/src/main/scala/quasar/qscript/Mergeable.scala
@@ -34,8 +34,8 @@ import scalaz._, Scalaz._
 object Mergeable {
   type Aux[T[_[_]], F[_]] = Mergeable[F] { type IT[F[_]] = T[F] }
 
-  implicit def const[T[_[_]]: EqualT]: Mergeable.Aux[T, Const[DeadEnd, ?]] =
-    new Mergeable[Const[DeadEnd, ?]] {
+  implicit def const[T[_[_]]: EqualT, A: Equal]: Mergeable.Aux[T, Const[A, ?]] =
+    new Mergeable[Const[A, ?]] {
       type IT[F[_]] = T[F]
 
       // NB: I think it is true that the buckets on p1 and p2 _must_ be equal
@@ -44,9 +44,9 @@ object Mergeable {
       def mergeSrcs(
         left: FreeMap[T],
         right: FreeMap[T],
-        p1: EnvT[Ann[T], Const[DeadEnd, ?], Hole],
-        p2: EnvT[Ann[T], Const[DeadEnd, ?], Hole]) =
-        (p1 ≟ p2).option(SrcMerge[EnvT[Ann[T], Const[DeadEnd, ?], Hole], FreeMap[IT]](p1, left, right))
+        p1: EnvT[Ann[T], Const[A, ?], Hole],
+        p2: EnvT[Ann[T], Const[A, ?], Hole]) =
+        (p1 ≟ p2).option(SrcMerge[EnvT[Ann[T], Const[A, ?], Hole], FreeMap[IT]](p1, left, right))
     }
 
   implicit def coproduct[T[_[_]], F[_], G[_]](

--- a/core/src/main/scala/quasar/qscript/QScriptCore.scala
+++ b/core/src/main/scala/quasar/qscript/QScriptCore.scala
@@ -223,13 +223,13 @@ object QScriptCore {
           case Take(src, from, count) =>
             Take(
               src,
-              freeTransCata(from)(liftCo(opt.applyToFreeQS[QScriptProject[T, ?], Hole])),
-              freeTransCata(count)(liftCo(opt.applyToFreeQS[QScriptProject[T, ?], Hole])))
+              freeTransCata(from)(liftCo(opt.applyToFreeQS[QScriptTotal[T, ?], Hole])),
+              freeTransCata(count)(liftCo(opt.applyToFreeQS[QScriptTotal[T, ?], Hole])))
           case Drop(src, from, count) =>
             Drop(
               src,
-              freeTransCata(from)(liftCo(opt.applyToFreeQS[QScriptProject[T, ?], Hole])),
-              freeTransCata(count)(liftCo(opt.applyToFreeQS[QScriptProject[T, ?], Hole])))
+              freeTransCata(from)(liftCo(opt.applyToFreeQS[QScriptTotal[T, ?], Hole])),
+              freeTransCata(count)(liftCo(opt.applyToFreeQS[QScriptTotal[T, ?], Hole])))
         }
       }
     }

--- a/core/src/main/scala/quasar/qscript/Read.scala
+++ b/core/src/main/scala/quasar/qscript/Read.scala
@@ -20,24 +20,15 @@ import quasar.fp._
 
 import matryoshka._
 import monocle.macros.Lenses
-import pathy.Path._
+import pathy._, Path._
 import scalaz._, Scalaz._
 
+// TODO: Abstract Read over the backend’s preferred path representation.
 /** A backend-resolved `Root`, which is now a path. */
-@Lenses final case class Read[A](src: A, path: AbsFile[Sandboxed])
+@Lenses final case class Read(path: AbsFile[Sandboxed])
 
 object Read {
-  implicit def equal[T[_[_]]]: Delay[Equal, Read] =
-    new Delay[Equal, Read] {
-      def apply[A](eq: Equal[A]) =
-        Equal.equal {
-          case (Read(a1, p1), Read(a2, p2)) => eq.equal(a1, a2) && p1 ≟ p2
-        }
-    }
-
-  implicit def traverse[T[_[_]]]: Traverse[Read] =
-    new Traverse[Read] {
-      def traverseImpl[G[_]: Applicative, A, B](fa: Read[A])(f: A => G[B]) =
-        f(fa.src) ∘ (Read(_, fa.path))
-    }
+  implicit def equal: Equal[Read] = Equal.equalBy(_.path)
+  implicit def show: Show[Read] =
+    Show.show(Cord("Read(") ++ _.path.show ++ Cord(")"))
 }

--- a/core/src/main/scala/quasar/qscript/SourcedPathable.scala
+++ b/core/src/main/scala/quasar/qscript/SourcedPathable.scala
@@ -121,8 +121,8 @@ object SourcedPathable {
           case Union(src, l, r) =>
             Union(
               src,
-              freeTransCata(l)(liftCo(opt.applyToFreeQS[QScriptProject[T, ?], Hole])),
-              freeTransCata(r)(liftCo(opt.applyToFreeQS[QScriptProject[T, ?], Hole])))
+              freeTransCata(l)(liftCo(opt.applyToFreeQS[QScriptTotal[T, ?], Hole])),
+              freeTransCata(r)(liftCo(opt.applyToFreeQS[QScriptTotal[T, ?], Hole])))
         }
       }
     }

--- a/core/src/main/scala/quasar/qscript/ThetaJoin.scala
+++ b/core/src/main/scala/quasar/qscript/ThetaJoin.scala
@@ -98,8 +98,8 @@ object ThetaJoin {
         def apply[A](tj: ThetaJoin[T, A]) =
           ThetaJoin(
             tj.src,
-            freeTransCata(tj.lBranch)(liftCo(opt.applyToFreeQS[QScriptProject[T, ?], Hole])),
-            freeTransCata(tj.rBranch)(liftCo(opt.applyToFreeQS[QScriptProject[T, ?], Hole])),
+            freeTransCata(tj.lBranch)(liftCo(opt.applyToFreeQS[QScriptTotal[T, ?], Hole])),
+            freeTransCata(tj.rBranch)(liftCo(opt.applyToFreeQS[QScriptTotal[T, ?], Hole])),
             normalizeMapFunc(tj.on),
             tj.f,
             normalizeMapFunc(tj.combine))

--- a/core/src/test/scala/quasar/qscript/QScript.scala
+++ b/core/src/test/scala/quasar/qscript/QScript.scala
@@ -32,10 +32,10 @@ import pathy.Path._
 import scalaz._, Scalaz._
 
 class QScriptSpec extends CompilerHelpers with ScalazMatchers {
-  val transform = new Transform[Fix, QScriptProject[Fix, ?]]
+  val transform = new Transform[Fix, QScriptTotal[Fix, ?]]
 
   // TODO: Narrow this to QScriptPure
-  type QS[A] = QScriptProject[Fix, A]
+  type QS[A] = QScriptTotal[Fix, A]
   val DE = implicitly[Const[DeadEnd, ?] :<: QS]
   val QC = implicitly[QScriptCore[Fix, ?] :<: QS]
   val SP = implicitly[SourcedPathable[Fix, ?] :<: QS]


### PR DESCRIPTION
- Eliminate the DeadEnd Empty case from QScript.
- Make Read not a functor
- Generalize FreeQS to include any QScript component.
- Track LeftShift provenance properly.