### PR TITLE
disable parallel execution for it tests in Travis

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- disable parallel execution of integration tests, which seems to contribute to build instability and doesn't help performance much anyway

--- a/build.sbt
+++ b/build.sbt
@@ -309,4 +309,5 @@ lazy val it = project
   // Configure various test tasks to run exclusively in the `ExclusiveTests` config.
   .settings(inConfig(ExclusiveTests)(Defaults.testTasks): _*)
   .settings(inConfig(ExclusiveTests)(exclusiveTasks(test, testOnly, testQuick)): _*)
+  .settings(parallelExecution in Test := !(sys.env contains "TRAVIS"))
   .enablePlugins(AutomateHeaderPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -309,5 +309,5 @@ lazy val it = project
   // Configure various test tasks to run exclusively in the `ExclusiveTests` config.
   .settings(inConfig(ExclusiveTests)(Defaults.testTasks): _*)
   .settings(inConfig(ExclusiveTests)(exclusiveTasks(test, testOnly, testQuick)): _*)
-  .settings(parallelExecution in Test := !(sys.env contains "TRAVIS"))
+  .settings(parallelExecution in Test := false)
   .enablePlugins(AutomateHeaderPlugin)


### PR DESCRIPTION
This simple change seems to eliminate "connection timeout" failures (which until recently were hangs).

However, the cost is steep: roughly 20 minutes longer to run build #1 in Travis (just over an hour vs about 40 minutes, in my most recent comparison). The times for the other 3 builds seem to be affected very little.

I'm submitting this to get a build everyone can look at, and also to raise the question of whether this is yet bad enough to consider this fix.