### PR TITLE
Change some test options.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,2 @@
+- Show all test timings
+- Abort test specification after first failure

--- a/foundation/src/test/scala/quasar/QuasarSpecification.scala
+++ b/foundation/src/test/scala/quasar/QuasarSpecification.scala
@@ -23,6 +23,9 @@ import org.specs2.scalaz.ScalazMatchers
 import scalaz._
 
 trait QuasarSpecification extends SpecificationLike with ScalazMatchers with PendingWithAccurateCoverage {
+  args(stopOnFail=true)
+  args.report(showtimes = true)
+
   implicit class Specs2ScalazOps[A : Equal : Show](lhs: A) {
     def must_=(rhs: A) = lhs must equal(rhs)
   }

--- a/foundation/src/test/scala/quasar/QuasarSpecification.scala
+++ b/foundation/src/test/scala/quasar/QuasarSpecification.scala
@@ -23,8 +23,11 @@ import org.specs2.scalaz.ScalazMatchers
 import scalaz._
 
 trait QuasarSpecification extends SpecificationLike with ScalazMatchers with PendingWithAccurateCoverage {
-  args(stopOnFail=true)
-  args.report(showtimes = true)
+  // Fail fast and repot all timings when running on CI.
+  if (scala.sys.env contains "TRAVIS") {
+    args(stopOnFail=true)
+    args.report(showtimes = true)
+  }
 
   implicit class Specs2ScalazOps[A : Equal : Show](lhs: A) {
     def must_=(rhs: A) = lhs must equal(rhs)

--- a/it/src/test/scala/quasar/fs/FileSystemTest.scala
+++ b/it/src/test/scala/quasar/fs/FileSystemTest.scala
@@ -50,7 +50,7 @@ abstract class FileSystemTest[S[_]](
   val fileSystems: Task[IList[FileSystemUT[S]]]
 ) extends quasar.QuasarSpecification {
 
-  args.report(showtimes = true)
+  sequential
 
   type F[A]      = Free[S, A]
   type FsTask[A] = FileSystemErrT[Task, A]

--- a/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/ReadFileSpec.scala
+++ b/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/ReadFileSpec.scala
@@ -27,7 +27,6 @@ import quasar.fs.ReadFile.ReadHandle
 import quasar.effect._
 
 import org.specs2.ScalaCheck
-import org.specs2.mutable.Specification
 
 import java.io._
 import pathy.Path.posixCodec
@@ -36,9 +35,7 @@ import scalaz._, Scalaz._, concurrent.Task
 
 import org.apache.spark._
 
-
-
-class ReadFileSpec extends Specification with ScalaCheck  {
+class ReadFileSpec extends quasar.QuasarSpecification with ScalaCheck  {
 
   type Eff0[A] = Coproduct[KeyValueStore[ReadHandle, SparkCursor, ?], Read[SparkContext, ?], A]
   type Eff1[A] = Coproduct[Task, Eff0, A]
@@ -87,7 +84,7 @@ class ReadFileSpec extends Specification with ScalaCheck  {
     KeyValueStore.fromTaskRef[ReadHandle, SparkCursor](kvsState) :+:
     Read.constant[Task, SparkContext](sc)
   }
-    
+
 
   private def inter(implicit sc: SparkContext): ReadFile ~> Task =
     readfile.interpret[Eff](local_readfile.input[Eff]) andThen foldMapNT[Eff, Task](run)


### PR DESCRIPTION
Stop running a specification on failure. Right now we don't
have the sort of test suite where there is useful information
to be found beyond the first failure.

Show all test timings.