### PR TITLE
Switch to sbt-assembly for artifact packaging

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,1 +1,0 @@
-- More declarative sbt publishing settings

--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,2 @@
+- Replace one-jar with sbt-assembly for "fat jar" creation
+  - Add the necessary exclusions to spark dependencies to play nice with assembly

--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ server, the tests are run against all supported versions of MongoDB, as well as 
 To build a JAR for the REPL, which allows entering commands at a command-line prompt, execute the following command:
 
 ```bash
-./sbt 'project repl' oneJar
+./sbt 'repl/assembly'
 ```
 
-The path of the JAR will be `./repl/target/scala-2.11/quasar-repl_2.11-[version]-one-jar.jar`, where `[version]` is the Quasar version number.
+The path of the JAR will be `./repl/target/scala-2.11/quasar-repl-assembly-[version].jar`, where `[version]` is the Quasar version number.
 
 To run the JAR, execute the following command:
 
@@ -119,10 +119,10 @@ java -jar [<path to jar>] [-c <config file>]
 To build a JAR containing a lightweight HTTP server that allows you to programmatically interact with Quasar, execute the following command:
 
 ```bash
-./sbt 'project web' oneJar
+./sbt 'web/assembly'
 ```
 
-The path of the JAR will be `./web/target/scala-2.11/quasar-web_2.11-[version]-one-jar.jar`, where `[version]` is the Quasar version number.
+The path of the JAR will be `./web/target/scala-2.11/quasar-web-assembly-[version].jar`, where `[version]` is the Quasar version number.
 
 To run the JAR, execute the following command:
 

--- a/build.sbt
+++ b/build.sbt
@@ -152,7 +152,6 @@ lazy val oneJarSettings =
   Seq(
     GithubKeys.assets := { Seq(oneJar.value) },
     GithubKeys.repoSlug := "quasar-analytics/quasar",
-
     releaseVersionFile := file("version.sbt"),
     releaseUseGlobalVersion := true,
     releaseProcess := Seq[ReleaseStep](
@@ -174,7 +173,7 @@ lazy val root = project.in(file("."))
 //          |
           core,
 //      / / | \ \
-  mongodb, skeleton, postgresql, // sparkcore,
+  mongodb, skeleton, postgresql, sparkcore,
 //      \ \ | / /
           main,
 //        /  \
@@ -256,15 +255,12 @@ lazy val postgresql = project
   .settings(commonSettings)
   .enablePlugins(AutomateHeaderPlugin)
 
-/* FIXME: Disabled because it breaks the Travis build
 lazy val sparkcore = project
   .settings(name := "quasar-sparkcore-internal")
   .dependsOn(core % BothScopes)
   .settings(commonSettings)
-  .settings(libraryDependencies +=
-    "org.apache.spark" % "spark-core_2.11" % "1.6.2")
+  .settings(libraryDependencies ++= Dependencies.sparkcore)
   .enablePlugins(AutomateHeaderPlugin)
-*/
 
 
 // frontends

--- a/build.sbt
+++ b/build.sbt
@@ -163,8 +163,7 @@ lazy val noPublishSettings = Seq(
 )
 
 lazy val githubReleaseSettings =
-  githubSettings ++
-  Seq(
+  githubSettings ++ Seq(
     GithubKeys.assets := { Seq(assembly.value) },
     GithubKeys.repoSlug := "quasar-analytics/quasar",
     releaseVersionFile := file("version.sbt"),
@@ -175,7 +174,8 @@ lazy val githubReleaseSettings =
       runTest,
       setReleaseVersion,
       commitReleaseVersion,
-      pushChanges))
+      pushChanges)
+  )
 
 lazy val root = project.in(file("."))
   .settings(commonSettings)
@@ -243,7 +243,6 @@ lazy val main = project
   .dependsOn(
     mongodb    % BothScopes,
     skeleton   % BothScopes,
-//  sparkcore  % BothScopes,
     postgresql % BothScopes)
   .settings(commonSettings)
   .settings(libraryDependencies ++= Dependencies.main)

--- a/build.sbt
+++ b/build.sbt
@@ -134,15 +134,11 @@ lazy val assemblySettings = Seq(
   test in assembly := {},
 
   assemblyMergeStrategy in assembly := {
-    case PathList("META-INF", "io.netty.versions.properties") =>
-      MergeStrategy.last
-    case PathList("org", "apache", "hadoop", "yarn", xs @ _*) =>
-      MergeStrategy.last
-    case PathList("com", "google", "common", "base", xs @ _*) =>
-      MergeStrategy.last
-    case other =>
-      val defaultStrat = (assemblyMergeStrategy in assembly).value
-      defaultStrat(other)
+    case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.last
+    case PathList("org", "apache", "hadoop", "yarn", xs @ _*) => MergeStrategy.last
+    case PathList("com", "google", "common", "base", xs @ _*) => MergeStrategy.last
+
+    case other => (assemblyMergeStrategy in assembly).value apply other
   }
 )
 
@@ -164,7 +160,7 @@ lazy val noPublishSettings = Seq(
 
 lazy val githubReleaseSettings =
   githubSettings ++ Seq(
-    GithubKeys.assets := { Seq(assembly.value) },
+    GithubKeys.assets := Seq(assembly.value),
     GithubKeys.repoSlug := "quasar-analytics/quasar",
     releaseVersionFile := file("version.sbt"),
     releaseUseGlobalVersion := true,

--- a/build.sbt
+++ b/build.sbt
@@ -176,6 +176,7 @@ lazy val githubReleaseSettings =
 lazy val root = project.in(file("."))
   .settings(commonSettings)
   .settings(noPublishSettings)
+  .settings(aggregate in assembly := false)
   .aggregate(
         foundation,
 //     / / | | \ \

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -58,8 +58,8 @@ object Dependencies {
     "io.netty"    % "netty-handler"        % nettyVersion
   )
   def sparkcore = Seq(
-    "io.netty"          %  "netty-all"                 % nettyVersion            % "compile",
-    ("org.apache.spark" %% "spark-core"                % "1.6.2"                 % "compile")
+    "io.netty"          %  "netty-all"  % nettyVersion,
+    ("org.apache.spark" %% "spark-core" % "1.6.2")
       .exclude("commons-beanutils", "commons-beanutils-core")
       .exclude("commons-collections", "commons-collections")
       .exclude("com.esotericsoftware.minlog", "minlog")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -57,6 +57,15 @@ object Dependencies {
     "io.netty"    % "netty-buffer"         % nettyVersion,
     "io.netty"    % "netty-handler"        % nettyVersion
   )
+  def sparkcore = Seq(
+    "io.netty"          %  "netty-all"                 % nettyVersion            % "compile",
+    ("org.apache.spark" %% "spark-core"                % "1.6.2"                 % "compile")
+      .exclude("commons-beanutils", "commons-beanutils-core")
+      .exclude("commons-collections", "commons-collections")
+      .exclude("com.esotericsoftware.minlog", "minlog")
+      .exclude("org.spark-project.spark", "unused")
+      .exclude("io.netty", "netty-all")
+  )
   def web = Seq(
     "ch.qos.logback"  % "logback-classic"     %      "1.1.7",
     "org.scodec"     %% "scodec-scalaz"       %     "1.3.0a",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += "Jenkins-CI" at "http://repo.jenkins-ci.org/repo"
 libraryDependencies += "org.kohsuke" % "github-api" % "1.59"
 
 addSbtPlugin("org.scoverage"         % "sbt-scoverage"   % "1.3.3")
-addSbtPlugin("org.scala-sbt.plugins" % "sbt-onejar"      % "0.8")
+addSbtPlugin("com.eed3si9n"          % "sbt-assembly"    % "0.14.3")
 addSbtPlugin("com.github.gseitz"     % "sbt-release"     % "1.0.3")
 addSbtPlugin("com.jsuereth"          % "sbt-pgp"         % "1.0.0")
 addSbtPlugin("org.wartremover"       % "sbt-wartremover" % "1.0.1")

--- a/scripts/build
+++ b/scripts/build
@@ -17,9 +17,6 @@ echo "Version:       $QUASAR_VERSION"
 echo "Web Jar:       $QUASAR_WEB_JAR"
 echo "Web Jar Dir:   $QUASAR_WEB_JAR_DIR"
 echo "Web Jar Path:  $QUASAR_WEB_JAR_PATH"
-echo "REPL Jar:      $QUASAR_REPL_JAR"
-echo "REPL Jar Dir:  $QUASAR_REPL_JAR_DIR"
-echo "REPL Jar Path: $QUASAR_REPL_JAR_PATH"
 
 QUASAR_MONGODB_TESTDB="quasar-test"
 QUASAR_MONGODB_HOST_2_6="localhost:27018"
@@ -64,7 +61,7 @@ if [[ "${JOB_NUM##*.}" == "1" ]]; then
   # Require that all header comments are present before proceeding, then
   # build and run all tests everywhere (including integration) and then re-compile without coverage
   # in order to get a jar that does not contain instrumentation. Generate doc.
-  "$SBT" -DisIsolatedEnv=${ISOLATED_ENV:=false} clean checkHeaders coverage test exclusive:test coverageReport "set coverageEnabled := false" oneJar doc
+  "$SBT" -DisIsolatedEnv=${ISOLATED_ENV:=false} clean checkHeaders coverage test exclusive:test coverageReport "set coverageEnabled := false" 'web/assembly' doc
 
   # Test to ensure the JAR file is valid:
   "$SCRIPT_DIR/testJar"

--- a/scripts/constants
+++ b/scripts/constants
@@ -16,12 +16,8 @@ mkdir -p "$TEMP_DIR"
 # quasar version, from build.sbt:
 QUASAR_VERSION=$(cat $WS_DIR/version.sbt | sed -n -e 's/^ *version.*:= "\(.*\)"[^\n]*/\1/p')
 
-QUASAR_WEB_JAR="quasar-web_2.11-$QUASAR_VERSION-one-jar.jar"
+QUASAR_WEB_JAR="quasar-web-assembly-${QUASAR_VERSION}.jar"
 QUASAR_WEB_JAR_DIR="$WS_DIR/web/target/scala-2.11"
 QUASAR_WEB_JAR_PATH="$QUASAR_WEB_JAR_DIR/$QUASAR_WEB_JAR"
-
-QUASAR_REPL_JAR="quasar-repl_2.11-$QUASAR_VERSION-one-jar.jar"
-QUASAR_REPL_JAR_DIR="$WS_DIR/repl/target/scala-2.11"
-QUASAR_REPL_JAR_PATH="$QUASAR_REPL_JAR_DIR/$QUASAR_REPL_JAR"
 
 echo "Quasar Version: $QUASAR_VERSION"

--- a/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/ReadFileSpec.scala
+++ b/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/ReadFileSpec.scala
@@ -46,7 +46,8 @@ class ReadFileSpec extends Specification with ScalaCheck  {
 
 
   "readfile" should {
-    "open - read chunk - close" in {
+    // FIXME: Skipping until we can avoid the local spark emulator which appears to leak resources, even after stop()
+    "open - read chunk - close" in skipped {
       // given
       import quasar.Data._
       implicit val sc = newSc()

--- a/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/ReadFileSpec.scala
+++ b/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/ReadFileSpec.scala
@@ -30,7 +30,6 @@ import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
 
 import java.io._
-import pathy.Path.posixCodec
 
 import scalaz._, Scalaz._, concurrent.Task
 
@@ -46,8 +45,9 @@ class ReadFileSpec extends Specification with ScalaCheck  {
 
 
   "readfile" should {
-    // FIXME: Skipping until we can avoid the local spark emulator which appears to leak resources, even after stop()
-    "open - read chunk - close" in skipped {
+    "open - read chunk - close" in skipped("Skipped until the local spark emulator can be avoided as it appears to leak resources, even after a context.stop()")
+/*
+    "open - read chunk - close" in {
       // given
       import quasar.Data._
       implicit val sc = newSc()
@@ -69,6 +69,7 @@ class ReadFileSpec extends Specification with ScalaCheck  {
       sc.stop()
       ok
     }
+*/
   }
 
   private def readOneChunk(f: AFile)


### PR DESCRIPTION
Also reenables the sparkcore project, but disables the offending readfile spec until we can get a handle on the resource leaks.