### PR TITLE
[#1284] Support for simple joins with $lookup on MongoDB 3.2 and later

### DIFF
--- a/CHANGELOG/feature.md
+++ b/CHANGELOG/feature.md
@@ -1,0 +1,4 @@
+- [#1284] handle very simple joins using $lookup when the backend is >= MongoDB 3.2
+   - works only for "trivial" joins where the condition is a simple equality relation between fields and there is no filtering on either side
+   - fall back to map-reduce in all other cases
+   - no checking of referenced collections; will fail if they are sharded

--- a/mongodb/src/main/scala/quasar/physical/mongodb/JoinHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/JoinHandler.scala
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TOOD: move to .planner package
+package quasar.physical.mongodb
+
+import quasar.Predef._
+import quasar.{TernaryFunc}
+import quasar.fp._
+import quasar.javascript._
+import quasar.jscore, jscore.{JsCore, JsFn}
+import quasar.std.StdLib._
+import quasar.physical.mongodb.accumulator._
+import quasar.physical.mongodb.expression._
+import Workflow._
+import WorkflowBuilder._
+
+import matryoshka._
+import scalaz._, Scalaz._
+
+final case class JoinHandler[F[_], G[_]](run: (TernaryFunc, JoinSource[F], JoinSource[F]) => G[WorkflowBuilder[F]]) {
+
+  def apply(tpe: TernaryFunc, left: JoinSource[F], right: JoinSource[F]): G[WorkflowBuilder[F]] =
+    run(tpe, left, right)
+}
+
+final case class JoinSource[F[_]](src: WorkflowBuilder[F], keys: List[WorkflowBuilder[F]], js: Option[List[JsFn]])
+
+object JoinHandler {
+
+  // FIXME: these have to match the names used in the logical plan. Should
+  //        change this to ensure left0/right0 are `Free` and pull the names
+  //        from those.
+  val LeftName: BsonField.Name = BsonField.Name("left")
+  val RightName: BsonField.Name = BsonField.Name("right")
+
+  /** When possible, plan a join using the more efficient \$lookup operator in
+    * the aggregation pipeline.
+    */
+  def pipeline[F[_]: Functor: Coalesce: Crush: Crystallize]
+    (implicit ev0: WorkflowOpCoreF :<: F, ev1: WorkflowOp3_2F :<: F, ev2: Show[WorkflowBuilder[F]])
+    : JoinHandler[F, OptionT[WorkflowBuilder.M, ?]] = JoinHandler({ (tpe, left, right) =>
+
+    val WB = WorkflowBuilder.Ops[F]
+
+    def lookup(
+      lSrc: WorkflowBuilder[F], lField: BsonField, lName: BsonField.Name,
+      rColl: Collection, rField: BsonField, rName: BsonField.Name) =
+    {
+      val left = WB.makeObject(lSrc, lName.asText)
+      val filtered = WB.filter(left,
+        List(ExprBuilder(left, \/-($var(DocField(lName \ lField))))),
+        { case List(f) => Selector.Doc(f -> Selector.Neq(Bson.Null)) })
+      workflow(filtered).map { case (left, _) =>
+        CollectionBuilder(
+          chain[Fix[F]](
+            left,
+            $lookup(rColl, lName \ lField, rField, rName),
+            $unwind(DocField(rName))),
+          Root(),
+          None)
+        }
+    }
+
+    (tpe, left, right) match {
+      case (set.InnerJoin, IsLookupInput(src, expr), IsLookupFrom(coll, field)) =>
+        lookup(src, expr, LeftName, coll, field, RightName).liftM[OptionT]
+
+      case (set.InnerJoin, IsLookupFrom(coll, field), IsLookupInput(src, expr)) =>
+        lookup(src, expr, RightName, coll, field, LeftName).liftM[OptionT]
+
+      case _ => OptionT.none
+    }
+  })
+
+  object IsLookupInput {
+    /** Matches a source which is suitable to be the "left" side of a
+      * \$lookup-based join; essentially, it needs to have a single key.
+      */
+    def unapply[F[_]](arg: JoinSource[F])(implicit ev: Equal[Fix[WorkflowBuilderF[F, ?]]])
+      : Option[(WorkflowBuilder[F], BsonField)] =
+      arg.keys match {
+        // TODO: generalize to handle more sources (notably ShapePreservingBuilders)
+        case List(Fix(ExprBuilderF(src, \/-($var(DocVar(_, Some(field))))))) if src ≟ arg.src =>
+          (src, field).some
+        case _ =>
+          None
+      }
+  }
+  object IsLookupFrom {
+    /** Matches a source which is suitable to be the "right" side of a
+      * \$lookup-based join; this has to be a \$project of a single field from
+      * a raw \$read.
+      */
+    def unapply[F[_]](arg: JoinSource[F])
+      (implicit ev0: WorkflowOpCoreF :<: F, ev1: Equal[Fix[WorkflowBuilderF[F, ?]]])
+      : Option[(Collection, BsonField)] =
+      arg match {
+        case JoinSource(
+              Fix(CollectionBuilderF(Fix($read(coll)), Root(), None)),
+              List(Fix(ExprBuilderF(src, \/-($var(DocVar(_, Some(field))))))),
+              _) if src ≟ arg.src =>
+          (coll, field).some
+        case _ =>
+          None
+      }
+  }
+
+  /** Plan an arbitrary join using only "core" operators, which always means a map-reduce. */
+  def mapReduce[F[_]: Functor: Coalesce: Crush: Crystallize]
+    (implicit ev0: WorkflowOpCoreF :<: F, ev1: Show[WorkflowBuilder[F]])
+    : JoinHandler[F, WorkflowBuilder.M] = JoinHandler({ (tpe, left0, right0) =>
+
+    val ops = Ops[F]
+    import ops._
+
+    val leftField0 = LeftName
+    val rightField0 = RightName
+
+    def keyMap(keyExpr: List[JsFn], rootField: BsonField.Name, otherField: BsonField.Name): Js.AnonFunDecl =
+      $MapF.mapKeyVal(("key", "value"),
+        keyExpr match {
+          case Nil => Js.Null
+          case _   =>
+            jscore.Obj(keyExpr.map(_(jscore.ident("value"))).zipWithIndex.foldLeft[ListMap[jscore.Name, JsCore]](ListMap[jscore.Name, JsCore]()) {
+              case (acc, (j, i)) => acc + (jscore.Name(i.toString) -> j)
+            }).toJs
+        },
+        Js.AnonObjDecl(List(
+          (otherField.asText, Js.AnonElem(Nil)),
+          (rootField.asText, Js.AnonElem(List(Js.Ident("value")))))))
+
+    def jsReduce(src: WorkflowBuilder[F], key: List[JsFn],
+                 rootField: BsonField.Name, otherField: BsonField.Name):
+        (WorkflowBuilder[F], FixOp[F]) =
+      (src, $map[F](keyMap(key, rootField, otherField), ListMap()))
+
+    def wbReduce(src: WorkflowBuilder[F], key: List[WorkflowBuilder[F]],
+                 rootField: BsonField.Name, otherField: BsonField.Name):
+        (WorkflowBuilder[F], FixOp[F]) =
+      (DocBuilder(
+        reduce(groupBy(src, key))($push(_)),
+        ListMap(
+          rootField             -> \/-($$ROOT),
+          otherField            -> \/-($literal(Bson.Arr(Nil))),
+          BsonField.Name("_id") -> \/-($include()))),
+        ι)
+
+    val (left, right, leftField, rightField) =
+      (left0.js, right0.js) match {
+        case (Some(js), _)
+            if preferMapReduce(left0.src) && !preferMapReduce(right0.src) =>
+          (wbReduce(right0.src, right0.keys, rightField0, leftField0),
+            jsReduce(left0.src, js, leftField0, rightField0),
+            rightField0, leftField0)
+        case (_, Some(js)) =>
+          (wbReduce(left0.src, left0.keys, leftField0, rightField0),
+            jsReduce(right0.src, js, rightField0, leftField0),
+            leftField0, rightField0)
+        case (Some(js), _) =>
+          (wbReduce(right0.src, right0.keys, rightField0, leftField0),
+            jsReduce(left0.src, js, leftField0, rightField0),
+            rightField0, leftField0)
+        case (None, None) =>
+          (wbReduce(left0.src, left0.keys, leftField0, rightField0),
+            wbReduce(right0.src, right0.keys, rightField0, leftField0),
+            leftField0, rightField0)
+      }
+
+    val nonEmpty: Selector.SelectorExpr = Selector.NotExpr(Selector.Size(0))
+
+    def padEmpty(side: BsonField): Expression =
+      $cond($eq($size($var(DocField(side))), $literal(Bson.Int32(0))),
+        $literal(Bson.Arr(List(Bson.Doc(ListMap())))),
+        $var(DocField(side)))
+
+    def buildProjection(l: Expression, r: Expression): FixOp[F] =
+      $project[F](Reshape(ListMap(leftField -> \/-(l), rightField -> \/-(r)))).apply(_)
+
+    // TODO exhaustive pattern match
+    def buildJoin(src: Fix[F], tpe: TernaryFunc): Fix[F] =
+      tpe match {
+        case set.FullOuterJoin =>
+          chain(src,
+            buildProjection(padEmpty(leftField), padEmpty(rightField)))
+        case set.LeftOuterJoin =>
+          chain(src,
+            $match[F](Selector.Doc(ListMap(
+              leftField.asInstanceOf[BsonField] -> nonEmpty))),
+            buildProjection($var(DocField(leftField)), padEmpty(rightField)))
+        case set.RightOuterJoin =>
+          chain(src,
+            $match[F](Selector.Doc(ListMap(
+              rightField.asInstanceOf[BsonField] -> nonEmpty))),
+            buildProjection(padEmpty(leftField), $var(DocField(rightField))))
+        case set.InnerJoin =>
+          chain(
+            src,
+            $match[F](
+              Selector.Doc(ListMap(
+                leftField.asInstanceOf[BsonField] -> nonEmpty,
+                rightField -> nonEmpty))))
+        case _ => scala.sys.error("How did this get here?")
+      }
+
+    val rightReduce = {
+      import Js._
+
+      AnonFunDecl(List("key", "values"),
+        List(
+          VarDef(List(("result",
+            AnonObjDecl(List(
+              (leftField.asText, AnonElem(Nil)),
+              (rightField.asText, AnonElem(Nil))))))),
+          Call(Select(Ident("values"), "forEach"),
+            List(AnonFunDecl(List("value"),
+              // TODO: replace concat here with a more efficient operation
+              //      (push or unshift)
+              List(
+                BinOp("=",
+                  Select(Ident("result"), leftField.asText),
+                  Call(Select(Select(Ident("result"), leftField.asText), "concat"),
+                    List(Select(Ident("value"), leftField.asText)))),
+                BinOp("=",
+                  Select(Ident("result"), rightField.asText),
+                  Call(Select(Select(Ident("result"), rightField.asText), "concat"),
+                    List(Select(Ident("value"), rightField.asText)))))))),
+          Return(Ident("result"))))
+    }
+
+    (workflow(left._1) |@| workflow(right._1)) { case ((l, _), (r, _)) =>
+      CollectionBuilder(
+        chain(
+          $foldLeft[F](
+            left._2(l),
+            chain(r, right._2, $reduce[F](rightReduce, ListMap()))),
+          (op: Fix[F]) => buildJoin(op, tpe),
+          $unwind[F](DocField(leftField)),
+          $unwind[F](DocField(rightField))),
+        Root(),
+        None)
+    }
+  })
+
+  // TODO: This is an approximation. If we could postpone this decision until
+  //      `Workflow.crush`, when we actually have a task (whether aggregation or
+  //       mapReduce) in hand, we would know for sure.
+  private def preferMapReduce[F[_]: Coalesce: Crush: Crystallize: Functor](wb: WorkflowBuilder[F])
+    (implicit ev0: WorkflowOpCoreF :<: F, ev1: Show[WorkflowBuilder[F]])
+    : Boolean = {
+    // TODO: Get rid of this when we functorize WorkflowTask
+    def checkTask(wt: workflowtask.WorkflowTask): Boolean = wt match {
+      case workflowtask.FoldLeftTask(_, _)     => true
+      case workflowtask.MapReduceTask(_, _, _) => true
+      case workflowtask.PipelineTask(src, _)   => checkTask(src)
+      case _                                   => false
+    }
+
+    workflow[F](wb).evalZero.fold(
+      κ(false),
+      wf => checkTask(task(Crystallize[F].crystallize(wf._1))))
+  }
+}

--- a/mongodb/src/main/scala/quasar/physical/mongodb/JoinHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/JoinHandler.scala
@@ -18,7 +18,6 @@
 package quasar.physical.mongodb
 
 import quasar.Predef._
-import quasar.{TernaryFunc}
 import quasar.fp._
 import quasar.javascript._
 import quasar.jscore, jscore.{JsCore, JsFn}
@@ -31,9 +30,9 @@ import WorkflowBuilder._
 import matryoshka._
 import scalaz._, Scalaz._
 
-final case class JoinHandler[F[_], G[_]](run: (TernaryFunc, JoinSource[F], JoinSource[F]) => G[WorkflowBuilder[F]]) {
+final case class JoinHandler[F[_], G[_]](run: (JoinType, JoinSource[F], JoinSource[F]) => G[WorkflowBuilder[F]]) {
 
-  def apply(tpe: TernaryFunc, left: JoinSource[F], right: JoinSource[F]): G[WorkflowBuilder[F]] =
+  def apply(tpe: JoinType, left: JoinSource[F], right: JoinSource[F]): G[WorkflowBuilder[F]] =
     run(tpe, left, right)
 }
 
@@ -191,7 +190,7 @@ object JoinHandler {
       $project[F](Reshape(ListMap(leftField -> \/-(l), rightField -> \/-(r)))).apply(_)
 
     // TODO exhaustive pattern match
-    def buildJoin(src: Fix[F], tpe: TernaryFunc): Fix[F] =
+    def buildJoin(src: Fix[F], tpe: JoinType): Fix[F] =
       tpe match {
         case set.FullOuterJoin =>
           chain(src,

--- a/mongodb/src/main/scala/quasar/physical/mongodb/optimize/optimize.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/optimize/optimize.scala
@@ -279,13 +279,13 @@ package object optimize {
     def inlineGroupProjects[F[_]: Functor](g: $GroupF[Fix[F]])
       (implicit I: WorkflowOpCoreF :<: F)
       : Option[(Fix[F], Grouped, Reshape.Shape)] = {
-      def collectShapesƒ: F[(Fix[F], (List[Reshape], Fix[F]))] => (List[Reshape], Fix[F]) =
+      def collectShapes: GAlgebra[(Fix[F], ?), F, (List[Reshape], Fix[F])] =
         {
           case $project(src, shape, _) => ((x: List[Reshape]) => shape :: x).first(src._2)
           case x                       => (Nil, Fix(x.map(_._1)))
         }
 
-      val (rs, src) = g.src.para(collectShapesƒ)
+      val (rs, src) = g.src.para(collectShapes)
 
       if (src == g.src) None
       else {

--- a/mongodb/src/main/scala/quasar/physical/mongodb/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/package.scala
@@ -17,6 +17,7 @@
 package quasar.physical
 
 import quasar.Predef.Vector
+import quasar.TernaryFunc
 import quasar.javascript.Js
 import quasar.fs.PhysicalError
 import quasar.namegen._
@@ -38,6 +39,9 @@ package object mongodb {
   type JavaScriptLog[A]        = Writer[JavaScriptPrg, A]
 
   type MongoDbIOLog[A] = JavaScriptLogT[MongoDbIO, A]
+
+  // TODO: actually give these funcs their own type
+  type JoinType = TernaryFunc
 
   // TODO: parameterize over label (SD-512)
   def freshName: State[NameGen, BsonField.Name] =

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflowtask/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflowtask/package.scala
@@ -94,14 +94,16 @@ package object workflowtask {
   private def shape(p: Pipeline): Option[List[BsonField.Name]] = {
     def src = shape(p.dropRight(1))
 
-    p.lastOption.flatMap(_.op.run match {
-      case \/-(IsShapePreserving(_))                    => src
+    p.lastOption.flatMap(_.op match {
+      case IsShapePreserving(_)                    => src
 
-      case \/-($ProjectF((), Reshape(shape), _))         => Some(shape.keys.toList)
-      case \/-($GroupF((), Grouped(shape), _))           => Some(shape.keys.toList)
-      case \/-($UnwindF((), _))                          => src
-      case \/-($RedactF((), _))                          => None
-      case \/-($GeoNearF((), _, _, _, _, _, _, _, _, _)) => src.map(_ :+ BsonField.Name("dist"))
+      case $project((), Reshape(shape), _)         => Some(shape.keys.toList)
+      case $group((), Grouped(shape), _)           => Some(shape.keys.toList)
+      case $unwind((), _)                          => src
+      case $redact((), _)                          => None
+      case $geoNear((), _, _, _, _, _, _, _, _, _) => src.map(_ :+ BsonField.Name("dist"))
+
+      case $lookup((), _, _, _, as)                => src.map(_ :+ as)
     })
   }
 }

--- a/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -74,20 +74,26 @@ class PlannerSpec extends quasar.QuasarSpecification with ScalaCheck with Compil
 
   val basePath = rootDir[Sandboxed] </> dir("db")
 
-  def queryPlanner(expr: Fix[Sql]) =
+  def queryPlanner(expr: Fix[Sql], ctx: MongoQueryModel) =
     queryPlan(expr, Variables.empty, basePath, 0L, None)
       .leftMap[CompilationError](CompilationError.ManyErrors(_))
       // TODO: Would be nice to error on Constant plans here, but property
       // tests currently run into that.
       .flatMap(_.fold(
         e => scala.sys.error("query evaluated to a constant, this won’t get to the backend"),
-        MongoDbPlanner.plan(_, MongoQueryModel.`3.2`).leftMap(CPlannerError(_))))
+        MongoDbPlanner.plan(_, ctx).leftMap(CPlannerError(_))))
 
-  def plan(query: String): Either[CompilationError, Crystallized[WorkflowF]] = {
+  def plan0(query: String, ctx: MongoQueryModel): Either[CompilationError, Crystallized[WorkflowF]] = {
     fixParser.parse(Query(query)).fold(
       e => scala.sys.error("parsing error: " + e.message),
-      queryPlanner(_).run).value.toEither
+      queryPlanner(_, ctx).run).value.toEither
   }
+
+  def plan2_6(query: String): Either[CompilationError, Crystallized[WorkflowF]] =
+    plan0(query, MongoQueryModel.`2.6`)
+
+  def plan(query: String): Either[CompilationError, Crystallized[WorkflowF]] =
+    plan0(query, MongoQueryModel.`3.2`)
 
   def plan(logical: Fix[LogicalPlan]): Either[PlannerError, Crystallized[WorkflowF]] = {
     (for {
@@ -101,7 +107,7 @@ class PlannerSpec extends quasar.QuasarSpecification with ScalaCheck with Compil
   def planLog(query: String): ParsingError \/ Vector[PhaseResult] =
     for {
       expr <- fixParser.parse(Query(query))
-    } yield queryPlanner(expr).run.written
+    } yield queryPlanner(expr, MongoQueryModel.`3.2`).run.written
 
   def beWorkflow(wf: Workflow) = beRight(equalToWorkflow(wf))
 
@@ -2842,8 +2848,8 @@ class PlannerSpec extends quasar.QuasarSpecification with ScalaCheck with Compil
         swapped: Boolean) =
       Crystallize[WorkflowF].crystallize(joinStructure0(left, leftName, leftBase, right, leftKey, rightKey, fin, swapped))
 
-    "plan simple join" in {
-      plan("select zips2.city from zips join zips2 on zips._id = zips2._id") must
+    "plan simple join (map-reduce)" in {
+      plan2_6("select zips2.city from zips join zips2 on zips._id = zips2._id") must
         beWorkflow(
           joinStructure(
             $read(Collection("db", "zips")), "__tmp0", $$ROOT,
@@ -2866,6 +2872,30 @@ class PlannerSpec extends quasar.QuasarSpecification with ScalaCheck with Compil
                     $literal(Bson.Undefined))),
                 IgnoreId)),
             false).op)
+    }
+
+    "plan simple join ($lookup)" in {
+      plan("select zips2.city from zips join zips2 on zips._id = zips2._id") must
+        beWorkflow(chain[Workflow](
+          $read(Collection("db", "zips")),
+          $match(Selector.Doc(
+            BsonField.Name("_id") -> Selector.Neq(Bson.Null))),
+          $project(reshape("left" -> $$ROOT)),
+          $lookup(
+            Collection("db", "zips2"),
+            BsonField.Name("left") \ BsonField.Name("_id"),
+            BsonField.Name("_id"),
+            BsonField.Name("right")),
+          $unwind(DocField(BsonField.Name("right"))),
+          $project(
+            reshape("city" ->
+              $cond(
+                $and(
+                  $lte($literal(Bson.Doc(ListMap())), $field("right")),
+                  $lt($field("right"), $literal(Bson.Arr(Nil)))),
+                $field("right", "city"),
+                $literal(Bson.Undefined))),
+            IgnoreId)))
     }
 
     "plan non-equi join" in {
@@ -2936,8 +2966,8 @@ class PlannerSpec extends quasar.QuasarSpecification with ScalaCheck with Compil
           false).op)
     }
 
-    "plan simple inner equi-join" in {
-      plan(
+    "plan simple inner equi-join (map-reduce)" in {
+      plan2_6(
         "select foo.name, bar.address from foo join bar on foo.id = bar.foo_id") must
       beWorkflow(
         joinStructure(
@@ -2969,6 +2999,38 @@ class PlannerSpec extends quasar.QuasarSpecification with ScalaCheck with Compil
                     $literal(Bson.Undefined))),
               IgnoreId)),
           false).op)
+    }
+
+    "plan simple inner equi-join ($lookup)" in {
+      plan(
+        "select foo.name, bar.address from foo join bar on foo.id = bar.foo_id") must
+      beWorkflow(chain[Workflow](
+        $read(Collection("db", "foo")),
+        $match(Selector.Doc(
+          BsonField.Name("id") -> Selector.Neq(Bson.Null))),
+        $project(reshape("left" -> $$ROOT)),
+        $lookup(
+          Collection("db", "bar"),
+          BsonField.Name("left") \ BsonField.Name("id"),
+          BsonField.Name("foo_id"),
+          BsonField.Name("right")),
+        $unwind(DocField(BsonField.Name("right"))),
+        $project(reshape(
+          "name" ->
+            $cond(
+              $and(
+                $lte($literal(Bson.Doc(ListMap())), $field("left")),
+                $lt($field("left"), $literal(Bson.Arr(Nil)))),
+              $field("left", "name"),
+              $literal(Bson.Undefined)),
+          "address" ->
+            $cond(
+              $and(
+                $lte($literal(Bson.Doc(ListMap())), $field("right")),
+                $lt($field("right"), $literal(Bson.Arr(Nil)))),
+              $field("right", "address"),
+              $literal(Bson.Undefined))),
+          IgnoreId)))
     }
 
     "plan simple outer equi-join with wildcard" in {
@@ -3063,8 +3125,8 @@ class PlannerSpec extends quasar.QuasarSpecification with ScalaCheck with Compil
           false).op)
     }
 
-    "plan 3-way right equi-join" in {
-      plan(
+    "plan 3-way right equi-join (map-reduce)" in {
+      plan2_6(
         "select foo.name, bar.address, baz.zip " +
           "from foo join bar on foo.id = bar.foo_id " +
           "right join baz on bar.id = baz.bar_id") must


### PR DESCRIPTION
Pull `join` out of WorkflowBuilder, and implement a pair of `JoinHandler`s with different requirements on the workflow type. If the plan's structure does not conform to the very simple pattern, then we fall back to map-reduce as before.

@jdegoes: This commit does not include any checking of the collections `$lookup` is applied to, so it will fail if the sources are in different databases, or if the collection being merged _in_ is sharded. These checks to prevent runtime errors are the next thing on my list. If you would rather not merge this code in a state where certain queries can fail, I will add that to this PR before it is merged. Otherwise, this is certainly useful as a demonstration of the benefit of `$lookup`.

A simple example joining the 29k-document `zips` dataset to itself runs at least 20x faster with `$lookup`:

```
💪 $ cd local3.0/quasar-test
💪 $ select a.city, b.state from zips as a join zips as b on a._id = b._id
MongoDB
db.zips.aggregate(...);
db.zips.mapReduce(...);
db.tmp.gen_ebcd9878_0.aggregate(...);

Query time: 4.2s
 city          | state |
---------------|-------|
 AGAWAM        | MA    |
...

💪 $ cd /local3.2/quasar-test
💪 $ select a.city, b.state from zips as a join zips as b on a._id = b._id
MongoDB
db.zips.aggregate(
  [
    { "$match": { "_id": { "$ne": null } } },
    { "$project": { "left": "$$ROOT" } },
    {
      "$lookup": {
        "from": "zips",
        "localField": "left._id",
        "foreignField": "_id",
        "as": "right"
      }
    },
    { "$unwind": "$right" },
    { "$limit": NumberLong("11") },
    {
      "$project": {...}
    },
    { "$project": { "city": true, "state": true, "_id": false } }],
  { "allowDiskUse": true });


Query time: 0.1s
 city          | state |
---------------|-------|
 AGAWAM        | MA    |
...
