### PR TITLE
Skip pending regression tests

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- improve build stability by treating "pending" regression tests as "skipped" in CI

--- a/build.sbt
+++ b/build.sbt
@@ -185,8 +185,11 @@ lazy val foundation = project
   .settings(publishSettings: _*)
   .settings(
     libraryDependencies ++= Dependencies.foundation,
-    publishArtifact in (Test, packageBin) := true)
-  .enablePlugins(AutomateHeaderPlugin)
+    publishArtifact in (Test, packageBin) := true,
+    isCIBuild := sys.env contains "TRAVIS",
+    buildInfoKeys := Seq[BuildInfoKey](version, ScoverageKeys.coverageEnabled, isCIBuild),
+    buildInfoPackage := "quasar.build")
+  .enablePlugins(AutomateHeaderPlugin, BuildInfoPlugin)
 
 lazy val ejson = project
   .settings(name := "quasar-ejson-internal")
@@ -220,11 +223,8 @@ lazy val core = project
     libraryDependencies ++= Dependencies.core,
     publishArtifact in (Test, packageBin) := true,
     ScoverageKeys.coverageMinimum := 79,
-    ScoverageKeys.coverageFailOnMinimum := true,
-    isCIBuild := sys.env contains "TRAVIS",
-    buildInfoKeys := Seq[BuildInfoKey](version, ScoverageKeys.coverageEnabled, isCIBuild),
-    buildInfoPackage := "quasar.build")
-  .enablePlugins(AutomateHeaderPlugin, BuildInfoPlugin)
+    ScoverageKeys.coverageFailOnMinimum := true)
+  .enablePlugins(AutomateHeaderPlugin)
 
 lazy val main = project
   .settings(name := "quasar-main-internal")

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import quasar.project._
 import quasar.project.build._
 
 import java.lang.Integer
-import scala.{List, Predef, None, Some, sys, Unit}, Predef.{any2ArrowAssoc, assert, augmentString}
+import scala.{Boolean, List, Predef, None, Some, sys, Unit}, Predef.{any2ArrowAssoc, assert, augmentString}
 import scala.collection.Seq
 import scala.collection.immutable.Map
 
@@ -155,6 +155,8 @@ lazy val oneJarSettings =
         commitReleaseVersion,
         pushChanges))
 
+lazy val isCIBuild = settingKey[Boolean]("True when building in any automated environment (e.g. Travis)")
+
 lazy val root = project.in(file("."))
   .settings(commonSettings: _*)
   .settings(noPublishSettings)
@@ -219,7 +221,8 @@ lazy val core = project
     publishArtifact in (Test, packageBin) := true,
     ScoverageKeys.coverageMinimum := 79,
     ScoverageKeys.coverageFailOnMinimum := true,
-    buildInfoKeys := Seq[BuildInfoKey](version, ScoverageKeys.coverageEnabled),
+    isCIBuild := sys.env contains "TRAVIS",
+    buildInfoKeys := Seq[BuildInfoKey](version, ScoverageKeys.coverageEnabled, isCIBuild),
     buildInfoPackage := "quasar.build")
   .enablePlugins(AutomateHeaderPlugin, BuildInfoPlugin)
 

--- a/core/src/test/scala/quasar/compiler.scala
+++ b/core/src/test/scala/quasar/compiler.scala
@@ -18,12 +18,11 @@ package quasar
 
 import quasar.Predef._
 import quasar.std._
-import quasar.specs2.PendingWithAccurateCoverage
 
 import matryoshka.Fix
 import org.specs2.scalaz._
 
-class CompilerSpec extends quasar.QuasarSpecification with CompilerHelpers with PendingWithAccurateCoverage with DisjunctionMatchers {
+class CompilerSpec extends quasar.QuasarSpecification with CompilerHelpers with DisjunctionMatchers {
   import StdLib._
   import agg._
   import array._

--- a/core/src/test/scala/quasar/semantics.scala
+++ b/core/src/test/scala/quasar/semantics.scala
@@ -17,13 +17,12 @@
 package quasar
 
 import quasar.Predef._
-import quasar.specs2._
 import quasar.sql.fixpoint._
 
 import matryoshka._, FunctorT.ops._
 import pathy.Path._
 
-class SemanticsSpec extends quasar.QuasarSpecification with PendingWithAccurateCoverage with TreeMatchers {
+class SemanticsSpec extends quasar.QuasarSpecification with TreeMatchers {
 
   "TransformSelect" should {
     import quasar.SemanticAnalysis._

--- a/core/src/test/scala/quasar/specs2/decorators.scala
+++ b/core/src/test/scala/quasar/specs2/decorators.scala
@@ -27,6 +27,7 @@ import org.specs2.execute._
  */
 trait PendingWithAccurateCoverage extends PendingUntilFixed {
   def isCoverageRun: Boolean = quasar.build.BuildInfo.coverageEnabled
+  def isCIBuild: Boolean = quasar.build.BuildInfo.isCIBuild
 
   /** Overrides the standard specs2 implicit. */
   implicit def toPendingWithAccurateCoverage[T: AsResult](t: => T) = new PendingWithAccurateCoverage(t)
@@ -36,6 +37,7 @@ trait PendingWithAccurateCoverage extends PendingUntilFixed {
 
     def pendingUntilFixed(m: String): Result =
       if (isCoverageRun) Skipped(m + " (pending example skipped during coverage run)")
+      else if (isCIBuild) Skipped(m + " (pending example skipped during CI build)")
       else toPendingUntilFixed(t).pendingUntilFixed(m)
   }
 }

--- a/core/src/test/scala/quasar/std/math.scala
+++ b/core/src/test/scala/quasar/std/math.scala
@@ -19,7 +19,7 @@ package quasar.std
 import quasar.Func
 import quasar.Predef._
 import quasar.TypeArbitrary
-import quasar.specs2.PendingWithAccurateCoverage
+
 
 import matryoshka.Fix
 import org.scalacheck.Arbitrary
@@ -30,7 +30,7 @@ import scalaz.ValidationNel
 import scalaz.Validation.FlatMap._
 import shapeless._
 
-class MathSpec extends quasar.QuasarSpecification with ScalaCheck with TypeArbitrary with ValidationMatchers with PendingWithAccurateCoverage {
+class MathSpec extends quasar.QuasarSpecification with ScalaCheck with TypeArbitrary with ValidationMatchers {
   import MathLib._
   import quasar.Type
   import quasar.Type.Const

--- a/core/src/test/scala/quasar/std/relations.scala
+++ b/core/src/test/scala/quasar/std/relations.scala
@@ -19,14 +19,14 @@ package quasar.std
 import quasar.Func
 import quasar.Predef._
 import quasar.TypeArbitrary
-import quasar.specs2.PendingWithAccurateCoverage
+
 
 import org.scalacheck.{Arbitrary, Gen, Prop}, Arbitrary.arbitrary
 import org.specs2.scalaz._
 import org.specs2.ScalaCheck
 import scalaz.Validation, Validation.FlatMap._
 
-class RelationsSpec extends quasar.QuasarSpecification with ScalaCheck with TypeArbitrary with ValidationMatchers with PendingWithAccurateCoverage {
+class RelationsSpec extends quasar.QuasarSpecification with ScalaCheck with TypeArbitrary with ValidationMatchers {
   import RelationsLib._
   import quasar.Type
   import quasar.Type.Const

--- a/core/src/test/scala/quasar/std/set.scala
+++ b/core/src/test/scala/quasar/std/set.scala
@@ -19,12 +19,12 @@ package quasar.std
 import quasar.Predef._
 import quasar.{Func, TypeArbitrary}
 import quasar.fp._
-import quasar.specs2.PendingWithAccurateCoverage
+
 
 import org.specs2.ScalaCheck
 import org.specs2.scalaz._
 
-class SetSpec extends quasar.QuasarSpecification with ScalaCheck with TypeArbitrary with ValidationMatchers with PendingWithAccurateCoverage {
+class SetSpec extends quasar.QuasarSpecification with ScalaCheck with TypeArbitrary with ValidationMatchers {
   import SetLib._
   import quasar.Data
   import quasar.Type

--- a/core/src/test/scala/quasar/types.scala
+++ b/core/src/test/scala/quasar/types.scala
@@ -27,7 +27,7 @@ import org.specs2.ScalaCheck
 import argonaut.JsonScalaz._
 import scalaz.Scalaz._
 
-class TypesSpec extends quasar.QuasarSpecification with ScalaCheck with ValidationMatchers with PendingWithAccurateCoverage {
+class TypesSpec extends quasar.QuasarSpecification with ScalaCheck with ValidationMatchers {
   import Type._
   import TypeArbitrary._, DataArbitrary._
 

--- a/foundation/src/test/scala/quasar/QuasarSpecification.scala
+++ b/foundation/src/test/scala/quasar/QuasarSpecification.scala
@@ -22,7 +22,7 @@ import org.specs2.mutable._
 import org.specs2.scalaz.ScalazMatchers
 import scalaz._
 
-trait QuasarSpecification extends SpecificationLike with ScalazMatchers {
+trait QuasarSpecification extends SpecificationLike with ScalazMatchers with PendingWithAccurateCoverage {
   implicit class Specs2ScalazOps[A : Equal : Show](lhs: A) {
     def must_=(rhs: A) = lhs must equal(rhs)
   }

--- a/foundation/src/test/scala/quasar/decorators.scala
+++ b/foundation/src/test/scala/quasar/decorators.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package quasar.specs2
+package quasar
 
 import quasar.Predef._
 

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -118,7 +118,11 @@ abstract class QueryRegressionTest[S[_]](
     s"${test.name} [${posixCodec.printPath(loc)}]" >> {
       test.backends.get(backendName) match {
         case Some(SkipDirective.Skip)    => skipped
-        case Some(SkipDirective.Pending) => runTest.pendingUntilFixed
+        case Some(SkipDirective.Pending) =>
+          if (quasar.build.BuildInfo.coverageEnabled)
+            Skipped(s"(pending example skipped during coverage run)")
+          else
+            runTest.pendingUntilFixed
         case None                        => runTest
       }
     }

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -120,7 +120,9 @@ abstract class QueryRegressionTest[S[_]](
         case Some(SkipDirective.Skip)    => skipped
         case Some(SkipDirective.Pending) =>
           if (quasar.build.BuildInfo.coverageEnabled)
-            Skipped(s"(pending example skipped during coverage run)")
+            Skipped("(pending example skipped during coverage run)")
+          else if (quasar.build.BuildInfo.isCIBuild)
+            Skipped("(pending example skipped during CI build)")
           else
             runTest.pendingUntilFixed
         case None                        => runTest

--- a/mongodb/src/test/scala/quasar/physical/mongodb/pipeline.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/pipeline.scala
@@ -19,13 +19,12 @@ package quasar.physical.mongodb
 import quasar._
 import quasar.Predef._
 import quasar.qscript._
-import quasar.specs2._
 
 import org.scalacheck._
 import org.specs2.ScalaCheck
 import scalaz._
 
-class PipelineSpec extends quasar.QuasarSpecification with ScalaCheck with ArbBsonField with PendingWithAccurateCoverage {
+class PipelineSpec extends quasar.QuasarSpecification with ScalaCheck with ArbBsonField {
   import quasar.physical.mongodb.accumulator._
   import quasar.physical.mongodb.expression._
   import Workflow._

--- a/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -23,7 +23,7 @@ import quasar.javascript._
 import quasar.qscript.SortDir
 import quasar.sql.{ParsingError, Query}
 import quasar.std._
-import quasar.specs2.PendingWithAccurateCoverage
+
 import quasar.sql.{fixpoint => sql, _}
 import quasar.std._
 
@@ -40,7 +40,7 @@ import org.threeten.bp.Instant
 import pathy.Path._
 import scalaz._, Scalaz._
 
-class PlannerSpec extends quasar.QuasarSpecification with ScalaCheck with CompilerHelpers with DisjunctionMatchers with PendingWithAccurateCoverage {
+class PlannerSpec extends quasar.QuasarSpecification with ScalaCheck with CompilerHelpers with DisjunctionMatchers {
   import StdLib.{set => s, _}
   import structural._
   import LogicalPlan._

--- a/mongodb/src/test/scala/quasar/physical/mongodb/workflowbuilder.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/workflowbuilder.scala
@@ -30,8 +30,7 @@ import scalaz._, Scalaz._
 class WorkflowBuilderSpec
     extends quasar.QuasarSpecification
     with DisjunctionMatchers
-    with TreeMatchers
-    with PendingWithAccurateCoverage {
+    with TreeMatchers {
   import Workflow._
   import WorkflowBuilder._
   import IdHandling._


### PR DESCRIPTION
This also makes skipping pending tests automatic for QuasarSpecification. We were previously using it inconsistently.