### PR TITLE
Refactor FileSystemDef monoid to not forget errors

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- Refactor FileSystemDef monoid to not forget errors

--- a/core/src/main/scala/quasar/fs/mount/MountRequestHandler.scala
+++ b/core/src/main/scala/quasar/fs/mount/MountRequestHandler.scala
@@ -55,7 +55,8 @@ final class MountRequestHandler[F[_], S[_]](
   )(implicit
     T0: F :<: T,
     T1: fsm.MountedFsRef :<: T,
-    T2: HierarchicalFsRef :<: T
+    T2: HierarchicalFsRef :<: T,
+    F: Monad[F]
   ): Free[T, MountingError \/ Unit] = {
     val handleMount: MntErrT[Free[T, ?], Unit] =
       EitherT(req match {

--- a/core/src/test/scala/quasar/fs/mount/FileSystemDefSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/FileSystemDefSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.fs.mount
+
+import quasar.Predef._
+import quasar.SKI.κ
+import quasar.{EnvironmentError, QuasarSpecification}
+import quasar.fs._
+
+import monocle.std.{disjunction => D}
+import monocle.std.nel._
+import monocle.function.Cons1
+import scalaz._, Scalaz._
+
+class FileSystemDefSpec extends QuasarSpecification {
+  import FileSystemDef._, EnvironmentError._
+
+  type DefId[A] = DefErrT[Id, A]
+
+  val defnResult =
+    DefinitionResult[Id](Empty.fileSystem[Id], ())
+
+  val successfulDef =
+    FileSystemDef(κ(defnResult.point[DefId].some))
+
+  val failedDef =
+    FileSystemDef(κ(Some(
+      connectionFailed("NOPE")
+        .right[NonEmptyList[String]]
+        .raiseError[DefId, DefinitionResult[Id]])))
+
+  val unhandledDef =
+    FileSystemDef[Id](κ(None))
+
+  val someType = FileSystemType("somefs")
+  val someUri = ConnectionUri("some://filesystem")
+
+  val firstErrMsg =
+    D.left[DefinitionError, DefinitionResult[Id]]  composePrism
+    D.left[NonEmptyList[String], EnvironmentError] composeLens
+    Cons1.head
+
+  "apply" should {
+    "return an unsupported filesytem error when unhandled" >> {
+      firstErrMsg.getOption(unhandledDef(someType, someUri).run) must
+        beSome(startWith("Unsupported filesystem"))
+    }
+  }
+
+  "orElse" should {
+    "return the first result when handled success" >> {
+      successfulDef.orElse(failedDef)(someType, someUri).run must be_\/-
+    }
+
+    "return the first result when handled failure" >> {
+      failedDef.orElse(successfulDef)(someType, someUri).run must be_-\/
+    }
+
+    "return the second result when unhandled" >> {
+      unhandledDef.orElse(successfulDef)(someType, someUri).run must be_\/-
+    }
+  }
+}


### PR DESCRIPTION
Now the monoid will only choose an alternate def if the first could not handle the arguments whereas previously we would try another if the first _did_ handle the arguments and failed.