### PR TITLE
clean up http4s thread pools after tests run

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- clean up http4s thread pools in regression tests

--- a/it/src/test/scala/quasar/server/ServiceSpec.scala
+++ b/it/src/test/scala/quasar/server/ServiceSpec.scala
@@ -58,8 +58,11 @@ class ServiceSpec extends quasar.QuasarSpecification {
 
     (for {
       svc           <- service
-      (_, shutdown) <- Http4sUtils.startServers(port, svc).liftM[MainErrT]
-      r             <- f(uri).onFinish(_ => shutdown).liftM[MainErrT]
+      (p, shutdown) <- Http4sUtils.startServers(port, svc).liftM[MainErrT]
+      r             <- f(uri)
+                          .onFinish(_ => shutdown)
+                          .onFinish(_ => p.run)
+                          .liftM[MainErrT]
     } yield r).run.unsafePerformSync
   }
 
@@ -242,5 +245,7 @@ class ServiceSpec extends quasar.QuasarSpecification {
     }
 
   }
+
+  step(client.shutdown.unsafePerformSync)
 
 }


### PR DESCRIPTION
- run the "servers" process which actually shuts down the server after
the "shutdown" effect is run
- also shutting down the client instance
- this reduces the number of leaked threads to a single pool (from one
pool per example)