### PR TITLE
[WIP] support for new pipeline ops in MongoDB 3.2 with type safety

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- [#1270]: add machinery to track the target the MongoDB version in the planner, and for the new $lookup and $sample operators

--- a/core/src/test/scala/quasar/specs2/matchers.scala
+++ b/core/src/test/scala/quasar/specs2/matchers.scala
@@ -110,14 +110,14 @@ trait DisjunctionMatchers {
     }
   }
 
-  def beRightDisjOrDiff[A, B](expected: B)(implicit rb: RenderTree[B]): Matcher[A \/ B] = new Matcher[A \/ B] {
+  def beRightDisjOrDiff[A, B: Equal](expected: B)(implicit rb: RenderTree[B]): Matcher[A \/ B] = new Matcher[A \/ B] {
     def apply[S <: A \/ B](s: Expectable[S]) = {
       val v = s.value
       v.fold(
         a => result(false, s"$v is right", s"$v is not right", s),
         b => {
           val d = (b.render diff expected.render).shows
-          result(b == expected,
+          result(b ≟ expected,
             s"\n$v is right and tree matches:\n$d",
             s"\n$v is right but tree does not match:\n$d",
             s)
@@ -134,6 +134,7 @@ trait DisjunctionMatchers {
     }
   }
 
+  // TODO: require and use Equal[B]
   def beRightDisjunction[A, B](expected: B)(implicit sb: Show[B]): Matcher[A \/ B] = new Matcher[A \/ B] {
     def apply[S <: A \/ B](s: Expectable[S]) = {
       val v = s.value
@@ -144,6 +145,7 @@ trait DisjunctionMatchers {
     }
   }
 
+  // TODO: require and use Equal[A]
   def beLeftDisjunction[A, B](expected: A)(implicit sa: Show[A]): Matcher[A \/ B] = new Matcher[A \/ B] {
     def apply[S <: A \/ B](s: Expectable[S]) = {
       val v = s.value

--- a/core/src/test/scala/quasar/sql/SqlParserSpec.scala
+++ b/core/src/test/scala/quasar/sql/SqlParserSpec.scala
@@ -33,6 +33,8 @@ class SQLParserSpec extends Specification with ScalaCheck with DisjunctionMatche
 
   implicit def stringToQuery(s: String): Query = Query(s)
 
+  implicit val sqlEqual: Equal[Fix[Sql]] = Equal.equalA
+
   def parse(query: Query): ParsingError \/ Fix[Sql] =
     fixParser.parse(query).map(_.makeTables(Nil))
 

--- a/foundation/src/main/scala/quasar/RenderTree.scala
+++ b/foundation/src/main/scala/quasar/RenderTree.scala
@@ -368,6 +368,13 @@ object RenderTree extends RenderTreeInstances {
         NonTerminal(List("Cofree"), None, List(t.head.render, RF(cofreeRenderTree[F, A]).render(t.tail)))
       }
     }
+
+  implicit def coproductRenderTree[F[_], G[_], A]
+    (implicit RF: RenderTree[F[A]], RG: RenderTree[G[A]])
+    : RenderTree[Coproduct[F, G, A]] = new RenderTree[Coproduct[F, G, A]] {
+    def render(v: Coproduct[F, G, A]) =
+      v.run.fold(RF.render, RG.render)
+  }
 }
 
 sealed abstract class RenderTreeInstances {

--- a/mongodb/src/main/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutor.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutor.scala
@@ -36,7 +36,7 @@ private[mongodb] final class JavaScriptWorkflowExecutor
 
   import JavaScriptWorkflowExecutor._
   import MapReduce.OutputCollection
-  import Workflow.$Sort
+  import Workflow.$SortF
 
   type ExprS[A] = State[Expr, A]
 
@@ -85,7 +85,7 @@ private[mongodb] final class JavaScriptWorkflowExecutor
       cfg.query.foldRight(cfg.projection.foldRight(List[Expr]())(_.toJs :: _))(_.bson.toJs :: _))
 
     tell(List(
-      foldExpr(cfg.sort)((keys, f) => Call(Select(f, "sort"), List($Sort.keyBson(keys).toJs))),
+      foldExpr(cfg.sort)((keys, f) => Call(Select(f, "sort"), List($SortF.keyBson(keys).toJs))),
       foldExpr(cfg.skip)((n, f) => Call(Select(f, "skip"), List(num(n)))),
       foldExpr(cfg.limit)((n, f) => Call(Select(f, "limit"), List(num(n)))))
       .sequence_[ExprS, Unit]

--- a/mongodb/src/main/scala/quasar/physical/mongodb/MongoDbIOWorkflowExecutor.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/MongoDbIOWorkflowExecutor.scala
@@ -38,7 +38,7 @@ private[mongodb] final class MongoDbIOWorkflowExecutor
   extends WorkflowExecutor[MongoDbIO, BsonCursor] {
 
   import MapReduce._
-  import Workflow.$Sort
+  import Workflow.$SortF
 
   private def foldS[F[_]: Foldable, S, A](fa: F[A])(f: (A, S) => S): State[S, Unit] =
     fa.traverseS_[S, Unit](a => MonadState[State[S,?], S].modify(f(a, _)))
@@ -89,7 +89,7 @@ private[mongodb] final class MongoDbIOWorkflowExecutor
     val configure = List(
       foldS(cfg.query)((q, fit: FIT) => fit.filter(q.bson)),
       foldS(cfg.projection)((p, fit: FIT) => fit.projection(p)),
-      foldS(cfg.sort)((keys, fit: FIT) => fit.sort($Sort.keyBson(keys))),
+      foldS(cfg.sort)((keys, fit: FIT) => fit.sort($SortF.keyBson(keys))),
       foldS(cfg.skip)((n, fit: FIT) => fit.skip(n.toInt)),
       foldS(cfg.limit)((n, fit: FIT) => fit.limit(n.toInt))
     ).sequenceS_[FIT, Unit].exec _

--- a/mongodb/src/main/scala/quasar/physical/mongodb/MongoQueryModel.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/MongoQueryModel.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.mongodb
+
+import scalaz.Semigroup
+
+sealed trait MongoQueryModel
+
+object MongoQueryModel {
+  /** The oldest supported version. */
+  case object `2.6` extends MongoQueryModel
+
+  /** Adds a few operators. */
+  case object `3.0` extends MongoQueryModel
+
+  /** Adds `$lookup` and `$distinct`, several new operators, and makes
+    * accumulation operators available in `$project`. */
+  case object `3.2` extends MongoQueryModel
+
+  implicit val semigroup: Semigroup[MongoQueryModel] =
+    new Semigroup[MongoQueryModel] {
+      def append(f1: MongoQueryModel, f2: => MongoQueryModel) = (f1, f2) match {
+        case (`3.2`, _) => `3.2`
+        case (_, `3.2`) => `3.2`
+        case (`3.0`, _) => `3.0`
+        case (_, `3.0`) => `3.0`
+        case (`2.6`, _) => `2.6`
+      }
+    }
+}

--- a/mongodb/src/main/scala/quasar/physical/mongodb/MongoQueryModel.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/MongoQueryModel.scala
@@ -27,8 +27,8 @@ object MongoQueryModel {
   /** Adds a few operators. */
   case object `3.0` extends MongoQueryModel
 
-  /** Adds `$lookup` and `$distinct`, several new operators, and makes
-    * accumulation operators available in `$project`. */
+  /** Adds \$lookup and \$distinct, several new operators, and makes
+    * accumulation operators available in \$project. */
   case object `3.2` extends MongoQueryModel
 
   implicit val semigroup: Semigroup[MongoQueryModel] =

--- a/mongodb/src/main/scala/quasar/physical/mongodb/WorkflowExecutor.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/WorkflowExecutor.scala
@@ -97,7 +97,7 @@ private[mongodb] abstract class WorkflowExecutor[F[_]: Monad, C] {
     *                  If not provided, a `NoDatabase` error is returned instead.
     */
   def evaluate(
-    workflow: Crystallized,
+    workflow: Crystallized[WorkflowF],
     defaultDb: Option[String]
   ): M[List[Bson] \/ WorkflowCursor[C]] =
     Workflow.task(workflow) match {
@@ -130,7 +130,7 @@ private[mongodb] abstract class WorkflowExecutor[F[_]: Monad, C] {
   /** Returns the `Collection` containing the results of executing the given
     * (crystallized) `Workflow`.
     */
-  def execute(workflow: Crystallized, dst: Collection): M[Collection] =
+  def execute(workflow: Crystallized[WorkflowF], dst: Collection): M[Collection] =
     execute0(Workflow task workflow, dst).run(Set()) flatMap { case (tmps, coll) =>
       (tmps - coll) traverse_ (c => asM(drop(c))) as coll
     }
@@ -193,7 +193,9 @@ private[mongodb] abstract class WorkflowExecutor[F[_]: Monad, C] {
     }
   }
 
-  private def execute0(wt: WorkflowTask, out: Collection): N[Collection] = {
+  private def execute0(wt: WorkflowTask, out: Collection)
+    (implicit ev: Workflow2_6F :<: WorkflowF)
+    : N[Collection] = {
     def unableToStore[A](bson: Bson): N[A] =
       insertFailed(
         bson,
@@ -226,7 +228,7 @@ private[mongodb] abstract class WorkflowExecutor[F[_]: Monad, C] {
         for {
           tmp <- tempColl(out.databaseName)
           src <- execute0(source, tmp)
-          _   <- asM(aggregate(src, pipeline ::: List($Out((), out))))
+          _   <- asM(aggregate(src, pipeline ::: List(PipelineOp($OutF((), out).shapePreserving))))
                    .liftM[TempsT]
         } yield out
 
@@ -275,35 +277,35 @@ private[mongodb] abstract class WorkflowExecutor[F[_]: Monad, C] {
     pl match {
       case (Nil, Nil) =>
         find(src, Find(None, None, None, skip, limit)) map (_.right)
-      case (List($Match((), sel)), Nil) =>
+      case (List(PipelineOp2_6($MatchF((), sel))), Nil) =>
         find(src, Find(sel.some, None, None, skip, limit)) map (_.right)
       case (List(Projectable(bson)), Nil) =>
         find(src, Find(None, bson.some, None, skip, limit)) map (_.right)
       case (Nil, List(Projectable(bson))) =>
         find(src, Find(None, bson.some, None, skip, limit)) map (_.right)
-      case (List($Sort((), keys)), Nil) =>
+      case (List(PipelineOp2_6($SortF((), keys))), Nil) =>
         find(src, Find(None, None, keys.some, skip, limit)) map (_.right)
-      case (List($Match((), sel), Projectable(bson)), Nil) =>
+      case (List(PipelineOp2_6($MatchF((), sel)), Projectable(bson)), Nil) =>
         find(src, Find(sel.some, bson.some, None, skip, limit)) map (_.right)
-      case (List($Match((), sel)), List(Projectable(bson))) =>
+      case (List(PipelineOp2_6($MatchF((), sel))), List(Projectable(bson))) =>
         find(src, Find(sel.some, bson.some, None, skip, limit)) map (_.right)
-      case (List($Match((), sel), $Sort((), keys)), Nil) =>
+      case (List(PipelineOp2_6($MatchF((), sel)), PipelineOp2_6($SortF((), keys))), Nil) =>
         find(src, Find(sel.some, None, keys.some, skip, limit)) map (_.right)
-      case (List(Projectable(bson), $Sort((), keys)), Nil) =>
+      case (List(Projectable(bson), PipelineOp2_6($SortF((), keys))), Nil) =>
         find(src, Find(None, bson.some, keys.some, skip, limit)) map (_.right)
-      case (List($Match((), sel), Projectable(bson), $Sort((), keys)), Nil) =>
+      case (List(PipelineOp2_6($MatchF((), sel)), Projectable(bson), PipelineOp2_6($SortF((), keys))), Nil) =>
         find(src, Find(sel.some, bson.some, keys.some, skip, limit)) map (_.right)
       case (List(Countable(field)), Nil) if skip ≟ None && limit ≟ None =>
         labeledCount(src, Count(None, None, None), field) map (_.left)
       case (Nil, List(Countable(field))) =>
         labeledCount(src, Count(None, skip, limit), field) map (_.left)
-      case (List($Match((), sel), Countable(field)), Nil) if skip ≟ None && limit ≟ None =>
+      case (List(PipelineOp2_6($MatchF((), sel)), Countable(field)), Nil) if skip ≟ None && limit ≟ None =>
         labeledCount(src, Count(sel.some, None, None), field) map (_.left)
-      case (List($Match((), sel)), List(Countable(field))) =>
+      case (List(PipelineOp2_6($MatchF((), sel))), List(Countable(field))) =>
         labeledCount(src, Count(sel.some, skip, limit), field) map (_.left)
       case (Distinctable(origField, newField), Nil) if skip ≟ None && limit ≟ None =>
         distinct(src, Distinct(origField, None), newField) map (_.right)
-      case ($Match((), sel) :: Distinctable(origField, newField), Nil) if skip ≟ None && limit ≟ None =>
+      case (PipelineOp2_6($MatchF((), sel)) :: Distinctable(origField, newField), Nil) if skip ≟ None && limit ≟ None =>
         distinct(src, Distinct(origField, sel.some), newField) map (_.right)
       case _ => aggregateCursor(src, pipeline) map (_.right)
     }
@@ -326,7 +328,7 @@ private[mongodb] abstract class WorkflowExecutor[F[_]: Monad, C] {
 }
 
 object WorkflowExecutor {
-  import Workflow.Crystallized
+  import Workflow.{Crystallized, WorkflowF}
 
   /** A cursor to the result of evaluating a `Workflow`, optionally paired with
     * the cursor's temporary source that should be dropped once the cursor is
@@ -369,7 +371,7 @@ object WorkflowExecutor {
     new JavaScriptWorkflowExecutor
 
   /** Interpret a `Workflow` into an equivalent JavaScript program. */
-  def toJS(workflow: Crystallized): WorkflowExecutionError \/ String =
+  def toJS(workflow: Crystallized[WorkflowF]): WorkflowExecutionError \/ String =
     javaScript.evaluate(workflow, none).run.run("tmp.gen").eval(0).run match {
       case (log, r) if log.isEmpty => r as ""
       case (log, r)                => r as Js.Stmts(log.toList).pprint(0)

--- a/mongodb/src/main/scala/quasar/physical/mongodb/WorkflowExecutor.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/WorkflowExecutor.scala
@@ -194,7 +194,7 @@ private[mongodb] abstract class WorkflowExecutor[F[_]: Monad, C] {
   }
 
   private def execute0(wt: WorkflowTask, out: Collection)
-    (implicit ev: Workflow2_6F :<: WorkflowF)
+    (implicit ev: WorkflowOpCoreF :<: WorkflowF)
     : N[Collection] = {
     def unableToStore[A](bson: Bson): N[A] =
       insertFailed(
@@ -277,35 +277,35 @@ private[mongodb] abstract class WorkflowExecutor[F[_]: Monad, C] {
     pl match {
       case (Nil, Nil) =>
         find(src, Find(None, None, None, skip, limit)) map (_.right)
-      case (List(PipelineOp2_6($MatchF((), sel))), Nil) =>
+      case (List(PipelineOpCore($MatchF((), sel))), Nil) =>
         find(src, Find(sel.some, None, None, skip, limit)) map (_.right)
       case (List(Projectable(bson)), Nil) =>
         find(src, Find(None, bson.some, None, skip, limit)) map (_.right)
       case (Nil, List(Projectable(bson))) =>
         find(src, Find(None, bson.some, None, skip, limit)) map (_.right)
-      case (List(PipelineOp2_6($SortF((), keys))), Nil) =>
+      case (List(PipelineOpCore($SortF((), keys))), Nil) =>
         find(src, Find(None, None, keys.some, skip, limit)) map (_.right)
-      case (List(PipelineOp2_6($MatchF((), sel)), Projectable(bson)), Nil) =>
+      case (List(PipelineOpCore($MatchF((), sel)), Projectable(bson)), Nil) =>
         find(src, Find(sel.some, bson.some, None, skip, limit)) map (_.right)
-      case (List(PipelineOp2_6($MatchF((), sel))), List(Projectable(bson))) =>
+      case (List(PipelineOpCore($MatchF((), sel))), List(Projectable(bson))) =>
         find(src, Find(sel.some, bson.some, None, skip, limit)) map (_.right)
-      case (List(PipelineOp2_6($MatchF((), sel)), PipelineOp2_6($SortF((), keys))), Nil) =>
+      case (List(PipelineOpCore($MatchF((), sel)), PipelineOpCore($SortF((), keys))), Nil) =>
         find(src, Find(sel.some, None, keys.some, skip, limit)) map (_.right)
-      case (List(Projectable(bson), PipelineOp2_6($SortF((), keys))), Nil) =>
+      case (List(Projectable(bson), PipelineOpCore($SortF((), keys))), Nil) =>
         find(src, Find(None, bson.some, keys.some, skip, limit)) map (_.right)
-      case (List(PipelineOp2_6($MatchF((), sel)), Projectable(bson), PipelineOp2_6($SortF((), keys))), Nil) =>
+      case (List(PipelineOpCore($MatchF((), sel)), Projectable(bson), PipelineOpCore($SortF((), keys))), Nil) =>
         find(src, Find(sel.some, bson.some, keys.some, skip, limit)) map (_.right)
       case (List(Countable(field)), Nil) if skip ≟ None && limit ≟ None =>
         labeledCount(src, Count(None, None, None), field) map (_.left)
       case (Nil, List(Countable(field))) =>
         labeledCount(src, Count(None, skip, limit), field) map (_.left)
-      case (List(PipelineOp2_6($MatchF((), sel)), Countable(field)), Nil) if skip ≟ None && limit ≟ None =>
+      case (List(PipelineOpCore($MatchF((), sel)), Countable(field)), Nil) if skip ≟ None && limit ≟ None =>
         labeledCount(src, Count(sel.some, None, None), field) map (_.left)
-      case (List(PipelineOp2_6($MatchF((), sel))), List(Countable(field))) =>
+      case (List(PipelineOpCore($MatchF((), sel))), List(Countable(field))) =>
         labeledCount(src, Count(sel.some, skip, limit), field) map (_.left)
       case (Distinctable(origField, newField), Nil) if skip ≟ None && limit ≟ None =>
         distinct(src, Distinct(origField, None), newField) map (_.right)
-      case (PipelineOp2_6($MatchF((), sel)) :: Distinctable(origField, newField), Nil) if skip ≟ None && limit ≟ None =>
+      case (PipelineOpCore($MatchF((), sel)) :: Distinctable(origField, newField), Nil) if skip ≟ None && limit ≟ None =>
         distinct(src, Distinct(origField, sel.some), newField) map (_.right)
       case _ => aggregateCursor(src, pipeline) map (_.right)
     }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/execution.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/execution.scala
@@ -43,11 +43,11 @@ private[mongodb] object execution {
     skip:       Option[Long],
     limit:      Option[Long])
 
-  /** Extractor to determine whether a `$Group` represents a simple `count()`.
+  /** Extractor to determine whether a `$GroupF` represents a simple `count()`.
     */
   object Countable {
     def unapply(op: PipelineOp): Option[BsonField.Name] = op match {
-      case $Group((), Grouped(map), \/-($literal(Bson.Null))) if map.size ≟ 1 =>
+      case PipelineOp2_6($GroupF((), Grouped(map), \/-($literal(Bson.Null)))) if map.size ≟ 1 =>
         map.headOption
           .filter(_._2 == $sum($literal(Bson.Int32(1))))
           .map(_._1)
@@ -58,7 +58,9 @@ private[mongodb] object execution {
   object Distinctable {
     def unapply(pipeline: workflowtask.Pipeline): Option[(BsonField.Name, BsonField.Name)] =
       pipeline match {
-        case List($Group((), Grouped(map), by), $Project((), Reshape(fields), IdHandling.IgnoreId | IdHandling.ExcludeId))
+        case List(
+          PipelineOp2_6($GroupF((), Grouped(map), by)),
+          PipelineOp2_6($ProjectF((), Reshape(fields), IdHandling.IgnoreId | IdHandling.ExcludeId)))
             if map.isEmpty && fields.size ≟ 1 =>
           fields.headOption.fold[Option[(BsonField.Name, BsonField.Name)]] (None)(field =>
             (by, field) match {
@@ -77,9 +79,9 @@ private[mongodb] object execution {
 
   object Projectable {
     def unapply(op: PipelineOp): Option[Bson.Doc] = op match {
-      case proj @ $Project((), Reshape(map), _)
+      case PipelineOp2_6(proj @ $ProjectF((), Reshape(map), _))
           if map.all(_ == \/-($include())) =>
-        proj.rhs.some
+        proj.pipelineRhs.some
       case _ => None
     }
   }
@@ -88,10 +90,15 @@ private[mongodb] object execution {
       ((workflowtask.Pipeline, workflowtask.Pipeline),
         (Option[Long], Option[Long])) =
     pipeline match {
-      case Nil                                => ((Nil, Nil), (None,   None))
-      case $Limit((), l) :: $Skip((), s) :: t => ((Nil, t),   (s.some, (l - s).some))
-      case $Limit((), l)                 :: t => ((Nil, t),   (None,   l.some))
-      case                  $Skip((), s) :: t => ((Nil, t),   (s.some, None))
-      case h                             :: t => (h :: (_: workflowtask.Pipeline)).first.first(extractRange(t))
+      case Nil                             => ((Nil, Nil), (None,   None))
+      case PipelineOp2_6($LimitF((), l)) ::
+            PipelineOp2_6($SkipF((), s)) ::
+            t                              => ((Nil, t),   (s.some, (l - s).some))
+      case PipelineOp2_6($LimitF((), l)) ::
+            t                              => ((Nil, t),   (None,   l.some))
+      case PipelineOp2_6($SkipF((), s))  ::
+            t                              => ((Nil, t),   (s.some, None))
+      case h                            ::
+            t                              => (h :: (_: workflowtask.Pipeline)).first.first(extractRange(t))
     }
 }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/execution.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/execution.scala
@@ -43,8 +43,7 @@ private[mongodb] object execution {
     skip:       Option[Long],
     limit:      Option[Long])
 
-  /** Extractor to determine whether a `$GroupF` represents a simple `count()`.
-    */
+  /** Extractor to determine whether a `$GroupF` represents a simple `count()`. */
   object Countable {
     def unapply(op: PipelineOp): Option[BsonField.Name] = op match {
       case PipelineOp2_6($GroupF((), Grouped(map), \/-($literal(Bson.Null)))) if map.size ≟ 1 =>

--- a/mongodb/src/main/scala/quasar/physical/mongodb/optimize/optimize.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/optimize/optimize.scala
@@ -30,32 +30,32 @@ package object optimize {
     import Workflow._
     import IdHandling._
 
-    private def deleteUnusedFields0(op: Workflow, usedRefs: Option[Set[DocVar]]):
-        Workflow = {
-      def getRefs[A](op: WorkflowF[Workflow], prev: Option[Set[DocVar]]):
+    private def deleteUnusedFields0[F[_]: Functor: Rewrite](op: Fix[F], usedRefs: Option[Set[DocVar]])
+      (implicit I: Workflow2_6F :<: F): Fix[F] = {
+      def getRefs[A](op: F[Fix[F]], prev: Option[Set[DocVar]]):
           Option[Set[DocVar]] = op match {
-        case $Group(_, _, _)            => Some(refs(op).toSet)
+        case $group(_, _, _)           => Some(Rewrite[F].refs(op).toSet)
         // FIXME: Since we can’t reliably identify which fields are used by a
         //        JS function, we need to assume they all are, until we hit the
-        //        next $Group or $Project.
-        case $Map(_, _, _)             => None
-        case $SimpleMap(_, _, _)       => None
-        case $FlatMap(_, _, _)         => None
-        case $Reduce(_, _, _)          => None
-        case $Project(_, _, IncludeId) => Some(refs(op).toSet + IdVar)
-        case $Project(_, _, _)         => Some(refs(op).toSet)
-        case $FoldLeft(_, _)           => prev.map(_ + IdVar)
-        case _                         => prev.map(_ ++ refs(op))
+        //        next $GroupF or $ProjectF.
+        case $map(_, _, _)             => None
+        case $simpleMap(_, _, _)       => None
+        case $flatMap(_, _, _)         => None
+        case $reduce(_, _, _)          => None
+        case $project(_, _, IncludeId) => Some(Rewrite[F].refs(op).toSet + IdVar)
+        case $project(_, _, _)         => Some(Rewrite[F].refs(op).toSet)
+        case $foldLeft(_, _)           => prev.map(_ + IdVar)
+        case _                         => prev.map(_ ++ Rewrite[F].refs(op))
       }
 
       def unused(defs: Set[DocVar], refs: Set[DocVar]): Set[DocVar] =
         defs.filterNot(d => refs.exists(ref => d.startsWith(ref) || ref.startsWith(d)))
 
-      def getDefs[A](op: WorkflowF[A]): Set[DocVar] = (op match {
-        case p @ $Project(_, _, _)      => p.getAll.map(_._1)
-        case g @ $Group(_, _, _)        => g.getAll.map(_._1)
-        case s @ $SimpleMap(_, _, _)    => s.getAll.getOrElse(Nil)
-        case _                          => Nil
+      def getDefs[A](op: F[A]): Set[DocVar] = (I.prj(op) match {
+        case Some(p @ $ProjectF(_, _, _))   => p.getAll.map(_._1)
+        case Some(g @ $GroupF(_, _, _))     => g.getAll.map(_._1)
+        case Some(s @ $SimpleMapF(_, _, _)) => s.getAll.getOrElse(Nil)
+        case _                             => Nil
       }).map(DocVar.ROOT(_)).toSet
 
       val pruned =
@@ -63,28 +63,29 @@ package object optimize {
           val unusedRefs =
             unused(getDefs(op.unFix), usedRefs).toList.flatMap(_.deref.toList)
           op.unFix match {
-            case p @ $Project(_, _, _)      =>
+            case Workflow2_6F(p @ $ProjectF(_, _, _))   =>
               val p1 = p.deleteAll(unusedRefs)
-              if (p1.shape.value.isEmpty) p1.src.unFix
-              else p1
-            case g @ $Group(_, _, _)        => g.deleteAll(unusedRefs.map(_.flatten.head))
-            case s @ $SimpleMap(_, _, _)    => s.deleteAll(unusedRefs)
-            case o                          => o
+              if (p1.shape.value.isEmpty) p1.pipeline.src.unFix
+              else I.inj(p1)
+            case Workflow2_6F(g @ $GroupF(_, _, _))     => I.inj(g.deleteAll(unusedRefs.map(_.flatten.head)))
+            case Workflow2_6F(s @ $SimpleMapF(_, _, _)) => I.inj(s.deleteAll(unusedRefs))
+            case o                                     => o
           }
         }
 
       Fix(pruned.map(deleteUnusedFields0(_, getRefs(pruned, usedRefs))))
     }
 
-    def deleteUnusedFields(op: Workflow) = deleteUnusedFields0(op, None)
+    def deleteUnusedFields[F[_]: Functor: Rewrite](op: Fix[F])(implicit ev: Workflow2_6F :<: F): Fix[F] =
+      deleteUnusedFields0(op, None)
 
     /** Converts a \$group with fields that duplicate keys into a \$group
       * without those fields followed by a \$project that projects those fields
       * from the key.
       */
-    val simplifyGroupƒ:
-        WorkflowF[Workflow] => Option[WorkflowF[Workflow]] = {
-      case $Group(src, Grouped(cont), id) =>
+    def simplifyGroupƒ[F[_]: Coalesce](implicit ev: Workflow2_6F :<: F):
+        F[Fix[F]] => Option[F[Fix[F]]] = {
+      case $group(src, Grouped(cont), id) =>
         val (newCont, proj) =
           cont.foldLeft[(ListMap[BsonField.Name, Accumulator], ListMap[BsonField.Name, Reshape.Shape])](
             (ListMap(), ListMap())) {
@@ -110,14 +111,16 @@ package object optimize {
         if (newCont == cont)
           None
         else
-          $Project(
-            Fix($Group(src, Grouped(newCont), id)),
-            Reshape(proj),
-            IgnoreId).some
+          chain(src,
+            $group[F](Grouped(newCont), id),
+            $project[F](
+              Reshape(proj),
+              IgnoreId)).unFix.some
       case _ => None
     }
 
-    private val reorderOpsƒ: WorkflowF[Workflow] => Option[WorkflowF[Workflow]] = {
+    private def reorderOpsƒ[F[_]: Coalesce](implicit I: Workflow2_6F :<: F)
+        : F[Fix[F]] => Option[F[Fix[F]]] = {
       def rewriteSelector(sel: Selector, defs: Map[DocVar, DocVar]): Option[Selector] =
         sel.mapUpFieldsM { f =>
           defs.toList.map {
@@ -129,25 +132,35 @@ package object optimize {
         }
 
       {
-        case $Skip(Fix($Project(src0, shape, id)), count) =>
-          $Project(Fix($Skip(src0, count)), shape, id).some
-        case $Skip(Fix($SimpleMap(src0, fn @ NonEmptyList(MapExpr(_), INil()), scope)), count) =>
-          $SimpleMap(Fix($Skip(src0, count)), fn, scope).some
+        case $skip(Fix($project(src0, shape, id)), count) =>
+          chain(src0,
+            $skip[F](count),
+            $project[F](shape, id)).unFix.some
+        case $skip(Fix($simpleMap(src0, fn @ NonEmptyList(MapExpr(_), INil()), scope)), count) =>
+          chain(src0,
+            $skip[F](count),
+            $simpleMap[F](fn, scope)).unFix.some
 
-        case $Limit(Fix($Project(src0, shape, id)), count) =>
-          $Project(Fix($Limit(src0, count)), shape, id).some
-        case $Limit(Fix($SimpleMap(src0, fn @ NonEmptyList(MapExpr(_), INil()), scope)), count) =>
-          $SimpleMap(Fix($Limit(src0, count)), fn, scope).some
+        case $limit(Fix($project(src0, shape, id)), count) =>
+          chain(src0,
+            $limit[F](count),
+            $project[F](shape, id)).unFix.some
+        case $limit(Fix($simpleMap(src0, fn @ NonEmptyList(MapExpr(_), INil()), scope)), count) =>
+          chain(src0,
+            $limit[F](count),
+            $simpleMap[F](fn, scope)).unFix.some
 
-        case $Match(Fix(p @ $Project(src0, shape, id)), sel) =>
+        case $match(Fix(Workflow2_6F(p @ $ProjectF(src0, shape, id))), sel) =>
           val defs = p.getAll.collect {
             case (n, $var(x))    => DocField(n) -> x
             case (n, $include()) => DocField(n) -> DocField(n)
           }.toMap
           rewriteSelector(sel, defs).map(sel =>
-            $Project(Fix($Match(src0, sel)), shape, id))
+            chain(src0,
+              $match[F](sel),
+              $project[F](shape, id)).unFix)
 
-        case $Match(Fix($SimpleMap(src0, fn @ NonEmptyList(MapExpr(jsFn), INil()), scope)), sel) => {
+        case $match(Fix($simpleMap(src0, exprs @ NonEmptyList(MapExpr(jsFn), INil()), scope)), sel) => {
           import quasar.javascript._
           def defs(expr: JsCore): Map[DocVar, DocVar] =
             expr.simplify match {
@@ -160,15 +173,19 @@ package object optimize {
               case _ => Map.empty
             }
           rewriteSelector(sel, defs(jsFn.expr)).map(sel =>
-            $SimpleMap(Fix($Match (src0, sel)), fn, scope))
+            chain(src0,
+              $match[F](sel),
+              $simpleMap[F](exprs, scope)).unFix)
         }
 
         case op => None
       }
     }
 
-    def reorderOps(wf: Workflow): Workflow = {
-      val reordered = wf.transCata(orOriginal(reorderOpsƒ))
+    def reorderOps[F[_]: Functor: Coalesce](wf: Fix[F])
+      (implicit I: Workflow2_6F :<: F)
+      : Fix[F] = {
+      val reordered = wf.transCata(orOriginal(reorderOpsƒ[F]))
       if (reordered == wf) wf else reorderOps(reordered)
     }
 
@@ -195,9 +212,9 @@ package object optimize {
       }
 
     private def inlineProject0(r: Reshape, rs: List[Reshape]): Option[Reshape] =
-      inlineProject($Project((), r, IdHandling.IgnoreId), rs)
+      inlineProject($ProjectF((), r, IdHandling.IgnoreId), rs)
 
-    def inlineProject[A](p: $Project[A], rs: List[Reshape]): Option[Reshape] = {
+    def inlineProject[A](p: $ProjectF[A], rs: List[Reshape]): Option[Reshape] = {
       val map = p.getAll.map { case (k, v) =>
         k -> (v match {
           case $include() =>
@@ -259,9 +276,10 @@ package object optimize {
       } yield unwound1 -> Grouped(values1)
     }
 
-    def inlineGroupProjects(g: $Group[Workflow]):
-        Option[(Workflow, Grouped, Reshape.Shape)] = {
-      val (rs, src) = g.src.para(collectShapes)
+    def inlineGroupProjects[F[_]: Functor](g: $GroupF[Fix[F]])
+      (implicit I: Workflow2_6F :<: F)
+      : Option[(Fix[F], Grouped, Reshape.Shape)] = {
+      val (rs, src) = g.src.para(collectShapes[F])
 
       if (src == g.src) None
       else {

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner.scala
@@ -602,7 +602,7 @@ object MongoDbPlanner {
   }
 
   def workflowƒ[F[_]: Functor: Coalesce: Crush: Crystallize]
-    (implicit I: Workflow2_6F :<: F, ev: Show[WorkflowBuilder[F]], WB: WorkflowBuilder.Ops[F])  // FIXME: don't need first two?
+    (implicit I: WorkflowOpCoreF :<: F, ev: Show[WorkflowBuilder[F]], WB: WorkflowBuilder.Ops[F])  // FIXME: don't need first two?
     : LogicalPlan[
         Cofree[LogicalPlan, (
           (OutputM[PartialSelector],
@@ -1094,7 +1094,7 @@ object MongoDbPlanner {
   }
 
   def plan0[F[_]: Functor: Coalesce: Crush: Crystallize](logical: Fix[LogicalPlan])
-      (implicit ev0: Workflow2_6F :<: F, ev1: Show[Fix[WorkflowBuilderF[F, ?]]], ev2: RenderTree[Fix[F]])
+      (implicit ev0: WorkflowOpCoreF :<: F, ev1: Show[Fix[WorkflowBuilderF[F, ?]]], ev2: RenderTree[Fix[F]])
       : EitherT[Writer[PhaseResults, ?], PlannerError, Crystallized[F]] = {
     // TODO[scalaz]: Shadow the scalaz.Monad.monadMTMAB SI-2712 workaround
     import EitherT.eitherTMonad

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner.scala
@@ -1148,7 +1148,7 @@ object MongoDbPlanner {
       case `3.2` =>
         plan0[Workflow3_2F](logical)
       case _     =>
-        plan0[Workflow2_6F](logical).map(_.inject[Workflow3_2F])
+        plan0[Workflow2_6F](logical).map(_.inject[WorkflowF])
     }
   }
 }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner.scala
@@ -319,14 +319,14 @@ object MongoDbPlanner {
         case ArrayProject  => Arity2(Access(_, _))
         case MakeObject => args match {
           case Sized(a1, a2) => (HasStr(a1) |@| HasJs(a2)) {
-            case (field, (sel, inputs)) => 
+            case (field, (sel, inputs)) =>
               (({ case (list: List[JsFn]) => JsFn(JsFn.defaultName, Obj(ListMap(Name(field) -> sel(list)(Ident(JsFn.defaultName))))) },
                 inputs.map(There(1, _))): PartialJs)
           }
         }
         case DeleteField => args match {
           case Sized(a1, a2) => (HasJs(a1) |@| HasStr(a2)) {
-            case ((sel, inputs), field) => 
+            case ((sel, inputs), field) =>
               (({ case (list: List[JsFn]) => JsFn(JsFn.defaultName, Call(ident("remove"),
                 List(sel(list)(Ident(JsFn.defaultName)), Literal(Js.Str(field))))) },
                 inputs.map(There(0, _))): PartialJs)
@@ -601,20 +601,21 @@ object MongoDbPlanner {
     }
   }
 
-  val workflowƒ:
-      LogicalPlan[
+  def workflowƒ[F[_]: Functor: Coalesce: Crush: Crystallize]
+    (implicit I: Workflow2_6F :<: F, ev: Show[WorkflowBuilder[F]], WB: WorkflowBuilder.Ops[F])  // FIXME: don't need first two?
+    : LogicalPlan[
         Cofree[LogicalPlan, (
           (OutputM[PartialSelector],
            OutputM[PartialJs]),
-          OutputM[WorkflowBuilder])]] =>
-      State[NameGen, OutputM[WorkflowBuilder]] = {
+          OutputM[WorkflowBuilder[F]])]] =>
+      State[NameGen, OutputM[Fix[WorkflowBuilderF[F, ?]]]] = {
     import WorkflowBuilder._
     import quasar.physical.mongodb.accumulator._
     import quasar.physical.mongodb.expression._
 
     type Input  = (OutputM[PartialSelector], OutputM[PartialJs])
-    type Output = M[WorkflowBuilder]
-    type Ann    = Cofree[LogicalPlan, (Input, OutputM[WorkflowBuilder])]
+    type Output = M[WorkflowBuilder[F]]
+    type Ann    = Cofree[LogicalPlan, (Input, OutputM[WorkflowBuilder[F]])]
 
     import LogicalPlan._
 
@@ -625,7 +626,7 @@ object MongoDbPlanner {
       }
     }
 
-    val HasKeys: Ann => OutputM[List[WorkflowBuilder]] = {
+    val HasKeys: Ann => OutputM[List[WorkflowBuilder[F]]] = {
       case MakeArrayN.Attr(array) => array.traverse(_.head._2)
       case n                      => n.head._2.map(List(_))
     }
@@ -651,7 +652,7 @@ object MongoDbPlanner {
 
     val HasJs: Ann => OutputM[PartialJs] = _.head._1._2
 
-    val HasWorkflow: Ann => OutputM[WorkflowBuilder] = _.head._2
+    val HasWorkflow: Ann => OutputM[WorkflowBuilder[F]] = _.head._2
 
     def invoke[N <: Nat](func: GenericFunc[N], args: Func.Input[Ann, N]): Output = {
 
@@ -687,22 +688,22 @@ object MongoDbPlanner {
       }
 
       def expr1(f: Expression => Expression): Output =
-        lift(Arity1(HasWorkflow)).flatMap(WorkflowBuilder.expr1(_)(f))
+        lift(Arity1(HasWorkflow)).flatMap(WB.expr1(_)(f))
 
       def groupExpr1(f: Expression => Accumulator): Output =
-        lift(Arity1(HasWorkflow).map(reduce(_)(f)))
+        lift(Arity1(HasWorkflow).map(WB.reduce(_)(f)))
 
-      def mapExpr(p: WorkflowBuilder)(f: Expression => Expression): Output =
-        WorkflowBuilder.expr1(p)(f)
+      def mapExpr(p: WorkflowBuilder[F])(f: Expression => Expression): Output =
+        WB.expr1(p)(f)
 
       def expr2[A](f: (Expression, Expression) => Expression): Output =
         lift(Arity2(HasWorkflow, HasWorkflow)).flatMap {
-          case (p1, p2) => WorkflowBuilder.expr2(p1, p2)(f)
+          case (p1, p2) => WB.expr2(p1, p2)(f)
         }
 
       def expr3(f: (Expression, Expression, Expression) => Expression): Output =
         lift(Arity3(HasWorkflow, HasWorkflow, HasWorkflow)).flatMap {
-          case (p1, p2, p3) => WorkflowBuilder.expr(List(p1, p2, p3)) {
+          case (p1, p2, p3) => WB.expr(List(p1, p2, p3)) {
             case List(e1, e2, e3) => f(e1, e2, e3)
           }
         }
@@ -719,7 +720,7 @@ object MongoDbPlanner {
         * selectors causes runtime errors when the expression ends up
         * in a $project or $simpleMap prior to $match.
         */
-      def breaksEvalOrder(ann: Cofree[LogicalPlan, OutputM[WorkflowBuilder]], f: InputFinder): Boolean = {
+      def breaksEvalOrder(ann: Cofree[LogicalPlan, OutputM[WorkflowBuilder[F]]], f: InputFinder): Boolean = {
         def isSimpleRef =
           f(ann).fold(
             κ(true),
@@ -737,15 +738,15 @@ object MongoDbPlanner {
       }
 
       func match {
-        case MakeArray => lift(Arity1(HasWorkflow).map(makeArray))
+        case MakeArray => lift(Arity1(HasWorkflow).map(WB.makeArray))
         case MakeObject =>
           lift(Arity2(HasText, HasWorkflow).map {
-            case (name, wf) => makeObject(wf, name)
+            case (name, wf) => WB.makeObject(wf, name)
           })
         case ObjectConcat =>
-          lift(Arity2(HasWorkflow, HasWorkflow)).flatMap((objectConcat(_, _)).tupled)
+          lift(Arity2(HasWorkflow, HasWorkflow)).flatMap((WB.objectConcat(_, _)).tupled)
         case ArrayConcat =>
-          lift(Arity2(HasWorkflow, HasWorkflow)).flatMap((arrayConcat(_, _)).tupled)
+          lift(Arity2(HasWorkflow, HasWorkflow)).flatMap((WB.arrayConcat(_, _)).tupled)
         case Filter =>
           args match {
             case Sized(a1, a2) =>
@@ -753,26 +754,26 @@ object MongoDbPlanner {
                 val on = a2.map(_._2)
                 HasSelector(a2).flatMap { case (sel, inputs) =>
                   if (!inputs.exists(breaksEvalOrder(on, _)))
-                    inputs.traverse(_(on)).map(filter(wf, _, sel))
+                    inputs.traverse(_(on)).map(WB.filter(wf, _, sel))
                   else
-                    HasWorkflow(a2).map(wf2 => filter(wf, List(wf2), {
+                    HasWorkflow(a2).map(wf2 => WB.filter(wf, List(wf2), {
                       case f :: Nil => Selector.Doc(f -> Selector.Eq(Bson.Bool(true)))
                     }))
                 } <+>
                   HasJs(a2).flatMap(js =>
                     // TODO: have this pass the JS args as the list of inputs … but right now, those inputs get converted to BsonFields, not ExprOps.
-                    js._2.traverse(_(on)).map(args => filter(wf, Nil, { case Nil => Selector.Where(js._1(args.map(κ(JsFn.identity)))(jscore.ident("this")).toJs) })))
+                    js._2.traverse(_(on)).map(args => WB.filter(wf, Nil, { case Nil => Selector.Where(js._1(args.map(κ(JsFn.identity)))(jscore.ident("this")).toJs) })))
               }))
           }
         case Drop =>
-          lift(Arity2(HasWorkflow, HasInt).map((skip(_, _)).tupled))
+          lift(Arity2(HasWorkflow, HasInt).map((WB.skip(_, _)).tupled))
         case Take =>
-          lift(Arity2(HasWorkflow, HasInt).map((limit(_, _)).tupled))
+          lift(Arity2(HasWorkflow, HasInt).map((WB.limit(_, _)).tupled))
         case InnerJoin | LeftOuterJoin | RightOuterJoin | FullOuterJoin =>
           args match {
             case Sized(left, right, comp) =>
-              splitConditions(comp).fold[M[WorkflowBuilder]](
-                fail(UnsupportedJoinCondition(Recursive[Cofree[?[_], (Input, OutputM[WorkflowBuilder])]].convertTo[LogicalPlan, Fix](comp))))(
+              splitConditions(comp).fold[M[WorkflowBuilder[F]]](
+                fail(UnsupportedJoinCondition(Recursive[Cofree[?[_], (Input, OutputM[WorkflowBuilder[F]])]].convertTo[LogicalPlan, Fix](comp))))(
                 c => {
                   val (leftKeys, rightKeys) = c.unzip
                   lift((HasWorkflow(left) |@|
@@ -783,10 +784,10 @@ object MongoDbPlanner {
                 })
           }
         case GroupBy =>
-          lift(Arity2(HasWorkflow, HasKeys).map((groupBy(_, _)).tupled))
+          lift(Arity2(HasWorkflow, HasKeys).map((WB.groupBy(_, _)).tupled))
         case OrderBy =>
           lift(Arity3(HasWorkflow, HasKeys, HasSortDirs).map {
-            case (p1, p2, dirs) => sortBy(p1, p2, dirs)
+            case (p1, p2, dirs) => WB.sortBy(p1, p2, dirs)
           })
 
         case Constantly => expr2((v, s) => v)
@@ -897,25 +898,25 @@ object MongoDbPlanner {
 
         case ToId        =>
           lift(Arity1(HasText).flatMap(str =>
-            BsonCodec.fromData(Data.Id(str)).map(WorkflowBuilder.pure)))
+            BsonCodec.fromData(Data.Id(str)).map(WB.pure)))
 
         case Between       => expr3((x, l, u) => $and($lte(l, x), $lte(x, u)))
 
         case ObjectProject =>
-          lift(Arity2(HasWorkflow, HasText).flatMap((projectField(_, _)).tupled))
+          lift(Arity2(HasWorkflow, HasText).flatMap((WB.projectField(_, _)).tupled))
         case ArrayProject =>
           lift(Arity2(HasWorkflow, HasInt).flatMap {
-            case (p, index) => projectIndex(p, index.toInt)
+            case (p, index) => WB.projectIndex(p, index.toInt)
           })
         case DeleteField  =>
-          lift(Arity2(HasWorkflow, HasText).flatMap((deleteField(_, _)).tupled))
-        case FlattenMap   => lift(Arity1(HasWorkflow).map(flattenMap))
-        case FlattenArray => lift(Arity1(HasWorkflow).map(flattenArray))
-        case Squash       => lift(Arity1(HasWorkflow).map(squash))
+          lift(Arity2(HasWorkflow, HasText).flatMap((WB.deleteField(_, _)).tupled))
+        case FlattenMap   => lift(Arity1(HasWorkflow).map(WB.flattenMap(_)))
+        case FlattenArray => lift(Arity1(HasWorkflow).map(WB.flattenArray(_)))
+        case Squash       => lift(Arity1(HasWorkflow).map(WB.squash))
         case Distinct     =>
-          lift(Arity1(HasWorkflow)).flatMap(distinct)
+          lift(Arity1(HasWorkflow)).flatMap(WB.distinct(_))
         case DistinctBy   =>
-          lift(Arity2(HasWorkflow, HasKeys)).flatMap((distinctBy(_, _)).tupled)
+          lift(Arity2(HasWorkflow, HasKeys)).flatMap((WB.distinctBy(_, _)).tupled)
 
         case _ => fail(UnsupportedFunction(func.name, "in workflow planner".some))
       }
@@ -930,10 +931,10 @@ object MongoDbPlanner {
     }
 
     def findArgs(partials: List[PartialJs], comp: Ann):
-        OutputM[List[List[WorkflowBuilder]]] =
+        OutputM[List[List[WorkflowBuilder[F]]]] =
       partials.traverse(_._2.traverse(_(comp.map(_._2))))
 
-    def applyPartials(partials: List[PartialJs], args: List[List[WorkflowBuilder]]):
+    def applyPartials(partials: List[PartialJs], args: List[List[WorkflowBuilder[F]]]):
         List[JsFn] =
       (partials zip args).map(l => l._1._1(l._2.map(κ(JsFn.identity))))
 
@@ -945,16 +946,16 @@ object MongoDbPlanner {
     node => node match {
       case ReadF(path) =>
         // Documentation on `QueryFile` guarantees absolute paths, so calling `mkAbsolute`
-        state(Collection.fromFile(mkAbsolute(rootDir, path)).bimap(PlanPathError, WorkflowBuilder.read))
+        state(Collection.fromFile(mkAbsolute(rootDir, path)).bimap(PlanPathError, WB.read))
       case ConstantF(data) =>
         state(BsonCodec.fromData(data).bimap(
           κ(NonRepresentableData(data)),
-          WorkflowBuilder.pure))
+          WB.pure))
       case InvokeF(func, args) =>
         val v = invoke(func, args) <+>
           lift(jsExprƒ(node.map(HasJs))).flatMap(pjs =>
             lift(pjs._2.traverse(_(Cofree(UnsupportedPlan(node, None).left, node.map(_.map(_._2)))))).flatMap(args =>
-              jsExpr(args, x => pjs._1(x.map(JsFn.const))(jscore.Ident(JsFn.defaultName)))))
+              WB.jsExpr(args, x => pjs._1(x.map(JsFn.const))(jscore.Ident(JsFn.defaultName)))))
         State(s => v.run(s).fold(e => s -> -\/(e), t => t._1 -> \/-(t._2)))
       case FreeF(name) =>
         state(-\/(InternalError("variable " + name + " is unbound")))
@@ -1020,7 +1021,7 @@ object MongoDbPlanner {
             lift(HasWorkflow(cont)))(
             f => lift((HasWorkflow(exp) |@| HasWorkflow(cont) |@| HasWorkflow(fallback))(
               (exp, cont, fallback) => {
-                expr1(exp)(f).flatMap(t => expr(List(t, cont, fallback)) {
+                WB.expr1(exp)(f).flatMap(t => WB.expr(List(t, cont, fallback)) {
                   case List(t, c, a) => $cond(t, c, a)
                 })
               })).join)
@@ -1092,8 +1093,9 @@ object MongoDbPlanner {
     }
   }
 
-  def plan(logical: Fix[LogicalPlan]):
-      EitherT[Writer[PhaseResults, ?], PlannerError, Crystallized] = {
+  def plan0[F[_]: Functor: Coalesce: Crush: Crystallize](logical: Fix[LogicalPlan])
+      (implicit ev0: Workflow2_6F :<: F, ev1: Show[Fix[WorkflowBuilderF[F, ?]]], ev2: RenderTree[Fix[F]])
+      : EitherT[Writer[PhaseResults, ?], PlannerError, Crystallized[F]] = {
     // TODO[scalaz]: Shadow the scalaz.Monad.monadMTMAB SI-2712 workaround
     import EitherT.eitherTMonad
     import StateT.stateTMonadState
@@ -1103,8 +1105,8 @@ object MongoDbPlanner {
     type PlanT[X[_], A] = EitherT[X, PlannerError, A]
     type GenT[X[_], A]  = StateT[X, NameGen, A]
     type W[A]           = Writer[PhaseResults, A]
-    type F[A]           = PlanT[W, A]
-    type M[A]           = GenT[F, A]
+    type P[A]           = PlanT[W, A]
+    type M[A]           = GenT[P, A]
 
     def log[A: RenderTree](label: String)(ma: M[A]): M[A] =
       ma flatMap { a =>
@@ -1113,12 +1115,12 @@ object MongoDbPlanner {
       }
 
     def swizzle[A](sa: StateT[PlannerError \/ ?, NameGen, A]): M[A] =
-      StateT[F, NameGen, A](ng => EitherT(sa.run(ng).point[W]))
+      StateT[P, NameGen, A](ng => EitherT(sa.run(ng).point[W]))
 
     def liftError[A](ea: PlannerError \/ A): M[A] =
       EitherT(ea.point[W]).liftM[GenT]
 
-    val wfƒ = workflowƒ ⋙ (_ ∘ (_ ∘ (_ ∘ normalize)))
+    val wfƒ = workflowƒ[F] ⋙ (_ ∘ (_ ∘ (_ ∘ normalize[F])))
 
     (for {
       cleaned <- log("Logical Plan (reduced typechecks)")(liftError(logical.cataM[PlannerError \/ ?, Fix[LogicalPlan]](Optimizer.assumeReadObjƒ)))
@@ -1126,7 +1128,27 @@ object MongoDbPlanner {
       prep <- log("Logical Plan (projections preferred)")(Optimizer.preferProjections(align).point[M])
       wb   <- log("Workflow Builder")                    (swizzle(swapM(lpParaZygoHistoS(prep)(annotateƒ, wfƒ))))
       wf1  <- log("Workflow (raw)")                      (swizzle(build(wb)))
-      wf2  <- log("Workflow (crystallized)")             (crystallize(wf1).point[M])
+      wf2  <- log("Workflow (crystallized)")             (Crystallize[F].crystallize(wf1).point[M])
     } yield wf2).evalZero
+  }
+
+  /** Translate the high-level "logical" plan to an executable MongoDB "physical"
+    * plan, taking into account the current runtime environment as captured by
+    * the given context (which is for the time being just the "query model"
+    * associated with the backend version.)
+    * Internally, the type of the plan being built constrains which operators
+    * can be used, but the resulting plan uses the largest, common type so that
+    * callers don't need to worry about it.
+    */
+  def plan(logical: Fix[LogicalPlan], queryContext: MongoQueryModel)
+    : EitherT[Writer[PhaseResults, ?], PlannerError, Crystallized[WorkflowF]] = {
+    import MongoQueryModel._
+
+    queryContext match {
+      case `3.2` =>
+        plan0[Workflow3_2F](logical)
+      case _     =>
+        plan0[Workflow2_6F](logical).map(_.inject[Workflow3_2F])
+    }
   }
 }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
@@ -29,7 +29,7 @@ import quasar.qscript._
 import matryoshka._, Recursive.ops._, FunctorT.ops._
 import scalaz._, Scalaz._
 
-sealed trait WorkflowBuilderF[+A]
+sealed trait WorkflowBuilderF[F[_], +A]
 
 object WorkflowBuilder {
   import quasar.physical.mongodb.accumulator._
@@ -38,7 +38,7 @@ object WorkflowBuilder {
   import IdHandling._
 
   /** A partial description of a query that can be run on an instance of MongoDB */
-  type WorkflowBuilder = Fix[WorkflowBuilderF]
+  type WorkflowBuilder[F[_]] = Fix[WorkflowBuilderF[F, ?]]
   /** If we know what the shape is, represents the list of Fields. */
   type Schema = Option[NonEmptyList[BsonField.Name]]
 
@@ -62,21 +62,21 @@ object WorkflowBuilder {
    * @param struct In the case of read, it's None. In the case where we are converting a WorkflowBuilder into
    *               a Workflow, we have access to the shape of this Workflow and encode it in `struct`.
    */
-  final case class CollectionBuilderF(
-    src: Workflow,
+  final case class CollectionBuilderF[F[_]](
+    src: Fix[F],
     base: Base,
-    struct: Schema) extends WorkflowBuilderF[Nothing]
+    struct: Schema) extends WorkflowBuilderF[F, Nothing]
   object CollectionBuilder {
-    def apply(graph: Workflow, base: Base, struct: Schema) =
-      Fix[WorkflowBuilderF](new CollectionBuilderF(graph, base, struct))
+    def apply[F[_]](graph: Fix[F], base: Base, struct: Schema) =
+      Fix[WorkflowBuilderF[F, ?]](new CollectionBuilderF(graph, base, struct))
   }
 
   /** For instance, \$match, \$skip, \$limit, \$sort */
-  final case class ShapePreservingBuilderF[A](
+  final case class ShapePreservingBuilderF[F[_]: Coalesce, A](
     src: A,
     inputs: List[A],
-    op: PartialFunction[List[BsonField], WorkflowOp])
-      extends WorkflowBuilderF[A]
+    op: PartialFunction[List[BsonField], WorkflowOp[F]])(implicit ev: Workflow2_6F :<: F)
+      extends WorkflowBuilderF[F, A]
   {
     lazy val dummyOp =
       op(
@@ -84,7 +84,7 @@ object WorkflowBuilder {
           case (_, index) => BsonField.Name("_" + index)
         })(
         // Nb. This read is an arbitrary value that allows us to compare the partial function
-        $read(Collection("", "")))
+        $read[F](Collection("", "")))
 
     override def equals(that: scala.Any) = that match {
       case that @ ShapePreservingBuilderF(src1, inputs1, op1) =>
@@ -94,19 +94,20 @@ object WorkflowBuilder {
     override def hashCode = List(src, inputs, dummyOp).hashCode
   }
   object ShapePreservingBuilder {
-    def apply(
-      src: WorkflowBuilder,
-      inputs: List[WorkflowBuilder],
-      op: PartialFunction[List[BsonField], WorkflowOp]) =
-      Fix[WorkflowBuilderF](new ShapePreservingBuilderF(src, inputs, op))
+    def apply[F[_]: Coalesce](
+      src: WorkflowBuilder[F],
+      inputs: List[WorkflowBuilder[F]],
+      op: PartialFunction[List[BsonField], WorkflowOp[F]])
+      (implicit ev: Workflow2_6F :<: F) =
+      Fix[WorkflowBuilderF[F, ?]](new ShapePreservingBuilderF(src, inputs, op))
   }
 
   /**
    * A query that produces a constant value.
    */
-  final case class ValueBuilderF(value: Bson) extends WorkflowBuilderF[Nothing]
+  final case class ValueBuilderF[F[_]](value: Bson) extends WorkflowBuilderF[F, Nothing]
   object ValueBuilder {
-    def apply(value: Bson) = Fix[WorkflowBuilderF](new ValueBuilderF(value))
+    def apply[F[_]](value: Bson) = Fix[WorkflowBuilderF[F, ?]](new ValueBuilderF(value))
   }
 
   /**
@@ -117,10 +118,10 @@ object WorkflowBuilder {
    * @param src The values on which to apply the Expression
    * @param expr The expression that procudes a new set of values given a set of values.
    */
-  final case class ExprBuilderF[A](src: A, expr: Expr) extends WorkflowBuilderF[A]
+  final case class ExprBuilderF[F[_], A](src: A, expr: Expr) extends WorkflowBuilderF[F, A]
   object ExprBuilder {
-    def apply(src: WorkflowBuilder, expr: Expr) =
-      Fix[WorkflowBuilderF](new ExprBuilderF(src, expr))
+    def apply[F[_]](src: WorkflowBuilder[F], expr: Expr) =
+      Fix[WorkflowBuilderF[F, ?]](new ExprBuilderF(src, expr))
   }
 
   /**
@@ -131,18 +132,18 @@ object WorkflowBuilder {
    * convert it to a GroupBuilder, and a nested Reshape can be realized with
    * a chain of DocBuilders, leaving the collapsing to Workflow.coalesce.
    */
-  final case class DocBuilderF[A](src: A, shape: ListMap[BsonField.Name, Expr])
-      extends WorkflowBuilderF[A]
+  final case class DocBuilderF[F[_], A](src: A, shape: ListMap[BsonField.Name, Expr])
+      extends WorkflowBuilderF[F, A]
   object DocBuilder {
-    def apply(src: WorkflowBuilder, shape: ListMap[BsonField.Name, Expr]) =
-      Fix[WorkflowBuilderF](new DocBuilderF(src, shape))
+    def apply[F[_]](src: WorkflowBuilder[F], shape: ListMap[BsonField.Name, Expr]) =
+      Fix[WorkflowBuilderF[F, ?]](new DocBuilderF(src, shape))
   }
 
-  final case class ArrayBuilderF[A](src: A, shape: List[Expr])
-      extends WorkflowBuilderF[A]
+  final case class ArrayBuilderF[F[_], A](src: A, shape: List[Expr])
+      extends WorkflowBuilderF[F, A]
   object ArrayBuilder {
-    def apply(src: WorkflowBuilder, shape: List[Expr]) =
-      Fix[WorkflowBuilderF](new ArrayBuilderF(src, shape))
+    def apply[F[_]](src: WorkflowBuilder[F], shape: List[Expr]) =
+      Fix[WorkflowBuilderF[F, ?]](new ArrayBuilderF(src, shape))
   }
 
   sealed trait Contents[+A]
@@ -167,7 +168,7 @@ object WorkflowBuilder {
   }
   import Contents._
 
-  def contentsToBuilder: Contents[Expr] => WorkflowBuilder => WorkflowBuilder = {
+  def contentsToBuilder[F[_]]: Contents[Expr] => WorkflowBuilder[F] => WorkflowBuilder[F] = {
     case Expr(expr) => ExprBuilder(_, expr)
     case Doc(doc)   => DocBuilder(_, doc)
     case Array(arr) => ArrayBuilder(_, arr)
@@ -176,15 +177,15 @@ object WorkflowBuilder {
   type GroupValue[A] = AccumOp[A] \/ A
   type GroupContents = DocContents[GroupValue[Expression]]
 
-  final case class GroupBuilderF[A](
+  final case class GroupBuilderF[F[_], A](
     src: A, keys: List[A], contents: GroupContents)
-      extends WorkflowBuilderF[A]
+      extends WorkflowBuilderF[F, A]
   object GroupBuilder {
-    def apply(
-      src: WorkflowBuilder,
-      keys: List[WorkflowBuilder],
+    def apply[F[_]](
+      src: WorkflowBuilder[F],
+      keys: List[WorkflowBuilder[F]],
       contents: GroupContents) =
-      Fix[WorkflowBuilderF](new GroupBuilderF(src, keys, contents))
+      Fix[WorkflowBuilderF[F, ?]](new GroupBuilderF(src, keys, contents))
   }
 
   sealed trait StructureType[A] {
@@ -205,11 +206,11 @@ object WorkflowBuilder {
       }
   }
 
-  final case class FlatteningBuilderF[A](src: A, fields: Set[StructureType[DocVar]])
-      extends WorkflowBuilderF[A]
+  final case class FlatteningBuilderF[F[_], A](src: A, fields: Set[StructureType[DocVar]])
+      extends WorkflowBuilderF[F, A]
   object FlatteningBuilder {
-    def apply(src: WorkflowBuilder, fields: Set[StructureType[DocVar]]) =
-      Fix[WorkflowBuilderF](new FlatteningBuilderF(src, fields))
+    def apply[F[_]](src: WorkflowBuilder[F], fields: Set[StructureType[DocVar]]) =
+      Fix[WorkflowBuilderF[F, ?]](new FlatteningBuilderF(src, fields))
   }
 
   /**
@@ -217,8 +218,8 @@ object WorkflowBuilder {
     entries are known. There should be at least one Expr in the list, otherwise
     it should be a DocBuilder.
     */
-  final case class SpliceBuilderF[A](src: A, structure: List[DocContents[Expr]])
-      extends WorkflowBuilderF[A] {
+  final case class SpliceBuilderF[F[_], A](src: A, structure: List[DocContents[Expr]])
+      extends WorkflowBuilderF[F, A] {
     def toJs: PlannerError \/ JsFn =
       structure.traverse {
         case Expr(unknown) => exprToJs(unknown)
@@ -229,12 +230,12 @@ object WorkflowBuilder {
         JsFn(jsBase, jscore.SpliceObjects(srcs.map(_(jscore.Ident(jsBase))))))
   }
   object SpliceBuilder {
-    def apply(src: WorkflowBuilder, structure: List[DocContents[Expr]]) =
-      Fix[WorkflowBuilderF](new SpliceBuilderF(src, structure))
+    def apply[F[_]](src: WorkflowBuilder[F], structure: List[DocContents[Expr]]) =
+      Fix[WorkflowBuilderF[F, ?]](new SpliceBuilderF(src, structure))
   }
 
-  final case class ArraySpliceBuilderF[A](src: A, structure: List[ArrayContents[Expr]])
-      extends WorkflowBuilderF[A] {
+  final case class ArraySpliceBuilderF[F[_], A](src: A, structure: List[ArrayContents[Expr]])
+      extends WorkflowBuilderF[F, A] {
     def toJs: PlannerError \/ JsFn =
       structure.traverse {
         case Expr(unknown) => exprToJs(unknown)
@@ -244,14 +245,14 @@ object WorkflowBuilder {
         JsFn(jsBase, jscore.SpliceArrays(srcs.map(_(jscore.Ident(jsBase))))))
   }
   object ArraySpliceBuilder {
-    def apply(src: WorkflowBuilder, structure: List[ArrayContents[Expr]]) =
-      Fix[WorkflowBuilderF](new ArraySpliceBuilderF(src, structure))
+    def apply[F[_]](src: WorkflowBuilder[F], structure: List[ArrayContents[Expr]]) =
+      Fix[WorkflowBuilderF[F, ?]](new ArraySpliceBuilderF(src, structure))
   }
 
   // NB: This instance can’t be derived, because of `dummyOp`.
-  implicit def WorkflowBuilderEqualF: EqualF[WorkflowBuilderF] =
-    new EqualF[WorkflowBuilderF] {
-      def equal[A: Equal](v1: WorkflowBuilderF[A], v2: WorkflowBuilderF[A]) = (v1, v2) match {
+  implicit def WorkflowBuilderEqualF[F[_]]: EqualF[WorkflowBuilderF[F, ?]] =
+    new EqualF[WorkflowBuilderF[F, ?]] {
+      def equal[A: Equal](v1: WorkflowBuilderF[F, A], v2: WorkflowBuilderF[F, A]) = (v1, v2) match {
         case (CollectionBuilderF(g1, b1, s1), CollectionBuilderF(g2, b2, s2)) =>
           g1 == g2 && b1 == b2 && s1 ≟ s2
         case (v1 @ ShapePreservingBuilderF(s1, i1, _), v2 @ ShapePreservingBuilderF(s2, i2, _)) =>
@@ -275,13 +276,15 @@ object WorkflowBuilder {
       }
     }
 
-  implicit val WorkflowBuilderTraverse: Traverse[WorkflowBuilderF] =
-    new Traverse[WorkflowBuilderF] {
+  implicit def WorkflowBuilderTraverse[F[_]: Coalesce]
+    (implicit ev: Workflow2_6F :<: F)
+    : Traverse[WorkflowBuilderF[F, ?]] =
+    new Traverse[WorkflowBuilderF[F, ?]] {
       def traverseImpl[G[_], A, B](
-        fa: WorkflowBuilderF[A])(
+        fa: WorkflowBuilderF[F, A])(
         f: A => G[B])(
         implicit G: Applicative[G]):
-          G[WorkflowBuilderF[B]] =
+          G[WorkflowBuilderF[F, B]] =
         fa match {
           case x @ CollectionBuilderF(_, _, _) => G.point(x)
           case ShapePreservingBuilderF(src, inputs, op) =>
@@ -301,7 +304,7 @@ object WorkflowBuilder {
         }
     }
 
-  val branchLengthƒ: WorkflowBuilderF[Int] => Int = {
+  def branchLengthƒ[F[_]]: WorkflowBuilderF[F, Int] => Int = {
     case CollectionBuilderF(_, _, _) => 0
     case ShapePreservingBuilderF(src, inputs, _) => 1 + src
     case ValueBuilderF(_) => 0
@@ -318,7 +321,9 @@ object WorkflowBuilder {
     * harder to pattern match. Should be applied before `objectConcat`,
     * `arrayConcat`, or `merge`.
     */
-  val normalizeƒ: WorkflowBuilderF[WorkflowBuilder] => Option[WorkflowBuilderF[WorkflowBuilder]] = {
+  def normalizeƒ[F[_]: Coalesce](implicit ev: Workflow2_6F :<: F)
+    : WorkflowBuilderF[F, Fix[WorkflowBuilderF[F, ?]]] => Option[WorkflowBuilderF[F, Fix[WorkflowBuilderF[F, ?]]]] = {
+
     def collapse(outer: Expr, inner: ListMap[BsonField.Name, Expr]): Option[Expr] = {
       def rewriteExpr(t: Expression)(applyExpr: PartialFunction[ExprOp[Expr], Option[Expr]]): Option[Expr] =
         t.cataM[Option, Expr] { x =>
@@ -399,23 +404,23 @@ object WorkflowBuilder {
       case ExprBuilderF(src, outerExpr) =>
         src.unFix match {
           case ExprBuilderF(wb0, -\/(js1)) =>
-            exprToJs(outerExpr).map(js => ExprBuilderF(wb0, -\/(js1 >>> js))).toOption
+            exprToJs(outerExpr).map(js => ExprBuilderF[F, WorkflowBuilder[F]](wb0, -\/(js1 >>> js))).toOption
           case ExprBuilderF(src0, contents) =>
             inln(outerExpr, Expr(contents)).map(expr => ExprBuilderF(src0, \/-(expr)))
           case DocBuilderF(src, innerShape) =>
             collapse(outerExpr, innerShape).map(ExprBuilderF(src, _))
           case ShapePreservingBuilderF(src0, inputs, op) =>
             ShapePreservingBuilderF(
-              Fix(normalize(ExprBuilderF(src0, outerExpr))),
+              Fix(normalize[F].apply(ExprBuilderF(src0, outerExpr))),
               inputs,
               op).some
           case GroupBuilderF(wb0, key, Expr(\/-($var(DocVar.ROOT(None))))) =>
             GroupBuilderF(
-              Fix(normalize(ExprBuilderF(wb0, outerExpr))),
+              Fix(normalize[F].apply(ExprBuilderF(wb0, outerExpr))),
               key,
               Expr(\/-($$ROOT))).some
           case GroupBuilderF(wb0, key, contents) =>
-            inln(outerExpr, contents).map(expr => GroupBuilderF(Fix(normalize(ExprBuilderF(wb0, \/-(expr)))), key, Expr(\/-($$ROOT))))
+            inln(outerExpr, contents).map(expr => GroupBuilderF(Fix(normalize[F].apply(ExprBuilderF(wb0, \/-(expr)))), key, Expr(\/-($$ROOT))))
           case _ => None
         }
       case DocBuilderF(Fix(DocBuilderF(src, innerShape)), outerShape) =>
@@ -423,12 +428,13 @@ object WorkflowBuilder {
       case DocBuilderF(Fix(ExprBuilderF(src, innerExpr)), outerShape) =>
         outerShape.traverse(inln(_, Expr(innerExpr))).map(exes => DocBuilderF(src, exes ∘ (_.right)))
       case DocBuilderF(Fix(ShapePreservingBuilderF(src, inputs, op)), shape) =>
-        ShapePreservingBuilderF(Fix(normalize(DocBuilderF(src, shape))), inputs, op).some
+        ShapePreservingBuilderF(Fix(normalize[F].apply(DocBuilderF(src, shape))), inputs, op).some
       case _ => None
     }
   }
 
-  val normalize = repeatedly(normalizeƒ)
+  def normalize[F[_]: Coalesce](implicit ev: Workflow2_6F :<: F) =
+    repeatedly(normalizeƒ[F])
 
   private def rewriteObjRefs(
     obj: ListMap[BsonField.Name, GroupValue[Expression]])(
@@ -476,19 +482,22 @@ object WorkflowBuilder {
 
   private val jsBase = jscore.Name("__val")
 
-  private def toCollectionBuilder(wb: WorkflowBuilder): M[CollectionBuilderF] =
+  private def toCollectionBuilder[F[_]: Coalesce]
+    (wb: WorkflowBuilder[F])
+    (implicit ev0: Workflow2_6F :<: F, ev1: Show[WorkflowBuilder[F]])
+    : M[CollectionBuilderF[F]] =
     wb.unFix match {
       case cb @ CollectionBuilderF(_, _, _) => emit(cb)
       case ValueBuilderF(value) =>
-        emit(CollectionBuilderF($pure(value), Root(), None))
+        emit(CollectionBuilderF($pure[F](value), Root(), None))
       case ShapePreservingBuilderF(src, inputs, op) =>
         // At least one argument has no deref (e.g. $$ROOT)
-        def case1(src: WorkflowBuilder, input: WorkflowBuilder, op: PartialFunction[List[BsonField], Workflow => Workflow], fields: List[Base]): M[CollectionBuilderF] = {
+        def case1(src: WorkflowBuilder[F], input: WorkflowBuilder[F], op: PartialFunction[List[BsonField], WorkflowOp[F]], fields: List[Base]): M[CollectionBuilderF[F]] = {
           emitSt(freshName).flatMap(name =>
             fields.traverse(f => (DocField(name) \\ f.toDocVar).deref).fold(
               scala.sys.error("prefixed ${name}, but still no field"))(
               op.lift(_).fold(
-                fail[CollectionBuilderF](UnsupportedFunction(set.Filter.name, Some("failed to build operation"))))(
+                fail[CollectionBuilderF[F]](UnsupportedFunction(set.Filter.name, Some("failed to build operation"))))(
                 op =>
                 (toCollectionBuilder(src) |@| toCollectionBuilder(DocBuilder(input, ListMap(name -> \/-($$ROOT))))) {
                   case (
@@ -502,18 +511,18 @@ object WorkflowBuilder {
         }
         // Every argument has a deref (so, a BsonField that can be given to the op)
         def case2(
-          src: WorkflowBuilder,
-          input: WorkflowBuilder,
+          src: WorkflowBuilder[F],
+          input: WorkflowBuilder[F],
           base: Base,
-          op: PartialFunction[List[BsonField], Workflow => Workflow],
+          op: PartialFunction[List[BsonField], WorkflowOp[F]],
           fields: List[BsonField]):
-            M[CollectionBuilderF] = {
+            M[CollectionBuilderF[F]] = {
           ((toCollectionBuilder(src) |@| toCollectionBuilder(input)) {
             case (
               CollectionBuilderF(_, _, srcStruct),
               CollectionBuilderF(graph, base0, bothStruct)) =>
-              op.lift(fields.map(f => base0.toDocVar.deref.map(_ \ f).getOrElse(f))).fold[M[CollectionBuilderF]](
-                fail[CollectionBuilderF](UnsupportedFunction(set.Filter.name, Some("failed to build operation"))))(
+              op.lift(fields.map(f => base0.toDocVar.deref.map(_ \ f).getOrElse(f))).fold[M[CollectionBuilderF[F]]](
+                fail[CollectionBuilderF[F]](UnsupportedFunction(set.Filter.name, Some("failed to build operation"))))(
                 { op =>
                   val g = chain(graph, op)
                   if (srcStruct ≟ bothStruct)
@@ -550,8 +559,8 @@ object WorkflowBuilder {
               CollectionBuilderF(
                 chain(graph,
                   rewriteExprPrefix(expr, base).fold(
-                    js => $simpleMap(NonEmptyList(MapExpr(JsFn(jsBase, jscore.Obj(ListMap(jscore.Name(name.asText) -> js(jscore.Ident(jsBase))))))), ListMap()),
-                    op => $project(Reshape(ListMap(name -> \/-(op)))))),
+                    js => $simpleMap[F](NonEmptyList(MapExpr(JsFn(jsBase, jscore.Obj(ListMap(jscore.Name(name.asText) -> js(jscore.Ident(jsBase))))))), ListMap()),
+                    op => $project[F](Reshape(ListMap(name -> \/-(op)))))),
                 Field(name),
                 None)
           })
@@ -559,18 +568,18 @@ object WorkflowBuilder {
         workflow(src).flatMap { case (wf, base) =>
           commonShape(rewriteDocPrefix(shape, base)).fold(
             fail(_),
-            s => shape.keys.toList.toNel.fold[M[CollectionBuilderF]](
+            s => shape.keys.toList.toNel.fold[M[CollectionBuilderF[F]]](
               fail(InternalError("A shape with no fields does not make sense")))(
               fields => emit(CollectionBuilderF(
                 chain(wf,
                   s.fold(
-                    jsExprs => $simpleMap(NonEmptyList(
+                    jsExprs => $simpleMap[F](NonEmptyList(
                       MapExpr(JsFn(jsBase,
                         jscore.Obj(jsExprs.map {
                           case (name, expr) => jscore.Name(name.asText) -> expr(jscore.Ident(jsBase))
                         })))),
                       ListMap()),
-                    exprOps => $project(Reshape(exprOps ∘ \/.right)))),
+                    exprOps => $project[F](Reshape(exprOps ∘ \/.right)))),
                 Root(),
                 fields.some))))
         }
@@ -579,7 +588,7 @@ object WorkflowBuilder {
           lift(shape.traverse(exprToJs).map(jsExprs =>
             CollectionBuilderF(
               chain(wf,
-                $simpleMap(NonEmptyList(
+                $simpleMap[F](NonEmptyList(
                   MapExpr(JsFn(jsBase,
                     jscore.Arr(jsExprs.map(_(base.toDocVar.toJs(jscore.Ident(jsBase))
                     )).toList)))),
@@ -621,7 +630,7 @@ object WorkflowBuilder {
                   case CollectionBuilderF(wf, base0, _) =>
                     CollectionBuilderF(
                       chain(wf,
-                        $group(Grouped(ListMap(rootName -> grouped)).rewriteRefs(prefixBase0(base0 \ base)),
+                        $group[F](Grouped(ListMap(rootName -> grouped)).rewriteRefs(prefixBase0(base0 \ base)),
                           key(base0))),
                       Field(rootName),
                       struct)
@@ -642,16 +651,16 @@ object WorkflowBuilder {
               if (grouped.isEmpty)
                 toCollectionBuilder(DocBuilder(src, ungrouped ∘ (_.right)))
               else
-                obj.keys.toList.toNel.fold[M[CollectionBuilderF]](
+                obj.keys.toList.toNel.fold[M[CollectionBuilderF[F]]](
                   fail(InternalError("A shape with no fields does not make sense")))(
                   fields => workflow(wb).flatMap { case (wf, base0) =>
                     emitSt(ungrouped.size match {
                       case 0 =>
-                        state[NameGen, Workflow](chain(wf,
-                          $group(Grouped(grouped).rewriteRefs(prefixBase0(base0 \ base)), key(base0))))
+                        state[NameGen, Fix[F]](chain(wf,
+                          $group[F](Grouped(grouped).rewriteRefs(prefixBase0(base0 \ base)), key(base0))))
                       case 1 =>
-                        state[NameGen, Workflow](chain(wf,
-                          $group(Grouped(
+                        state[NameGen, Fix[F]](chain(wf,
+                          $group[F](Grouped(
                             obj.transform {
                               case (_, -\/(v)) =>
                                 accumulator.rewriteGroupRefs(v)(prefixBase0(base0 \ base))
@@ -659,23 +668,23 @@ object WorkflowBuilder {
                                 $push(rewriteExprRefs(v)(prefixBase0(base0 \ base)))
                             }),
                             key(base0)),
-                          $unwind(DocField(ungrouped.head._1))))
+                          $unwind[F](DocField(ungrouped.head._1))))
                       case _ => for {
                         ungroupedName <- freshName
                         groupedName <- freshName
                       } yield
                         chain(wf,
-                          $project(Reshape(ListMap(
+                          $project[F](Reshape(ListMap(
                             ungroupedName -> -\/(Reshape(ungrouped.map {
                               case (k, v) => k -> \/-(rewriteExprRefs(v)(prefixBase0(base0 \ base)))
                             })),
                             groupedName -> \/-($$ROOT)))),
-                          $group(Grouped(
+                          $group[F](Grouped(
                             (grouped ∘ (accumulator.rewriteGroupRefs(_)(prefixBase0(Field(groupedName) \ base0)))) +
                               (ungroupedName -> $push($var(DocField(ungroupedName))))),
                             key(Field(groupedName) \ base0)),
-                          $unwind(DocField(ungroupedName)),
-                          $project(Reshape(obj.transform {
+                          $unwind[F](DocField(ungroupedName)),
+                          $project[F](Reshape(obj.transform {
                             case (k, -\/ (_)) => \/-($var(DocField(k)))
                             case (k,  \/-(_)) => \/-($var(DocField(ungroupedName \ k)))
                           })))
@@ -690,9 +699,9 @@ object WorkflowBuilder {
         toCollectionBuilder(src).map {
           case CollectionBuilderF(graph, base, struct) =>
             CollectionBuilderF(fields.foldRight(graph) {
-              case (StructureType.Array(field), acc) => $unwind(base.toDocVar \\ field)(acc)
+              case (StructureType.Array(field), acc) => $unwind[F](base.toDocVar \\ field).apply(acc)
               case (StructureType.Object(field), acc) =>
-                $simpleMap(NonEmptyList(FlatExpr(JsFn(jsBase, (base.toDocVar \\ field).toJs(jscore.Ident(jsBase))))), ListMap())(acc)
+                $simpleMap[F](NonEmptyList(FlatExpr(JsFn(jsBase, (base.toDocVar \\ field).toJs(jscore.Ident(jsBase))))), ListMap()).apply(acc)
             }, base, struct)
         }
       case sb @ SpliceBuilderF(_, _) =>
@@ -701,7 +710,7 @@ object WorkflowBuilder {
             sb.toJs.map { splice =>
               CollectionBuilderF(
                 chain(wf,
-                  $simpleMap(NonEmptyList(MapExpr(JsFn(jsBase, (base.toDocVar.toJs >>> splice)(jscore.Ident(jsBase))))), ListMap())),
+                  $simpleMap[F](NonEmptyList(MapExpr(JsFn(jsBase, (base.toDocVar.toJs >>> splice)(jscore.Ident(jsBase))))), ListMap())),
                 Root(),
                 None)
             })
@@ -712,27 +721,31 @@ object WorkflowBuilder {
             sb.toJs.map { splice =>
               CollectionBuilderF(
                 chain(wf,
-                  $simpleMap(NonEmptyList(MapExpr(JsFn(jsBase, (base.toDocVar.toJs >>> splice)(jscore.Ident(jsBase))))), ListMap())),
+                  $simpleMap[F](NonEmptyList(MapExpr(JsFn(jsBase, (base.toDocVar.toJs >>> splice)(jscore.Ident(jsBase))))), ListMap())),
                 Root(),
                 None)
             })
         }
     }
 
-  def workflow(wb: WorkflowBuilder): M[(Workflow, Base)] =
+  def workflow[F[_]: Coalesce](wb: WorkflowBuilder[F])
+    (implicit ev0: Workflow2_6F :<: F, ev1: Show[WorkflowBuilder[F]])
+    : M[(Fix[F], Base)] =
     toCollectionBuilder(wb).map(x => (x.src, x.base))
 
-  def shift(base: Base, struct: Schema, graph: Workflow): (Workflow, Base) = {
+  def shift[F[_]: Coalesce](base: Base, struct: Schema, graph: Fix[F])
+    (implicit ev: Workflow2_6F :<: F)
+    : (Fix[F], Base) = {
     (base, struct) match {
       case (Field(ExprName), None) => (graph, Field(ExprName))
       case (_,       None)         =>
         (chain(graph,
-          Workflow.$project(Reshape(ListMap(ExprName -> \/-($var(base.toDocVar)))),
+          Workflow.$project[F](Reshape(ListMap(ExprName -> \/-($var(base.toDocVar)))),
             ExcludeId)),
           Field(ExprName))
       case (_,       Some(fields)) =>
         (chain(graph,
-          Workflow.$project(
+          Workflow.$project[F](
             Reshape(fields.map(name =>
               name -> \/-($var((base \ name).toDocVar))).toList.toListMap),
             if (fields.element(IdName)) IncludeId else ExcludeId)),
@@ -740,26 +753,31 @@ object WorkflowBuilder {
     }
   }
 
-  def build(wb: WorkflowBuilder): M[Workflow] =
+  def build[F[_]: Coalesce](wb: WorkflowBuilder[F])
+    (implicit ev0: Workflow2_6F :<: F, ev1: Show[WorkflowBuilder[F]])
+    : M[Fix[F]] =
     toCollectionBuilder(wb).map {
       case CollectionBuilderF(graph, base, struct) =>
         if (base == Root()) graph
         else shift(base, struct, graph)._1
     }
 
-  private def $project(shape: Reshape): WorkflowOp =
-    Workflow.$project(
+  private def $project[F[_]: Coalesce](shape: Reshape)
+    (implicit ev: Workflow2_6F :<: F)
+    : WorkflowOp[F] =
+    Workflow.$project[F](
       shape,
       shape.get(IdName).fold[IdHandling](IgnoreId)(κ(IncludeId)))
 
-  def asLiteral(wb: WorkflowBuilder): Option[Bson] = wb.unFix match {
+  def asLiteral[F[_]](wb: WorkflowBuilder[F]): Option[Bson] = wb.unFix match {
     case ValueBuilderF(value)                  => Some(value)
     case ExprBuilderF(_, \/-($literal(value))) => Some(value)
     case _                                     => None
   }
 
-  private def fold1Builders(builders: List[WorkflowBuilder]):
-      Option[M[(WorkflowBuilder, List[Expression])]] =
+  private def fold1Builders[F[_]: Coalesce](builders: List[WorkflowBuilder[F]])
+    (implicit ev0: Workflow2_6F :<: F, ev1: Show[WorkflowBuilder[F]])
+    : Option[M[(WorkflowBuilder[F], List[Expression])]] =
     builders match {
       case Nil             => None
       case builder :: Nil  => Some(emit((builder, List($$ROOT))))
@@ -768,7 +786,7 @@ object WorkflowBuilder {
           (builder, $literal(bson) +: fields)
         })
       case builder :: rest =>
-        Some(rest.foldLeftM[M, (WorkflowBuilder, List[Expression])](
+        Some(rest.foldLeftM[M, (WorkflowBuilder[F], List[Expression])](
           (builder, List($$ROOT))) {
           case ((wf, fields), Fix(ValueBuilderF(bson))) =>
             emit((wf, fields :+ $literal(bson)))
@@ -779,67 +797,16 @@ object WorkflowBuilder {
         })
     }
 
-  private def foldBuilders(src: WorkflowBuilder, others: List[WorkflowBuilder]): M[(WorkflowBuilder, Base, List[Base])] =
-    others.foldLeftM[M, (WorkflowBuilder, Base, List[Base])](
+  private def foldBuilders[F[_]: Coalesce](src: WorkflowBuilder[F], others: List[WorkflowBuilder[F]])
+    (implicit ev0: Workflow2_6F :<: F, ev1: Show[WorkflowBuilder[F]])
+    : M[(WorkflowBuilder[F], Base, List[Base])] =
+    others.foldLeftM[M, (WorkflowBuilder[F], Base, List[Base])](
       (src, Root(), Nil)) {
       case ((wf, base, fields), x) =>
         merge(wf, x).map { case (lbase, rbase, src) =>
           (src, lbase \ base, fields.map(lbase \ _) :+ rbase)
         }
     }
-
-  def filter(src: WorkflowBuilder, those: List[WorkflowBuilder], sel: PartialFunction[List[BsonField], Selector]):
-      WorkflowBuilder =
-    ShapePreservingBuilder(src, those, PartialFunction(fields => $match(sel(fields))))
-
-  def expr1(wb: WorkflowBuilder)(f: Expression => Expression):
-      M[WorkflowBuilder] =
-    expr(List(wb)) { case List(e) => f(e) }
-
-  def expr2(
-    wb1: WorkflowBuilder, wb2: WorkflowBuilder)(
-    f: (Expression, Expression) => Expression):
-      M[WorkflowBuilder] =
-    expr(List(wb1, wb2)) { case List(e1, e2) => f(e1, e2) }
-
-  def expr(
-    wbs: List[WorkflowBuilder])(
-    f: List[Expression] => Expression):
-      M[WorkflowBuilder] = {
-    fold1Builders(wbs).fold[M[WorkflowBuilder]](
-      fail(InternalError("impossible – no arguments")))(
-      _.map { case (wb, exprs) => Fix(normalize(ExprBuilderF(wb, \/-(f(exprs))))) })
-  }
-
-  def jsExpr1(wb: WorkflowBuilder, js: JsFn): WorkflowBuilder =
-    ExprBuilder(wb, -\/(js))
-
-  def jsExpr(wbs: List[WorkflowBuilder], f: List[JsCore] => JsCore):
-      M[WorkflowBuilder] =
-    fold1Builders(wbs).fold[M[WorkflowBuilder]](
-      fail(InternalError("impossible – no arguments")))(
-      _.flatMap { case (wb, exprs) =>
-        lift(exprs.traverse(toJs).map(jses => Fix(normalize(ExprBuilderF(wb, -\/(JsFn(jsBase, f(jses.map(_(jscore.Ident(jsBase)))))))))))
-      })
-
-  def makeObject(wb: WorkflowBuilder, name: String): WorkflowBuilder =
-    wb.unFix match {
-      case ValueBuilderF(value) =>
-        ValueBuilder(Bson.Doc(ListMap(name -> value)))
-      case GroupBuilderF(src, key, Expr(cont)) =>
-        GroupBuilder(src, key, Doc(ListMap(BsonField.Name(name) -> cont)))
-      case ExprBuilderF(src, expr) =>
-        DocBuilder(src, ListMap(BsonField.Name(name) -> expr))
-      case ShapePreservingBuilderF(src, inputs, op) =>
-        ShapePreservingBuilder(makeObject(src, name), inputs, op)
-      case _ =>
-        DocBuilder(wb, ListMap(BsonField.Name(name) -> \/-($$ROOT)))
-    }
-
-  def makeArray(wb: WorkflowBuilder): WorkflowBuilder = wb.unFix match {
-    case ValueBuilderF(value) => ValueBuilder(Bson.Arr(List(value)))
-    case _ => ArrayBuilder(wb, List(\/-($$ROOT)))
-  }
 
   /** The location of the desired content relative to the current $$ROOT.
     *
@@ -929,494 +896,13 @@ object WorkflowBuilder {
     }
   }
 
-  // TODO: handle concating value, expr, or collection with group (#439)
-  def objectConcat(wb1: WorkflowBuilder, wb2: WorkflowBuilder):
-      M[WorkflowBuilder] = {
-    def impl(wb1: WorkflowBuilder, wb2: WorkflowBuilder, combine: Combine): M[WorkflowBuilder] = {
-      def delegate = impl(wb2, wb1, combine.flip)
-
-      def mergeGroups(s1: WorkflowBuilder, s2: WorkflowBuilder, c1: GroupContents, c2: GroupContents, keys: List[WorkflowBuilder]):
-          M[((Base, Base), WorkflowBuilder)] =
-        merge(s1, s2).flatMap { case (lbase, rbase, src) =>
-          combine(
-            rewriteGroupRefs(c1)(prefixBase0(lbase)),
-            rewriteGroupRefs(c2)(prefixBase0(rbase)))(mergeContents).map {
-            case ((lb, rb), contents) =>
-              combine(lb, rb)((_, _) -> GroupBuilder(src, keys, contents))
-          }
-        }
-
-      (wb1.unFix, wb2.unFix) match {
-        case (ShapePreservingBuilderF(s1, i1, o1), ShapePreservingBuilderF(s2, i2, o2))
-            if i1 == i2 && o1 == o2 =>
-          impl(s1, s2, combine).map(ShapePreservingBuilder(_, i1, o1))
-
-        case (
-          v1 @ ShapePreservingBuilderF(
-            Fix(DocBuilderF(_, shape1)), inputs1, _),
-          GroupBuilderF(
-            Fix(v2 @ ShapePreservingBuilderF(_, inputs2, _)),
-            Nil, _))
-          if inputs1 ≟ inputs2 && v1.dummyOp == v2.dummyOp =>
-          impl(GroupBuilder(wb1, Nil, Doc(shape1.keys.toList.map(n => n -> \/-($var(DocField(n)))).toListMap)), wb2, combine)
-        case (
-          GroupBuilderF(
-          Fix(v1 @ ShapePreservingBuilderF(_, inputs1, op1)),
-            Nil, _),
-          v2 @ ShapePreservingBuilderF(Fix(DocBuilderF(_, _)), inputs2, op2))
-          if inputs1 ≟ inputs2 && v1.dummyOp == v2.dummyOp => delegate
-
-        case (
-          v1 @ ShapePreservingBuilderF(
-            Fix(DocBuilderF(_, shape1)), inputs1, _),
-          DocBuilderF(
-            Fix(GroupBuilderF(
-              Fix(v2 @ ShapePreservingBuilderF(_, inputs2, _)),
-              Nil, _)),
-           shape2))
-          if inputs1 ≟ inputs2 && v1.dummyOp == v2.dummyOp =>
-          impl(GroupBuilder(wb1, Nil, Doc(shape1.keys.toList.map(n => n -> \/-($var(DocField(n)))).toListMap)), wb2, combine)
-        case (
-          DocBuilderF(
-            Fix(GroupBuilderF(
-              Fix(v1 @ ShapePreservingBuilderF(_, inputs1, _)),
-              Nil, _)),
-            shape2),
-          v2 @ ShapePreservingBuilderF(Fix(DocBuilderF(_, _)), inputs2, _))
-          if inputs1 ≟ inputs2 && v1.dummyOp == v2.dummyOp => delegate
-
-        case (ShapePreservingBuilderF(s, i, o), _) =>
-          impl(s, wb2, combine).map(ShapePreservingBuilder(_, i, o))
-        case (_, ShapePreservingBuilderF(_, _, _)) => delegate
-
-        case (ValueBuilderF(Bson.Doc(map1)), ValueBuilderF(Bson.Doc(map2))) =>
-          emit(ValueBuilder(Bson.Doc(combine(map1, map2)(_ ++ _))))
-
-        case (ValueBuilderF(Bson.Doc(map1)), DocBuilderF(s2, shape2)) =>
-          emit(DocBuilder(s2,
-            combine(
-              map1.map { case (k, v) => BsonField.Name(k) -> \/-($literal(v)) },
-              shape2)(_ ++ _)))
-        case (DocBuilderF(_, _), ValueBuilderF(Bson.Doc(_))) => delegate
-
-        case (ValueBuilderF(Bson.Doc(map1)), GroupBuilderF(s1, k1, Doc(c2))) =>
-          val content = combine(
-            map1.map { case (k, v) => BsonField.Name(k) -> -\/($first($literal(v))) },
-            c2)(_ ++ _)
-          emit(GroupBuilder(s1, k1, Doc(content)))
-        case (GroupBuilderF(_, _, Doc(_)), ValueBuilderF(_)) => delegate
-
-        case (
-          GroupBuilderF(src1, keys1, Expr(\/-($var(DocVar.ROOT(_))))),
-          GroupBuilderF(src2, keys2, Expr(\/-($var(DocVar.ROOT(_))))))
-            if keys1 ≟ keys2 =>
-          impl(src1, src2, combine).map(GroupBuilder(_, keys1, Expr(\/-($$ROOT))))
-
-        case (
-          GroupBuilderF(s1, keys1, c1 @ Doc(_)),
-          GroupBuilderF(s2, keys2,    c2 @ Doc(_)))
-            if keys1 ≟ keys2 =>
-          mergeGroups(s1, s2, c1, c2, keys1).map(_._2)
-
-        case (
-          GroupBuilderF(s1, keys1, c1 @ Doc(d1)),
-          DocBuilderF(Fix(GroupBuilderF(s2, keys2, c2)), shape2))
-            if keys1 ≟ keys2 =>
-          mergeGroups(s1, s2, c1, c2, keys1).map { case ((glbase, grbase), g) =>
-            DocBuilder(g, combine(
-              d1.transform { case (n, _) => \/-($var(DocField(n))) },
-              shape2 ∘ (rewriteExprPrefix(_, grbase)))(_ ++ _))
-          }
-        case (
-          DocBuilderF(Fix(GroupBuilderF(_, k1, _)), _),
-          GroupBuilderF(_, k2, Doc(_)))
-            if k1 ≟ k2 =>
-          delegate
-
-        case (
-          DocBuilderF(Fix(GroupBuilderF(s1, keys1, c1)), shape1),
-          DocBuilderF(Fix(GroupBuilderF(s2, keys2, c2)), shape2))
-            if keys1 ≟ keys2 =>
-          mergeGroups(s1, s2, c1, c2, keys1).flatMap {
-            case ((glbase, grbase), g) =>
-              emit(DocBuilder(g, combine(
-                shape1 ∘ (rewriteExprPrefix(_, glbase)),
-                shape2 ∘ (rewriteExprPrefix(_, grbase)))(_ ++ _)))
-          }
-
-        case (
-          DocBuilderF(_, shape),
-          GroupBuilderF(_, Nil, _)) =>
-          impl(
-            GroupBuilder(wb1, Nil, Doc(shape.map { case (n, _) => n -> \/-($var(DocField(n))) })),
-            wb2,
-            combine)
-        case (
-          GroupBuilderF(_, Nil, _),
-          DocBuilderF(_, _)) =>
-          delegate
-
-        case (
-          GroupBuilderF(_, _, Doc(cont1)),
-          GroupBuilderF(_, Nil, _)) =>
-          impl(
-            GroupBuilder(wb1, Nil, Doc(cont1.map { case (n, _) => n -> \/-($var(DocField(n))) })),
-            wb2,
-            combine)
-        case (
-          GroupBuilderF(_, Nil, _),
-          GroupBuilderF(_, _, _)) =>
-          delegate
-
-        case (
-          DocBuilderF(_, shape),
-          DocBuilderF(Fix(GroupBuilderF(_, Nil, _)), _)) =>
-          impl(
-            GroupBuilder(wb1, Nil, Doc(shape.map { case (n, _) => n -> \/-($var(DocField(n))) })),
-            wb2,
-            combine)
-        case (
-          DocBuilderF(Fix(GroupBuilderF(_, Nil, _)), _),
-          DocBuilderF(_, _)) =>
-          delegate
-
-        case (DocBuilderF(s1, shape1), DocBuilderF(s2, shape2)) =>
-          merge(s1, s2).map { case (lbase, rbase, src) =>
-            DocBuilder(src, combine(
-              rewriteDocPrefix(shape1, lbase),
-              rewriteDocPrefix(shape2, rbase))(_ ++ _))
-          }
-
-        case (DocBuilderF(src1, shape), ExprBuilderF(src2, expr)) =>
-          merge(src1, src2).map { case (left, right, list) =>
-            SpliceBuilder(list, combine(
-              Doc(rewriteDocPrefix(shape, left)),
-              Expr(rewriteExprPrefix(expr, right)))(List(_, _)))
-          }
-        case (ExprBuilderF(_, _), DocBuilderF(_, _)) => delegate
-
-        case (ExprBuilderF(src1, expr1), ExprBuilderF(src2, expr2)) =>
-          merge(src1, src2).map { case (left, right, list) =>
-            SpliceBuilder(list, combine(
-              Expr(rewriteExprPrefix(expr1, left)),
-              Expr(rewriteExprPrefix(expr2, right)))(List(_, _)))
-          }
-
-        case (SpliceBuilderF(src1, structure1), DocBuilderF(src2, shape2)) =>
-          merge(src1, src2).map { case (left, right, list) =>
-            SpliceBuilder(list, combine(
-              structure1,
-              List(Doc(rewriteDocPrefix(shape2, right))))(_ ++ _))
-          }
-        case (DocBuilderF(_, _), SpliceBuilderF(_, _)) => delegate
-
-        case (SpliceBuilderF(src1, structure1), ExprBuilderF(src2, expr2)) =>
-          merge(src1, src2).map { case (left, right, list) =>
-            SpliceBuilder(list, combine(
-              structure1,
-              List(Expr(rewriteExprPrefix(expr2, right))))(_ ++ _))
-          }
-        case (ExprBuilderF(_, _), SpliceBuilderF(_, _)) => delegate
-
-        case (SpliceBuilderF(src1, structure1), CollectionBuilderF(_, _, _)) =>
-          merge(src1, wb2).map { case (_, right, list) =>
-            SpliceBuilder(list, combine(
-              structure1,
-              List(Expr(\/-($var(right.toDocVar)))))(_ ++ _))
-          }
-        case (CollectionBuilderF(_, _, _), SpliceBuilderF(_, _)) => delegate
-
-        case (DocBuilderF(src, shape), CollectionBuilderF(_, _, _)) =>
-          merge(src, wb2).map { case (left, right, list) =>
-            SpliceBuilder(list, combine(
-              Doc(rewriteDocPrefix(shape, left)),
-              Expr(\/-($var(right.toDocVar))))(List(_, _)))
-          }
-        case (CollectionBuilderF(_, _, _), DocBuilderF(_, _)) => delegate
-
-        case (ValueBuilderF(Bson.Doc(map1)), CollectionBuilderF(_, base, _)) =>
-          emit(SpliceBuilder(wb2,
-            combine(
-              Doc(map1.map { case (k, v) => BsonField.Name(k) -> \/-($literal(v)) }),
-              Expr(\/-($$ROOT)))(List(_, _))))
-        case (CollectionBuilderF(_, _, _), ValueBuilderF(Bson.Doc(_))) =>
-          delegate
-
-        case (ValueBuilderF(Bson.Doc(map1)), SpliceBuilderF(src, structure)) =>
-          emit(SpliceBuilder(src,
-            combine(
-              List(Doc(map1.map { case (k, v) => BsonField.Name(k) -> \/-($literal(v)) })),
-              structure)(_ ++ _)))
-        case (SpliceBuilderF(_, _), ValueBuilderF(Bson.Doc(_))) =>
-          delegate
-
-        case (
-          DocBuilderF(s1 @ Fix(
-            ArraySpliceBuilderF(_, _)),
-            shape1),
-          GroupBuilderF(_, _, Doc(c2))) =>
-          merge(s1, wb2).map { case (lbase, rbase, src) =>
-            DocBuilder(src,
-              combine(
-                rewriteDocPrefix(shape1, lbase),
-                c2.map { case (n, _) => (n, rewriteExprPrefix(\/-($var(DocField(n))), rbase)) })(_ ++ _))
-          }
-        case (GroupBuilderF(_, _, _), DocBuilderF(Fix(ArraySpliceBuilderF(_, _)), _)) => delegate
-
-        case _ => fail(UnsupportedFunction(
-          structural.ObjectConcat.name,
-          Some("unrecognized shapes:\n" + wb1.show + "\n" + wb2.show)))
-      }
-    }
-
-    impl(wb1, wb2, unflipped)
-  }
-
-  def arrayConcat(left: WorkflowBuilder, right: WorkflowBuilder):
-      M[WorkflowBuilder] = {
-    def impl(wb1: WorkflowBuilder, wb2: WorkflowBuilder, combine: Combine):
-        M[WorkflowBuilder] = {
-      def delegate = impl(wb2, wb1, combine.flip)
-
-      (wb1.unFix, wb2.unFix) match {
-        case (ValueBuilderF(Bson.Arr(seq1)), ValueBuilderF(Bson.Arr(seq2))) =>
-          emit(ValueBuilder(Bson.Arr(seq1 ++ seq2)))
-
-        case (ValueBuilderF(Bson.Arr(seq)), ArrayBuilderF(src, shape)) =>
-          emit(ArrayBuilder(src,
-            combine(seq.map(x => \/-($literal(x))), shape)(_ ++ _)))
-        case (ArrayBuilderF(_, _), ValueBuilderF(Bson.Arr(_))) => delegate
-
-        case (
-          ArrayBuilderF(Fix(
-            v1 @ ShapePreservingBuilderF(src1, inputs1, op1)), shape1),
-          v2 @ ShapePreservingBuilderF(src2, inputs2, op2))
-          if inputs1 ≟ inputs2 && v1.dummyOp == v2.dummyOp =>
-          merge(src1, src2).map { case (lbase, rbase, wb) =>
-            ShapePreservingBuilder(
-              ArraySpliceBuilder(wb, combine(
-                Array(shape1.map(rewriteExprPrefix(_, lbase))),
-                Expr(\/-($var(rbase.toDocVar))))(List(_, _))),
-              inputs1, op1)
-          }
-        case (ShapePreservingBuilderF(_, in1, op1), ArrayBuilderF(Fix(ShapePreservingBuilderF(_, in2, op2)), _)) => delegate
-
-        case (
-          v1 @ ShapePreservingBuilderF(src1, inputs1, op1),
-          ArrayBuilderF(Fix(
-            GroupBuilderF(Fix(
-              v2 @ ShapePreservingBuilderF(src2, inputs2, _)),
-              Nil, cont2)),
-            shape2))
-            if inputs1 ≟ inputs2 && v1.dummyOp == v2.dummyOp =>
-          merge(src1, src2).flatMap { case (lbase, rbase, wb) =>
-            combine(Expr(\/-($var(lbase.toDocVar))), rewriteGroupRefs(cont2)(prefixBase0(rbase)))(mergeContents).map { case ((lbase1, rbase1), cont) =>
-              ShapePreservingBuilder(
-                ArraySpliceBuilder(
-                  GroupBuilder(wb, Nil, cont),
-                  combine(
-                    Expr(\/-($var(lbase1.toDocVar))),
-                    Array(shape2.map(rewriteExprPrefix(_, rbase1))))(List(_, _))),
-                inputs1, op1)
-            }
-          }
-        case (
-          ArrayBuilderF(Fix(
-            GroupBuilderF(Fix(
-              v1 @ ShapePreservingBuilderF(_, inputs1, _)),
-              Nil, _)), _),
-          v2 @ ShapePreservingBuilderF(_, inputs2, _))
-            if inputs1 ≟ inputs2 && v1.dummyOp == v2.dummyOp => delegate
-
-        case (ShapePreservingBuilderF(s, i, o), _) =>
-          impl(s, wb2, combine).map(ShapePreservingBuilder(_, i, o))
-        case (_, ShapePreservingBuilderF(_, _, _)) => delegate
-
-        case (ArrayBuilderF(src1, shape1), ArrayBuilderF(src2, shape2)) =>
-          merge(src1, src2).map { case (lbase, rbase, wb) =>
-            ArrayBuilder(wb,
-              shape1.map(rewriteExprPrefix(_, lbase)) ++
-                shape2.map(rewriteExprPrefix(_, rbase)))
-          }
-        case (ArrayBuilderF(src1, shape1), ExprBuilderF(src2, expr2)) =>
-          merge(src1, src2).map { case (left, right, list) =>
-            ArraySpliceBuilder(list, combine(
-              Array(shape1.map(rewriteExprPrefix(_, left))),
-              Expr(rewriteExprPrefix(expr2, right)))(List(_, _)))
-          }
-        case (ExprBuilderF(_, _), ArrayBuilderF(_, _)) => delegate
-
-        case (ArrayBuilderF(src1, shape1), GroupBuilderF(_, _, _)) =>
-          merge(src1, wb2).map { case (left, right, wb) =>
-            ArraySpliceBuilder(wb, combine(
-              Array(shape1.map(rewriteExprPrefix(_, left))),
-              Expr(\/-($var(right.toDocVar))))(List(_, _)))
-          }
-        case (GroupBuilderF(_, _, _), ArrayBuilderF(_, _)) => delegate
-
-        case (ValueBuilderF(Bson.Arr(seq1)), ExprBuilderF(src2, expr2)) =>
-          emit(ArraySpliceBuilder(src2, combine(
-            Array(seq1.map(x => \/-($literal(x)))),
-            Expr(expr2))(List(_, _))))
-        case (ExprBuilderF(_, _), ValueBuilderF(Bson.Arr(_))) => delegate
-
-        case (ArraySpliceBuilderF(src1, structure1), ArrayBuilderF(src2, shape2)) =>
-          merge(src1, src2).map { case (left, right, list) =>
-            ArraySpliceBuilder(list, combine(
-              structure1,
-              List(Array(shape2.map(rewriteExprPrefix(_, right)))))(_ ++ _))
-          }
-        case (ArrayBuilderF(_, _), ArraySpliceBuilderF(_, _)) => delegate
-
-        case (ArraySpliceBuilderF(src1, structure1), ExprBuilderF(src2, expr2)) =>
-          merge(src1, src2).map { case (_, right, list) =>
-            ArraySpliceBuilder(list, combine(
-              structure1,
-              List(Expr(rewriteExprPrefix(expr2, right))))(_ ++ _))
-          }
-        case (ExprBuilderF(_, _), ArraySpliceBuilderF(_, _)) => delegate
-
-        case (ArraySpliceBuilderF(src1, structure1), ValueBuilderF(bson2)) =>
-          emit(ArraySpliceBuilder(src1, combine(structure1, List(Expr(\/-($literal(bson2)))))(_ ++ _)))
-        case (ValueBuilderF(_), ArraySpliceBuilderF(_, _)) => delegate
-
-        case _ =>
-          fail(UnsupportedFunction(
-            structural.ArrayConcat.name,
-            Some("values are not both arrays")))
-      }
-    }
-
-    impl(left, right, unflipped)
-  }
-
-  def flattenMap(wb: WorkflowBuilder): WorkflowBuilder = wb.unFix match {
-    case ShapePreservingBuilderF(src, inputs, op) =>
-      ShapePreservingBuilder(flattenMap(src), inputs, op)
-    case GroupBuilderF(src, keys, Expr(\/-($var(DocVar.ROOT(None))))) =>
-      GroupBuilder(flattenMap(src), keys, Expr(\/-($$ROOT)))
-    case _ => FlatteningBuilder(wb, Set(StructureType.Object(DocVar.ROOT())))
-  }
-
-  def flattenArray(wb: WorkflowBuilder): WorkflowBuilder = wb.unFix match {
-    case ShapePreservingBuilderF(src, inputs, op) =>
-      ShapePreservingBuilder(flattenArray(src), inputs, op)
-    case GroupBuilderF(src, keys, Expr(\/-($var(DocVar.ROOT(None))))) =>
-      GroupBuilder(flattenArray(src), keys, Expr(\/-($$ROOT)))
-    case _ => FlatteningBuilder(wb, Set(StructureType.Array(DocVar.ROOT())))
-  }
-
-  def projectField(wb: WorkflowBuilder, name: String):
-      PlannerError \/ WorkflowBuilder =
-    wb.unFix match {
-      case ShapePreservingBuilderF(src, inputs, op) =>
-        projectField(src, name).map(ShapePreservingBuilder(_, inputs, op))
-      case ValueBuilderF(Bson.Doc(fields)) =>
-        fields.get(name).fold[PlannerError \/ WorkflowBuilder](
-          -\/(UnsupportedFunction(structural.ObjectProject.name, Some("value does not contain a field ‘" + name + "’."))))(
-          x => \/-(ValueBuilder(x)))
-      case ValueBuilderF(_) =>
-        -\/(UnsupportedFunction(structural.ObjectProject.name, Some("value is not a document.")))
-      case GroupBuilderF(wb0, key, Expr(\/-($var(dv)))) =>
-        projectField(wb0, name).map(GroupBuilder(_, key, Expr(\/-($var(dv)))))
-      case GroupBuilderF(wb0, key, Doc(doc)) =>
-        doc.get(BsonField.Name(name)).fold[PlannerError \/ WorkflowBuilder](
-          -\/(UnsupportedFunction(structural.ObjectProject.name, Some("group does not contain a field ‘" + name + "’."))))(
-          x => \/-(GroupBuilder(wb0, key, Expr(x))))
-      case DocBuilderF(wb, doc) =>
-        doc.get(BsonField.Name(name)).fold[PlannerError \/ WorkflowBuilder](
-          -\/(UnsupportedFunction(structural.ObjectProject.name, Some("document does not contain a field ‘" + name + "’."))))(
-          expr => \/-(ExprBuilder(wb, expr)))
-      case ExprBuilderF(wb0,  -\/(js1)) =>
-        \/-(ExprBuilder(wb0,
-          -\/(JsFn(jsBase, DocField(BsonField.Name(name)).toJs(js1(jscore.Ident(jsBase)))))))
-      case ExprBuilderF(wb, \/-($var(DocField(field)))) =>
-        \/-(ExprBuilder(wb, \/-($var(DocField(field \ BsonField.Name(name))))))
-      case _ => \/-(ExprBuilder(wb, \/-($var(DocField(BsonField.Name(name))))))
-    }
-
-  def projectIndex(wb: WorkflowBuilder, index: Int): PlannerError \/ WorkflowBuilder =
-    wb.unFix match {
-      case ValueBuilderF(Bson.Arr(elems)) =>
-        if (index < elems.length) // UGH!
-          \/-(ValueBuilder(elems(index)))
-        else
-          -\/(UnsupportedFunction(
-            structural.ArrayProject.name,
-            Some("value does not contain index ‘" + index + "’.")))
-      case ArrayBuilderF(wb0, elems) =>
-        if (index < elems.length) // UGH!
-          \/-(ExprBuilder(wb0, elems(index)))
-        else
-          -\/(UnsupportedFunction(
-            structural.ArrayProject.name,
-            Some("array does not contain index ‘" + index + "’.")))
-      case ValueBuilderF(_) =>
-        -\/(UnsupportedFunction(
-          structural.ArrayProject.name,
-          Some("value is not an array.")))
-      case DocBuilderF(_, _) =>
-        -\/(UnsupportedFunction(
-          structural.ArrayProject.name,
-          Some("value is not an array.")))
-      case _ =>
-        jsExpr1(wb, JsFn(jsBase,
-          jscore.Access(jscore.Ident(jsBase), jscore.Literal(Js.num(index.toLong))))).right
-    }
-
-  def deleteField(wb: WorkflowBuilder, name: String):
-      PlannerError \/ WorkflowBuilder =
-    wb.unFix match {
-      case ShapePreservingBuilderF(src, inputs, op) =>
-        deleteField(src, name).map(ShapePreservingBuilder(_, inputs, op))
-      case ValueBuilderF(Bson.Doc(fields)) =>
-        \/-(ValueBuilder(Bson.Doc(fields - name)))
-      case ValueBuilderF(_) =>
-        -\/(UnsupportedFunction(
-          structural.DeleteField.name,
-          Some("value is not a document.")))
-      case GroupBuilderF(wb0, key, Expr(\/-($var(DocVar.ROOT(None))))) =>
-        deleteField(wb0, name).map(GroupBuilder(_, key, Expr(\/-($$ROOT))))
-      case GroupBuilderF(wb0, key, Doc(doc)) =>
-        \/-(GroupBuilder(wb0, key, Doc(doc - BsonField.Name(name))))
-      case DocBuilderF(wb0, doc) =>
-        \/-(DocBuilder(wb0, doc - BsonField.Name(name)))
-      case _ => jsExpr1(wb, JsFn(jsBase,
-        // FIXME: Need to pull this back up from the top level (SD-665)
-        jscore.Call(jscore.ident("remove"),
-          List(jscore.Ident(jsBase), jscore.Literal(Js.Str(name)))))).right
-    }
-
-  def groupBy(src: WorkflowBuilder, keys: List[WorkflowBuilder]):
-      WorkflowBuilder =
-    GroupBuilder(src, keys, Expr(\/-($$ROOT)))
-
-  def reduce(wb: WorkflowBuilder)(f: Expression => Accumulator): WorkflowBuilder =
-    wb.unFix match {
-      case GroupBuilderF(wb0, keys, Expr(\/-(expr))) =>
-        GroupBuilder(wb0, keys, Expr(-\/(f(expr))))
-      case ShapePreservingBuilderF(src @ Fix(GroupBuilderF(_, _, Expr(\/-(_)))), inputs, op) =>
-        ShapePreservingBuilder(reduce(src)(f), inputs, op)
-      case _ =>
-        GroupBuilder(wb, Nil, Expr(-\/(f($$ROOT))))
-    }
-
-  def sortBy(
-    src: WorkflowBuilder, keys: List[WorkflowBuilder], sortTypes: List[SortDir]):
-      WorkflowBuilder =
-    ShapePreservingBuilder(
-      src,
-      keys,
-      // TODO[ASP]: This pattern match is non total!
-      // possible solution: make sortTypes and the argument to this partial function NonEmpty
-      _.zip(sortTypes) match {
-        case x :: xs => $sort(NonEmptyList.nel(x, IList.fromList(xs)))
-      })
 
   // TODO: This is an approximation. If we could postpone this decision until
   //      `Workflow.crush`, when we actually have a task (whether aggregation or
   //       mapReduce) in hand, we would know for sure.
-  def preferMapReduce(wb: WorkflowBuilder): Boolean = {
+  def preferMapReduce[F[_]: Coalesce: Crush: Crystallize: Functor](wb: WorkflowBuilder[F])
+    (implicit ev0: Workflow2_6F :<: F, ev1: Show[WorkflowBuilder[F]])
+    : Boolean = {
     // TODO: Get rid of this when we functorize WorkflowTask
     def checkTask(wt: workflowtask.WorkflowTask): Boolean = wt match {
       case workflowtask.FoldLeftTask(_, _)     => true
@@ -1425,18 +911,22 @@ object WorkflowBuilder {
       case _                                   => false
     }
 
-    workflow(wb).evalZero.fold(
+    workflow[F](wb).evalZero.fold(
       κ(false),
-      wf => checkTask(task(crystallize(wf._1))))
+      wf => checkTask(task(Crystallize[F].crystallize(wf._1))))
   }
 
-  def join(left0: WorkflowBuilder, right0: WorkflowBuilder,
+  def join[F[_]: Functor: Coalesce: Crush: Crystallize](left0: WorkflowBuilder[F], right0: WorkflowBuilder[F],
     tpe: GenericFunc[_],
-    leftKey0: List[WorkflowBuilder], leftJs0: Option[List[JsFn]],
-    rightKey0: List[WorkflowBuilder], rightJs0: Option[List[JsFn]]):
-      M[WorkflowBuilder] = {
+    leftKey0: List[WorkflowBuilder[F]], leftJs0: Option[List[JsFn]],
+    rightKey0: List[WorkflowBuilder[F]], rightJs0: Option[List[JsFn]])
+    (implicit ev0: Workflow2_6F :<: F, ev1: Show[WorkflowBuilder[F]])
+    : M[WorkflowBuilder[F]] = {
 
     import Js._
+
+    val ops = Ops[F]
+    import ops._
 
     // FIXME: these have to match the names used in the logical plan. Should
     //        change this to ensure left0/right0 are `Free` and pull the names
@@ -1445,7 +935,7 @@ object WorkflowBuilder {
     val rightField0: BsonField.Name = BsonField.Name("right")
 
     def keyMap(keyExpr: List[JsFn], rootField: BsonField.Name, otherField: BsonField.Name): AnonFunDecl =
-      $Map.mapKeyVal(("key", "value"),
+      $MapF.mapKeyVal(("key", "value"),
         keyExpr match {
           case Nil => Js.Null
           case _   =>
@@ -1457,14 +947,14 @@ object WorkflowBuilder {
           (otherField.asText, AnonElem(Nil)),
           (rootField.asText, AnonElem(List(Ident("value")))))))
 
-    def jsReduce(src: WorkflowBuilder, key: List[JsFn],
+    def jsReduce(src: WorkflowBuilder[F], key: List[JsFn],
                  rootField: BsonField.Name, otherField: BsonField.Name):
-        (WorkflowBuilder, WorkflowOp) =
-      (src, $map(keyMap(key, rootField, otherField), ListMap()))
+        (WorkflowBuilder[F], WorkflowOp[F]) =
+      (src, $map[F](keyMap(key, rootField, otherField), ListMap()))
 
-    def wbReduce(src: WorkflowBuilder, key: List[WorkflowBuilder],
+    def wbReduce(src: WorkflowBuilder[F], key: List[WorkflowBuilder[F]],
                  rootField: BsonField.Name, otherField: BsonField.Name):
-        (WorkflowBuilder, WorkflowOp) =
+        (WorkflowBuilder[F], WorkflowOp[F]) =
       (DocBuilder(
         reduce(groupBy(src, key))($push(_)),
         ListMap(
@@ -1501,29 +991,29 @@ object WorkflowBuilder {
         $literal(Bson.Arr(List(Bson.Doc(ListMap())))),
         $var(DocField(side)))
 
-    def buildProjection(l: Expression, r: Expression): WorkflowOp =
-      $project(Reshape(ListMap(leftField -> \/-(l), rightField -> \/-(r))))(_)
+    def buildProjection(l: Expression, r: Expression): WorkflowOp[F] =
+      $project[F](Reshape(ListMap(leftField -> \/-(l), rightField -> \/-(r)))).apply(_)
 
     // TODO exhaustive pattern match
-    def buildJoin(src: Workflow, tpe: GenericFunc[_]): Workflow =
+    def buildJoin(src: Fix[F], tpe: GenericFunc[_]): Fix[F] =
       tpe match {
         case set.FullOuterJoin =>
           chain(src,
             buildProjection(padEmpty(leftField), padEmpty(rightField)))
         case set.LeftOuterJoin =>
           chain(src,
-            $match(Selector.Doc(ListMap(
+            $match[F](Selector.Doc(ListMap(
               leftField.asInstanceOf[BsonField] -> nonEmpty))),
             buildProjection($var(DocField(leftField)), padEmpty(rightField)))
         case set.RightOuterJoin =>
           chain(src,
-            $match(Selector.Doc(ListMap(
+            $match[F](Selector.Doc(ListMap(
               rightField.asInstanceOf[BsonField] -> nonEmpty))),
             buildProjection(padEmpty(leftField), $var(DocField(rightField))))
         case set.InnerJoin =>
           chain(
             src,
-            $match(
+            $match[F](
               Selector.Doc(ListMap(
                 leftField.asInstanceOf[BsonField] -> nonEmpty,
                 rightField -> nonEmpty))))
@@ -1555,28 +1045,20 @@ object WorkflowBuilder {
     (workflow(left._1) |@| workflow(right._1)) { case ((l, _), (r, _)) =>
       CollectionBuilder(
         chain(
-          $foldLeft(
+          $foldLeft[F](
             left._2(l),
-            chain(r, right._2, $reduce(rightReduce, ListMap()))),
-          buildJoin(_, tpe),
-          $unwind(DocField(leftField)),
-          $unwind(DocField(rightField))),
+            chain(r, right._2, $reduce[F](rightReduce, ListMap()))),
+          (op: Fix[F]) => buildJoin(op, tpe),
+          $unwind[F](DocField(leftField)),
+          $unwind[F](DocField(rightField))),
         Root(),
         None)
     }
   }
 
-  def limit(wb: WorkflowBuilder, count: Long) =
-    ShapePreservingBuilder(wb, Nil, { case Nil => $limit(count) })
-
-  def skip(wb: WorkflowBuilder, count: Long) =
-    ShapePreservingBuilder(wb, Nil, { case Nil => $skip(count) })
-
-  def squash(wb: WorkflowBuilder): WorkflowBuilder = wb
-
   // TODO: Cases that match on `$$ROOT` should be generalized to look up the
   //       shape of any DocVar in the source.
-  @tailrec def findKeys(wb: WorkflowBuilder): Option[Base] = {
+  @tailrec def findKeys[F[_]](wb: WorkflowBuilder[F]): Option[Base] = {
     wb.unFix match {
       case CollectionBuilderF(_, _, s2) => s2.map(s => Subset(s.toSet))
       case DocBuilderF(_, shape) => Subset(shape.keySet).some
@@ -1592,20 +1074,23 @@ object WorkflowBuilder {
     }
   }
 
-  private def findSort(src: WorkflowBuilder)(distincting: WorkflowBuilder => M[WorkflowBuilder]):
-      M[WorkflowBuilder] = {
+  private def findSort[F[_]: Coalesce]
+    (src: WorkflowBuilder[F])
+    (distincting: WorkflowBuilder[F] => M[WorkflowBuilder[F]])
+    (implicit ev0: Workflow2_6F :<: F, ev1: Show[WorkflowBuilder[F]])
+    : M[WorkflowBuilder[F]] = {
     @tailrec
-    def loop(wb: WorkflowBuilder): M[WorkflowBuilder] =
+    def loop(wb: WorkflowBuilder[F]): M[WorkflowBuilder[F]] =
       wb.unFix match {
         case spb @ ShapePreservingBuilderF(spbSrc, sortKeys, f) =>
           spb.dummyOp.unFix match {
-            case $Sort(_, _) =>
+            case $sort(_, _) =>
               foldBuilders(src, sortKeys).flatMap {
                 case (newSrc, dv, ks) =>
-                  distincting(Fix(normalize(ExprBuilderF(newSrc, \/-($var(dv.toDocVar)))))).map { dist =>
+                  distincting(Fix(normalize[F].apply(ExprBuilderF(newSrc, \/-($var(dv.toDocVar)))))).map { dist =>
                     val spb = ShapePreservingBuilder(
-                      Fix(normalize(ExprBuilderF(dist, \/-($var(dv.toDocVar))))),
-                      ks.map(k => Fix(normalize(ExprBuilderF(dist, \/-($var(k.toDocVar)))))), f)
+                      Fix(normalize[F].apply(ExprBuilderF(dist, \/-($var(dv.toDocVar))))),
+                      ks.map(k => Fix(normalize[F].apply(ExprBuilderF(dist, \/-($var(k.toDocVar)))))), f)
                     dv match {
                       case Subset(ks) => DocBuilder(spb, ks.toList.map(k => k -> \/-($var(DocField(k)))).toListMap)
                       case _ => spb
@@ -1619,32 +1104,9 @@ object WorkflowBuilder {
     loop(src)
   }
 
-  def distinct(src: WorkflowBuilder): M[WorkflowBuilder] =
-    findKeys(src).fold(
-      lift(deleteField(src, "_id")).flatMap(del => distinctBy(del, List(del))))(
-      ks => ks match {
-        case Root() => distinctBy(src, List(src))
-        case Field(k) =>
-          distinctBy(src, List(Fix(normalize(ExprBuilderF(src, \/-($var(DocField(k))))))))
-        case Subset(ks) =>
-          val keys = ks.toList.map(k => Fix(normalize(ExprBuilderF(src, \/-($var(DocField(k)))))))
-          findSort(src) { newSrc =>
-            findKeys(newSrc)
-              .cata(
-                {
-                  case Subset(fields) => fields.toList.map(k => k -> $first($var(DocField(k))).left[Expression]).right
-                  case b => InternalError(s"Expected a Subset but found $b").left
-                },
-                List().right)
-              .fold(fail, i => GroupBuilder(newSrc, keys, Doc(i.toListMap)).point[M])
-          }
-      })
-
-  def distinctBy(src: WorkflowBuilder, keys: List[WorkflowBuilder]): M[WorkflowBuilder] =
-    findSort(src)(s => reduce(groupBy(s, keys))($first(_)).point[M])
-
-  private def merge(left: WorkflowBuilder, right: WorkflowBuilder):
-      M[(Base, Base, WorkflowBuilder)] = {
+  private def merge[F[_]: Coalesce](left: Fix[WorkflowBuilderF[F, ?]], right: Fix[WorkflowBuilderF[F, ?]])
+    (implicit I: Workflow2_6F :<: F, ev: Show[Fix[WorkflowBuilderF[F, ?]]])
+    : M[(Base, Base, Fix[WorkflowBuilderF[F, ?]])] = {
     def delegate =
       merge(right, left).map { case (r, l, merged) => (l, r, merged) }
 
@@ -1770,7 +1232,7 @@ object WorkflowBuilder {
       case (
         FlatteningBuilderF(src0, fields0),
         FlatteningBuilderF(src1, fields1)) =>
-        left.cata(branchLengthƒ) cmp right.cata(branchLengthƒ) match {
+        left.cata(branchLengthƒ[F]) cmp right.cata(branchLengthƒ[F]) match {
           case Ordering.LT =>
             merge(left, src1).map { case (lbase, rbase, wb) =>
               (lbase, rbase, FlatteningBuilder(wb, fields1.map(_.map(rbase.toDocVar \\ _))))
@@ -1816,17 +1278,19 @@ object WorkflowBuilder {
       case (ArrayBuilderF(src, shape), _) =>
         merge(src, right).flatMap { case (lbase, rbase, wb) =>
           workflow(ArrayBuilder(wb, shape.map(rewriteExprPrefix(_, lbase)))).flatMap { case (wf, base) =>
-            wf.unFix match {
-              case $Project(src, Reshape(shape), idx) =>
-                emitSt(freshName.map(rName =>
-                  (lbase, Field(rName),
-                    CollectionBuilder(
-                      chain(src,
-                        $project(Reshape(shape + (rName -> \/-($var(rbase.toDocVar)))))),
-                      Root(),
-                      None))))
-              case _ => fail(InternalError("couldn’t merge array"))
-            }
+            I.prj(wf.unFix).cata(
+              {
+                case $ProjectF(psrc, Reshape(shape), idx) =>
+                  emitSt(freshName.map(rName =>
+                    (lbase, Field(rName),
+                      CollectionBuilder(
+                        chain(psrc,
+                          $project[F](Reshape(shape + (rName -> \/-($var(rbase.toDocVar)))))),
+                        Root(),
+                        None))))
+                case _ => fail(InternalError("couldn’t merge array"))
+              },
+              fail(InternalError("couldn’t merge unrecognized op: " + wf)))
           }
         }
       case (_, ArrayBuilderF(_, _)) => delegate
@@ -1836,14 +1300,612 @@ object WorkflowBuilder {
     }
   }
 
-  def read(coll: Collection) = CollectionBuilder($read(coll), Root(), None)
-  def pure(bson: Bson) = ValueBuilder(bson)
+  final class Ops[F[_]: Coalesce](implicit ev: Workflow2_6F :<: F) {
+    def read(coll: Collection): WorkflowBuilder[F] =
+      CollectionBuilder($read[F](coll), Root(), None)
 
-  implicit def WorkflowBuilderRenderTree(implicit RG: RenderTree[Contents[GroupValue[Expression]]], RC: RenderTree[Contents[Expr]]): RenderTree[WorkflowBuilder] =
-    new RenderTree[WorkflowBuilder] {
+    def pure(bson: Bson): WorkflowBuilder[F] = ValueBuilder(bson)
+
+    def limit(wb: WorkflowBuilder[F], count: Long): WorkflowBuilder[F] =
+      ShapePreservingBuilder(wb, Nil, { case Nil => $limit[F](count) })
+
+    def skip(wb: WorkflowBuilder[F], count: Long): WorkflowBuilder[F] =
+      ShapePreservingBuilder(wb, Nil, { case Nil => $skip[F](count) })
+
+    def squash[F[_]](wb: WorkflowBuilder[F]): WorkflowBuilder[F] = wb
+
+    def filter
+      (src: WorkflowBuilder[F],
+        those: List[WorkflowBuilder[F]],
+        sel: PartialFunction[List[BsonField], Selector])
+      : WorkflowBuilder[F] =
+      ShapePreservingBuilder(src, those, PartialFunction(fields => $match[F](sel(fields))))
+
+    def expr1
+      (wb: WorkflowBuilder[F])
+      (f: Expression => Expression)
+      (implicit ev0: Workflow2_6F :<: F, ev1: Show[WorkflowBuilder[F]])
+      : M[WorkflowBuilder[F]] =
+      expr(List(wb)) { case List(e) => f(e) }
+
+    def expr2
+      (wb1: WorkflowBuilder[F], wb2: WorkflowBuilder[F])
+      (f: (Expression, Expression) => Expression)
+      (implicit ev0: Workflow2_6F :<: F, ev1: Show[WorkflowBuilder[F]])
+      : M[WorkflowBuilder[F]] =
+      expr(List(wb1, wb2)) { case List(e1, e2) => f(e1, e2) }
+
+    def expr
+      (wbs: List[WorkflowBuilder[F]])
+      (f: List[Expression] => Expression)
+      (implicit ev0: Show[WorkflowBuilder[F]])
+      : M[WorkflowBuilder[F]] = {
+      fold1Builders(wbs).fold[M[WorkflowBuilder[F]]](
+        fail(InternalError("impossible – no arguments")))(
+        _.map { case (wb, exprs) => Fix(normalize[F].apply(ExprBuilderF(wb, \/-(f(exprs))))) })
+    }
+
+    // FIXME: no constraints
+    def jsExpr1(wb: WorkflowBuilder[F], js: JsFn): WorkflowBuilder[F] =
+      ExprBuilder(wb, -\/(js))
+
+    def jsExpr(wbs: List[WorkflowBuilder[F]], f: List[JsCore] => JsCore)
+      (implicit ev0: Show[WorkflowBuilder[F]])
+      : M[WorkflowBuilder[F]] =
+      fold1Builders(wbs).fold[M[WorkflowBuilder[F]]](
+        fail(InternalError("impossible – no arguments")))(
+        _.flatMap { case (wb, exprs) =>
+          lift(exprs.traverse(toJs).map(jses => Fix(normalize[F].apply(ExprBuilderF(wb, -\/(JsFn(jsBase, f(jses.map(_(jscore.Ident(jsBase)))))))))))
+        })
+
+    def makeObject(wb: WorkflowBuilder[F], name: String): WorkflowBuilder[F] =
+      wb.unFix match {
+        case ValueBuilderF(value) =>
+          ValueBuilder(Bson.Doc(ListMap(name -> value)))
+        case GroupBuilderF(src, key, Expr(cont)) =>
+          GroupBuilder(src, key, Doc(ListMap(BsonField.Name(name) -> cont)))
+        case ExprBuilderF(src, expr) =>
+          DocBuilder(src, ListMap(BsonField.Name(name) -> expr))
+        case ShapePreservingBuilderF(src, inputs, op) =>
+          ShapePreservingBuilder(makeObject(src, name), inputs, op)
+        case _ =>
+          DocBuilder(wb, ListMap(BsonField.Name(name) -> \/-($$ROOT)))
+      }
+
+    def makeArray(wb: WorkflowBuilder[F]): WorkflowBuilder[F] = wb.unFix match {
+      case ValueBuilderF(value) => ValueBuilder(Bson.Arr(List(value)))
+      case _ => ArrayBuilder(wb, List(\/-($$ROOT)))
+    }
+
+    def flattenMap(wb: WorkflowBuilder[F]): WorkflowBuilder[F] =
+      wb.unFix match {
+        case ShapePreservingBuilderF(src, inputs, op) =>
+          ShapePreservingBuilder(flattenMap(src), inputs, op)
+        case GroupBuilderF(src, keys, Expr(\/-($var(DocVar.ROOT(None))))) =>
+          GroupBuilder(flattenMap(src), keys, Expr(\/-($$ROOT)))
+        case _ => FlatteningBuilder(wb, Set(StructureType.Object(DocVar.ROOT())))
+      }
+
+    def flattenArray(wb: WorkflowBuilder[F]): WorkflowBuilder[F] =
+      wb.unFix match {
+        case ShapePreservingBuilderF(src, inputs, op) =>
+          ShapePreservingBuilder(flattenArray(src), inputs, op)
+        case GroupBuilderF(src, keys, Expr(\/-($var(DocVar.ROOT(None))))) =>
+          GroupBuilder(flattenArray(src), keys, Expr(\/-($$ROOT)))
+        case _ => FlatteningBuilder(wb, Set(StructureType.Array(DocVar.ROOT())))
+      }
+
+    def projectField(wb: WorkflowBuilder[F], name: String): PlannerError \/ WorkflowBuilder[F] =
+      wb.unFix match {
+        case ShapePreservingBuilderF(src, inputs, op) =>
+          projectField(src, name).map(ShapePreservingBuilder(_, inputs, op))
+        case ValueBuilderF(Bson.Doc(fields)) =>
+          fields.get(name).fold[PlannerError \/ WorkflowBuilder[F]](
+            -\/(UnsupportedFunction(structural.ObjectProject.name, Some("value does not contain a field ‘" + name + "’."))))(
+            x => \/-(ValueBuilder(x)))
+        case ValueBuilderF(_) =>
+          -\/(UnsupportedFunction(structural.ObjectProject.name, Some("value is not a document.")))
+        case GroupBuilderF(wb0, key, Expr(\/-($var(dv)))) =>
+          projectField(wb0, name).map(GroupBuilder(_, key, Expr(\/-($var(dv)))))
+        case GroupBuilderF(wb0, key, Doc(doc)) =>
+          doc.get(BsonField.Name(name)).fold[PlannerError \/ WorkflowBuilder[F]](
+            -\/(UnsupportedFunction(structural.ObjectProject.name, Some("group does not contain a field ‘" + name + "’."))))(
+            x => \/-(GroupBuilder(wb0, key, Expr(x))))
+        case DocBuilderF(wb, doc) =>
+          doc.get(BsonField.Name(name)).fold[PlannerError \/ WorkflowBuilder[F]](
+            -\/(UnsupportedFunction(structural.ObjectProject.name, Some("document does not contain a field ‘" + name + "’."))))(
+            expr => \/-(ExprBuilder(wb, expr)))
+        case ExprBuilderF(wb0,  -\/(js1)) =>
+          \/-(ExprBuilder(wb0,
+            -\/(JsFn(jsBase, DocField(BsonField.Name(name)).toJs(js1(jscore.Ident(jsBase)))))))
+        case ExprBuilderF(wb, \/-($var(DocField(field)))) =>
+          \/-(ExprBuilder(wb, \/-($var(DocField(field \ BsonField.Name(name))))))
+        case _ => \/-(ExprBuilder(wb, \/-($var(DocField(BsonField.Name(name))))))
+      }
+
+    def projectIndex(wb: WorkflowBuilder[F], index: Int): PlannerError \/ WorkflowBuilder[F] =
+      wb.unFix match {
+        case ValueBuilderF(Bson.Arr(elems)) =>
+          if (index < elems.length) // UGH!
+            \/-(ValueBuilder(elems(index)))
+          else
+            -\/(UnsupportedFunction(
+              structural.ArrayProject.name,
+              Some("value does not contain index ‘" + index + "’.")))
+        case ArrayBuilderF(wb0, elems) =>
+          if (index < elems.length) // UGH!
+            \/-(ExprBuilder(wb0, elems(index)))
+          else
+            -\/(UnsupportedFunction(
+              structural.ArrayProject.name,
+              Some("array does not contain index ‘" + index + "’.")))
+        case ValueBuilderF(_) =>
+          -\/(UnsupportedFunction(
+            structural.ArrayProject.name,
+            Some("value is not an array.")))
+        case DocBuilderF(_, _) =>
+          -\/(UnsupportedFunction(
+            structural.ArrayProject.name,
+            Some("value is not an array.")))
+        case _ =>
+          jsExpr1(wb, JsFn(jsBase,
+            jscore.Access(jscore.Ident(jsBase), jscore.Literal(Js.num(index.toLong))))).right
+      }
+
+    def deleteField(wb: WorkflowBuilder[F], name: String): PlannerError \/ WorkflowBuilder[F] =
+      wb.unFix match {
+        case ShapePreservingBuilderF(src, inputs, op) =>
+          deleteField(src, name).map(ShapePreservingBuilder(_, inputs, op))
+        case ValueBuilderF(Bson.Doc(fields)) =>
+          \/-(ValueBuilder(Bson.Doc(fields - name)))
+        case ValueBuilderF(_) =>
+          -\/(UnsupportedFunction(
+            structural.DeleteField.name,
+            Some("value is not a document.")))
+        case GroupBuilderF(wb0, key, Expr(\/-($var(DocVar.ROOT(None))))) =>
+          deleteField(wb0, name).map(GroupBuilder(_, key, Expr(\/-($$ROOT))))
+        case GroupBuilderF(wb0, key, Doc(doc)) =>
+          \/-(GroupBuilder(wb0, key, Doc(doc - BsonField.Name(name))))
+        case DocBuilderF(wb0, doc) =>
+          \/-(DocBuilder(wb0, doc - BsonField.Name(name)))
+        case _ => jsExpr1(wb, JsFn(jsBase,
+          // FIXME: Need to pull this back up from the top level (SD-665)
+          jscore.Call(jscore.ident("remove"),
+            List(jscore.Ident(jsBase), jscore.Literal(Js.Str(name)))))).right
+      }
+
+    def groupBy(src: WorkflowBuilder[F], keys: List[WorkflowBuilder[F]])
+      : WorkflowBuilder[F] =
+      GroupBuilder(src, keys, Expr(\/-($$ROOT)))
+
+    def reduce(wb: WorkflowBuilder[F])(f: Expression => Accumulator): WorkflowBuilder[F] =
+      wb.unFix match {
+        case GroupBuilderF(wb0, keys, Expr(\/-(expr))) =>
+          GroupBuilder(wb0, keys, Expr(-\/(f(expr))))
+        case ShapePreservingBuilderF(src @ Fix(GroupBuilderF(_, _, Expr(\/-(_)))), inputs, op) =>
+          ShapePreservingBuilder(reduce(src)(f), inputs, op)
+        case _ =>
+          GroupBuilder(wb, Nil, Expr(-\/(f($$ROOT))))
+      }
+
+    def sortBy
+      (src: WorkflowBuilder[F], keys: List[WorkflowBuilder[F]], sortTypes: List[SortDir])
+      : WorkflowBuilder[F] =
+      ShapePreservingBuilder(
+        src,
+        keys,
+        // TODO[ASP]: This pattern match is non total!
+        // possible solution: make sortTypes and the argument to this partial function NonEmpty
+        _.zip(sortTypes) match {
+          case x :: xs => $sort[F](NonEmptyList.nel(x, IList.fromList(xs)))
+        })
+
+    def distinct(src: WorkflowBuilder[F])
+      (implicit ev0: Show[WorkflowBuilder[F]])
+      : M[WorkflowBuilder[F]] =
+      findKeys(src).fold(
+        lift(deleteField(src, "_id")).flatMap(del => distinctBy(del, List(del))))(
+        ks => ks match {
+          case Root() => distinctBy(src, List(src))
+          case Field(k) =>
+            distinctBy(src, List(Fix(normalize[F].apply(ExprBuilderF(src, \/-($var(DocField(k))))))))
+          case Subset(ks) =>
+            val keys = ks.toList.map(k => Fix(normalize[F].apply(ExprBuilderF(src, \/-($var(DocField(k)))))))
+            findSort(src) { newSrc =>
+              findKeys(newSrc)
+                .cata(
+                  {
+                    case Subset(fields) => fields.toList.map(k => k -> $first($var(DocField(k))).left[Expression]).right
+                    case b => InternalError(s"Expected a Subset but found $b").left
+                  },
+                  List().right)
+                .fold(fail, i => GroupBuilder(newSrc, keys, Doc(i.toListMap)).point[M])
+            }
+        })
+
+    def distinctBy(src: WorkflowBuilder[F], keys: List[WorkflowBuilder[F]])
+      (implicit ev0: Show[WorkflowBuilder[F]])
+      : M[WorkflowBuilder[F]] =
+      findSort(src)(s => reduce(groupBy(s, keys))($first(_)).point[M])
+
+    // TODO: handle concating value, expr, or collection with group (#439)
+    def objectConcat(wb1: WorkflowBuilder[F], wb2: WorkflowBuilder[F])
+      (implicit ev0: Show[WorkflowBuilder[F]])
+      : M[WorkflowBuilder[F]] = {
+      def impl(wb1: WorkflowBuilder[F], wb2: WorkflowBuilder[F], combine: Combine): M[WorkflowBuilder[F]] = {
+        def delegate = impl(wb2, wb1, combine.flip)
+
+        def mergeGroups(s1: WorkflowBuilder[F], s2: WorkflowBuilder[F], c1: GroupContents, c2: GroupContents, keys: List[WorkflowBuilder[F]]):
+            M[((Base, Base), WorkflowBuilder[F])] =
+          merge(s1, s2).flatMap { case (lbase, rbase, src) =>
+            combine(
+              rewriteGroupRefs(c1)(prefixBase0(lbase)),
+              rewriteGroupRefs(c2)(prefixBase0(rbase)))(mergeContents(_, _)).map {
+              case ((lb, rb), contents) =>
+                combine(lb, rb)((_, _) -> GroupBuilder(src, keys, contents))
+            }
+          }
+
+        (wb1.unFix, wb2.unFix) match {
+          case (ShapePreservingBuilderF(s1, i1, o1), ShapePreservingBuilderF(s2, i2, o2))
+              if i1 == i2 && o1 == o2 =>
+            impl(s1, s2, combine).map(ShapePreservingBuilder(_, i1, o1))
+
+          case (
+            v1 @ ShapePreservingBuilderF(
+              Fix(DocBuilderF(_, shape1)), inputs1, _),
+            GroupBuilderF(
+              Fix(v2 @ ShapePreservingBuilderF(_, inputs2, _)),
+              Nil, _))
+            if inputs1 ≟ inputs2 && v1.dummyOp == v2.dummyOp =>
+            impl(GroupBuilder(wb1, Nil, Doc(shape1.keys.toList.map(n => n -> \/-($var(DocField(n)))).toListMap)), wb2, combine)
+          case (
+            GroupBuilderF(
+            Fix(v1 @ ShapePreservingBuilderF(_, inputs1, op1)),
+              Nil, _),
+            v2 @ ShapePreservingBuilderF(Fix(DocBuilderF(_, _)), inputs2, op2))
+            if inputs1 ≟ inputs2 && v1.dummyOp == v2.dummyOp => delegate
+
+          case (
+            v1 @ ShapePreservingBuilderF(
+              Fix(DocBuilderF(_, shape1)), inputs1, _),
+            DocBuilderF(
+              Fix(GroupBuilderF(
+                Fix(v2 @ ShapePreservingBuilderF(_, inputs2, _)),
+                Nil, _)),
+             shape2))
+            if inputs1 ≟ inputs2 && v1.dummyOp == v2.dummyOp =>
+            impl(GroupBuilder(wb1, Nil, Doc(shape1.keys.toList.map(n => n -> \/-($var(DocField(n)))).toListMap)), wb2, combine)
+          case (
+            DocBuilderF(
+              Fix(GroupBuilderF(
+                Fix(v1 @ ShapePreservingBuilderF(_, inputs1, _)),
+                Nil, _)),
+              shape2),
+            v2 @ ShapePreservingBuilderF(Fix(DocBuilderF(_, _)), inputs2, _))
+            if inputs1 ≟ inputs2 && v1.dummyOp == v2.dummyOp => delegate
+
+          case (ShapePreservingBuilderF(s, i, o), _) =>
+            impl(s, wb2, combine).map(ShapePreservingBuilder(_, i, o))
+          case (_, ShapePreservingBuilderF(_, _, _)) => delegate
+
+          case (ValueBuilderF(Bson.Doc(map1)), ValueBuilderF(Bson.Doc(map2))) =>
+            emit(ValueBuilder(Bson.Doc(combine(map1, map2)(_ ++ _))))
+
+          case (ValueBuilderF(Bson.Doc(map1)), DocBuilderF(s2, shape2)) =>
+            emit(DocBuilder(s2,
+              combine(
+                map1.map { case (k, v) => BsonField.Name(k) -> \/-($literal(v)) },
+                shape2)(_ ++ _)))
+          case (DocBuilderF(_, _), ValueBuilderF(Bson.Doc(_))) => delegate
+
+          case (ValueBuilderF(Bson.Doc(map1)), GroupBuilderF(s1, k1, Doc(c2))) =>
+            val content = combine(
+              map1.map { case (k, v) => BsonField.Name(k) -> -\/($first($literal(v))) },
+              c2)(_ ++ _)
+            emit(GroupBuilder(s1, k1, Doc(content)))
+          case (GroupBuilderF(_, _, Doc(_)), ValueBuilderF(_)) => delegate
+
+          case (
+            GroupBuilderF(src1, keys1, Expr(\/-($var(DocVar.ROOT(_))))),
+            GroupBuilderF(src2, keys2, Expr(\/-($var(DocVar.ROOT(_))))))
+              if keys1 ≟ keys2 =>
+            impl(src1, src2, combine).map(GroupBuilder(_, keys1, Expr(\/-($$ROOT))))
+
+          case (
+            GroupBuilderF(s1, keys1, c1 @ Doc(_)),
+            GroupBuilderF(s2, keys2,    c2 @ Doc(_)))
+              if keys1 ≟ keys2 =>
+            mergeGroups(s1, s2, c1, c2, keys1).map(_._2)
+
+          case (
+            GroupBuilderF(s1, keys1, c1 @ Doc(d1)),
+            DocBuilderF(Fix(GroupBuilderF(s2, keys2, c2)), shape2))
+              if keys1 ≟ keys2 =>
+            mergeGroups(s1, s2, c1, c2, keys1).map { case ((glbase, grbase), g) =>
+              DocBuilder(g, combine(
+                d1.transform { case (n, _) => \/-($var(DocField(n))) },
+                shape2 ∘ (rewriteExprPrefix(_, grbase)))(_ ++ _))
+            }
+          case (
+            DocBuilderF(Fix(GroupBuilderF(_, k1, _)), _),
+            GroupBuilderF(_, k2, Doc(_)))
+              if k1 ≟ k2 =>
+            delegate
+
+          case (
+            DocBuilderF(Fix(GroupBuilderF(s1, keys1, c1)), shape1),
+            DocBuilderF(Fix(GroupBuilderF(s2, keys2, c2)), shape2))
+              if keys1 ≟ keys2 =>
+            mergeGroups(s1, s2, c1, c2, keys1).flatMap {
+              case ((glbase, grbase), g) =>
+                emit(DocBuilder(g, combine(
+                  shape1 ∘ (rewriteExprPrefix(_, glbase)),
+                  shape2 ∘ (rewriteExprPrefix(_, grbase)))(_ ++ _)))
+            }
+
+          case (
+            DocBuilderF(_, shape),
+            GroupBuilderF(_, Nil, _)) =>
+            impl(
+              GroupBuilder(wb1, Nil, Doc(shape.map { case (n, _) => n -> \/-($var(DocField(n))) })),
+              wb2,
+              combine)
+          case (
+            GroupBuilderF(_, Nil, _),
+            DocBuilderF(_, _)) =>
+            delegate
+
+          case (
+            GroupBuilderF(_, _, Doc(cont1)),
+            GroupBuilderF(_, Nil, _)) =>
+            impl(
+              GroupBuilder(wb1, Nil, Doc(cont1.map { case (n, _) => n -> \/-($var(DocField(n))) })),
+              wb2,
+              combine)
+          case (
+            GroupBuilderF(_, Nil, _),
+            GroupBuilderF(_, _, _)) =>
+            delegate
+
+          case (
+            DocBuilderF(_, shape),
+            DocBuilderF(Fix(GroupBuilderF(_, Nil, _)), _)) =>
+            impl(
+              GroupBuilder(wb1, Nil, Doc(shape.map { case (n, _) => n -> \/-($var(DocField(n))) })),
+              wb2,
+              combine)
+          case (
+            DocBuilderF(Fix(GroupBuilderF(_, Nil, _)), _),
+            DocBuilderF(_, _)) =>
+            delegate
+
+          case (DocBuilderF(s1, shape1), DocBuilderF(s2, shape2)) =>
+            merge(s1, s2).map { case (lbase, rbase, src) =>
+              DocBuilder(src, combine(
+                rewriteDocPrefix(shape1, lbase),
+                rewriteDocPrefix(shape2, rbase))(_ ++ _))
+            }
+
+          case (DocBuilderF(src1, shape), ExprBuilderF(src2, expr)) =>
+            merge(src1, src2).map { case (left, right, list) =>
+              SpliceBuilder(list, combine(
+                Doc(rewriteDocPrefix(shape, left)),
+                Expr(rewriteExprPrefix(expr, right)))(List(_, _)))
+            }
+          case (ExprBuilderF(_, _), DocBuilderF(_, _)) => delegate
+
+          case (ExprBuilderF(src1, expr1), ExprBuilderF(src2, expr2)) =>
+            merge(src1, src2).map { case (left, right, list) =>
+              SpliceBuilder(list, combine(
+                Expr(rewriteExprPrefix(expr1, left)),
+                Expr(rewriteExprPrefix(expr2, right)))(List(_, _)))
+            }
+
+          case (SpliceBuilderF(src1, structure1), DocBuilderF(src2, shape2)) =>
+            merge(src1, src2).map { case (left, right, list) =>
+              SpliceBuilder(list, combine(
+                structure1,
+                List(Doc(rewriteDocPrefix(shape2, right))))(_ ++ _))
+            }
+          case (DocBuilderF(_, _), SpliceBuilderF(_, _)) => delegate
+
+          case (SpliceBuilderF(src1, structure1), ExprBuilderF(src2, expr2)) =>
+            merge(src1, src2).map { case (left, right, list) =>
+              SpliceBuilder(list, combine(
+                structure1,
+                List(Expr(rewriteExprPrefix(expr2, right))))(_ ++ _))
+            }
+          case (ExprBuilderF(_, _), SpliceBuilderF(_, _)) => delegate
+
+          case (SpliceBuilderF(src1, structure1), CollectionBuilderF(_, _, _)) =>
+            merge(src1, wb2).map { case (_, right, list) =>
+              SpliceBuilder(list, combine(
+                structure1,
+                List(Expr(\/-($var(right.toDocVar)))))(_ ++ _))
+            }
+          case (CollectionBuilderF(_, _, _), SpliceBuilderF(_, _)) => delegate
+
+          case (DocBuilderF(src, shape), CollectionBuilderF(_, _, _)) =>
+            merge(src, wb2).map { case (left, right, list) =>
+              SpliceBuilder(list, combine(
+                Doc(rewriteDocPrefix(shape, left)),
+                Expr(\/-($var(right.toDocVar))))(List(_, _)))
+            }
+          case (CollectionBuilderF(_, _, _), DocBuilderF(_, _)) => delegate
+
+          case (ValueBuilderF(Bson.Doc(map1)), CollectionBuilderF(_, base, _)) =>
+            emit(SpliceBuilder(wb2,
+              combine(
+                Doc(map1.map { case (k, v) => BsonField.Name(k) -> \/-($literal(v)) }),
+                Expr(\/-($$ROOT)))(List(_, _))))
+          case (CollectionBuilderF(_, _, _), ValueBuilderF(Bson.Doc(_))) =>
+            delegate
+
+          case (ValueBuilderF(Bson.Doc(map1)), SpliceBuilderF(src, structure)) =>
+            emit(SpliceBuilder(src,
+              combine(
+                List(Doc(map1.map { case (k, v) => BsonField.Name(k) -> \/-($literal(v)) })),
+                structure)(_ ++ _)))
+          case (SpliceBuilderF(_, _), ValueBuilderF(Bson.Doc(_))) =>
+            delegate
+
+          case (
+            DocBuilderF(s1 @ Fix(
+              ArraySpliceBuilderF(_, _)),
+              shape1),
+            GroupBuilderF(_, _, Doc(c2))) =>
+            merge(s1, wb2).map { case (lbase, rbase, src) =>
+              DocBuilder(src,
+                combine(
+                  rewriteDocPrefix(shape1, lbase),
+                  c2.map { case (n, _) => (n, rewriteExprPrefix(\/-($var(DocField(n))), rbase)) })(_ ++ _))
+            }
+          case (GroupBuilderF(_, _, _), DocBuilderF(Fix(ArraySpliceBuilderF(_, _)), _)) => delegate
+
+          case _ => fail(UnsupportedFunction(
+            structural.ObjectConcat.name,
+            Some("unrecognized shapes:\n" + wb1.show + "\n" + wb2.show)))
+        }
+      }
+
+      impl(wb1, wb2, unflipped)
+    }
+
+    def arrayConcat(left: WorkflowBuilder[F], right: WorkflowBuilder[F])
+      (implicit ev0: Show[WorkflowBuilder[F]])
+      : M[WorkflowBuilder[F]] = {
+      def impl(wb1: WorkflowBuilder[F], wb2: WorkflowBuilder[F], combine: Combine):
+          M[WorkflowBuilder[F]] = {
+        def delegate = impl(wb2, wb1, combine.flip)
+
+        (wb1.unFix, wb2.unFix) match {
+          case (ValueBuilderF(Bson.Arr(seq1)), ValueBuilderF(Bson.Arr(seq2))) =>
+            emit(ValueBuilder(Bson.Arr(seq1 ++ seq2)))
+
+          case (ValueBuilderF(Bson.Arr(seq)), ArrayBuilderF(src, shape)) =>
+            emit(ArrayBuilder(src,
+              combine(seq.map(x => \/-($literal(x))), shape)(_ ++ _)))
+          case (ArrayBuilderF(_, _), ValueBuilderF(Bson.Arr(_))) => delegate
+
+          case (
+            ArrayBuilderF(Fix(
+              v1 @ ShapePreservingBuilderF(src1, inputs1, op1)), shape1),
+            v2 @ ShapePreservingBuilderF(src2, inputs2, op2))
+            if inputs1 ≟ inputs2 && v1.dummyOp == v2.dummyOp =>
+            merge(src1, src2).map { case (lbase, rbase, wb) =>
+              ShapePreservingBuilder(
+                ArraySpliceBuilder(wb, combine(
+                  Array(shape1.map(rewriteExprPrefix(_, lbase))),
+                  Expr(\/-($var(rbase.toDocVar))))(List(_, _))),
+                inputs1, op1)
+            }
+          case (ShapePreservingBuilderF(_, in1, op1), ArrayBuilderF(Fix(ShapePreservingBuilderF(_, in2, op2)), _)) => delegate
+
+          case (
+            v1 @ ShapePreservingBuilderF(src1, inputs1, op1),
+            ArrayBuilderF(Fix(
+              GroupBuilderF(Fix(
+                v2 @ ShapePreservingBuilderF(src2, inputs2, _)),
+                Nil, cont2)),
+              shape2))
+              if inputs1 ≟ inputs2 && v1.dummyOp == v2.dummyOp =>
+            merge(src1, src2).flatMap { case (lbase, rbase, wb) =>
+              combine(Expr(\/-($var(lbase.toDocVar))), rewriteGroupRefs(cont2)(prefixBase0(rbase)))(mergeContents(_, _)).map { case ((lbase1, rbase1), cont) =>
+                ShapePreservingBuilder(
+                  ArraySpliceBuilder(
+                    GroupBuilder(wb, Nil, cont),
+                    combine(
+                      Expr(\/-($var(lbase1.toDocVar))),
+                      Array(shape2.map(rewriteExprPrefix(_, rbase1))))(List(_, _))),
+                  inputs1, op1)
+              }
+            }
+          case (
+            ArrayBuilderF(Fix(
+              GroupBuilderF(Fix(
+                v1 @ ShapePreservingBuilderF(_, inputs1, _)),
+                Nil, _)), _),
+            v2 @ ShapePreservingBuilderF(_, inputs2, _))
+              if inputs1 ≟ inputs2 && v1.dummyOp == v2.dummyOp => delegate
+
+          case (ShapePreservingBuilderF(s, i, o), _) =>
+            impl(s, wb2, combine).map(ShapePreservingBuilder(_, i, o))
+          case (_, ShapePreservingBuilderF(_, _, _)) => delegate
+
+          case (ArrayBuilderF(src1, shape1), ArrayBuilderF(src2, shape2)) =>
+            merge(src1, src2).map { case (lbase, rbase, wb) =>
+              ArrayBuilder(wb,
+                shape1.map(rewriteExprPrefix(_, lbase)) ++
+                  shape2.map(rewriteExprPrefix(_, rbase)))
+            }
+          case (ArrayBuilderF(src1, shape1), ExprBuilderF(src2, expr2)) =>
+            merge(src1, src2).map { case (left, right, list) =>
+              ArraySpliceBuilder(list, combine(
+                Array(shape1.map(rewriteExprPrefix(_, left))),
+                Expr(rewriteExprPrefix(expr2, right)))(List(_, _)))
+            }
+          case (ExprBuilderF(_, _), ArrayBuilderF(_, _)) => delegate
+
+          case (ArrayBuilderF(src1, shape1), GroupBuilderF(_, _, _)) =>
+            merge(src1, wb2).map { case (left, right, wb) =>
+              ArraySpliceBuilder(wb, combine(
+                Array(shape1.map(rewriteExprPrefix(_, left))),
+                Expr(\/-($var(right.toDocVar))))(List(_, _)))
+            }
+          case (GroupBuilderF(_, _, _), ArrayBuilderF(_, _)) => delegate
+
+          case (ValueBuilderF(Bson.Arr(seq1)), ExprBuilderF(src2, expr2)) =>
+            emit(ArraySpliceBuilder(src2, combine(
+              Array(seq1.map(x => \/-($literal(x)))),
+              Expr(expr2))(List(_, _))))
+          case (ExprBuilderF(_, _), ValueBuilderF(Bson.Arr(_))) => delegate
+
+          case (ArraySpliceBuilderF(src1, structure1), ArrayBuilderF(src2, shape2)) =>
+            merge(src1, src2).map { case (left, right, list) =>
+              ArraySpliceBuilder(list, combine(
+                structure1,
+                List(Array(shape2.map(rewriteExprPrefix(_, right)))))(_ ++ _))
+            }
+          case (ArrayBuilderF(_, _), ArraySpliceBuilderF(_, _)) => delegate
+
+          case (ArraySpliceBuilderF(src1, structure1), ExprBuilderF(src2, expr2)) =>
+            merge(src1, src2).map { case (_, right, list) =>
+              ArraySpliceBuilder(list, combine(
+                structure1,
+                List(Expr(rewriteExprPrefix(expr2, right))))(_ ++ _))
+            }
+          case (ExprBuilderF(_, _), ArraySpliceBuilderF(_, _)) => delegate
+
+          case (ArraySpliceBuilderF(src1, structure1), ValueBuilderF(bson2)) =>
+            emit(ArraySpliceBuilder(src1, combine(structure1, List(Expr(\/-($literal(bson2)))))(_ ++ _)))
+          case (ValueBuilderF(_), ArraySpliceBuilderF(_, _)) => delegate
+
+          case _ =>
+            fail(UnsupportedFunction(
+              structural.ArrayConcat.name,
+              Some("values are not both arrays")))
+        }
+      }
+
+      impl(left, right, unflipped)
+    }
+  }
+  object Ops {
+    implicit def apply[F[_]: Coalesce](implicit ev: Workflow2_6F :<: F): Ops[F] =
+      new Ops[F]
+  }
+
+  implicit def WorkflowBuilderRenderTree[F[_]]
+    (implicit
+      RG: RenderTree[Contents[GroupValue[Expression]]],
+      RC: RenderTree[Contents[Expr]],
+      RF: RenderTree[Fix[F]]
+    ): RenderTree[Fix[WorkflowBuilderF[F, ?]]] =
+    new RenderTree[Fix[WorkflowBuilderF[F, ?]]] {
       val nodeType = "WorkflowBuilder" :: Nil
 
-      def render(v: WorkflowBuilder) = v.unFix match {
+      def render(v: WorkflowBuilder[F]) = v.unFix match {
         case CollectionBuilderF(graph, base, struct) =>
           NonTerminal("CollectionBuilder" :: nodeType, Some(base.toString),
             graph.render ::

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflowop.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflowop.scala
@@ -29,6 +29,7 @@ import matryoshka._, Recursive.ops._, FunctorT.ops._
 import monocle.syntax.all._
 import scalaz._, Scalaz._
 import shapeless.contrib.scalaz._
+import simulacrum.typeclass
 
 sealed trait IdHandling
 object IdHandling {
@@ -47,7 +48,7 @@ object IdHandling {
   }
 }
 
-/**
+/*
   A Workflow is a graph of atomic operations, with WorkflowOps for the vertices.
   We crush them down into a WorkflowTask. This `crush` gives us a location to
   optimize our workflow decisions. EG, A sequence of simple ops may be combined
@@ -60,16 +61,64 @@ object IdHandling {
   we can build others potentially on top of them (including reordering
   non-pipelines around pipelines, etc.).
   */
-sealed trait WorkflowF[+A]
+
+/** Ops that are provided by all supported MongoDB versions, or are internal to
+  * quasar and supported everywhere. */
+sealed trait Workflow2_6F[+A]
+object Workflow2_6F {
+  // NB: this extractor has to be used instead of the simpler ones provided for
+  // each op if you need to bind the op itself, and not just its fields.
+  // For example: `case $project(src, shape, id) => ` vs.
+  // `case Workflow2_6F(p @ $ProjectF(_, _, _)) =>`
+  def unapply[F[_], A](fa: F[A])(implicit I: Workflow2_6F :<: F): Option[Workflow2_6F[A]] =
+    I.prj(fa)
+}
+/** Ops that are provided by MongoDB since 3.2. */
+sealed trait WorkflowNewIn3_2F[+A]
+object WorkflowNewIn3_2F {
+  // NB: this extractor has to be used instead of the simpler ones provided for
+  // each op if you need to bind the op itself, and not just its fields.
+  // For example: `case $lookup(src, from, lf, ff, as) => ` vs.
+  // `case WorkflowNewIn3_2F(l @ $LookupF(_, _, _, _, _)) =>`
+  def unapply[F[_], A](fa: F[A])(implicit I: WorkflowNewIn3_2F :<: F): Option[WorkflowNewIn3_2F[A]] =
+    I.prj(fa)
+}
+
 object Workflow {
   import quasar.physical.mongodb.accumulator._
   import quasar.physical.mongodb.expression._
   import IdHandling._
   import MapReduce._
 
+  type Workflow3_2F[A] = Coproduct[WorkflowNewIn3_2F, Workflow2_6F, A]
+
+  // This one will always track the superset of all versions, which is the
+  // type you want to accept where possible.
+  type WorkflowF[A] = Workflow3_2F[A]
+
+  type Workflow2_6 = Fix[Workflow2_6F]
+  type Workflow3_2 = Fix[Workflow3_2F]
   type Workflow = Fix[WorkflowF]
-  type WorkflowOp = Workflow => Workflow
-  type PipelineOp = PipelineF[Unit]
+
+  type WorkflowOp[F[_]] = Fix[F] => Fix[F]
+
+  /** A "newtype" for ops that appear in pipelines, for use mostly after a
+    * workflow is constructed, with fixed type that can represent any workflow.
+    */
+  final case class PipelineOp(op: Workflow3_2F[Unit], bson: Bson.Doc) {
+    def rewrite[F[_]](f: F[Unit] => Option[PipelineF[F, Unit]])
+      (implicit I: F :<: Workflow3_2F): PipelineOp =
+      I.prj(op).flatMap(f).cata(PipelineOp(_), this)
+  }
+  object PipelineOp {
+    def apply[F[_]](f: PipelineF[F, Unit])(implicit I: F :<: Workflow3_2F): PipelineOp =
+      PipelineOp(I.inj(f.wf), f.bson)
+  }
+  /** Provides an extractor for 2.6 ops wrapped up in `PipelineOp`. */
+  object PipelineOp2_6 {
+    def unapply(p: PipelineOp): Option[Workflow2_6F[Unit]] =
+      Inject[Workflow2_6F, Workflow3_2F].prj(p.op)
+  }
 
   val ExprLabel  = "value"
   val ExprName   = BsonField.Name(ExprLabel)
@@ -114,185 +163,195 @@ object Workflow {
       }
     }
 
-  implicit val PipelineFTraverse: Traverse[PipelineF] =
-    new Traverse[PipelineF] {
-      def traverseImpl[G[_], A, B](fa: PipelineF[A])(f: A => G[B])
-        (implicit G: Applicative[G]):
-          G[PipelineF[B]] = fa match {
-        case $Match(src, sel)         => G.apply(f(src))($Match(_, sel))
-        case $Project(src, shape, id) => G.apply(f(src))($Project(_, shape, id))
-        case $Redact(src, value)      => G.apply(f(src))($Redact(_, value))
-        case $Limit(src, count)       => G.apply(f(src))($Limit(_, count))
-        case $Skip(src, count)        => G.apply(f(src))($Skip(_, count))
-        case $Unwind(src, field)      => G.apply(f(src))($Unwind(_, field))
-        case $Group(src, grouped, by) => G.apply(f(src))($Group(_, grouped, by))
-        case $Sort(src, value)        => G.apply(f(src))($Sort(_, value))
-        case $GeoNear(src, near, distanceField, limit, maxDistance, query, spherical, distanceMultiplier, includeLocs, uniqueDocs) =>
-          G.apply(f(src))($GeoNear(_, near, distanceField, limit, maxDistance, query, spherical, distanceMultiplier, includeLocs, uniqueDocs))
-        case $Out(src, col)           => G.apply(f(src))($Out(_, col))
-      }
-    }
+  // implicit val PipelineFTraverse: Traverse[PipelineF] =
+  //   new Traverse[PipelineF] {
+  //     def traverseImpl[G[_], A, B](fa: PipelineF[A])(f: A => G[B])
+  //       (implicit G: Applicative[G]):
+  //         G[PipelineF[B]] = fa match {
+  //       case $MatchF(src, sel)         => G.apply(f(src))($MatchF(_, sel))
+  //       case $ProjectF(src, shape, id) => G.apply(f(src))($ProjectF(_, shape, id))
+  //       case $RedactF(src, value)      => G.apply(f(src))($RedactF(_, value))
+  //       case $LimitF(src, count)       => G.apply(f(src))($LimitF(_, count))
+  //       case $SkipF(src, count)        => G.apply(f(src))($SkipF(_, count))
+  //       case $UnwindF(src, field)      => G.apply(f(src))($UnwindF(_, field))
+  //       case $GroupF(src, grouped, by) => G.apply(f(src))($GroupF(_, grouped, by))
+  //       case $SortF(src, value)        => G.apply(f(src))($SortF(_, value))
+  //       case $GeoNearF(src, near, distanceField, limit, maxDistance, query, spherical, distanceMultiplier, includeLocs, uniqueDocs) =>
+  //         G.apply(f(src))($GeoNearF(_, near, distanceField, limit, maxDistance, query, spherical, distanceMultiplier, includeLocs, uniqueDocs))
+  //       case $OutF(src, col)           => G.apply(f(src))($OutF(_, col))
+  //     }
+  //   }
 
-  implicit val WorkflowFTraverse: Traverse[WorkflowF] =
-    new Traverse[WorkflowF] {
-      def traverseImpl[G[_], A, B](fa: WorkflowF[A])(f: A => G[B])
+  implicit val Workflow2_6FTraverse: Traverse[Workflow2_6F] =
+    new Traverse[Workflow2_6F] {
+      def traverseImpl[G[_], A, B](fa: Workflow2_6F[A])(f: A => G[B])
         (implicit G: Applicative[G]):
-          G[WorkflowF[B]] = fa match {
-        case x @ $Pure(_)             => G.point(x)
-        case x @ $Read(_)             => G.point(x)
-        case $Map(src, fn, scope)     => G.apply(f(src))($Map(_, fn, scope))
-        case $FlatMap(src, fn, scope) => G.apply(f(src))($FlatMap(_, fn, scope))
-        case $SimpleMap(src, exprs, scope) =>
-          G.apply(f(src))($SimpleMap(_, exprs, scope))
-        case $Reduce(src, fn, scope)  => G.apply(f(src))($Reduce(_, fn, scope))
-        case $FoldLeft(head, tail)    =>
-          G.apply2(f(head), tail.traverse(f))($FoldLeft(_, _))
+          G[Workflow2_6F[B]] = fa match {
+        case x @ $PureF(_)             => G.point(x)
+        case x @ $ReadF(_)             => G.point(x)
+        case $MapF(src, fn, scope)     => G.apply(f(src))($MapF(_, fn, scope))
+        case $FlatMapF(src, fn, scope) => G.apply(f(src))($FlatMapF(_, fn, scope))
+        case $SimpleMapF(src, exprs, scope) =>
+          G.apply(f(src))($SimpleMapF(_, exprs, scope))
+        case $ReduceF(src, fn, scope)  => G.apply(f(src))($ReduceF(_, fn, scope))
+        case $FoldLeftF(head, tail)    =>
+          G.apply2(f(head), tail.traverse(f))($FoldLeftF(_, _))
         // NB: Would be nice to replace the rest of this impl with the following
         //     line, but the invariant definition of Traverse doesn’t allow it.
         // case p: PipelineF[_]          => PipelineFTraverse.traverseImpl(p)(f)
-        case $Match(src, sel)         => G.apply(f(src))($Match(_, sel))
-        case $Project(src, shape, id) => G.apply(f(src))($Project(_, shape, id))
-        case $Redact(src, value)      => G.apply(f(src))($Redact(_, value))
-        case $Limit(src, count)       => G.apply(f(src))($Limit(_, count))
-        case $Skip(src, count)        => G.apply(f(src))($Skip(_, count))
-        case $Unwind(src, field)      => G.apply(f(src))($Unwind(_, field))
-        case $Group(src, grouped, by) => G.apply(f(src))($Group(_, grouped, by))
-        case $Sort(src, value)        => G.apply(f(src))($Sort(_, value))
-        case $GeoNear(src, near, distanceField, limit, maxDistance, query, spherical, distanceMultiplier, includeLocs, uniqueDocs) =>
-          G.apply(f(src))($GeoNear(_, near, distanceField, limit, maxDistance, query, spherical, distanceMultiplier, includeLocs, uniqueDocs))
-        case $Out(src, col)           => G.apply(f(src))($Out(_, col))
+        case $MatchF(src, sel)         => G.apply(f(src))($MatchF(_, sel))
+        case $ProjectF(src, shape, id) => G.apply(f(src))($ProjectF(_, shape, id))
+        case $RedactF(src, value)      => G.apply(f(src))($RedactF(_, value))
+        case $LimitF(src, count)       => G.apply(f(src))($LimitF(_, count))
+        case $SkipF(src, count)        => G.apply(f(src))($SkipF(_, count))
+        case $UnwindF(src, field)      => G.apply(f(src))($UnwindF(_, field))
+        case $GroupF(src, grouped, by) => G.apply(f(src))($GroupF(_, grouped, by))
+        case $SortF(src, value)        => G.apply(f(src))($SortF(_, value))
+        case $GeoNearF(src, near, distanceField, limit, maxDistance, query, spherical, distanceMultiplier, includeLocs, uniqueDocs) =>
+          G.apply(f(src))($GeoNearF(_, near, distanceField, limit, maxDistance, query, spherical, distanceMultiplier, includeLocs, uniqueDocs))
+        case $OutF(src, col)           => G.apply(f(src))($OutF(_, col))
       }
     }
 
-  def task(fop: Crystallized): WorkflowTask =
-    (finish(_, _)).tupled(fop.op.para(crush))._2.transAna(normalize)
+  implicit val WorkflowNewIn3_2FTraverse: Traverse[WorkflowNewIn3_2F] =
+    new Traverse[WorkflowNewIn3_2F] {
+      def traverseImpl[G[_], A, B](fa: WorkflowNewIn3_2F[A])(f: A => G[B])
+        (implicit G: Applicative[G]):
+          G[WorkflowNewIn3_2F[B]] = fa match {
+        case $LookupF(src, from, localField, foreignField, as) =>
+          G.apply(f(src))($LookupF(_, from, localField, foreignField, as))
+        case $SampleF(src, size)       => G.apply(f(src))($SampleF(_, size))
+      }
+    }
 
-  val coalesceƒ: WorkflowF[Workflow] => Option[WorkflowF[Workflow]] = {
-    case $Match(src, selector) => src.unFix match {
-      case $Sort(src0, value) =>
-        $Sort(Fix($Match(src0, selector)), value).some
-      case $Match(src0, sel0) =>
-        $Match(src0, sel0 ⊹ selector).some
-      case _ => None
-    }
-    case p @ $Project(src, shape, id) => src.unFix match {
-      case $Project(src0, shape0, id0) =>
-        inlineProject(p, List(shape0)).map($Project(src0, _, id0 |+| id))
-      // Would like to inline a $project into a preceding $simpleMap, but
-      // This is not safe, because sometimes a $project is inserted after
-      // $simpleMap specifically to pull fields out of `value`, and those
-      // $project ops need to be preserved.
-      // case $SimpleMap(src0, js, flatten, scope) =>
-      //   shape.toJs.fold(
-      //     κ(op),
-      //     jsShape => chain(src0,
-      //       $simpleMap(
-      //         JsMacro(base =>
-      //           jscore.Let(
-      //             ListMap("__tmp" -> js(base)),
-      //             jsShape(jscore.Ident("__tmp")))),
-      //         flatten, scope)))
-      case $Group(src, grouped, by) if id != ExcludeId =>
-        inlineProjectGroup(shape, grouped).map($Group(src, _, by))
-      case $Unwind(Fix($Group(src, grouped, by)), unwound)
-          if id != ExcludeId =>
-        inlineProjectUnwindGroup(shape, unwound, grouped).map { case (unwound, grouped) =>
-          $Unwind(Fix($Group(src, grouped, by)), unwound)
-        }
-      case _ => None
-    }
-    case $Sort(Fix($Sort(src, sort1)), sort2) =>
-      $Sort(src, sort2 ⊹ sort1).some
-    case $Limit(src, count) => src.unFix match {
-      case $Limit(src0, count0) =>
-        $Limit(src0, count0 min count).some
-      case $Skip(src0, count0) =>
-        $Skip(Fix($Limit(src0, count0 + count)), count0).some
-      case _ => None
-    }
-    case $Skip(src, count) => src.unFix match {
-      case $Skip(src0, count0) => $Skip(src0, count0 + count).some
-      case _                   => None
-    }
-    case $Group(src, grouped, \/-($literal(bson))) if bson != Bson.Null =>
-      $Group(src, grouped, \/-($literal(Bson.Null))).some
-    case op0 @ $Group(_, _, _) =>
-      inlineGroupProjects(op0).map(($Group[Workflow](_, _, _)).tupled)
-    case $GeoNear(src, _, _, _, _, _, _, _, _, _) => src.unFix match {
-      // FIXME: merge the params
-      case $GeoNear(_, _, _, _, _, _, _, _, _, _) => None
-      case _                                      => None
-    }
-    case $Map(src, fn, scope) => src.unFix match {
-      case $Map(src0, fn0, scope0) =>
-        Reshape.mergeMaps(scope0, scope).map(
-          $Map(src0, $Map.compose(fn, fn0), _))
-      case $FlatMap(src0, fn0, scope0) =>
-        Reshape.mergeMaps(scope0, scope).map(
-          $FlatMap(src0, $FlatMap.mapCompose(fn, fn0), _))
-      case _                   => None
-    }
-    case $FlatMap(src, fn, scope) => src.unFix match {
-      case $Map(src0, fn0, scope0)     =>
-        Reshape.mergeMaps(scope0, scope).map(
-          $FlatMap(src0, $Map.compose(fn, fn0), _))
-      case $FlatMap(src0, fn0, scope0) =>
-        Reshape.mergeMaps(scope0, scope).map(
-          $FlatMap(src0, $FlatMap.kleisliCompose(fn, fn0), _))
-      case _                   => None
-    }
-    case sm @ $SimpleMap(src, _, _) => src.unFix match {
-      case sm0 @ $SimpleMap(_, _, _) => (sm0 >>> sm).some
-      case _                         => None
-    }
-    case $FoldLeft(head, tail) => head.unFix match {
-      case $FoldLeft(head0, tail0) =>
-        $FoldLeft(head0, tail0 ⊹ tail).some
-      case _                       => None
-    }
-    case $Out(src, _) => src.unFix match {
-      case r @ $Read(_) => r.some
-      case _            => None
-    }
-    case _ => None
+  def task[F[_]: Functor](fop: Crystallized[F])(implicit C: Crush[F]): WorkflowTask =
+    (finish(_, _)).tupled(fop.op.para(C.crush))._2.transAna(normalize)
+
+  @typeclass sealed trait Coalesce[F[_]] {
+    def coalesceƒ: F[Fix[F]] => Option[F[Fix[F]]]
+
+    def coalesce: F[Fix[F]] => F[Fix[F]] = repeatedly(coalesceƒ)
   }
 
-  val coalesce = repeatedly(coalesceƒ)
-
-  def pipeline[A <: PipelineF[Workflow]](op: A):
-      Option[(DocVar, WorkflowTask, List[PipelineOp])] =
-    op match {
-      case $Match(src, selector) =>
-        def pipelinable(sel: Selector): Boolean = sel match {
-          case Selector.Where(_) => false
-          case comp: Selector.CompoundSelector =>
-            pipelinable(comp.left) && pipelinable(comp.right)
-          case _ => true
-        }
-        if (pipelinable(selector)) {
-          lazy val (base, crushed) = src.para(crush)
-          src.unFix match {
-            case p: PipelineF[Workflow] => pipeline(p).cata(
-              { case (base, up, prev) => Some((base, up, prev :+ rewriteRefs(PipelineFTraverse.void(op), prefixBase(base)))) },
-
-              Some((base, crushed, List(rewriteRefs(PipelineFTraverse.void(op), prefixBase(base))))))
-            case _ => Some((base, crushed, List(rewriteRefs(PipelineFTraverse.void(op), prefixBase(base)))))
+  // NB: no need for a typeclass if implementing this way, but will be needed as
+  // soon as we need to coalesce anything _into_ a type that isn't 2.6.
+  def coalesceAll[F[_]: Functor](implicit I: Workflow2_6F :<: F): Coalesce[F] = new Coalesce[F] {
+    def coalesceƒ: F[Fix[F]] => Option[F[Fix[F]]] = {
+      case $match(src, selector) => src.unFix match {
+        case $sort(src0, value) =>
+          I.inj($SortF(Fix(I.inj($MatchF(src0, selector))), value)).some
+        case $match(src0, sel0) =>
+          I.inj($MatchF(src0, sel0 ⊹ selector)).some
+        case _ => None
+      }
+      case Workflow2_6F(p @ $ProjectF(src, shape, id)) => src.unFix match {
+        case $project(src0, shape0, id0) =>
+          inlineProject(p, List(shape0)).map(sh => I.inj($ProjectF(src0, sh, id0 |+| id)))
+        // Would like to inline a $project into a preceding $simpleMap, but
+        // This is not safe, because sometimes a $project is inserted after
+        // $simpleMap specifically to pull fields out of `value`, and those
+        // $project ops need to be preserved.
+        // case $SimpleMapF(src0, js, flatten, scope) =>
+        //   shape.toJs.fold(
+        //     κ(op),
+        //     jsShape => chain(src0,
+        //       $simpleMap(
+        //         JsMacro(base =>
+        //           jscore.Let(
+        //             ListMap("__tmp" -> js(base)),
+        //             jsShape(jscore.Ident("__tmp")))),
+        //         flatten, scope)))
+        case $group(src, grouped, by) if id != ExcludeId =>
+          inlineProjectGroup(shape, grouped).map(gr => I.inj($GroupF(src, gr, by)))
+        case $unwind(Fix($group(src, grouped, by)), unwound)
+            if id != ExcludeId =>
+          inlineProjectUnwindGroup(shape, unwound, grouped).map { case (unwound, grouped) =>
+            I.inj($UnwindF(Fix(I.inj($GroupF(src, grouped, by))), unwound))
           }
-        }
-        else None
-      // TODO: Not all $Groups can be pipelined. Need to determine when we may
-      //       need the group command or a map/reduce.
-      case _ => Some(alwaysPipePipe(op))
+        case _ => None
+      }
+      case $sort(Fix($sort(src, sort1)), sort2) =>
+        I.inj($SortF(src, sort2 ⊹ sort1)).some
+      case $limit(src, count) => src.unFix match {
+        case $limit(src0, count0) =>
+          I.inj($LimitF(src0, count0 min count)).some
+        case $skip(src0, count0) =>
+          I.inj($SkipF(Fix(I.inj($LimitF(src0, count0 + count))), count0)).some
+        case _ => None
+      }
+      case $skip(src, count) => src.unFix match {
+        case $skip(src0, count0) => I.inj($SkipF(src0, count0 + count)).some
+        case _                   => None
+      }
+      case $group(src, grouped, \/-($literal(bson))) if bson != Bson.Null =>
+        I.inj($GroupF(src, grouped, \/-($literal(Bson.Null)))).some
+      case Workflow2_6F(op0 @ $GroupF(_, _, _)) =>
+        inlineGroupProjects(op0).map { case (src, gr, by) => I.inj($GroupF(src, gr, by)) }
+      case $geoNear(src, _, _, _, _, _, _, _, _, _) => src.unFix match {
+        // FIXME: merge the params
+        case $geoNear(_, _, _, _, _, _, _, _, _, _) => None
+        case _                                      => None
+      }
+      case $map(src, fn, scope) => src.unFix match {
+        case $map(src0, fn0, scope0) =>
+          Reshape.mergeMaps(scope0, scope).map(sc =>
+            I.inj($MapF(src0, $MapF.compose(fn, fn0), sc)))
+        case $flatMap(src0, fn0, scope0) =>
+          Reshape.mergeMaps(scope0, scope).map(sc =>
+            I.inj($FlatMapF(src0, $FlatMapF.mapCompose(fn, fn0), sc)))
+        case _                   => None
+      }
+      case $flatMap(src, fn, scope) => src.unFix match {
+        case $map(src0, fn0, scope0)     =>
+          Reshape.mergeMaps(scope0, scope).map(sc =>
+            I.inj($FlatMapF(src0, $MapF.compose(fn, fn0), sc)))
+        case $flatMap(src0, fn0, scope0) =>
+          Reshape.mergeMaps(scope0, scope).map(sc =>
+            I.inj($FlatMapF(src0, $FlatMapF.kleisliCompose(fn, fn0), sc)))
+        case _                   => None
+      }
+      case Workflow2_6F(sm @ $SimpleMapF(src, _, _)) => src.unFix match {
+        case Workflow2_6F(sm0 @ $SimpleMapF(_, _, _)) => I.inj(sm0 >>> sm).some
+        case _                                      => None
+      }
+      case Workflow2_6F($FoldLeftF(head, tail)) => head.unFix match {
+        case Workflow2_6F($FoldLeftF(head0, tail0)) =>
+          I.inj($FoldLeftF(head0, tail0 ⊹ tail)).some
+        case _                       => None
+      }
+      case $out(src, _) => src.unFix match {
+        case $read(_) => src.unFix.some
+        case _        => None
+      }
+      case _ => None
     }
+  }
+  implicit lazy val coalesce2_6: Coalesce[Workflow2_6F] = coalesceAll[Workflow2_6F]
+  implicit lazy val coalesce3_2: Coalesce[Workflow3_2F] = coalesceAll[Workflow3_2F]
 
-  /**
-    Returns both the final WorkflowTask as well as a DocVar indicating the base
-    of the collection.
+  def toPipelineOp[F[_]: Rewrite: Functor, A](op: PipelineF[F, A], base: DocVar)(implicit I: F :<: Workflow3_2F): PipelineOp =
+    PipelineOp(I.inj(Rewrite[F].rewriteRefs(op.wf.void, prefixBase(base))), op.bson)
+
+
+  /** Operations that are applied to a completed workflow to produce an
+    * executable WorkflowTask. NB: when this is applied, information about the
+    * the type of plan (i.e. the required MongoDB version) is discarded.
     */
-  private val crush: WorkflowF[(Fix[WorkflowF], (DocVar, WorkflowTask))] => (DocVar, WorkflowTask) = {
-      case $Pure(value) => (DocVar.ROOT(), PureTask(value))
-      case $Read(coll)  => (DocVar.ROOT(), ReadTask(coll))
-      case op @ $Match((src, rez), selector) =>
+  @typeclass sealed trait Crush[F[_]] {
+    /**
+      Returns both the final WorkflowTask as well as a DocVar indicating the base
+      of the collection.
+      */
+    def crush(op: F[(Fix[F], (DocVar, WorkflowTask))]): (DocVar, WorkflowTask)
+
+    def pipeline(op: PipelineF[F, Fix[F]]): Option[(DocVar, WorkflowTask, List[PipelineOp])]
+  }
+
+  implicit def crush3_2(implicit I: Workflow2_6F :<: Workflow3_2F): Crush[Workflow3_2F] = new Crush[Workflow3_2F] {
+    def crush(op: Workflow3_2F[(Fix[Workflow3_2F], (DocVar, WorkflowTask))]): (DocVar, WorkflowTask) = op match {
+      case $pure(value) => (DocVar.ROOT(), PureTask(value))
+      case $read(coll)  => (DocVar.ROOT(), ReadTask(coll))
+      case Workflow2_6F(op @ $MatchF((src, rez), selector)) =>
         // TODO: If we ever allow explicit request of cursors (instead of
         //       collections), we could generate a FindQuery here.
         lazy val nonPipeline = {
@@ -301,25 +360,25 @@ object Workflow {
             MapReduceTask(
               crushed,
               MapReduce(
-                $Map.mapFn(base match {
-                  case DocVar(DocVar.ROOT, None) => $Map.mapNOP
-                  case _                         => $Map.mapProject(base)
+                $MapF.mapFn(base match {
+                  case DocVar(DocVar.ROOT, None) => $MapF.mapNOP
+                  case _                         => $MapF.mapProject(base)
                 }),
-                $Reduce.reduceNOP,
+                $ReduceF.reduceNOP,
                 // TODO: Get rid of this asInstanceOf!
-                selection = Some(rewriteRefs(PipelineFTraverse.void(op).asInstanceOf[$Match[Workflow]], prefixBase(base)).selector)),
+                selection = Some(Rewrite[Workflow2_6F].rewriteRefs(Functor[Workflow2_6F].void(op), prefixBase(base)).asInstanceOf[$MatchF[Workflow2_6]].selector)),
               None))
         }
-        pipeline($Match(src, selector)) match {
+        pipeline($MatchF[Workflow3_2](src, selector).shapePreserving.fmap(ι, I)) match {
           case Some((base, up, mine)) => (base, PipelineTask(up, mine))
           case None                   => nonPipeline
         }
-      case p: PipelineF[(Fix[WorkflowF], (DocVar, WorkflowTask))] =>
+      case IsPipeline(p) =>
         alwaysPipePipe(p.reparent(p.src._1)) match {
           case (base, up, pipe) => (base, PipelineTask(up, pipe))
         }
 
-      case op @ $Map((_, (base, src1 @ MapReduceTask(src0, mr @ MapReduce(m, r, sel, sort, limit, None, scope0, _, _), oa))), fn, scope) if m == $Map.mapNOP && r == $Reduce.reduceNOP =>
+      case Workflow2_6F(op @ $MapF((_, (base, src1 @ MapReduceTask(src0, mr @ MapReduce(m, r, sel, sort, limit, None, scope0, _, _), oa))), fn, scope)) if m == $MapF.mapNOP && r == $ReduceF.reduceNOP =>
         Reshape.mergeMaps(scope0, scope).fold(
           op.newMR(base, src1, sel, sort, limit))(
           s => base -> MapReduceTask(
@@ -328,18 +387,18 @@ object Workflow {
                applyLens MapReduce._scope set s,
             oa))
 
-      case op @ $Map((_, (base, src1 @ MapReduceTask(src0, mr @ MapReduce(_, _, _, _, _, None, scope0, _, _), oa))), fn, scope) =>
+      case Workflow2_6F(op @ $MapF((_, (base, src1 @ MapReduceTask(src0, mr @ MapReduce(_, _, _, _, _, None, scope0, _, _), oa))), fn, scope)) =>
         Reshape.mergeMaps(scope0, scope).fold(
           op.newMR(base, src1, None, None, None))(
           s => base -> MapReduceTask(
             src0,
-            mr applyLens MapReduce._finalizer set Some($Map.finalizerFn(fn))
+            mr applyLens MapReduce._finalizer set Some($MapF.finalizerFn(fn))
                applyLens MapReduce._scope set s,
             oa))
 
-      case op @ $SimpleMap(_, _, _) => crush(op.raw)
+      case Workflow2_6F(op @ $SimpleMapF(_, _, _)) => crush(I.inj(op.raw))
 
-      case op @ $Reduce((_, (base, src1 @ MapReduceTask(src0, mr @ MapReduce(_, reduceNOP, _, _, _, None, scope0, _, _), oa))), fn, scope) =>
+      case Workflow2_6F(op @ $ReduceF((_, (base, src1 @ MapReduceTask(src0, mr @ MapReduce(_, reduceNOP, _, _, _, None, scope0, _, _), oa))), fn, scope)) =>
         Reshape.mergeMaps(scope0, scope).fold(
           op.newMR(base, src1, None, None, None))(
           s => base -> MapReduceTask(
@@ -348,57 +407,146 @@ object Workflow {
                applyLens MapReduce._scope set s,
             oa))
 
-      case op: MapReduceF[_] =>
-        op.src match {
-          case (_, (base, PipelineTask(src0, List($Match(_, sel))))) =>
+      case Workflow2_6F(op: MapReduceF[_]) =>
+        op.singleSource.src match {
+          case (_, (base, PipelineTask(src0, List(PipelineOp2_6($MatchF(_, sel)))))) =>
             op.newMR(base, src0, Some(sel), None, None)
-          case (_, (base, PipelineTask(src0, List($Sort(_, sort))))) =>
+          case (_, (base, PipelineTask(src0, List(PipelineOp2_6($SortF(_, sort)))))) =>
             op.newMR(base, src0, None, Some(sort), None)
-          case (_, (base, PipelineTask(src0, List($Limit(_, count))))) =>
+          case (_, (base, PipelineTask(src0, List(PipelineOp2_6($LimitF(_, count)))))) =>
             op.newMR(base, src0, None, None, Some(count))
-          case (_, (base, PipelineTask(src0, List($Match(_, sel), $Sort(_, sort))))) =>
+          case (_, (base, PipelineTask(src0, List(PipelineOp2_6($MatchF(_, sel)), PipelineOp2_6($SortF(_, sort)))))) =>
             op.newMR(base, src0, Some(sel), Some(sort), None)
-          case (_, (base, PipelineTask(src0, List($Match(_, sel), $Limit(_, count))))) =>
+          case (_, (base, PipelineTask(src0, List(PipelineOp2_6($MatchF(_, sel)), PipelineOp2_6($LimitF(_, count)))))) =>
             op.newMR(base, src0, Some(sel), None, Some(count))
-          case (_, (base, PipelineTask(src0, List($Sort(_, sort), $Limit(_, count))))) =>
+          case (_, (base, PipelineTask(src0, List(PipelineOp2_6($SortF(_, sort)), PipelineOp2_6($LimitF(_, count)))))) =>
             op.newMR(base, src0, None, Some(sort), Some(count))
-          case (_, (base, PipelineTask(src0, List($Match(_, sel), $Sort(_, sort), $Limit(_, count))))) =>
+          case (_, (base, PipelineTask(src0, List(PipelineOp2_6($MatchF(_, sel)), PipelineOp2_6($SortF(_, sort)), PipelineOp2_6($LimitF(_, count)))))) =>
             op.newMR(base, src0, Some(sel), Some(sort), Some(count))
           case (_, (base, srcTask)) =>
             val (nb, task) = finish(base, srcTask)
             op.newMR(nb, task, None, None, None)
         }
 
-      case $FoldLeft(head, tail) =>
+      case Workflow2_6F($FoldLeftF(head, tail)) =>
         (ExprVar,
           FoldLeftTask(
             (finish(_, _)).tupled(head._2)._2,
             tail.map(_._2._2 match {
               case MapReduceTask(src, mr, _) =>
-                // FIXME: $FoldLeft currently always reduces, but in future we’ll
+                // FIXME: $FoldLeftF currently always reduces, but in future we’ll
                 //        want to have more control.
                 MapReduceTask(src, mr, Some(MapReduce.Action.Reduce(Some(true))))
               // NB: `finalize` should ensure that the final op is always a
-              //     $Reduce.
+              //     $ReduceF.
               case src => scala.sys.error("not a mapReduce: " + src)
             })))
     }
 
-  val collectShapes: WorkflowF[(Workflow, (List[Reshape], Workflow))] => (List[Reshape], Workflow) = {
-    case $Project(src, shape, _) =>
-      ((x: List[Reshape]) => shape :: x).first(src._2)
-    case x                       => (Nil, Fix(x.map(_._1)))
+    def pipeline(op: PipelineF[Workflow3_2F, Workflow3_2]):
+        Option[(DocVar, WorkflowTask, List[PipelineOp])] =
+      op.wf match {
+        case $match(src, selector) =>
+          def pipelinable(sel: Selector): Boolean = sel match {
+            case Selector.Where(_) => false
+            case comp: Selector.CompoundSelector =>
+              pipelinable(comp.left) && pipelinable(comp.right)
+            case _ => true
+          }
+
+          if (pipelinable(selector)) {
+            lazy val (base, crushed) = src.para(Crush[Workflow3_2F].crush)
+            src.unFix match {
+              case IsPipeline(p) => pipeline(p).cata(
+                { case (base, up, prev) => Some((base, up, prev :+ toPipelineOp(op, base))) },
+                Some((base, crushed, List(toPipelineOp(op, base)))))
+              case _ => Some((base, crushed, List(toPipelineOp(op, base))))
+            }
+          }
+          else None
+        // TODO: Not all $GroupFs can be pipelined. Need to determine when we may
+        //       need the group command or a map/reduce.
+        case _ => Some(alwaysPipePipe(op))
+      }
+
+    def alwaysPipePipe(op: PipelineF[Workflow3_2F, Fix[Workflow3_2F]])
+      : (DocVar, WorkflowTask, Pipeline) = {
+      lazy val (base, crushed) = (finish(_, _)).tupled(op.src.para(crush))
+      // TODO: this is duplicated in `WorkflowBuilder.rewrite`
+      def repairBase(base: DocVar) = I.prj(op.wf) match {
+        case Some($GroupF(_, _, _))   => DocVar.ROOT()
+        case Some($ProjectF(_, _, _)) => DocVar.ROOT()
+        case _                       => base
+      }
+      op.src.unFix match {
+        case IsPipeline(p) => pipeline(p).cata(
+          {
+            case (base, up, prev) =>
+              val (nb, task) = finish(base, up)
+              (repairBase(nb),
+                task,
+                prev :+ toPipelineOp(op, nb))
+          },
+          (repairBase(base),
+            crushed,
+            List(toPipelineOp(op, base))))
+        case _ =>
+          (repairBase(base),
+            crushed,
+            List(toPipelineOp(op, base)))
+      }
+    }
   }
+
+  def crushInjected[F[_]: Functor, G[_]: Functor](implicit I: F :<: G, CG: Crush[G]): Crush[F] =
+    new Crush[F] {
+      def crush(op: F[(Fix[F], (DocVar, WorkflowTask))]): (DocVar, WorkflowTask) =
+        CG.crush(I.inj(op.map { case (f, t) => (f.transCata(I.inj(_)), t) }))
+
+      def pipeline(p: PipelineF[F, Fix[F]]): Option[(DocVar, WorkflowTask, List[PipelineOp])] =
+        CG.pipeline(p.fmap(_.transCata(I.inj(_)), I))
+    }
+
+  implicit val crush2_6: Crush[Workflow2_6F] = crushInjected[Workflow2_6F, Workflow3_2F]
+
+  def collectShapes[F[_]](implicit I: Workflow2_6F :<: F)
+    : F[(Fix[F], (List[Reshape], Fix[F]))] => (List[Reshape], Fix[F]) =
+    I.prj(_) match {
+      case Some($ProjectF(src, shape, _)) =>
+        ((x: List[Reshape]) => shape :: x).first(src._2)
+      case Some(x)                       => (Nil, Fix(I.inj(x.map(_._1))))
+      case None                          => ???  // TODO
+    }
 
   // helper for rewriteRefs
   def prefixBase(base: DocVar): PartialFunction[DocVar, DocVar] =
     PartialFunction(base \\ _)
 
+  // TODO: this is almost exclusively use for `refs`, which could be implemented
+  // in a simpler way. There is exactly one use of `rewriteRefs`, which is in
+  // this file.
+  @typeclass sealed trait Rewrite[F[_]] {
+    def rewriteRefs[A](op: F[A], applyVar: PartialFunction[DocVar, DocVar]): F[A]
+
+    final def refs[A](op: F[A]): List[DocVar] = {
+      // FIXME: Sorry world
+      val vf = new scala.collection.mutable.ListBuffer[DocVar]
+      ignore(rewriteRefs(op, { case v => ignore(vf += v); v }))
+      vf.toList
+    }
+
+    // def rewriteBase[A](op: F[A], base: DocVar): DocVar
+
+    // def rewrite[A](op: F[A], base: DocVar): (F[A], DocVar) =
+    //   (rewriteRefs(op, prefixBase(base)), rewriteBase(op, base))
+  }
+
+  implicit val rewrite2_6: Rewrite[Workflow2_6F] = new Rewrite[Workflow2_6F] {
   // TODO: Make this a trait, and implement it for actual types, rather than all
   //       in here (already done for ExprOp and Reshape). (#438)
-  def rewriteRefs[A <: WorkflowF[_]](
-    op: A, applyVar0: PartialFunction[DocVar, DocVar]):
-      A = {
+  def rewriteRefs[A](
+    op: Workflow2_6F[A], applyVar0: PartialFunction[DocVar, DocVar]):
+      Workflow2_6F[A] = {
     val applyVar = (f: DocVar) => applyVar0.lift(f).getOrElse(f)
 
     def applyFieldName(name: BsonField): BsonField = {
@@ -412,82 +560,272 @@ object Workflow {
     def applyNel[A](m: NonEmptyList[(BsonField, A)]): NonEmptyList[(BsonField, A)] = m.map(t => applyFieldName(t._1) -> t._2)
 
     (op match {
-      case $Project(src, shape, xId) =>
-        $Project(src, shape.rewriteRefs(applyVar0), xId)
-      case $Group(src, grouped, by)  =>
-        $Group(src,
+      case $ProjectF(src, shape, xId) =>
+        $ProjectF(src, shape.rewriteRefs(applyVar0), xId)
+      case $GroupF(src, grouped, by)  =>
+        $GroupF(src,
           grouped.rewriteRefs(applyVar0),
           by.bimap(_.rewriteRefs(applyVar0), rewriteExprRefs(_)(applyVar0)))
-      case $Match(src, s)            => $Match(src, applySelector(s))
-      case $Redact(src, e)           => $Redact(src, rewriteExprRefs(e)(applyVar0))
-      case $Unwind(src, f)           => $Unwind(src, applyVar(f))
-      case $Sort(src, l)             => $Sort(src, applyNel(l))
-      case g: $GeoNear[_]            =>
+      case $MatchF(src, s)            => $MatchF(src, applySelector(s))
+      case $RedactF(src, e)           => $RedactF(src, rewriteExprRefs(e)(applyVar0))
+      case $UnwindF(src, f)           => $UnwindF(src, applyVar(f))
+      case $SortF(src, l)             => $SortF(src, applyNel(l))
+      case g: $GeoNearF[_]            =>
         g.copy(
           distanceField = applyFieldName(g.distanceField),
           query = g.query.map(applySelector))
       case _                          => op
-    }).asInstanceOf[A]
+    })//.asInstanceOf[Workflow2_6F[A]]
   }
 
-  final def refs[A <: WorkflowF[_]](op: A): List[DocVar] = {
-    // FIXME: Sorry world
-    val vf = new scala.collection.mutable.ListBuffer[DocVar]
-    ignore(rewriteRefs(op, { case v => ignore(vf += v); v }))
-    vf.toList
+    // def rewriteBase[A <: Workflow2_6F[_]](op: A, base: DocVar) = op match {
+    //   case $GroupF(_, _, _)   => DocVar.ROOT()
+    //   case $ProjectF(_, _, _) => DocVar.ROOT()
+    //   case _                 => base
+    // }
   }
 
-  def rewrite[A <: WorkflowF[_]](op: A, base: DocVar): (A, DocVar) =
-    (rewriteRefs(op, prefixBase(base)),
-      op match {
-        case $Group(_, _, _)   => DocVar.ROOT()
-        case $Project(_, _, _) => DocVar.ROOT()
-        case _                 => base
+  def rewriteNothing[F[_]]: Rewrite[F] = new Rewrite[F] {
+    def rewriteRefs[A]
+      (op: F[A], applyVar0: PartialFunction[DocVar, DocVar]) = op
+
+    // def rewriteBase[A <: F[_]](op: A, base: DocVar) = base
+  }
+
+  implicit val rewrite3_2: Rewrite[WorkflowNewIn3_2F] = rewriteNothing[WorkflowNewIn3_2F]
+
+  implicit def coproductRewrite[F[_], G[_]](implicit RF: Rewrite[F], RG: Rewrite[G]): Rewrite[Coproduct[F, G, ?]] = new Rewrite[Coproduct[F, G, ?]] {
+    def rewriteRefs[A](op: Coproduct[F, G, A], applyVar0: PartialFunction[DocVar, DocVar]) =
+      op.run.fold(
+        fa => Coproduct.leftc(RF.rewriteRefs(fa, applyVar0)),
+        ga => Coproduct.rightc(RG.rewriteRefs(ga, applyVar0)))
+
+    // def rewriteBase[A <: Coproduct[F, G, _]](op: A, base: DocVar) =
+    //   base
+  }
+
+  def simpleShape[F[_]](op: Fix[F])(implicit I: F :<: Workflow3_2F): Option[List[BsonField.Name]] = {
+    I.inj(op.unFix).run.fold[Option[List[BsonField.Name]]](
+      {
+        case $LookupF(_, _, _, _, _) => ???
+        case $SampleF(_, _)          => ???
+      },
+      {
+        case $PureF(Bson.Doc(value))          =>
+          value.keys.toList.map(BsonField.Name(_)).some
+        case $ProjectF(_, Reshape(value), id) =>
+          (if (id == IncludeId) IdName :: value.keys.toList
+          else value.keys.toList).some
+        case sm @ $SimpleMapF(_, _, _)        =>
+          def loop(expr: JsCore): Option[List[jscore.Name]] =
+            expr.simplify match {
+              case jscore.Obj(value)      => value.keys.toList.some
+              case jscore.Let(_, _, body) => loop(body)
+              case _ => None
+            }
+          loop(sm.simpleExpr.expr).map(_.map(n => BsonField.Name(n.value)))
+        case $GroupF(_, Grouped(value), _)    => (IdName :: value.keys.toList).some
+        case $UnwindF(src, _)                 => simpleShape(src)
+        case IsShapePreserving(sp)            => simpleShape(sp.src)
+        case _                                => None
       })
-
-  def simpleShape(op: Workflow): Option[List[BsonField.Name]] = op.unFix match {
-    case $Pure(Bson.Doc(value))          =>
-      value.keys.toList.map(BsonField.Name(_)).some
-    case $Project(_, Reshape(value), id) =>
-      (if (id == IncludeId) IdName :: value.keys.toList
-      else value.keys.toList).some
-    case sm @ $SimpleMap(_, _, _)        =>
-      def loop(expr: JsCore): Option[List[jscore.Name]] =
-        expr.simplify match {
-          case jscore.Obj(value)      => value.keys.toList.some
-          case jscore.Let(_, _, body) => loop(body)
-          case _ => None
-        }
-      loop(sm.simpleExpr.expr).map(_.map(n => BsonField.Name(n.value)))
-    case $Group(_, Grouped(value), _)    => (IdName :: value.keys.toList).some
-    case $Unwind(src, _)                 => simpleShape(src)
-    case sp: ShapePreservingF[_]         => simpleShape(sp.src)
-    case _                               => None
   }
 
-  /** Operations without an input. */
-  sealed trait SourceOp extends WorkflowF[Nothing]
+  @typeclass sealed trait Classify[F[_]] {
+    def source[A](op: F[A]):          Option[SourceF[F, A]]
 
-  /** Operations with a single source op. */
-  sealed trait SingleSourceF[A] extends WorkflowF[A] {
+    def singleSource[A](op: F[A]):    Option[SingleSourceF[F, A]]
+    def pipeline[A](op: F[A]):        Option[PipelineF[F, A]]
+    def shapePreserving[A](op: F[A]): Option[ShapePreservingF[F, A]]
+  }
+
+  implicit val classify2_6: Classify[Workflow2_6F] = new Classify[Workflow2_6F] {
+    override def source[A](op: Workflow2_6F[A]) = op match {
+      case $ReadF(_) | $PureF(_) => SourceF(op).some
+      case _ => None
+    }
+
+    override def singleSource[A](op: Workflow2_6F[A]) = op match {
+      case op @ $MatchF(src, _)        => op.shapePreserving.widen[A].some
+      case op @ $ProjectF(src, _, _)   => op.pipeline.widen[A].some
+      case op @ $RedactF(src, _)       => op.pipeline.widen[A].some
+      case op @ $SkipF(src, _)         => op.shapePreserving.widen[A].some
+      case op @ $LimitF(src, _)        => op.shapePreserving.widen[A].some
+      case op @ $UnwindF(src, _)       => op.pipeline.widen[A].some
+      case op @ $GroupF(src, _, _)     => op.pipeline.widen[A].some
+      case op @ $SortF(src, _)         => op.shapePreserving.widen[A].some
+      case op @ $GeoNearF(_, _, _, _, _, _, _, _, _, _) => op.pipeline.widen[A].some
+      case op @ $OutF(src, _)          => op.shapePreserving.widen[A].some
+      case op @ $MapF(src, _, _)       => op.singleSource.widen[A].some
+      case op @ $SimpleMapF(src, _, _) => op.singleSource.widen[A].some
+      case op @ $FlatMapF(src, _, _)   => op.singleSource.widen[A].some
+      case op @ $ReduceF(src, _, _)    => op.singleSource.widen[A].some
+      case _ => None
+    }
+
+    override def pipeline[A](op: Workflow2_6F[A]) = op match {
+      case op @ $MatchF(_, _)      => op.shapePreserving.widen[A].some
+      case op @ $ProjectF(_, _, _) => op.pipeline.widen[A].some
+      case op @ $RedactF(_, _)     => op.pipeline.widen[A].some
+      case op @ $SkipF(src, _)     => op.shapePreserving.widen[A].some
+      case op @ $LimitF(src, _)    => op.shapePreserving.widen[A].some
+      case op @ $UnwindF(src, _)   => op.pipeline.widen[A].some
+      case op @ $GroupF(src, _, _) => op.pipeline.widen[A].some
+      case op @ $SortF(src, _)     => op.shapePreserving.widen[A].some
+      case op @ $GeoNearF(_, _, _, _, _, _, _, _, _, _) => op.pipeline.widen[A].some
+      case op @ $OutF(src, _)      => op.shapePreserving.widen[A].some
+      case _ => None
+    }
+
+    override def shapePreserving[A](op: Workflow2_6F[A]) = op match {
+      case op @ $MatchF(_, _) => op.shapePreserving.widen[A].some
+      case op @ $SkipF(_, _)  => op.shapePreserving.widen[A].some
+      case op @ $LimitF(_, _) => op.shapePreserving.widen[A].some
+      case op @ $SortF(_, _)  => op.shapePreserving.widen[A].some
+      case op @ $OutF(_, _)   => op.shapePreserving.widen[A].some
+      case _ => None
+    }
+  }
+
+  implicit val classifyNewIn3_2: Classify[WorkflowNewIn3_2F] = new Classify[WorkflowNewIn3_2F] {
+    override def source[A](op: WorkflowNewIn3_2F[A]) =
+      None
+
+    override def singleSource[A](op: WorkflowNewIn3_2F[A]) = op match {
+      case op @ $LookupF(src, _, _, _, _) => op.pipeline.widen[A].some
+      case op @ $SampleF(src, _)          => op.pipeline.widen[A].some
+    }
+
+    override def pipeline[A](op: WorkflowNewIn3_2F[A]) = op match {
+      case op @ $LookupF(src, _, _, _, _) => op.pipeline.widen[A].some
+      case op @ $SampleF(src, _)          => op.pipeline.widen[A].some
+    }
+
+    override def shapePreserving[A](op: WorkflowNewIn3_2F[A]) =
+      None
+  }
+
+  implicit def coproductClassify[F[_]: Functor, G[_]: Functor, A]
+    (implicit CF: Classify[F], CG: Classify[G])
+    : Classify[Coproduct[F, G, ?]] = new Classify[Coproduct[F, G, ?]] {
+    def source[A](v: Coproduct[F, G, A]) =
+      v.run.fold(
+        CF.source(_).map(_.fmap(Coproduct.leftc[F, G, A](_))),
+        CG.source(_).map(_.fmap(Coproduct.rightc[F, G, A](_))))
+
+    def singleSource[A](v: Coproduct[F, G, A]) =
+      v.run.fold(
+        CF.singleSource(_).map(_.fmap(ι, Inject[F, Coproduct[F, G, ?]])),
+        CG.singleSource(_).map(_.fmap(ι, Inject[G, Coproduct[F, G, ?]])))
+
+    def pipeline[A](v: Coproduct[F, G, A]) =
+      v.run.fold(
+        CF.pipeline(_).map(_.fmap(ι, Inject[F, Coproduct[F, G, ?]])),
+        CG.pipeline(_).map(_.fmap(ι, Inject[G, Coproduct[F, G, ?]])))
+
+    def shapePreserving[A](v: Coproduct[F, G, A]) =
+      v.run.fold(
+        CF.shapePreserving(_).map(_.fmap(ι, Inject[F, Coproduct[F, G, ?]])),
+        CG.shapePreserving(_).map(_.fmap(ι, Inject[G, Coproduct[F, G, ?]])))
+  }
+
+
+  /** Newtype for source ops (that is, ops that are themselves sources). */
+  // TODO: prevent construction of invalid instances
+  final case class SourceF[F[_]: Functor, A](wf: F[A]) {
+    def op: F[Unit] = wf.void
+
+    def fmap[G[_]: Functor, B](f: F[A] => G[B]): SourceF[G, B] =
+      SourceF(f(wf))
+  }
+  object IsSource {
+    def unapply[F[_], A](op: F[A])(implicit F: Classify[F]): Option[SourceF[F, A]] =
+      F.source(op)
+  }
+
+  /** Newtype for ops which have a single source op. */
+  // TODO: prevent construction of invalid instances
+  sealed trait SingleSourceF[F[_], A] { self =>
+    def wf: F[A]
     def src: A
-    def reparent[B](newSrc: B): SingleSourceF[B]
+    def reparent[B](newSrc: B): SingleSourceF[F, B]
+
     /** Reparenting that handles coalescing (but is more restrictive as a
       * result).
       */
-    def reparentW(newSrc: Workflow): Workflow = Fix(reparent(newSrc))
+    // TODO: this doesn't seem to actually handle coalescing, so what was the
+    // comment referring to?
+    def reparentW(newSrc: Fix[F]): Fix[F] = Fix(reparent(newSrc).wf)
+
+    def fmap[G[_]: Functor, B](f: A => B, g: F ~> G): SingleSourceF[G, B] =
+      new SingleSourceF[G, B] {
+        val src = f(self.src)
+        val wf = g(self.reparent(src).wf)
+        def reparent[C](newSrc: C) = self.reparent(newSrc).fmap(ι, g)
+      }
+
+    // NB: needed because making A covariant breaks pattern-matching ("GADT skolem" errors)
+    def widen[B >: A]: SingleSourceF[F, B] = reparent(src)
+  }
+  object IsSingleSource {
+    def unapply[F[_], A](op: F[A])(implicit F: Classify[F]): Option[SingleSourceF[F, A]] =
+      F.singleSource(op)
   }
 
-  /**
-   * This should be renamed once the other PipelineOp goes away, but it is the
-   * subset of operations that can ever be pipelined.
-   */
-  abstract sealed class PipelineF[A](op: String) extends SingleSourceF[A] {
-    override def reparent[B](newSrc: B): PipelineF[B]
+  /** Newtype for ops which can appear in aggregation pipeline. */
+  // TODO: prevent construction of invalid instances
+  sealed trait PipelineF[F[_], A] extends SingleSourceF[F, A] { self =>
+    // NB: narrows the result type
+    def reparent[B](newSrc: B): PipelineF[F, B]
+
+    def op: String
     def rhs: Bson
     def bson: Bson.Doc = Bson.Doc(ListMap(op -> rhs))
+
+    // NB: narrows the result type
+    override def fmap[G[_]: Functor, B](f: A => B, g: F ~> G): PipelineF[G, B] =
+      new PipelineF[G, B] {
+        val src = f(self.src)
+        val wf = g(self.reparent(src).wf)
+        def reparent[C](newSrc: C) = self.reparent(newSrc).fmap(ι, g)
+
+        def op = self.op
+        def rhs = self.rhs
+      }
+
+    // NB: needed because making A covariant breaks pattern-matching ("GADT skolem" errors)
+    override def widen[B >: A]: PipelineF[F, B] = reparent(src)
   }
-  abstract sealed class ShapePreservingF[A](op: String) extends PipelineF[A](op)
+  object IsPipeline {
+    def unapply[F[_], A](op: F[A])(implicit F: Classify[F]): Option[PipelineF[F, A]] =
+      F.pipeline(op)
+  }
+
+  /** Newtype for ops which preserve the shape of the input. */
+  // TODO: prevent construction of invalid instances
+  sealed trait ShapePreservingF[F[_], A] extends PipelineF[F, A] { self =>
+    // NB: narrows the result type
+    def reparent[B](newSrc: B): ShapePreservingF[F, B]
+
+    // NB: narrows the result type
+    override def fmap[G[_]: Functor, B](f: A => B, g: F ~> G): ShapePreservingF[G, B] =
+      new ShapePreservingF[G, B] {
+        val src = f(self.src)
+        val wf = g(self.reparent(src).wf)
+        def reparent[C](newSrc: C) = self.reparent(newSrc).fmap(ι, g)
+
+        def op = self.op
+        def rhs = self.rhs
+      }
+
+    // NB: needed because making A covariant breaks pattern-matching ("GADT skolem" errors)
+    override def widen[B >: A]: ShapePreservingF[F, B] = reparent(src)
+  }
+  object IsShapePreserving {
+    def unapply[F[_], A](op: F[A])(implicit F: Classify[F]): Option[ShapePreservingF[F, A]] =
+      F.shapePreserving(op)
+  }
+
 
   /**
    * Flattens the sequence of operations like so:
@@ -503,145 +841,170 @@ object Workflow {
    * \$limit(7)(match)
    * }}}
    */
-  def chain(src: Workflow, op1: WorkflowOp, ops: (WorkflowOp)*): Workflow =
+  def chain[A](src: A, op1: A => A, ops: (A => A)*): A =
     ops.foldLeft(op1(src))((s, o) => o(s))
 
   /** A type for a `Workflow` which has had `crystallize` applied to it. */
-  final case class Crystallized(op: Workflow)
+  final case class Crystallized[F[_]](op: Fix[F]) {
+    def inject[G[_]: Functor](implicit F: Functor[F], I: F :<: G): Crystallized[G] =
+      copy(op = op.transCata(I.inj(_)))
+  }
 
-  /**
-    Performs some irreversible conversions, meant to be used once, after the
-    entire workflow has been generated.
-    */
+  @typeclass sealed trait Crystallize[F[_]] {
+    /**
+      Performs some irreversible conversions, meant to be used once, after the
+      entire workflow has been generated.
+      */
+    def crystallize(op: Fix[F]): Crystallized[F]
+  }
+
+  // NB: no need for a typeclass if implementing this way, but will be needed as
+  // soon as we need to coalesce anything _into_ a type that isn't 2.6.
+  def crystallizeAll[F[_]: Functor: Classify: Coalesce: Rewrite](implicit I: Workflow2_6F :<: F, ev1: F :<: Workflow3_2F): Crystallize[F] = new Crystallize[F] {
   // probable conversions
-  // to $Map:          $Project
-  // to $FlatMap:      $Match, $Limit (using scope), $Skip (using scope), $Unwind, $GeoNear
-  // to $Map/$Reduce:  $Group
-  // ???:              $Redact
-  // none:             $Sort
-  // NB: We don’t convert a $Project after a map/reduce op because it could
+  // to $MapF:          $ProjectF
+  // to $FlatMapF:      $MatchF, $LimitF (using scope), $SkipF (using scope), $UnwindF, $GeoNearF
+  // to $MapF/$ReduceF:  $GroupF
+  // ???:              $RedactF
+  // none:             $SortF
+  // NB: We don’t convert a $ProjectF after a map/reduce op because it could
   //     affect the final shape unnecessarily.
-  def crystallize(op: Workflow): Crystallized = {
-    def unwindSrc(uw: $Unwind[Fix[WorkflowF]]): WorkflowF[Fix[WorkflowF]] =
+  def crystallize(op: Fix[F]): Crystallized[F] = {
+    def unwindSrc(uw: $UnwindF[Fix[F]]): F[Fix[F]] =
       uw.src.unFix match {
-        case uw1 @ $Unwind(_, _) => unwindSrc(uw1)
+        case Workflow2_6F(uw1 @ $UnwindF(_, _)) => unwindSrc(uw1)
         case src => src
       }
 
-    val uncleanƒ: WorkflowF[Workflow] => Workflow = {
-      case x @ $SimpleMap(_, _, _) => Fix(x.raw)
-      case x                       => Fix(x)
+    val uncleanƒ: F[Fix[F]] => Fix[F] = {
+      case Workflow2_6F(x @ $SimpleMapF(_, _, _)) => Fix(I.inj(x.raw))
+      case x                                     => Fix(x)
     }
 
-    val crystallizeƒ: WorkflowF[Workflow] => WorkflowF[Workflow] = {
-      case mr: MapReduceF[Workflow] => mr.src.unFix match {
-        case $Project(src, shape, _)  =>
+    val crystallizeƒ: F[Fix[F]] => F[Fix[F]] = {
+      case Workflow2_6F(mr: MapReduceF[Fix[F]]) => mr.singleSource.src.unFix match {
+        case $project(src, shape, _)  =>
           shape.toJs.fold(
-            κ(mr),
+            κ(I.inj(mr)),
             x => {
               val base = jscore.Name("__rez")
-              mr.reparentW(Fix(
-                $SimpleMap(
-                  src,
-                  NonEmptyList(MapExpr(JsFn(base, x(jscore.Ident(base))))),
-                  ListMap()))).unFix
+              mr.singleSource.fmap(ι, I).reparentW(
+                chain(src,
+                  $simpleMap[F](
+                    NonEmptyList(MapExpr(JsFn(base, x(jscore.Ident(base))))),
+                    ListMap()))).unFix
             })
-        case uw @ $Unwind(_, _) if !unwindSrc(uw).isInstanceOf[PipelineF[_]] =>
-          mr.reparentW(Fix(uw.flatmapop)).unFix
-        case _                        => mr
+        case Workflow2_6F(uw @ $UnwindF(_, _)) if IsPipeline.unapply(unwindSrc(uw)).isEmpty =>
+          mr.singleSource.fmap(ι, I).reparentW(Fix(I.inj(uw.flatmapop))).unFix
+        case _                        => I.inj(mr)
       }
-      case $FoldLeft(head, tail) =>
-        $FoldLeft(
-          Fix($Project(head,
-            Reshape(ListMap(ExprName -> \/-($$ROOT))),
-            IncludeId)),
+      case Workflow2_6F($FoldLeftF(head, tail)) =>
+        I.inj($FoldLeftF[Fix[F]](
+          chain(head,
+            $project[F](
+              Reshape(ListMap(ExprName -> \/-($$ROOT))),
+              IncludeId)),
           tail.map(x => x.unFix match {
-            case $Reduce(_, _, _) => x
-            case _ => Fix($Reduce(x, $Reduce.reduceFoldLeft, ListMap()))
-          }))
+            case $reduce(_, _, _) => x
+            case _ => chain(x, $reduce[F]($ReduceF.reduceFoldLeft, ListMap()))
+          })))
 
       case op => op
     }
 
     val finished =
-      deleteUnusedFields(reorderOps(op.transCata(orOriginal(simplifyGroupƒ))))
+      deleteUnusedFields(reorderOps(op.transCata(orOriginal(simplifyGroupƒ[F]))))
 
-    def fixShape(wf: Workflow) =
+    def fixShape(wf: Fix[F]) =
       Workflow.simpleShape(wf).fold(
         finished)(
-        n => $project(Reshape(n.map(_ -> \/-($include())).toListMap), IgnoreId)(finished))
+        n => $project[F](Reshape(n.map(_ -> \/-($include())).toListMap), IgnoreId).apply(finished))
 
-    def promoteKnownShape(wf: Workflow): Workflow = wf.unFix match {
-      case $SimpleMap(_, _, _)     => fixShape(wf)
-      case sp: ShapePreservingF[_] => promoteKnownShape(sp.src)
-      case _                       => finished
+    def promoteKnownShape(wf: Fix[F]): Fix[F] = wf.unFix match {
+      case $simpleMap(_, _, _)   => fixShape(wf)
+      case IsShapePreserving(sp) => promoteKnownShape(sp.src)
+      case _                     => finished
     }
 
     Crystallized(
-      promoteKnownShape(finished).transAna(crystallizeƒ).transCata[WorkflowF](coalesce)
+      promoteKnownShape(finished).transAna(crystallizeƒ).transCata[F](Coalesce[F].coalesce)
         // TODO: this can coalesce more cases, but hasn’t been done thus far and
         //       requires rewriting many tests in a much less readable way.
         // .cata[Workflow](x => coalesce(uncleanƒ(x).unFix))
     )
+  }}
+
+  implicit lazy val crystallize2_6: Crystallize[Workflow2_6F] = crystallizeAll[Workflow2_6F]
+  implicit lazy val crystallize3_2: Crystallize[Workflow3_2F] = crystallizeAll[Workflow3_2F]
+
+  final case class $PureF(value: Bson) extends Workflow2_6F[Nothing]
+  object $pure {
+    def apply[F[_]: Coalesce](value: Bson)(implicit I: Workflow2_6F :<: F) =
+      Fix(Coalesce[F].coalesce(I.inj($PureF(value))))
+
+    def unapply[F[_], A](op: F[A])(implicit I: Workflow2_6F :<: F)
+      : Option[Bson] =
+      I.prj(op) collect {
+        case $PureF(value) => (value)
+      }
   }
 
-  final case class $Pure(value: Bson) extends SourceOp
-  def $pure(value: Bson) = Fix(coalesce($Pure(value)))
+  final case class $ReadF(coll: Collection) extends Workflow2_6F[Nothing]
+  object $read {
+    def apply[F[_]: Coalesce](coll: Collection)(implicit I: Workflow2_6F :<: F) =
+      Fix(Coalesce[F].coalesce(I.inj($ReadF(coll))))
 
-  final case class $Read(coll: Collection) extends SourceOp
-  def $read(coll: Collection) = Fix(coalesce($Read(coll)))
-
-  final case class $Match[A](src: A, selector: Selector)
-      extends ShapePreservingF[A]("$match") {
-    def reparent[B](newSrc: B) = copy(src = newSrc)
-    def rhs = selector.bson
-  }
-  object $Match {
-    def make(selector: Selector)(src: Workflow): Workflow =
-      Fix(coalesce($Match(src, selector)))
-  }
-  val $match = $Match.make _
-
-  private def alwaysPipePipe(op: PipelineF[Workflow]):
-      (DocVar, WorkflowTask, Pipeline) = {
-    lazy val (base, crushed) = (finish(_, _)).tupled(op.src.para(crush))
-    // TODO: this is duplicated in `WorkflowBuilder.rewrite`
-    def repairBase(base: DocVar) = op match {
-      case $Group(_, _, _)   => DocVar.ROOT()
-      case $Project(_, _, _) => DocVar.ROOT()
-      case _                  => base
-    }
-    op.src.unFix match {
-      case p: PipelineF[Workflow] => pipeline(p).cata(
-        {
-          case (base, up, prev) =>
-            val (nb, task) = finish(base, up)
-            (repairBase(nb),
-              task,
-              prev :+ rewriteRefs(PipelineFTraverse.void(op), prefixBase(nb)))
-        },
-        (repairBase(base),
-          crushed,
-          List(rewriteRefs(PipelineFTraverse.void(op), prefixBase(base)))))
-      case _ =>
-        (repairBase(base),
-          crushed,
-          List(rewriteRefs(PipelineFTraverse.void(op), prefixBase(base))))
-    }
+    def unapply[F[_], A](op: F[A])(implicit I: Workflow2_6F :<: F)
+      : Option[Collection] =
+      I.prj(op) collect {
+        case $ReadF(coll) => (coll)
+      }
   }
 
-  final case class $Project[A](src: A, shape: Reshape, idExclusion: IdHandling)
-      extends PipelineF[A]("$project") {
-    def reparent[B](newSrc: B): $Project[B] = copy(src = newSrc)
-    def rhs: Bson.Doc = idExclusion match {
+  final case class $MatchF[A](src: A, selector: Selector)
+    extends Workflow2_6F[A]  { self =>
+    def shapePreserving: ShapePreservingF[Workflow2_6F, A] =
+      new ShapePreservingF[Workflow2_6F, A] {
+        def wf = self
+        def src = self.src
+        def reparent[B](newSrc: B) = self.copy(src = newSrc).shapePreserving
+
+        def op = "$match"
+        def rhs = selector.bson
+      }
+  }
+  object $match {
+    def apply[F[_]: Coalesce](selector: Selector)
+      (implicit I: Workflow2_6F :<: F): WorkflowOp[F] =
+      src => Fix(Coalesce[F].coalesce(I.inj($MatchF(src, selector))))
+
+    def unapply[F[_], A](op: F[A])(implicit I: Workflow2_6F :<: F)
+      : Option[(A, Selector)] =
+      I.prj(op) collect {
+        case $MatchF(src, sel) => (src, sel)
+      }
+  }
+
+  final case class $ProjectF[A](src: A, shape: Reshape, idExclusion: IdHandling)
+      extends Workflow2_6F[A] { self =>
+    def pipelineRhs: Bson.Doc = idExclusion match {
       case IdHandling.ExcludeId =>
         Bson.Doc(shape.bson.value + (Workflow.IdLabel -> Bson.Bool(false)))
       case _         => shape.bson
     }
-    def empty: $Project[A] = $Project.EmptyDoc(src)
+    def pipeline: PipelineF[Workflow2_6F, A] =
+      new PipelineF[Workflow2_6F, A] {
+        def wf = self
+        def src = self.src
+        def reparent[B](newSrc: B) = self.copy(src = newSrc).pipeline
 
-    def set(field: BsonField, value: Reshape.Shape): $Project[A] =
-      $Project(src,
+        def op = "$project"
+        def rhs = self.pipelineRhs
+      }
+    def empty: $ProjectF[A] = $ProjectF.EmptyDoc(src)
+
+    def set(field: BsonField, value: Reshape.Shape): $ProjectF[A] =
+      $ProjectF(src,
         shape.set(field, value),
         if (field == IdName) IncludeId else idExclusion)
 
@@ -660,32 +1023,32 @@ object Workflow {
       }
     }
 
-    def setAll(fvs: Iterable[(BsonField, Reshape.Shape)]): $Project[A] =
-      $Project(
+    def setAll(fvs: Iterable[(BsonField, Reshape.Shape)]): $ProjectF[A] =
+      $ProjectF(
         src,
         Reshape.setAll(shape, fvs),
         if (fvs.exists(_._1 == IdName)) IncludeId else idExclusion)
 
-    def deleteAll(fields: List[BsonField]): $Project[A] =
-      $Project(src,
+    def deleteAll(fields: List[BsonField]): $ProjectF[A] =
+      $ProjectF(src,
         Reshape.setAll(Reshape.EmptyDoc,
           Reshape.getAll(this.shape)
             .filterNot(t => fields.exists(t._1.startsWith(_)))
             .map(t => t._1 -> \/-(t._2))),
         if (fields.contains(IdName)) ExcludeId else idExclusion)
 
-    def id: $Project[A] = {
-      def loop(prefix: Option[BsonField], p: $Project[A]): $Project[A] = {
+    def id: $ProjectF[A] = {
+      def loop(prefix: Option[BsonField], p: $ProjectF[A]): $ProjectF[A] = {
         def nest(child: BsonField): BsonField =
           prefix.map(_ \ child).getOrElse(child)
 
-        $Project(
+        $ProjectF(
           p.src,
           Reshape(
             p.shape.value.transform {
               case (k, v) =>
                 v.fold(
-                  r => -\/(loop(Some(nest(k)), $Project(p.src, r, p.idExclusion)).shape),
+                  r => -\/(loop(Some(nest(k)), $ProjectF(p.src, r, p.idExclusion)).shape),
                   κ(\/-($var(DocVar.ROOT(nest(k))))))
             }),
           p.idExclusion)
@@ -694,172 +1057,303 @@ object Workflow {
       loop(None, this)
     }
   }
-  object $Project {
-    def make(shape: Reshape, id: IdHandling)(src: Workflow): Workflow =
-      Fix(coalesce($Project(src, shape, id)))
-
-    def EmptyDoc[A](src: A) = $Project(src, Reshape.EmptyDoc, ExcludeId)
+  object $ProjectF {
+    def EmptyDoc[A](src: A) = $ProjectF(src, Reshape.EmptyDoc, ExcludeId)
   }
-  val $project = $Project.make _
+  object $project {
+    def apply[F[_]: Coalesce](shape: Reshape, id: IdHandling)
+      (implicit I: Workflow2_6F :<: F): WorkflowOp[F] =
+      src => Fix(Coalesce[F].coalesce(I.inj($ProjectF(src, shape, id))))
 
-  final case class $Redact[A](src: A, value: Expression)
-      extends PipelineF[A]("$redact") {
-    def reparent[B](newSrc: B) = copy(src = newSrc)
-    def rhs = value.cata(bsonƒ)
+    def unapply[F[_], A](op: F[A])(implicit I: Workflow2_6F :<: F)
+      : Option[(A, Reshape, IdHandling)] =
+      I.prj(op) collect {
+        case $ProjectF(src, shape, id) => (src, shape, id)
+      }
   }
-  object $Redact {
-    def make(value: Expression)(src: Workflow): Workflow =
-      Fix(coalesce($Redact(src, value)))
+
+  final case class $RedactF[A](src: A, value: Expression)
+    extends Workflow2_6F[A] { self =>
+    def pipeline: PipelineF[Workflow2_6F, A] =
+      new PipelineF[Workflow2_6F, A] {
+        def wf = self
+        def src = self.src
+        def reparent[B](newSrc: B) = self.copy(src = newSrc).pipeline
+
+        def op = "$redact"
+        def rhs = value.cata(bsonƒ)
+      }
+  }
+  object $RedactF {
+    // def make(value: Expression)(src: Workflow): Workflow =
+    //   Fix(coalesce($RedactF(src, value)))
 
     val DESCEND = DocVar(DocVar.Name("DESCEND"),  None)
     val PRUNE   = DocVar(DocVar.Name("PRUNE"),    None)
     val KEEP    = DocVar(DocVar.Name("KEEP"),     None)
   }
-  val $redact = $Redact.make _
+  object $redact {
+    def apply[F[_]: Coalesce](value: Expression)
+      (implicit I: Workflow2_6F :<: F): WorkflowOp[F] =
+      src => Fix(Coalesce[F].coalesce(I.inj($RedactF(src, value))))
 
-  final case class $Limit[A](src: A, count: Long)
-      extends ShapePreservingF[A]("$limit") {
-    def reparent[B](newSrc: B) = copy(src = newSrc)
-    def rhs = Bson.Int64(count)
+    def unapply[F[_], A](op: F[A])(implicit I: Workflow2_6F :<: F)
+      : Option[(A, Expression)] =
+      I.prj(op) collect {
+        case $RedactF(src, value) => (src, value)
+      }
   }
-  object $Limit {
-    def make(count: Long)(src: Workflow): Workflow =
-      Fix(coalesce($Limit(src, count)))
-  }
-  val $limit = $Limit.make _
 
-  final case class $Skip[A](src: A, count: Long)
-      extends ShapePreservingF[A]("$skip") {
-    def reparent[B](newSrc: B) = copy(src = newSrc)
-    def rhs = Bson.Int64(count)
-  }
-  object $Skip {
-    def make(count: Long)(src: Workflow): Workflow =
-      Fix(coalesce($Skip(src, count)))
-  }
-  val $skip = $Skip.make _
+  final case class $LimitF[A](src: A, count: Long)
+      extends Workflow2_6F[A] { self =>
+    def shapePreserving: ShapePreservingF[Workflow2_6F, A] =
+      new ShapePreservingF[Workflow2_6F, A] {
+        def wf = self
+        def src = self.src
+        def reparent[B](newSrc: B) = self.copy(src = newSrc).shapePreserving
 
-  final case class $Unwind[A](src: A, field: DocVar)
-      extends PipelineF[A]("$unwind") {
-    lazy val flatmapop = $SimpleMap(src, NonEmptyList(FlatExpr(field.toJs)), ListMap())
-    def reparent[B](newSrc: B) = copy(src = newSrc)
-    def rhs = field.bson
+        def op = "$limit"
+        def rhs = Bson.Int64(count)
+      }
   }
-  object $Unwind {
-    def make(field: DocVar)(src: Workflow): Workflow =
-      Fix(coalesce($Unwind(src, field)))
+  object $limit {
+    def apply[F[_]: Coalesce](count: Long)
+      (implicit I: Workflow2_6F :<: F): WorkflowOp[F] =
+      src => Fix(Coalesce[F].coalesce(I.inj($LimitF(src, count))))
+
+    def unapply[F[_], A](op: F[A])(implicit I: Workflow2_6F :<: F): Option[(A, Long)] =
+      I.prj(op).collect {
+        case $LimitF(src, count) => (src, count)
+      }
   }
-  val $unwind = $Unwind.make _
 
-  final case class $Group[A](src: A, grouped: Grouped, by: Reshape.Shape)
-      extends PipelineF[A]("$group") {
+  final case class $SkipF[A](src: A, count: Long)
+      extends Workflow2_6F[A] { self =>
+    def shapePreserving: ShapePreservingF[Workflow2_6F, A] =
+      new ShapePreservingF[Workflow2_6F, A] {
+        def wf = self
+        def src = self.src
+        def reparent[B](newSrc: B) = self.copy(src = newSrc).shapePreserving
 
-    def reparent[B](newSrc: B) = copy(src = newSrc)
-    def rhs = {
-      val Bson.Doc(m) = grouped.bson
-      Bson.Doc(m + (Workflow.IdLabel -> by.fold(_.bson, _.cata(bsonƒ))))
-    }
+        def op = "$skip"
+        def rhs = Bson.Int64(count)
+      }
+  }
+  object $skip {
+    def apply[F[_]: Coalesce](count: Long)
+      (implicit I: Workflow2_6F :<: F): WorkflowOp[F] =
+      src => Fix(Coalesce[F].coalesce(I.inj($SkipF(src, count))))
+
+    def unapply[F[_], A](op: F[A])(implicit I: Workflow2_6F :<: F): Option[(A, Long)] =
+      I.prj(op).collect {
+        case $SkipF(src, count) => (src, count)
+      }
+  }
+
+  final case class $UnwindF[A](src: A, field: DocVar)
+      extends Workflow2_6F[A] { self =>
+    def pipeline: PipelineF[Workflow2_6F, A] =
+      new PipelineF[Workflow2_6F, A] {
+        def wf = self
+        def src = self.src
+        def reparent[B](newSrc: B) = self.copy(src = newSrc).pipeline
+
+        def op = "$unwind"
+        def rhs = field.bson
+      }
+    lazy val flatmapop = $SimpleMapF(src, NonEmptyList(FlatExpr(field.toJs)), ListMap())
+  }
+  object $unwind {
+    def apply[F[_]: Coalesce](field: DocVar)
+      (implicit I: Workflow2_6F :<: F): WorkflowOp[F] =
+      src => Fix(Coalesce[F].coalesce(I.inj($UnwindF(src, field))))
+
+    def unapply[F[_], A](op: F[A])(implicit I: Workflow2_6F :<: F)
+      : Option[(A, DocVar)] =
+      I.prj(op) collect {
+        case $UnwindF(src, field) => (src, field)
+      }
+  }
+
+  final case class $GroupF[A](src: A, grouped: Grouped, by: Reshape.Shape)
+      extends Workflow2_6F[A] { self =>
+
+    def pipeline: PipelineF[Workflow2_6F, A] =
+      new PipelineF[Workflow2_6F, A] {
+        def wf = self
+        def src = self.src
+        def reparent[B](newSrc: B) = self.copy(src = newSrc).pipeline
+
+        def op = "$group"
+        def rhs = {
+          val Bson.Doc(m) = grouped.bson
+          Bson.Doc(m + (Workflow.IdLabel -> by.fold(_.bson, _.cata(bsonƒ))))
+        }
+      }
 
     def empty = copy(grouped = Grouped(ListMap()))
 
     def getAll: List[(BsonField.Name, Accumulator)] =
       grouped.value.toList
 
-    def deleteAll(fields: List[BsonField.Name]): Workflow.$Group[A] = {
+    def deleteAll(fields: List[BsonField.Name]): Workflow.$GroupF[A] = {
       empty.setAll(getAll.filterNot(t => fields.contains(t._1)))
     }
 
     def setAll(vs: Seq[(BsonField.Name, Accumulator)]) = copy(grouped = Grouped(ListMap(vs: _*)))
   }
-  object $Group {
-    def make(grouped: Grouped, by: Reshape.Shape)(src: Workflow): Workflow =
-      Fix(coalesce($Group(src, grouped, by)))
-  }
-  val $group = $Group.make _
+  object $group {
+    def apply[F[_]: Coalesce](grouped: Grouped, by: Reshape.Shape)
+      (implicit I: Workflow2_6F :<: F): WorkflowOp[F] =
+      src => Fix(Coalesce[F].coalesce(I.inj($GroupF(src, grouped, by))))
 
-  final case class $Sort[A](src: A, value: NonEmptyList[(BsonField, SortDir)])
-      extends ShapePreservingF[A]("$sort") {
-    def reparent[B](newSrc: B) = copy(src = newSrc)
-    // Note: ListMap preserves the order of entries.
-    def rhs: Bson.Doc = $Sort.keyBson(value)
+    def unapply[F[_], A](op: F[A])(implicit I: Workflow2_6F :<: F)
+      : Option[(A, Grouped, Reshape.Shape)] =
+      I.prj(op) collect {
+        case $GroupF(src, grouped, shape) => (src, grouped, shape)
+      }
   }
-  object $Sort {
-    def make(value: NonEmptyList[(BsonField, SortDir)])(src: Workflow):
-        Workflow =
-      Fix(coalesce($Sort(src, value)))
 
+  final case class $SortF[A](src: A, value: NonEmptyList[(BsonField, SortDir)])
+      extends Workflow2_6F[A] { self =>
+    def shapePreserving: ShapePreservingF[Workflow2_6F, A] =
+      new ShapePreservingF[Workflow2_6F, A] {
+        def wf = self
+        def src = self.src
+        def reparent[B](newSrc: B) = self.copy(src = newSrc).shapePreserving
+
+        def op = "$sort"
+        // Note: ListMap preserves the order of entries.
+        def rhs: Bson.Doc = $SortF.keyBson(value)
+      }
+  }
+  object $SortF {
     def keyBson(value: NonEmptyList[(BsonField, SortDir)]) =
       Bson.Doc(ListMap((value.map { case (k, t) => k.asText -> sortDirToBson(t) }).list.toList: _*))
   }
-  val $sort = $Sort.make _
+  object $sort {
+    def apply[F[_]: Coalesce](value: NonEmptyList[(BsonField, SortDir)])
+      (implicit I: Workflow2_6F :<: F): WorkflowOp[F] =
+      src => Fix(Coalesce[F].coalesce(I.inj($SortF(src, value))))
+
+    def unapply[F[_], A](op: F[A])(implicit I: Workflow2_6F :<: F)
+      : Option[(A, NonEmptyList[(BsonField, SortDir)])] =
+      I.prj(op) collect {
+        case $SortF(src, value) => (src, value)
+      }
+  }
 
   /**
-   * TODO: If an \$Out has anything after it, we need to either do
+   * TODO: If an \$OutF has anything after it, we need to either do
    * {{{\$seq(\$out(src, dst), after(\$read(dst), ...))}}}
    * or
    * {{{\$Fork(src, List(\$out(_, dst), after(_, ...)))}}}
    * The latter seems preferable, but currently the forking semantics are not
    * clear.
    */
-  final case class $Out[A](src: A, collection: Collection)
-      extends ShapePreservingF[A]("$out") {
-    def reparent[B](newSrc: B) = copy(src = newSrc)
-    def rhs = Bson.Text(collection.collectionName)
-  }
-  object $Out {
-    def make(collection: Collection)(src: Workflow): Workflow =
-      Fix(coalesce($Out(src, collection)))
-  }
-  val $out = $Out.make _
+  final case class $OutF[A](src: A, collection: Collection)
+      extends Workflow2_6F[A] { self =>
+    def shapePreserving: ShapePreservingF[Workflow2_6F, A] =
+      new ShapePreservingF[Workflow2_6F, A] {
+        def wf = self
+        def src = self.src
+        def reparent[B](newSrc: B) =
+          self.copy(src = newSrc).shapePreserving
 
-  final case class $GeoNear[A](
+        def op = "$out"
+        def rhs = Bson.Text(collection.collectionName)
+      }
+  }
+  object $out {
+    def apply[F[_]: Coalesce](collection: Collection)
+      (implicit I: Workflow2_6F :<: F): WorkflowOp[F] =
+      src => Fix(Coalesce[F].coalesce(I.inj($OutF(src, collection))))
+
+    def unapply[F[_], A](op: F[A])(implicit I: Workflow2_6F :<: F)
+      : Option[(A, Collection)] =
+      I.prj(op) collect {
+        case $OutF(src, collection) => (src, collection)
+      }
+  }
+
+  final case class $GeoNearF[A](
     src: A,
     near: (Double, Double), distanceField: BsonField,
     limit: Option[Int], maxDistance: Option[Double],
     query: Option[Selector], spherical: Option[Boolean],
     distanceMultiplier: Option[Double], includeLocs: Option[BsonField],
     uniqueDocs: Option[Boolean])
-      extends PipelineF[A]("$geonear") {
-    def reparent[B](newSrc: B) = copy(src = newSrc)
-    def rhs = Bson.Doc(List(
-      List("near"           -> Bson.Arr(Bson.Dec(near._1) :: Bson.Dec(near._2) :: Nil)),
-      List("distanceField"  -> distanceField.bson),
-      limit.toList.map(limit => "limit" -> Bson.Int32(limit)),
-      maxDistance.toList.map(maxDistance => "maxDistance" -> Bson.Dec(maxDistance)),
-      query.toList.map(query => "query" -> query.bson),
-      spherical.toList.map(spherical => "spherical" -> Bson.Bool(spherical)),
-      distanceMultiplier.toList.map(distanceMultiplier => "distanceMultiplier" -> Bson.Dec(distanceMultiplier)),
-      includeLocs.toList.map(includeLocs => "includeLocs" -> includeLocs.bson),
-      uniqueDocs.toList.map(uniqueDocs => "uniqueDocs" -> Bson.Bool(uniqueDocs))
-    ).flatten.toListMap)
-  }
-  object $GeoNear {
-    def make(
-      near: (Double, Double), distanceField: BsonField,
-      limit: Option[Int], maxDistance: Option[Double],
-      query: Option[Selector], spherical: Option[Boolean],
-      distanceMultiplier: Option[Double], includeLocs: Option[BsonField],
-      uniqueDocs: Option[Boolean])(
-      src: Workflow):
-        Workflow =
-      Fix(coalesce($GeoNear(src, near, distanceField, limit, maxDistance, query, spherical, distanceMultiplier, includeLocs, uniqueDocs)))
-  }
-  val $geoNear = $GeoNear.make _
+      extends Workflow2_6F[A] { self =>
+    def pipeline: PipelineF[Workflow2_6F, A] =
+      new PipelineF[Workflow2_6F, A] {
+        def wf = self
+        def src = self.src
+        def reparent[B](newSrc: B) = self.copy(src = newSrc).pipeline
 
-  sealed trait MapReduceF[A] extends SingleSourceF[A] {
-    def newMR(base: DocVar, src: WorkflowTask, sel: Option[Selector], sort: Option[NonEmptyList[(BsonField, SortDir)]], count: Option[Long]): (DocVar, WorkflowTask)
+        def op = "$geoNear"
+        def rhs = Bson.Doc(List(
+          List("near"           -> Bson.Arr(Bson.Dec(near._1) :: Bson.Dec(near._2) :: Nil)),
+          List("distanceField"  -> distanceField.bson),
+          limit.toList.map(limit => "limit" -> Bson.Int32(limit)),
+          maxDistance.toList.map(maxDistance => "maxDistance" -> Bson.Dec(maxDistance)),
+          query.toList.map(query => "query" -> query.bson),
+          spherical.toList.map(spherical => "spherical" -> Bson.Bool(spherical)),
+          distanceMultiplier.toList.map(distanceMultiplier => "distanceMultiplier" -> Bson.Dec(distanceMultiplier)),
+          includeLocs.toList.map(includeLocs => "includeLocs" -> includeLocs.bson),
+          uniqueDocs.toList.map(uniqueDocs => "uniqueDocs" -> Bson.Bool(uniqueDocs))
+        ).flatten.toListMap)
+      }
+  }
+  object $geoNear {
+    def apply[F[_]: Coalesce]
+      (near: (Double, Double), distanceField: BsonField,
+        limit: Option[Int], maxDistance: Option[Double],
+        query: Option[Selector], spherical: Option[Boolean],
+        distanceMultiplier: Option[Double], includeLocs: Option[BsonField],
+        uniqueDocs: Option[Boolean])
+      (implicit I: Workflow2_6F :<: F): WorkflowOp[F] =
+        src => Fix(Coalesce[F].coalesce(I.inj($GeoNearF(
+          src, near, distanceField, limit, maxDistance, query, spherical, distanceMultiplier, includeLocs, uniqueDocs))))
+
+    def unapply[F[_], A](op: F[A])(implicit I: Workflow2_6F :<: F)
+      : Option[(A, (Double, Double), BsonField, Option[Int], Option[Double],
+        Option[Selector], Option[Boolean], Option[Double], Option[BsonField],
+        Option[Boolean])] =
+      I.prj(op) collect {
+        case $GeoNearF(src, n, df, l, md, q, s, dm, il, ud) =>
+          (src, n, df, l, md, q, s, dm, il, ud)
+      }
+  }
+
+  sealed trait MapReduceF[A] extends Workflow2_6F[A] {
+    def singleSource: SingleSourceF[Workflow2_6F, A]
+
+    def newMR[F[_]](
+      base: DocVar,
+      src: WorkflowTask,
+      sel: Option[Selector],
+      sort: Option[NonEmptyList[(BsonField, SortDir)]],
+      count: Option[Long])
+      : (DocVar, WorkflowTask)
   }
 
   /**
     Takes a function of two parameters. The first is the current key (which
     defaults to `this._id`, but may have been overridden by previous
-    [Flat]\$Maps) and the second is the document itself. The function must
+    [Flat]\$MapFs) and the second is the document itself. The function must
     return a 2-element array containing the new key and new value.
     */
-  final case class $Map[A](src: A, fn: Js.AnonFunDecl, scope: Scope) extends MapReduceF[A] {
-    import $Map._
+  final case class $MapF[A](src: A, fn: Js.AnonFunDecl, scope: Scope) extends MapReduceF[A] { self =>
+    def singleSource: SingleSourceF[Workflow2_6F, A] =
+      new SingleSourceF[Workflow2_6F, A] {
+        def wf = self
+        def src = self.src
+        def reparent[B](newSrc: B) = self.copy(src = newSrc).singleSource
+      }
 
-    def newMR(base: DocVar, src: WorkflowTask, sel: Option[Selector], sort: Option[NonEmptyList[(BsonField, SortDir)]], count: Option[Long]) =
+    import $MapF._
+
+    def newMR[F[_]](base: DocVar, src: WorkflowTask, sel: Option[Selector], sort: Option[NonEmptyList[(BsonField, SortDir)]], count: Option[Long]) =
       (ExprVar,
         MapReduceTask(
           src,
@@ -868,18 +1362,12 @@ object Workflow {
               case DocVar(DocVar.ROOT, None) => this.fn
               case _ => compose(this.fn, mapProject(base))
             }),
-            $Reduce.reduceNOP,
+            $ReduceF.reduceNOP,
             selection = sel, inputSort = sort, limit = count, scope = scope),
           None))
-
-    def reparent[B](newSrc: B) = copy(src = newSrc)
   }
-  object $Map {
+  object $MapF {
     import jscore._
-
-    def make(fn: Js.AnonFunDecl, scope: Scope)(src: Workflow):
-        Workflow =
-      Fix(coalesce($Map(src, fn, scope)))
 
     def compose(g: Js.AnonFunDecl, f: Js.AnonFunDecl): Js.AnonFunDecl =
       Js.AnonFunDecl(List("key", "value"), List(
@@ -911,12 +1399,28 @@ object Workflow {
             Js.Null,
             Js.Call(fn, List(Js.Select(Js.This, IdLabel), Js.This))))))
   }
-  val $map = $Map.make _
+  object $map {
+    def apply[F[_]: Coalesce](fn: Js.AnonFunDecl, scope: Scope)
+      (implicit I: Workflow2_6F :<: F): WorkflowOp[F] =
+      src => Fix(Coalesce[F].coalesce(I.inj($MapF(src, fn, scope))))
 
-  // FIXME: this one should become $Map, with the other one being replaced by
+    def unapply[F[_], A](op: F[A])(implicit I: Workflow2_6F :<: F)
+      : Option[(A, Js.AnonFunDecl, Scope)] =
+      I.prj(op) collect {
+        case $MapF(src, fn, scope) => (src, fn, scope)
+      }
+  }
+
+  // FIXME: this one should become $MapF, with the other one being replaced by
   // a new op that combines a map and reduce operation?
-  final case class $SimpleMap[A](src: A, exprs: NonEmptyList[CardinalExpr[JsFn]], scope: Scope)
-      extends MapReduceF[A] {
+  final case class $SimpleMapF[A](src: A, exprs: NonEmptyList[CardinalExpr[JsFn]], scope: Scope)
+      extends MapReduceF[A] { self =>
+    def singleSource: SingleSourceF[Workflow2_6F, A] =
+      new SingleSourceF[Workflow2_6F, A] {
+        def wf = self
+        def src = self.src
+        def reparent[B](newSrc: B) = self.copy(src = newSrc).singleSource
+      }
     def getAll: Option[List[BsonField]] = {
       def loop(x: JsCore): Option[List[BsonField]] = x match {
         case jscore.Obj(values) => Some(values.toList.flatMap { case (k, v) =>
@@ -931,7 +1435,7 @@ object Workflow {
       loop(simpleExpr(jscore.ident("?")))
     }
 
-    def deleteAll(fields: List[BsonField]): $SimpleMap[A] = {
+    def deleteAll(fields: List[BsonField]): $SimpleMapF[A] = {
       def loop(x: JsCore, fields: List[List[BsonField.Name]]): Option[JsCore] = x match {
         case jscore.Obj(values) => Some(jscore.Obj(
           values.collect(Function.unlift[(jscore.Name, JsCore), (jscore.Name, JsCore)] { t =>
@@ -952,7 +1456,7 @@ object Workflow {
 
       exprs match {
         case NonEmptyList(MapExpr(expr), INil()) =>
-          $SimpleMap(src,
+          $SimpleMapF(src,
             NonEmptyList(
               MapExpr(JsFn(jscore.Name("base"), loop(expr(jscore.ident("base")), fields.map(_.flatten.toList)).getOrElse(jscore.Literal(Js.Null))))),
             scope)
@@ -989,8 +1493,8 @@ object Workflow {
       body(exprs.toList.zipWithIndex.map(("each" + _).second))
     }
 
-    def >>>(that: $SimpleMap[A]) = {
-      $SimpleMap(
+    def >>>(that: $SimpleMapF[A]) = {
+      $SimpleMapF(
         this.src,
         (this.exprs.last, that.exprs.head) match {
           case (MapExpr(l), MapExpr(r)) =>
@@ -1008,34 +1512,29 @@ object Workflow {
 
       exprs match {
         case NonEmptyList(MapExpr(expr), INil()) =>
-          $Map(src,
+          $MapF(src,
             Js.AnonFunDecl(List("key", "value"), List(
               Js.Return(Arr(List(
                 ident("key"),
                 expr(ident("value")))).toJs))),
-            scope <+> $SimpleMap.implicitScope(funcs)
+            scope <+> $SimpleMapF.implicitScope(funcs)
           )
         case _ =>
-          $FlatMap(src, fn, $SimpleMap.implicitScope(funcs + "clone") ++ scope)
+          $FlatMapF(src, fn, $SimpleMapF.implicitScope(funcs + "clone") ++ scope)
       }
     }
 
-    def newMR(base: DocVar, src: WorkflowTask, sel: Option[Selector], sort: Option[NonEmptyList[(BsonField, SortDir)]], count: Option[Long]) =
+    def newMR[F[_]](base: DocVar, src: WorkflowTask, sel: Option[Selector], sort: Option[NonEmptyList[(BsonField, SortDir)]], count: Option[Long]) =
       raw.newMR(base, src, sel, sort, count)
-
-    def reparent[B](newSrc: B) = copy(src = newSrc)
 
     def simpleExpr = exprs.foldRight(JsFn.identity) {
       case (MapExpr(expr), acc) => expr >>> acc
       case (_,             acc) => acc
     }
   }
-  object $SimpleMap {
-    def make(exprs: NonEmptyList[CardinalExpr[JsFn]], scope: Scope)(src: Workflow): Workflow =
-      Fix(coalesce($SimpleMap(src, exprs, scope)))
-
+  object $SimpleMapF {
     def implicitScope(fs: Set[String]) =
-      $SimpleMap.jsLibrary.filter(x => fs.contains(x._1))
+      $SimpleMapF.jsLibrary.filter(x => fs.contains(x._1))
 
     val jsLibrary = ListMap(
       "remove" -> Bson.JavaScript(
@@ -1064,40 +1563,51 @@ object Workflow {
                 Js.Access(Js.Ident("src"), Js.Ident("i")))))),
           Js.Return(Js.Ident("dest"))))))
   }
-  val $simpleMap = $SimpleMap.make _
+  object $simpleMap {
+    def apply[F[_]: Coalesce](exprs: NonEmptyList[CardinalExpr[JsFn]], scope: Scope)
+      (implicit I: Workflow2_6F :<: F): WorkflowOp[F] =
+      src => Fix(Coalesce[F].coalesce(I.inj($SimpleMapF(src, exprs, scope))))
+
+    def unapply[F[_], A](op: F[A])(implicit I: Workflow2_6F :<: F)
+      : Option[(A, NonEmptyList[CardinalExpr[JsFn]], Scope)] =
+      I.prj(op) collect {
+        case $SimpleMapF(src, exprs, scope) => (src, exprs, scope)
+      }
+  }
 
   /**
     Takes a function of two parameters. The first is the current key (which
     defaults to `this._id`, but may have been overridden by previous
-    [Flat]\$Maps) and the second is the document itself. The function must
+    [Flat]\$MapFs) and the second is the document itself. The function must
     return an array of 2-element arrays, each containing a new key and a new
     value.
     */
-  final case class $FlatMap[A](src: A, fn: Js.AnonFunDecl, scope: Scope)
-      extends MapReduceF[A] {
-    import $FlatMap._
+  final case class $FlatMapF[A](src: A, fn: Js.AnonFunDecl, scope: Scope)
+      extends MapReduceF[A] { self =>
+    def singleSource: SingleSourceF[Workflow2_6F, A] =
+      new SingleSourceF[Workflow2_6F, A] {
+        def wf = self
+        def src = self.src
+        def reparent[B](newSrc: B) = self.copy(src = newSrc).singleSource
+      }
 
-    def newMR(base: DocVar, src: WorkflowTask, sel: Option[Selector], sort: Option[NonEmptyList[(BsonField, SortDir)]], count: Option[Long]) =
+    import $FlatMapF._
+
+    def newMR[F[_]](base: DocVar, src: WorkflowTask, sel: Option[Selector], sort: Option[NonEmptyList[(BsonField, SortDir)]], count: Option[Long]) =
       (ExprVar,
         MapReduceTask(
           src,
           MapReduce(
             mapFn(base match {
               case DocVar(DocVar.ROOT, None) => this.fn
-              case _ => $Map.compose(this.fn, $Map.mapProject(base))
+              case _ => $MapF.compose(this.fn, $MapF.mapProject(base))
             }),
-            $Reduce.reduceNOP,
+            $ReduceF.reduceNOP,
             selection = sel, inputSort = sort, limit = count, scope = scope),
           None))
-
-    def reparent[B](newSrc: B) = copy(src = newSrc)
   }
-  object $FlatMap {
+  object $FlatMapF {
     import Js._
-
-    def make(fn: Js.AnonFunDecl, scope: Scope)(src: Workflow):
-        Workflow =
-      Fix(coalesce($FlatMap(src, fn, scope)))
 
     private def composition(g: Js.AnonFunDecl, f: Js.AnonFunDecl) =
       Call(
@@ -1126,35 +1636,46 @@ object Workflow {
               List(Call(Select(Ident("emit"), "apply"),
                 List(Null, Ident("__rez")))))))))
   }
-  val $flatMap = $FlatMap.make _
+  object $flatMap {
+    def apply[F[_]: Coalesce](fn: Js.AnonFunDecl, scope: Scope)
+      (implicit I: Workflow2_6F :<: F): WorkflowOp[F] =
+      src => Fix(Coalesce[F].coalesce(I.inj($FlatMapF(src, fn, scope))))
+
+    def unapply[F[_], A](op: F[A])(implicit I: Workflow2_6F :<: F)
+      : Option[(A, Js.AnonFunDecl, Scope)] =
+      I.prj(op) collect {
+        case $FlatMapF(src, fn, scope) => (src, fn, scope)
+      }
+  }
 
   /**
     Takes a function of two parameters – a key and an array of values. The
     function must return a single value.
     */
-  final case class $Reduce[A](src: A, fn: Js.AnonFunDecl, scope: Scope)
-      extends MapReduceF[A] {
-    def newMR(base: DocVar, src: WorkflowTask, sel: Option[Selector], sort: Option[NonEmptyList[(BsonField, SortDir)]], count: Option[Long]) =
+  final case class $ReduceF[A](src: A, fn: Js.AnonFunDecl, scope: Scope)
+      extends MapReduceF[A] { self =>
+    def singleSource: SingleSourceF[Workflow2_6F, A] =
+      new SingleSourceF[Workflow2_6F, A] {
+        def wf = self
+        def src = self.src
+        def reparent[B](newSrc: B) = self.copy(src = newSrc).singleSource
+      }
+
+    def newMR[F[_]](base: DocVar, src: WorkflowTask, sel: Option[Selector], sort: Option[NonEmptyList[(BsonField, SortDir)]], count: Option[Long]) =
       (ExprVar,
         MapReduceTask(
           src,
           MapReduce(
-            $Map.mapFn(base match {
-              case DocVar(DocVar.ROOT, None) => $Map.mapNOP
-              case _                         => $Map.mapProject(base)
+            $MapF.mapFn(base match {
+              case DocVar(DocVar.ROOT, None) => $MapF.mapNOP
+              case _                         => $MapF.mapProject(base)
             }),
             this.fn,
             selection = sel, inputSort = sort, limit = count, scope = scope),
           None))
-
-    def reparent[B](newSrc: B) = copy(src = newSrc)
   }
-  object $Reduce {
+  object $ReduceF {
     import jscore._
-
-    def make(fn: Js.AnonFunDecl, scope: Scope)(src: Workflow):
-        Workflow =
-      Fix(coalesce($Reduce(src, fn, scope)))
 
     val reduceNOP =
       Js.AnonFunDecl(List("key", "values"), List(
@@ -1168,57 +1689,134 @@ object Workflow {
             List(copyAllFields(ident("value"), Name("rez")))))),
         Js.Return(Js.Ident("rez"))))
   }
-  val $reduce = $Reduce.make _
+  object $reduce {
+    def apply[F[_]: Coalesce](fn: Js.AnonFunDecl, scope: Scope)
+      (implicit I: Workflow2_6F :<: F): WorkflowOp[F] =
+      src => Fix(Coalesce[F].coalesce(I.inj($ReduceF(src, fn, scope))))
+
+    def unapply[F[_], A](op: F[A])(implicit I: Workflow2_6F :<: F)
+      : Option[(A, Js.AnonFunDecl, Scope)] =
+      I.prj(op) collect {
+        case $ReduceF(src, fn, scope) => (src, fn, scope)
+      }
+  }
+
+  final case class $LookupF[A](
+    src: A,
+    from: Collection,
+    localField: BsonField.Name,
+    foreignField: BsonField.Name,
+    as: BsonField.Name)
+    extends WorkflowNewIn3_2F[A] { self =>
+    def pipeline: PipelineF[WorkflowNewIn3_2F, A] =
+      new PipelineF[WorkflowNewIn3_2F, A] {
+        def wf = self
+        def src = self.src
+        def reparent[B](newSrc: B) = self.copy(src = newSrc).pipeline
+
+        def op = "$lookup"
+        def rhs = Bson.Doc(ListMap(
+          "from" -> Bson.Text(from.collectionName),
+          "localField" -> localField.bson,
+          "foreignField" -> foreignField.bson,
+          "as" -> as.bson
+        ))
+      }
+  }
+  object $lookup {
+    def $loookup[F[_]: Coalesce](
+      from: Collection,
+      localField: BsonField.Name,
+      foreignField: BsonField.Name,
+      as: BsonField.Name)
+      (implicit I: WorkflowNewIn3_2F :<: F): WorkflowOp[F] =
+        src => Fix(Coalesce[F].coalesce(I.inj($LookupF(src, from, localField, foreignField, as))))
+
+    def unapply[F[_], A](op: F[A])(implicit I: WorkflowNewIn3_2F :<: F)
+      : Option[(A, Collection, BsonField.Name, BsonField.Name, BsonField.Name)] =
+      I.prj(op) collect {
+        case $LookupF(src, from, lf, ff, as) => (src, from, lf, ff, as)
+      }
+  }
+
+  final case class $SampleF[A](src: A, size: Int)
+    extends WorkflowNewIn3_2F[A] { self =>
+    def pipeline: PipelineF[WorkflowNewIn3_2F, A] =
+      new PipelineF[WorkflowNewIn3_2F, A] {
+        def wf = self
+        def src = self.src
+        def reparent[B](newSrc: B) = copy(src = newSrc).pipeline
+
+        def op = "$sample"
+        def rhs = Bson.Int32(size)
+      }
+  }
+  object $sample {
+    def apply[F[_]: Coalesce](size: Int)(implicit I: WorkflowNewIn3_2F :<: F): WorkflowOp[F] =
+      src => Fix(Coalesce[F].coalesce(I.inj($SampleF(src, size))))
+
+    def unapply[F[_], A](op: F[A])(implicit I: WorkflowNewIn3_2F :<: F)
+      : Option[(A, Int)] =
+      I.prj(op) collect {
+        case $SampleF(src, size) => (src, size)
+      }
+    }
 
   /**
     Performs a sequence of operations, sequentially, merging their results.
     */
-  final case class $FoldLeft[A](head: A, tail: NonEmptyList[A])
-      extends WorkflowF[A]
-  object $FoldLeft {
-    def make(head: Workflow, tail: NonEmptyList[Workflow]):
-        Workflow =
-      Fix(coalesce($FoldLeft(head, tail)))
-  }
-  def $foldLeft(first: Workflow, second: Workflow, rest: Workflow*) =
-    $FoldLeft.make(first, NonEmptyList.nel(second, IList.fromList(rest.toList)))
+  final case class $FoldLeftF[A](head: A, tail: NonEmptyList[A])
+      extends Workflow2_6F[A]
+  object $foldLeft {
+    def apply[F[_]: Coalesce](first: Fix[F], second: Fix[F], rest: Fix[F]*)
+      (implicit I: Workflow2_6F :<: F): Fix[F] =
+      Fix(Coalesce[F].coalesce(I.inj($FoldLeftF(first, NonEmptyList.nel(second, IList.fromList(rest.toList))))))
 
-  implicit val WorkflowFRenderTree: RenderTree[WorkflowF[Unit]] = new RenderTree[WorkflowF[Unit]] {
+    // FIXME: the rsult should be in NonEmptyList, but it gives a compile error
+    // saying "this is a GADT skolem"
+    def unapply[F[_], A](op: F[A])(implicit I: Workflow2_6F :<: F)
+      : Option[(A, List[A])] =
+      I.prj(op) collect {
+        case $FoldLeftF(head, tail) => (head, tail.toList)
+      }
+  }
+
+  implicit def Workflow2_6FRenderTree: RenderTree[Workflow2_6F[Unit]] = new RenderTree[Workflow2_6F[Unit]] {
     val wfType = "Workflow" :: Nil
 
-    def render(v: WorkflowF[Unit]) = v match {
-      case $Pure(value)       => Terminal("$Pure" :: wfType, Some(value.toString))
-      case $Read(coll)        => coll.render.copy(nodeType = "$Read" :: wfType)
-      case $Match(_, sel)     =>
-        NonTerminal("$Match" :: wfType, None, sel.render :: Nil)
-      case $Project(_, shape, xId) =>
-        NonTerminal("$Project" :: wfType, None,
+    def render(v: Workflow2_6F[Unit]) = v match {
+      case $PureF(value)       => Terminal("$PureF" :: wfType, Some(value.toString))
+      case $ReadF(coll)        => coll.render.copy(nodeType = "$ReadF" :: wfType)
+      case $MatchF(_, sel)     =>
+        NonTerminal("$MatchF" :: wfType, None, sel.render :: Nil)
+      case $ProjectF(_, shape, xId) =>
+        NonTerminal("$ProjectF" :: wfType, None,
           Reshape.renderReshape(shape) :+
-            Terminal(xId.toString :: "$Project" :: wfType, None))
-      case $Redact(_, value) => NonTerminal("$Redact" :: wfType, None,
+            Terminal(xId.toString :: "$ProjectF" :: wfType, None))
+      case $RedactF(_, value) => NonTerminal("$RedactF" :: wfType, None,
         value.render ::
           Nil)
-      case $Limit(_, count)  => Terminal("$Limit" :: wfType, Some(count.shows))
-      case $Skip(_, count)   => Terminal("$Skip" :: wfType, Some(count.shows))
-      case $Unwind(_, field) => Terminal("$Unwind" :: wfType, Some(field.toString))
-      case $Group(_, grouped, -\/(by)) =>
-        val nt = "$Group" :: wfType
+      case $LimitF(_, count)  => Terminal("$LimitF" :: wfType, Some(count.shows))
+      case $SkipF(_, count)   => Terminal("$SkipF" :: wfType, Some(count.shows))
+      case $UnwindF(_, field) => Terminal("$UnwindF" :: wfType, Some(field.toString))
+      case $GroupF(_, grouped, -\/(by)) =>
+        val nt = "$GroupF" :: wfType
         NonTerminal(nt, None,
           grouped.render ::
             NonTerminal("By" :: nt, None, Reshape.renderReshape(by)) ::
             Nil)
-      case $Group(_, grouped, \/-(expr)) =>
-        val nt = "$Group" :: wfType
+      case $GroupF(_, grouped, \/-(expr)) =>
+        val nt = "$GroupF" :: wfType
         NonTerminal(nt, None,
           grouped.render ::
             Terminal("By" :: nt, Some(expr.toString)) ::
             Nil)
-      case $Sort(_, value)   =>
-        val nt = "$Sort" :: wfType
+      case $SortF(_, value)   =>
+        val nt = "$SortF" :: wfType
         NonTerminal(nt, None,
           value.map { case (field, st) => Terminal("SortKey" :: nt, Some(field.asText + " -> " + st)) }.toList)
-      case $GeoNear(_, near, distanceField, limit, maxDistance, query, spherical, distanceMultiplier, includeLocs, uniqueDocs) =>
-        val nt = "$GeoNear" :: wfType
+      case $GeoNearF(_, near, distanceField, limit, maxDistance, query, spherical, distanceMultiplier, includeLocs, uniqueDocs) =>
+        val nt = "$GeoNearF" :: wfType
         NonTerminal(nt, None,
           Terminal("Near" :: nt, Some(near.shows)) ::
             Terminal("DistanceField" :: nt, Some(distanceField.toString)) ::
@@ -1231,58 +1829,79 @@ object Workflow {
             Terminal("UniqueDocs" :: nt, Some(uniqueDocs.shows)) ::
             Nil)
 
-      case $Map(_, fn, scope) =>
-        val nt = "$Map" :: wfType
+      case $MapF(_, fn, scope) =>
+        val nt = "$MapF" :: wfType
         NonTerminal(nt, None,
           JSRenderTree.render(fn) ::
             Terminal("Scope" :: nt, Some((scope ∘ (_.toJs.pprint(2))).toString)) ::
             Nil)
-      case $FlatMap(_, fn, scope) =>
-        val nt = "$FlatMap" :: wfType
+      case $FlatMapF(_, fn, scope) =>
+        val nt = "$FlatMapF" :: wfType
         NonTerminal(nt, None,
           JSRenderTree.render(fn) ::
             Terminal("Scope" :: nt, Some((scope ∘ (_.toJs.pprint(2))).toString)) ::
             Nil)
-      case $SimpleMap(_, exprs, scope) =>
-        val nt = "$SimpleMap" :: wfType
+      case $SimpleMapF(_, exprs, scope) =>
+        val nt = "$SimpleMapF" :: wfType
         NonTerminal(nt, None,
           exprs.toList.map {
             case MapExpr(e)  => NonTerminal("Map" :: nt, None, List(e.render))
 	    case FlatExpr(e) => NonTerminal("Flatten" :: nt, None, List(e.render))
           } :+
             Terminal("Scope" :: nt, Some((scope ∘ (_.toJs.pprint(2))).toString)))
-      case $Reduce(_, fn, scope) =>
-        val nt = "$Reduce" :: wfType
+      case $ReduceF(_, fn, scope) =>
+        val nt = "$ReduceF" :: wfType
         NonTerminal(nt, None,
           JSRenderTree.render(fn) ::
             Terminal("Scope" :: nt, Some((scope ∘ (_.toJs.pprint(2))).toString)) ::
             Nil)
-      case $Out(_, coll) => coll.render.copy(nodeType = "$Out" :: wfType)
-      case $FoldLeft(_, _) => Terminal("$FoldLeft" :: wfType, None)
+      case $OutF(_, coll) => coll.render.copy(nodeType = "$OutF" :: wfType)
+      case $FoldLeftF(_, _) => Terminal("$FoldLeftF" :: wfType, None)
     }
   }
 
-  implicit val WorkflowRenderTree: RenderTree[Workflow] =
-    new RenderTree[Workflow] {
+  implicit def WorkflowNewIn3_2FRenderTree: RenderTree[WorkflowNewIn3_2F[Unit]] = new RenderTree[WorkflowNewIn3_2F[Unit]] {
+    val wfType = "Workflow3.2" :: Nil
+
+    def render(v: WorkflowNewIn3_2F[Unit]) = v match {
+      case $LookupF(_, from, localField, foreignField, as) =>
+        Terminal("$LookupF" :: wfType, Some(s"$from with $foreignField = $localField as $as"))
+      case $SampleF(_, size) =>
+        Terminal("$SampleF" :: wfType, Some(size.toString))
+    }
+  }
+
+  // TODO: where does this belong?
+  implicit def coproductRenderTree[F[_], G[_], A]
+    (implicit RF: RenderTree[F[A]], RG: RenderTree[G[A]])
+    : RenderTree[Coproduct[F, G, A]] = new RenderTree[Coproduct[F, G, A]] {
+    def render(v: Coproduct[F, G, A]) =
+      v.run.fold(RF.render, RG.render)
+  }
+
+  implicit def WorkflowRenderTree[F[_]: Traverse: Classify]
+    (implicit ev0: Workflow2_6F :<: F, ev1: RenderTree[F[Unit]])
+    : RenderTree[Fix[F]] =
+    new RenderTree[Fix[F]] {
       val wfType = "Workflow" :: Nil
 
-      def chain(op: Workflow): List[RenderedTree] = op.unFix match {
-        case ss: SingleSourceF[Workflow] =>
-          chain(ss.src) :+ Traverse[WorkflowF].void(ss).render
+      def chain(op: Fix[F]): List[RenderedTree] = op.unFix match {
+        case IsSingleSource(ss) =>
+          chain(ss.src) :+ Traverse[F].void(ss.wf).render
         case ms => List(render(Fix(ms)))
       }
 
-      def render(v: Workflow) = v.unFix match {
-        case op: SourceOp    => op.void.render
-        case _: SingleSourceF[Workflow] =>
+      def render(v: Fix[F]) = v.unFix match {
+        case IsSource(s)       => s.op.render
+        case IsSingleSource(_) =>
           NonTerminal("Chain" :: wfType, None, chain(v))
-        case $FoldLeft(_, _) =>
-          NonTerminal("$FoldLeft" :: wfType, None, v.children.map(render(_)))
+        case $foldLeft(_, _) =>
+          NonTerminal("$FoldLeftF" :: wfType, None, v.children.map(render(_)))
       }
     }
 
-  implicit val CrystallizedRenderTree: RenderTree[Crystallized] =
-    new RenderTree[Crystallized] {
-      def render(v: Crystallized) = v.op.render
+  implicit def CrystallizedRenderTree[F[_]](implicit R: RenderTree[Fix[F]]): RenderTree[Crystallized[F]] =
+    new RenderTree[Crystallized[F]] {
+      def render(v: Crystallized[F]) = v.op.render
     }
 }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflowtask/ast.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflowtask/ast.scala
@@ -83,7 +83,7 @@ object WorkflowTaskF {
     new (RenderTree ~> λ[α => RenderTree[WorkflowTaskF[α]]]) {
       def apply[α](ra: RenderTree[α]) = new RenderTree[WorkflowTaskF[α]] {
         val RC = RenderTree[Collection]
-        val RO = RenderTree[Workflow3_2F[Unit]]
+        val RO = RenderTree[WorkflowF[Unit]]
         val RJ = RenderTree[Js]
         val RS = RenderTree[Selector]
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflowtask/ast.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflowtask/ast.scala
@@ -19,15 +19,14 @@ package quasar.physical.mongodb.workflowtask
 import quasar.Predef._
 import quasar.{RenderTree, Terminal, NonTerminal}
 import quasar.javascript._
-import quasar.physical.mongodb.{Bson, Collection, MapReduce, Selector}
-import quasar.physical.mongodb.Workflow._
+import quasar.physical.mongodb.{Bson, Collection, MapReduce, Selector, Workflow}
 
 import scalaz._, Scalaz._
 
-/** A WorkflowTask approximately represents one request to MongoDB.
-  */
+/** A WorkflowTask approximately represents one request to MongoDB. */
 sealed trait WorkflowTaskF[A]
 object WorkflowTaskF {
+  import Workflow._
   import MapReduce._
 
   /** A task that returns a necessarily small amount of raw data. */

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflowtask/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflowtask/package.scala
@@ -30,27 +30,23 @@ package object workflowtask {
 
   type Pipeline = List[PipelineOp]
 
-  // TODO: This should work for any WorkflowF that contains $Project – data
-  //       types a la carte.
-  val simplifyProject: PipelineF ~> PipelineF =
-    new (PipelineF ~> PipelineF) {
-      def apply[α](op: PipelineF[α]) = op match {
-        case $Project(src, Reshape(cont), id) =>
-          $Project(src,
-            Reshape(cont.map {
-              case (k, \/-($var(DocField(v)))) if k == v => k -> $include().right
-              case x                                     => x
-            }),
-            id)
-        case _ => op
-      }
+  val simplifyProject: Workflow2_6F[Unit] => Option[PipelineF[Workflow2_6F, Unit]] =
+    {
+      case $ProjectF(src, Reshape(cont), id) =>
+        $ProjectF(src,
+          Reshape(cont.map {
+            case (k, \/-($var(DocField(v)))) if k == v => k -> $include().right
+            case x                                     => x
+          }),
+          id).pipeline.some
+      case _ => None
     }
 
-  val normalize: WorkflowTaskF ~> WorkflowTaskF =
+  def normalize: WorkflowTaskF ~> WorkflowTaskF =
     new (WorkflowTaskF ~> WorkflowTaskF) {
       def apply[α](wt: WorkflowTaskF[α]) = wt match {
         case PipelineTaskF(src, pipeline) =>
-          PipelineTaskF(src, pipeline.map(simplifyProject(_)))
+          PipelineTaskF(src, pipeline.map(_.rewrite[Workflow2_6F](simplifyProject(_))))
         case x => x
       }
     }
@@ -60,16 +56,16 @@ package object workflowtask {
       (DocVar, WorkflowTask) = task match {
     case PipelineTask(src, pipeline) =>
       // possibly toss duplicate `_id`s created by `Unwind`s
-      val uwIdx = pipeline.lastIndexWhere {
-        case $Unwind(_, _) => true;
+      val uwIdx = pipeline.map(_.op.run).lastIndexWhere {
+        case \/-($UnwindF(_, _)) => true
         case _ => false
       }
       // we’re fine if there’s no `Unwind`, or some existing op fixes the `_id`s
       if (uwIdx == -1 ||
-        pipeline.indexWhere(
-          { case $Group(_, _, _)           => true
-            case $Project(_, _, ExcludeId) => true
-            case _                         => false
+        pipeline.map(_.op.run).indexWhere(
+          { case \/-($GroupF(_, _, _))           => true
+            case \/-($ProjectF(_, _, ExcludeId)) => true
+            case _                              => false
           },
           uwIdx) != -1)
         (base, task)
@@ -79,18 +75,18 @@ package object workflowtask {
             PipelineTask(
               src,
               pipeline :+
-              $Project((),
-                Reshape(names.map(_ -> $include().right).toListMap),
-                ExcludeId)))
+                PipelineOp($ProjectF((),
+                  Reshape(names.map(_ -> $include().right).toListMap),
+                  ExcludeId).pipeline)))
 
         case None =>
           (Workflow.ExprVar,
             PipelineTask(
               src,
               pipeline :+
-                $Project((),
+                PipelineOp($ProjectF((),
                   Reshape(ListMap(Workflow.ExprName -> $var(base).right)),
-                  ExcludeId)))
+                  ExcludeId).pipeline)))
       }
     case _ => (base, task)
   }
@@ -98,14 +94,14 @@ package object workflowtask {
   private def shape(p: Pipeline): Option[List[BsonField.Name]] = {
     def src = shape(p.dropRight(1))
 
-    p.lastOption.flatMap(_ match {
-      case op: ShapePreservingF[_]                 => src
+    p.lastOption.flatMap(_.op.run match {
+      case \/-(IsShapePreserving(_))                    => src
 
-      case $Project((), Reshape(shape), _)         => Some(shape.keys.toList)
-      case $Group((), Grouped(shape), _)           => Some(shape.keys.toList)
-      case $Unwind((), _)                          => src
-      case $Redact((), _)                          => None
-      case $GeoNear((), _, _, _, _, _, _, _, _, _) => src.map(_ :+ BsonField.Name("dist"))
+      case \/-($ProjectF((), Reshape(shape), _))         => Some(shape.keys.toList)
+      case \/-($GroupF((), Grouped(shape), _))           => Some(shape.keys.toList)
+      case \/-($UnwindF((), _))                          => src
+      case \/-($RedactF((), _))                          => None
+      case \/-($GeoNearF((), _, _, _, _, _, _, _, _, _)) => src.map(_ :+ BsonField.Name("dist"))
     })
   }
 }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflowtask/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflowtask/package.scala
@@ -30,7 +30,7 @@ package object workflowtask {
 
   type Pipeline = List[PipelineOp]
 
-  val simplifyProject: Workflow2_6F[Unit] => Option[PipelineF[Workflow2_6F, Unit]] =
+  val simplifyProject: WorkflowOpCoreF[Unit] => Option[PipelineF[WorkflowOpCoreF, Unit]] =
     {
       case $ProjectF(src, Reshape(cont), id) =>
         $ProjectF(src,
@@ -46,7 +46,7 @@ package object workflowtask {
     new (WorkflowTaskF ~> WorkflowTaskF) {
       def apply[α](wt: WorkflowTaskF[α]) = wt match {
         case PipelineTaskF(src, pipeline) =>
-          PipelineTaskF(src, pipeline.map(_.rewrite[Workflow2_6F](simplifyProject(_))))
+          PipelineTaskF(src, pipeline.map(_.rewrite[WorkflowOpCoreF](simplifyProject(_))))
         case x => x
       }
     }

--- a/mongodb/src/test/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutionSpec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutionSpec.scala
@@ -33,24 +33,24 @@ class JavaScriptWorkflowExecutionSpec extends Specification with DisjunctionMatc
   import Workflow._
 
   def toJS(wf: Workflow): WorkflowExecutionError \/ String =
-    WorkflowExecutor.toJS(crystallize(wf))
+    WorkflowExecutor.toJS(Crystallize[WorkflowF].crystallize(wf))
 
   "Executing 'Workflow' as JavaScript" should {
 
     "write trivial workflow to JS" in {
-      val wf = $read(Collection("db", "zips"))
+      val wf = $read[WorkflowF](Collection("db", "zips"))
 
       toJS(wf) must beRightDisjunction("db.zips.find();\n")
     }
 
     "write trivial workflow to JS with fancy collection name" in {
-      val wf = $read(Collection("db", "tmp.123"))
+      val wf = $read[WorkflowF](Collection("db", "tmp.123"))
 
       toJS(wf) must beRightDisjunction("db.getCollection(\"tmp.123\").find();\n")
     }
 
     "be empty for pure values" in {
-      val wf = $pure(Bson.Arr(List(
+      val wf = $pure[WorkflowF](Bson.Arr(List(
         Bson.Doc(ListMap("foo" -> Bson.Int64(1))),
         Bson.Doc(ListMap("bar" -> Bson.Int64(2))))))
 
@@ -59,8 +59,8 @@ class JavaScriptWorkflowExecutionSpec extends Specification with DisjunctionMatc
 
     "write simple query to JS" in {
       val wf = chain(
-        $read(Collection("db", "zips")),
-        $match(Selector.Doc(
+        $read[WorkflowF](Collection("db", "zips")),
+        $match[WorkflowF](Selector.Doc(
           BsonField.Name("pop") -> Selector.Gte(Bson.Int64(1000)))))
 
       toJS(wf) must beRightDisjunction(
@@ -70,8 +70,8 @@ class JavaScriptWorkflowExecutionSpec extends Specification with DisjunctionMatc
 
     "write limit to JS" in {
       val wf = chain(
-        $read(Collection("db", "zips")),
-        $limit(10))
+        $read[WorkflowF](Collection("db", "zips")),
+        $limit[WorkflowF](10))
 
       toJS(wf) must beRightDisjunction(
         """db.zips.find().limit(10);
@@ -80,9 +80,9 @@ class JavaScriptWorkflowExecutionSpec extends Specification with DisjunctionMatc
 
     "write project and limit to JS" in {
       val wf = chain(
-        $read(Collection("db", "zips")),
-        $limit(10),
-        $project(
+        $read[WorkflowF](Collection("db", "zips")),
+        $limit[WorkflowF](10),
+        $project[WorkflowF](
           Reshape(ListMap(
             BsonField.Name("city") -> $include().right)),
           IdHandling.ExcludeId))
@@ -94,11 +94,11 @@ class JavaScriptWorkflowExecutionSpec extends Specification with DisjunctionMatc
 
     "write filter, project, and limit to JS" in {
       val wf = chain(
-        $read(Collection("db", "zips")),
-        $match(Selector.Doc(
+        $read[WorkflowF](Collection("db", "zips")),
+        $match[WorkflowF](Selector.Doc(
           BsonField.Name("pop") -> Selector.Lt(Bson.Int64(1000)))),
-        $limit(10),
-        $project(
+        $limit[WorkflowF](10),
+        $project[WorkflowF](
           Reshape(ListMap(
             BsonField.Name("city") -> $include().right)),
           IdHandling.ExcludeId))
@@ -113,10 +113,10 @@ class JavaScriptWorkflowExecutionSpec extends Specification with DisjunctionMatc
 
     "write simple count to JS" in {
       val wf = chain(
-        $read(Collection("db", "zips")),
-        $match(Selector.Doc(
+        $read[WorkflowF](Collection("db", "zips")),
+        $match[WorkflowF](Selector.Doc(
           BsonField.Name("pop") -> Selector.Gte(Bson.Int64(1000)))),
-        $group(
+        $group[WorkflowF](
           Grouped(ListMap(
             BsonField.Name("num") -> $sum($literal(Bson.Int32(1))))),
           $literal(Bson.Null).right))
@@ -128,12 +128,12 @@ class JavaScriptWorkflowExecutionSpec extends Specification with DisjunctionMatc
 
     "write simple distinct to JS" in {
       val wf = chain(
-        $read(Collection("db", "zips")),
-        $group(
+        $read[WorkflowF](Collection("db", "zips")),
+        $group[WorkflowF](
           Grouped(ListMap()),
           Reshape(ListMap(
             BsonField.Name("0") -> $field("city").right)).left),
-        $project(
+        $project[WorkflowF](
           Reshape(ListMap(
             BsonField.Name("c") -> $field("_id", "0").right)),
           IdHandling.ExcludeId))
@@ -145,14 +145,14 @@ class JavaScriptWorkflowExecutionSpec extends Specification with DisjunctionMatc
 
     "write filtered distinct to JS" in {
       val wf = chain(
-        $read(Collection("db", "zips")),
-        $match(Selector.Doc(
+        $read[WorkflowF](Collection("db", "zips")),
+        $match[WorkflowF](Selector.Doc(
           BsonField.Name("pop") -> Selector.Gte(Bson.Int64(1000)))),
-        $group(
+        $group[WorkflowF](
           Grouped(ListMap()),
           Reshape(ListMap(
             BsonField.Name("0") -> $field("city").right)).left),
-        $project(
+        $project[WorkflowF](
           Reshape(ListMap(
             BsonField.Name("c") -> $field("_id", "0").right)),
           IdHandling.ExcludeId))
@@ -165,8 +165,8 @@ class JavaScriptWorkflowExecutionSpec extends Specification with DisjunctionMatc
 
     "write simple pipeline workflow to JS" in {
       val wf = chain(
-        $read(Collection("db", "zips")),
-        $match(Selector.Doc(
+        $read[WorkflowF](Collection("db", "zips")),
+        $match[WorkflowF](Selector.Doc(
           BsonField.Name("pop") -> Selector.Gte(Bson.Int64(1000)))))
 
       toJS(wf) must beRightDisjunction(
@@ -176,12 +176,12 @@ class JavaScriptWorkflowExecutionSpec extends Specification with DisjunctionMatc
 
     "write chained pipeline workflow to JS find()" in {
       val wf = chain(
-        $read(Collection("db", "zips")),
-        $match(Selector.Doc(
+        $read[WorkflowF](Collection("db", "zips")),
+        $match[WorkflowF](Selector.Doc(
           BsonField.Name("pop") -> Selector.Lte(Bson.Int64(1000)))),
-        $match(Selector.Doc(
+        $match[WorkflowF](Selector.Doc(
           BsonField.Name("pop") -> Selector.Gte(Bson.Int64(100)))),
-        $sort(NonEmptyList(BsonField.Name("city") -> SortDir.Ascending)))
+        $sort[WorkflowF](NonEmptyList(BsonField.Name("city") -> SortDir.Ascending)))
 
       toJS(wf) must beRightDisjunction(
         """db.zips.find(
@@ -196,16 +196,16 @@ class JavaScriptWorkflowExecutionSpec extends Specification with DisjunctionMatc
 
     "write chained pipeline workflow to JS" in {
       val wf = chain(
-        $read(Collection("db", "zips")),
-        $match(Selector.Doc(
+        $read[WorkflowF](Collection("db", "zips")),
+        $match[WorkflowF](Selector.Doc(
           BsonField.Name("pop") -> Selector.Lte(Bson.Int64(1000)))),
-        $match(Selector.Doc(
+        $match[WorkflowF](Selector.Doc(
           BsonField.Name("pop") -> Selector.Gte(Bson.Int64(100)))),
-        $group(
+        $group[WorkflowF](
           Grouped(ListMap(
             BsonField.Name("pop") -> $sum($field("pop")))),
           $field("city").right),
-        $sort(NonEmptyList(BsonField.Name("_id") -> SortDir.Ascending)))
+        $sort[WorkflowF](NonEmptyList(BsonField.Name("_id") -> SortDir.Ascending)))
 
       toJS(wf) must beRightDisjunction(
         """db.zips.aggregate(
@@ -225,12 +225,12 @@ class JavaScriptWorkflowExecutionSpec extends Specification with DisjunctionMatc
 
     "write map-reduce Workflow to JS" in {
       val wf = chain(
-        $read(Collection("db", "zips")),
-        $map($Map.mapKeyVal(("key", "value"),
+        $read[WorkflowF](Collection("db", "zips")),
+        $map[WorkflowF]($MapF.mapKeyVal(("key", "value"),
           Js.Select(Js.Ident("value"), "city"),
           Js.Select(Js.Ident("value"), "pop")),
           ListMap()),
-        $reduce(Js.AnonFunDecl(List("key", "values"), List(
+        $reduce[WorkflowF](Js.AnonFunDecl(List("key", "values"), List(
           Js.Return(Js.Call(
             Js.Select(Js.Ident("Array"), "sum"),
             List(Js.Ident("values")))))),
@@ -252,8 +252,8 @@ class JavaScriptWorkflowExecutionSpec extends Specification with DisjunctionMatc
 
     "write $where condition to JS" in {
       val wf = chain(
-        $read(Collection("db", "zips2")),
-        $match(Selector.Where(Js.Ident("foo"))))
+        $read[WorkflowF](Collection("db", "zips2")),
+        $match[WorkflowF](Selector.Where(Js.Ident("foo"))))
 
       toJS(wf) must beRightDisjunction(
         """db.zips2.mapReduce(
@@ -272,20 +272,20 @@ class JavaScriptWorkflowExecutionSpec extends Specification with DisjunctionMatc
 
     "write join Workflow to JS" in {
       val wf =
-        $foldLeft(
+        $foldLeft[WorkflowF](
           chain(
-            $read(Collection("db", "zips1")),
-            $match(Selector.Doc(
+            $read[WorkflowF](Collection("db", "zips1")),
+            $match[WorkflowF](Selector.Doc(
               BsonField.Name("city") -> Selector.Eq(Bson.Text("BOULDER"))))),
           chain(
-            $read(Collection("db", "zips2")),
-            $match(Selector.Doc(
+            $read[WorkflowF](Collection("db", "zips2")),
+            $match[WorkflowF](Selector.Doc(
               BsonField.Name("pop") -> Selector.Lte(Bson.Int64(1000)))),
-            $map($Map.mapKeyVal(("key", "value"),
+            $map[WorkflowF]($MapF.mapKeyVal(("key", "value"),
               Js.Select(Js.Ident("value"), "city"),
               Js.Select(Js.Ident("value"), "pop")),
               ListMap()),
-            $reduce(Js.AnonFunDecl(List("key", "values"), List(
+            $reduce[WorkflowF](Js.AnonFunDecl(List("key", "values"), List(
               Js.Return(Js.Call(
                 Js.Select(Js.Ident("Array"), "sum"),
                 List(Js.Ident("values")))))),

--- a/mongodb/src/test/scala/quasar/physical/mongodb/pipeline.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/pipeline.scala
@@ -159,14 +159,14 @@ class PipelineSpec extends Specification with ScalaCheck with ArbBsonField with 
 
     "remove one un-nested field" in {
       val op = $SimpleMapF(
-        $read[Workflow2_6F](Collection("db", "foo")),
+        $read[WorkflowOpCoreF](Collection("db", "foo")),
         NonEmptyList(MapExpr(JsFn(Name("x"),
           obj(
             "a" -> Select(ident("x"), "x"),
             "b" -> Select(ident("x"), "y"))))),
         ListMap())
       val exp = $SimpleMapF(
-        $read[Workflow2_6F](Collection("db", "foo")),
+        $read[WorkflowOpCoreF](Collection("db", "foo")),
         NonEmptyList(MapExpr(JsFn(Name("x"),
           obj(
             "a" -> Select(ident("x"), "x"))))),
@@ -176,7 +176,7 @@ class PipelineSpec extends Specification with ScalaCheck with ArbBsonField with 
 
     "remove one nested field" in {
       val op = $SimpleMapF(
-        $read[Workflow2_6F](Collection("db", "foo")),
+        $read[WorkflowOpCoreF](Collection("db", "foo")),
         NonEmptyList(MapExpr(JsFn(Name("x"),
           obj(
             "a" -> Select(ident("x"), "x"),
@@ -185,7 +185,7 @@ class PipelineSpec extends Specification with ScalaCheck with ArbBsonField with 
               "d" -> Select(ident("x"), "z")))))),
         ListMap())
       val exp = $SimpleMapF(
-        $read[Workflow2_6F](Collection("db", "foo")),
+        $read[WorkflowOpCoreF](Collection("db", "foo")),
         NonEmptyList(MapExpr(JsFn(Name("x"),
           obj(
             "a" -> Select(ident("x"), "x"),
@@ -197,7 +197,7 @@ class PipelineSpec extends Specification with ScalaCheck with ArbBsonField with 
 
     "remove whole nested object" in {
       val op = $SimpleMapF(
-        $read[Workflow2_6F](Collection("db", "foo")),
+        $read[WorkflowOpCoreF](Collection("db", "foo")),
         NonEmptyList(MapExpr(JsFn(Name("x"),
           obj(
             "a" -> Select(ident("x"), "x"),
@@ -205,7 +205,7 @@ class PipelineSpec extends Specification with ScalaCheck with ArbBsonField with 
               "c" -> Select(ident("x"), "y")))))),
         ListMap())
       val exp = $SimpleMapF(
-        $read[Workflow2_6F](Collection("db", "foo")),
+        $read[WorkflowOpCoreF](Collection("db", "foo")),
         NonEmptyList(MapExpr(JsFn(Name("x"),
           obj(
             "a" -> Select(ident("x"), "x"))))),

--- a/mongodb/src/test/scala/quasar/physical/mongodb/pipeline.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/pipeline.scala
@@ -39,7 +39,7 @@ class PipelineSpec extends Specification with ScalaCheck with ArbBsonField with 
     Gen.oneOf(ops(0), ops(1), ops.drop(2): _*)
   }) }
 
-  def genProject(size: Int): Gen[$Project[Unit]] = for {
+  def genProject(size: Int): Gen[$ProjectF[Unit]] = for {
     fields <- Gen.nonEmptyListOf(for {
       c  <- Gen.alphaChar
       cs <- Gen.alphaStr
@@ -52,39 +52,39 @@ class PipelineSpec extends Specification with ScalaCheck with ArbBsonField with 
         genExpr.map(\/-(_)))
     } yield BsonField.Name(field) -> value)
     id <- Gen.oneOf(IdHandling.ExcludeId, IdHandling.IncludeId)
-  } yield $Project((), Reshape(ListMap(fields: _*)), id)
+  } yield $ProjectF((), Reshape(ListMap(fields: _*)), id)
 
-  implicit def arbProject = Arbitrary[$Project[Unit]](Gen.resize(5, Gen.sized(genProject)))
+  implicit def arbProject = Arbitrary[$ProjectF[Unit]](Gen.resize(5, Gen.sized(genProject)))
 
   def genRedact = for {
-    value <- Gen.oneOf($Redact.DESCEND, $Redact.KEEP, $Redact.PRUNE)
-  } yield $Redact((), $var(value))
+    value <- Gen.oneOf($RedactF.DESCEND, $RedactF.KEEP, $RedactF.PRUNE)
+  } yield $RedactF((), $var(value))
 
   def unwindGen = for {
     c <- Gen.alphaChar
-  } yield $Unwind((), DocField(BsonField.Name(c.toString)))
+  } yield $UnwindF((), DocField(BsonField.Name(c.toString)))
 
   def genGroup = for {
     i <- Gen.chooseNum(1, 10)
-  } yield $Group((),
+  } yield $GroupF((),
     Grouped(ListMap(BsonField.Name("docsByAuthor" + i.toString) -> $sum($literal(Bson.Int32(1))))),
     \/-($var(DocField(BsonField.Name("author" + i)))))
 
   def genGeoNear = for {
     i <- Gen.chooseNum(1, 10)
-  } yield $GeoNear((), (40.0, -105.0), BsonField.Name("distance" + i), None, None, None, None, None, None, None)
+  } yield $GeoNearF((), (40.0, -105.0), BsonField.Name("distance" + i), None, None, None, None, None, None, None)
 
   def genOut = for {
     i <- Gen.chooseNum(1, 10)
-  } yield $Out((), Collection("db", "result" + i))
+  } yield $OutF((), Collection("db", "result" + i))
 
   def pipelineOpGens(size: Int): List[Gen[PipelineOp]] = {
-    genProject(size) ::
-    genRedact ::
-    unwindGen ::
-    genGroup ::
-    genGeoNear ::
-    genOut ::
+    genProject(size).map(op => PipelineOp(op.pipeline)) ::
+    genRedact.map(op => PipelineOp(op.pipeline)) ::
+    unwindGen.map(op => PipelineOp(op.pipeline)) ::
+    genGroup.map(op => PipelineOp(op.pipeline)) ::
+    genGeoNear.map(op => PipelineOp(op.pipeline)) ::
+    genOut.map(op => PipelineOp(op.shapePreserving)) ::
     arbitraryShapePreservingOpGens.map(g => for { sp <- g } yield sp.op)
   }
 
@@ -101,19 +101,19 @@ class PipelineSpec extends Specification with ScalaCheck with ArbBsonField with 
   def arbitraryShapePreservingOpGens = {
     def matchGen = for {
       c <- Gen.alphaChar
-    } yield ShapePreservingPipelineOp($Match((), Selector.Doc(BsonField.Name(c.toString) -> Selector.Eq(Bson.Int32(-1)))))
+    } yield ShapePreservingPipelineOp(PipelineOp($MatchF((), Selector.Doc(BsonField.Name(c.toString) -> Selector.Eq(Bson.Int32(-1)))).shapePreserving))
 
     def skipGen = for {
       i <- Gen.chooseNum(0, Long.MaxValue)
-    } yield ShapePreservingPipelineOp($Skip((), i))
+    } yield ShapePreservingPipelineOp(PipelineOp($SkipF((), i).shapePreserving))
 
     def limitGen = for {
       i <- Gen.chooseNum(1, Long.MaxValue)
-    } yield ShapePreservingPipelineOp($Limit((), i))
+    } yield ShapePreservingPipelineOp(PipelineOp($LimitF((), i).shapePreserving))
 
     def sortGen = for {
       c <- Gen.alphaChar
-    } yield ShapePreservingPipelineOp($Sort((), NonEmptyList(BsonField.Name("name1") -> SortDir.Ascending)))
+    } yield ShapePreservingPipelineOp(PipelineOp($SortF((), NonEmptyList(BsonField.Name("name1") -> SortDir.Ascending)).shapePreserving))
 
     List(matchGen, limitGen, skipGen, sortGen)
   }
@@ -129,13 +129,13 @@ class PipelineSpec extends Specification with ScalaCheck with ArbBsonField with 
   }) }
 
   "Project.id" should {
-    "be idempotent" ! prop { (p: $Project[Unit]) =>
+    "be idempotent" ! prop { (p: $ProjectF[Unit]) =>
       p.id must_== p.id.id
     }
   }
 
   "Project.get" should {
-    "retrieve whatever value it was set to" ! prop { (p: $Project[Unit], f: BsonField) =>
+    "retrieve whatever value it was set to" ! prop { (p: $ProjectF[Unit], f: BsonField) =>
       val One = $literal(Bson.Int32(1))
 
       p.set(f, \/-(One)).get(DocVar.ROOT(f)) must (beSome(\/-(One)))
@@ -143,13 +143,13 @@ class PipelineSpec extends Specification with ScalaCheck with ArbBsonField with 
   }
 
   "Project.setAll" should {
-    "actually set all" ! prop { (p: $Project[Unit]) =>
+    "actually set all" ! prop { (p: $ProjectF[Unit]) =>
       p.setAll(p.getAll.map(t => t._1 -> \/-(t._2))) must_== p
     }.pendingUntilFixed("result could have `_id -> _id` inserted without changing semantics")
   }
 
   "Project.deleteAll" should {
-    "return empty when everything is deleted" ! prop { (p: $Project[Unit]) =>
+    "return empty when everything is deleted" ! prop { (p: $ProjectF[Unit]) =>
       p.deleteAll(p.getAll.map(_._1)) must_== p.empty
     }
   }
@@ -158,15 +158,15 @@ class PipelineSpec extends Specification with ScalaCheck with ArbBsonField with 
     import jscore._
 
     "remove one un-nested field" in {
-      val op = $SimpleMap(
-        $read(Collection("db", "foo")),
+      val op = $SimpleMapF(
+        $read[Workflow2_6F](Collection("db", "foo")),
         NonEmptyList(MapExpr(JsFn(Name("x"),
           obj(
             "a" -> Select(ident("x"), "x"),
             "b" -> Select(ident("x"), "y"))))),
         ListMap())
-      val exp = $SimpleMap(
-        $read(Collection("db", "foo")),
+      val exp = $SimpleMapF(
+        $read[Workflow2_6F](Collection("db", "foo")),
         NonEmptyList(MapExpr(JsFn(Name("x"),
           obj(
             "a" -> Select(ident("x"), "x"))))),
@@ -175,8 +175,8 @@ class PipelineSpec extends Specification with ScalaCheck with ArbBsonField with 
     }
 
     "remove one nested field" in {
-      val op = $SimpleMap(
-        $read(Collection("db", "foo")),
+      val op = $SimpleMapF(
+        $read[Workflow2_6F](Collection("db", "foo")),
         NonEmptyList(MapExpr(JsFn(Name("x"),
           obj(
             "a" -> Select(ident("x"), "x"),
@@ -184,8 +184,8 @@ class PipelineSpec extends Specification with ScalaCheck with ArbBsonField with 
               "c" -> Select(ident("x"), "y"),
               "d" -> Select(ident("x"), "z")))))),
         ListMap())
-      val exp = $SimpleMap(
-        $read(Collection("db", "foo")),
+      val exp = $SimpleMapF(
+        $read[Workflow2_6F](Collection("db", "foo")),
         NonEmptyList(MapExpr(JsFn(Name("x"),
           obj(
             "a" -> Select(ident("x"), "x"),
@@ -196,16 +196,16 @@ class PipelineSpec extends Specification with ScalaCheck with ArbBsonField with 
     }
 
     "remove whole nested object" in {
-      val op = $SimpleMap(
-        $read(Collection("db", "foo")),
+      val op = $SimpleMapF(
+        $read[Workflow2_6F](Collection("db", "foo")),
         NonEmptyList(MapExpr(JsFn(Name("x"),
           obj(
             "a" -> Select(ident("x"), "x"),
             "b" -> obj(
               "c" -> Select(ident("x"), "y")))))),
         ListMap())
-      val exp = $SimpleMap(
-        $read(Collection("db", "foo")),
+      val exp = $SimpleMapF(
+        $read[Workflow2_6F](Collection("db", "foo")),
         NonEmptyList(MapExpr(JsFn(Name("x"),
           obj(
             "a" -> Select(ident("x"), "x"))))),

--- a/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -2782,7 +2782,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     def joinStructure0(
       left: Workflow, leftName: String, leftBase: Expression, right: Workflow,
       leftKey: Reshape.Shape, rightKey: (String, Expression, Reshape.Shape) \/ JsCore,
-      fin: WorkflowOp[WorkflowF],
+      fin: FixOp[WorkflowF],
       swapped: Boolean) = {
 
       val (leftLabel, rightLabel) =
@@ -2839,7 +2839,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     def joinStructure(
         left: Workflow, leftName: String, leftBase: Expression, right: Workflow,
         leftKey: Reshape.Shape, rightKey: (String, Expression, Reshape.Shape) \/ JsCore,
-        fin: WorkflowOp[WorkflowF],
+        fin: FixOp[WorkflowF],
         swapped: Boolean) =
       Crystallize[WorkflowF].crystallize(joinStructure0(left, leftName, leftBase, right, leftKey, rightKey, fin, swapped))
 

--- a/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -3362,7 +3362,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
       wf.foldMap(_.unFix match {
         case IsSingleSource(op) =>
           Workflow.simpleShape(op.src).map { shape =>
-            val refs = Rewrite[WorkflowF].refs(op.wf)
+            val refs = Refs[WorkflowF].refs(op.wf)
             val missing = refs.collect { case v @ DocVar(_, Some(f)) if !shape.contains(f.flatten.head) => v }
             if (missing.isEmpty) Nil
             else List(missing.map(_.bson).mkString(", ") + " missing in\n" + Fix[WorkflowF](op.wf).show)

--- a/mongodb/src/test/scala/quasar/physical/mongodb/workflowbuilder.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/workflowbuilder.scala
@@ -45,6 +45,8 @@ class WorkflowBuilderSpec
   val readZips = read(Collection("db", "zips"))
   def pureInt(n: Int) = pure(Bson.Int32(n))
 
+  implicit val workflowEqual: Equal[Fix[WorkflowF]] = Equal.equalA
+
   "WorkflowBuilder" should {
 
     "make simple read" in {
@@ -650,7 +652,7 @@ class WorkflowBuilderSpec
         pop <- projectField(grouped, "pop")
       } yield reduce(pop)($sum(_))
       op.map(render) must beRightDisjunction(
-        """GroupBuilder(48712dc)
+        """GroupBuilder
           |├─ ExprBuilder
           |│  ├─ CollectionBuilder(Root())
           |│  │  ├─ $ReadF(db; zips)

--- a/mongodb/src/test/scala/quasar/physical/mongodb/workflowop.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/workflowop.scala
@@ -583,9 +583,6 @@ class WorkflowSpec extends Specification with TreeMatchers {
     import quasar.physical.mongodb.workflowtask._
     import quasar.jscore._
 
-    // val WF: Workflow2_6F[Unit] => WorkflowF[Unit] = Inject[Workflow2_6F, WorkflowF].inj(_)
-
-
     "convert $match with $where into map/reduce" in {
       task(crystallize(chain[Workflow](
         $read(Collection("db", "zips")),


### PR DESCRIPTION
For an introduction, see the first commit's comment.

This is not ready to merge yet:
- needs to be rebased/merged with master
- names and other details could use another look
- some drift has occurred that I intend to clean up to reduce noise

But I would very much appreciate any feedback on whether there are easier ways to do some of what I'm doing here.

If any large-scale changes result from feedback, I'll close this and re-submit a cleaned-up PR.

@sellout: feel free to give as much or as little time as you can afford. I'm afraid you're the only one with much hope of understanding the ramifications of much of this.