### PR TITLE
Run Spark-local tests only when env QUASAR_SPARK_LOCAL is set

### DIFF
--- a/full-it-tests.sh
+++ b/full-it-tests.sh
@@ -9,6 +9,9 @@ docker run --name some-mongo -p 27017:27017 -d mongo
 echo "set QUASAR_MONGODB_3_2 variable"
 export QUASAR_MONGODB_3_2="{\"mongodb\":{\"connectionUri\":\"mongodb://localhost:27017\"}}"
 
+echo "set QUASAR_SPARK_LOCAL to local-cluster mode"
+export QUASAR_SPARK_LOCAL="{\"sparklocal\":{\"connectionUri\":\"local[*]\"}}"
+
 echo "run tests"
 ./sbt test
 

--- a/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/ReadFileSpec.scala
+++ b/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/ReadFileSpec.scala
@@ -101,7 +101,6 @@ class ReadFileSpec extends Specification with ScalaCheck  {
     slData <- OptionT(Task.now(uriData.asInstanceOf[Obj].value.get("sparklocal")))
     uri <- OptionT(Task.now(slData.asInstanceOf[Obj].value.get("connectionUri")))
   } yield {
-    println("************ ")
     val master = uri.asInstanceOf[Str].value
     val config = new SparkConf().setMaster(master).setAppName(this.getClass().getName())
     new SparkContext(config)

--- a/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/ReadFileSpec.scala
+++ b/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/ReadFileSpec.scala
@@ -19,21 +19,23 @@ package quasar.physical.sparkcore.fs
 
 import quasar.Predef._
 import quasar.Data
+import quasar.Data._
+import quasar.console
 import quasar.fp.TaskRef
 import quasar.fp.numeric._
 import quasar.fp.free._
 import quasar.fs._
 import quasar.fs.ReadFile.ReadHandle
 import quasar.effect._
+import quasar.Data
+import quasar.DataCodec
+
+import java.io._
 
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
-
-import java.io._
 import pathy.Path.posixCodec
-
 import scalaz._, Scalaz._, concurrent.Task
-
 import org.apache.spark._
 
 
@@ -47,25 +49,26 @@ class ReadFileSpec extends Specification with ScalaCheck  {
 
   "readfile" should {
     "open - read chunk - close" in {
-      // given
-      import quasar.Data._
-      implicit val sc = newSc()
-
-      val content = List(
-        """{"login" : "john", "age" : 28}""",
-        """{"login" : "kate", "age" : 31}"""
-      )
-      val path: String = tempFile(content)
-      val aFile: AFile = sandboxAbs(posixCodec.parseAbsFile(path).get)
-      // when
-      readOneChunk(aFile).run.foldMap(inter).unsafePerformSync must beLike {
-        case \/-(results) =>
-          // then
-          results.size must be_==(2)
-          results must contain(Obj(ListMap("login" -> Str("john"), "age" -> Int(28))))
-          results must contain(Obj(ListMap("login" -> Str("kate"), "age" -> Int(31))))
-      }
-      sc.stop()
+      // run tests only when spark cluster is present
+      (newSc().map { sc =>
+        // given
+        import quasar.Data._
+        val content = List(
+          """{"login" : "john", "age" : 28}""",
+          """{"login" : "kate", "age" : 31}"""
+        )
+        val path: String = tempFile(content)
+        val aFile: AFile = sandboxAbs(posixCodec.parseAbsFile(path).get)
+        // when
+        readOneChunk(aFile).run.foldMap(inter(sc)).unsafePerformSync must beLike {
+          case \/-(results) =>
+            // then
+            results.size must be_==(2)
+            results must contain(Obj(ListMap("login" -> Str("john"), "age" -> Int(28))))
+            results must contain(Obj(ListMap("login" -> Str("kate"), "age" -> Int(31))))
+        }
+        sc.stop()
+      }).run.unsafePerformSync
       ok
     }
   }
@@ -92,8 +95,15 @@ class ReadFileSpec extends Specification with ScalaCheck  {
   private def inter(implicit sc: SparkContext): ReadFile ~> Task =
     readfile.interpret[Eff](local_readfile.input[Eff]) andThen foldMapNT[Eff, Task](run)
 
-  private def newSc(): SparkContext = {
-    val config = new SparkConf().setMaster("local[*]").setAppName(this.getClass().getName())
+  private def newSc(): OptionT[Task, SparkContext] = for {
+    uriStr <- console.readEnv("QUASAR_SPARK_LOCAL")
+    uriData <- OptionT(Task.now(DataCodec.parse(uriStr)(DataCodec.Precise).toOption))
+    slData <- OptionT(Task.now(uriData.asInstanceOf[Obj].value.get("sparklocal")))
+    uri <- OptionT(Task.now(slData.asInstanceOf[Obj].value.get("connectionUri")))
+  } yield {
+    println("************ ")
+    val master = uri.asInstanceOf[Str].value
+    val config = new SparkConf().setMaster(master).setAppName(this.getClass().getName())
     new SparkContext(config)
   }
 


### PR DESCRIPTION
Ignore tests otherwise

note: This tests 'ReadFileSpec' is going to be deleted once all algebras are implemented and they will be tested using generic `FileSystemSpec` test. But for now we want to disable tests for Spark if somebody is not willing to run them