### PR TITLE
WIP - qscript debugging

### DIFF
--- a/core/src/main/scala/quasar/qscript/Optimize.scala
+++ b/core/src/main/scala/quasar/qscript/Optimize.scala
@@ -341,19 +341,19 @@ class Optimize[T[_[_]]: Recursive: Corecursive: EqualT: ShowT] {
              TJ: ThetaJoin[T, ?] :<: F,
              PB: ProjectBucket[T, ?] :<: F,
              FI: F :<: QScriptTotal[T, ?]):
-      F[T[F]] => F[T[F]] = //scala.Predef.identity[F[T[F]]]
-    (quasar.fp.free.injectedNT[F](simplifyProjections).apply(_: F[T[F]])) ⋙
-      Normalizable[F].normalize ⋙
-      quasar.fp.free.injectedNT[F](elideNopJoin[F]) ⋙
-      liftFG(elideConstantJoin[F, F](rebaseT[F])) ⋙
-      liftFF(repeatedly(coalesceQC[F, F](optionIdF[F], NaturalTransformation.refl[F]))) ⋙
-      liftFG(coalesceMapShift[F, F](optionIdF[F])) ⋙
-      liftFG(coalesceMapJoin[F, F](optionIdF[F])) ⋙
-      liftFG(simplifySP[F, F](optionIdF[F])) ⋙
-      liftFG(compactLeftShift[F, F]) ⋙
-      Normalizable[F].normalize ⋙
-      liftFF(compactReduction[F]) ⋙
-      liftFG(elideNopMap[F])
+      F[T[F]] => F[T[F]] = scala.Predef.identity[F[T[F]]]
+    //(quasar.fp.free.injectedNT[F](simplifyProjections).apply(_: F[T[F]])) ⋙
+    //  Normalizable[F].normalize ⋙
+    //  quasar.fp.free.injectedNT[F](elideNopJoin[F]) ⋙
+    //  liftFG(elideConstantJoin[F, F](rebaseT[F])) ⋙
+    //  liftFF(repeatedly(coalesceQC[F, F](optionIdF[F], NaturalTransformation.refl[F]))) ⋙
+    //  liftFG(coalesceMapShift[F, F](optionIdF[F])) ⋙
+    //  liftFG(coalesceMapJoin[F, F](optionIdF[F])) ⋙
+    //  liftFG(simplifySP[F, F](optionIdF[F])) ⋙
+    //  liftFG(compactLeftShift[F, F]) ⋙
+    //  Normalizable[F].normalize ⋙
+    //  liftFF(compactReduction[F]) ⋙
+    //  liftFG(elideNopMap[F])
 
   def applyToFreeQS[F[_]: Traverse: Normalizable](
     implicit QC: QScriptCore[T, ?] :<: F,
@@ -361,17 +361,17 @@ class Optimize[T[_[_]]: Recursive: Corecursive: EqualT: ShowT] {
              TJ: ThetaJoin[T, ?] :<: F,
              PB: ProjectBucket[T, ?] :<: F,
              FI: F :<: QScriptTotal[T, ?]):
-      F[T[CoEnv[Hole, F, ?]]] => CoEnv[Hole, F, T[CoEnv[Hole, F, ?]]] = //thing => CoEnv(thing.right[Hole])
-    (quasar.fp.free.injectedNT[F](simplifyProjections).apply(_: F[T[CoEnv[Hole, F, ?]]])) ⋙
-      Normalizable[F].normalize ⋙
-      quasar.fp.free.injectedNT[F](elideNopJoin[F]) ⋙
-      liftFG(elideConstantJoin[F, CoEnv[Hole, F, ?]](rebaseTCo[F])) ⋙
-      liftFF(repeatedly(coalesceQC[F, CoEnv[Hole, F, ?]](extractCoEnv[F, Hole], wrapCoEnv[F, Hole]))) ⋙
-      liftFG(coalesceMapShift[F, CoEnv[Hole, F, ?]](extractCoEnv[F, Hole])) ⋙
-      liftFG(coalesceMapJoin[F, CoEnv[Hole, F, ?]](extractCoEnv[F, Hole])) ⋙
-      liftFG(simplifySP[F, CoEnv[Hole, F, ?]](extractCoEnv[F, Hole])) ⋙
-      liftFG(compactLeftShift[F, CoEnv[Hole, F, ?]]) ⋙
-      Normalizable[F].normalize ⋙
-      liftFF(compactReduction[CoEnv[Hole, F, ?]]) ⋙
-      (fa => QC.prj(fa).fold(CoEnv(fa.right[Hole]))(elideNopMapCo[F, Hole]))  // TODO remove duplication with `elideNopMap`
+      F[T[CoEnv[Hole, F, ?]]] => CoEnv[Hole, F, T[CoEnv[Hole, F, ?]]] = thing => CoEnv(thing.right[Hole])
+    //(quasar.fp.free.injectedNT[F](simplifyProjections).apply(_: F[T[CoEnv[Hole, F, ?]]])) ⋙
+    //  Normalizable[F].normalize ⋙
+    //  quasar.fp.free.injectedNT[F](elideNopJoin[F]) ⋙
+    //  liftFG(elideConstantJoin[F, CoEnv[Hole, F, ?]](rebaseTCo[F])) ⋙
+    //  liftFF(repeatedly(coalesceQC[F, CoEnv[Hole, F, ?]](extractCoEnv[F, Hole], wrapCoEnv[F, Hole]))) ⋙
+    //  liftFG(coalesceMapShift[F, CoEnv[Hole, F, ?]](extractCoEnv[F, Hole])) ⋙
+    //  liftFG(coalesceMapJoin[F, CoEnv[Hole, F, ?]](extractCoEnv[F, Hole])) ⋙
+    //  liftFG(simplifySP[F, CoEnv[Hole, F, ?]](extractCoEnv[F, Hole])) ⋙
+    //  liftFG(compactLeftShift[F, CoEnv[Hole, F, ?]]) ⋙
+    //  Normalizable[F].normalize ⋙
+    //  liftFF(compactReduction[CoEnv[Hole, F, ?]]) ⋙
+    //  (fa => QC.prj(fa).fold(CoEnv(fa.right[Hole]))(elideNopMapCo[F, Hole]))  // TODO remove duplication with `elideNopMap`
 }

--- a/core/src/main/scala/quasar/qscript/QScriptCore.scala
+++ b/core/src/main/scala/quasar/qscript/QScriptCore.scala
@@ -165,12 +165,21 @@ object QScriptCore {
                 EnvT((Ann(_,  v2), Map(_, m2)))) =>
             // TODO: optimize cases where one side is a subset of the other
             val (mf, lv, rv) = concat(v1 >> m1 >> left, v2 >> m2 >> right)
-            val (buck, newBuckets) = concatBuckets(b1.map(_ >> m1))
-            val (full, buckAccess, valAccess) = concat(buck, mf)
-            SrcMerge(
-              EnvT((Ann(newBuckets.map(_ >> buckAccess), valAccess), Map(SrcHole, full): QScriptCore[T, Hole])),
-              lv,
-              rv).some
+            concatBuckets(b1.map(_ >> m1)) match {
+              case Some((buck, newBuckets)) => {
+                val (full, buckAccess, valAccess) = concat(buck, mf)
+                SrcMerge(
+                  EnvT((Ann(newBuckets.list.toList.map(_ >> buckAccess), valAccess), Map(SrcHole, full): QScriptCore[T, Hole])),
+                  lv,
+                  rv).some
+              }
+              case None =>
+                SrcMerge(
+                  EnvT((Ann(Nil, HoleF[T]), Map(SrcHole, mf): QScriptCore[T, Hole])),
+                  lv,
+                  rv).some
+
+            }
 
           case (EnvT((Ann(b1, v1), Reduce(_, bucket1, func1, rep1))),
                 EnvT((Ann(b2, v2), Reduce(_, bucket2, func2, rep2)))) =>

--- a/core/src/main/scala/quasar/qscript/Transform.scala
+++ b/core/src/main/scala/quasar/qscript/Transform.scala
@@ -254,7 +254,7 @@ class Transform[T[_[_]]: Recursive: Corecursive: FunctorT: EqualT: ShowT, F[_]: 
       }
       case None =>
         EnvT((
-          Ann[T](Nil, HoleF[T]),
+          EmptyAnn[T],
           QC.inj(Map(EnvT((EmptyAnn[T], src)).embed, func(lval, rval).embed))))
     }
   }
@@ -554,6 +554,7 @@ class Transform[T[_[_]]: Recursive: Corecursive: FunctorT: EqualT: ShowT, F[_]: 
     case LogicalPlan.InvokeFUnapply(func @ UnaryFunc(_, _, _, _, _, _, _, _), Sized(a1))
         if func.effect ≟ Mapping =>
       val Ann(buckets, value) = a1.project.ask
+      scala.Predef.println(s"<><><><><>res is ${MapFunc.translateUnaryMapping(func)(HoleF[T])} with ${a1.show}")
       concatBuckets(buckets) match {
         case Some((buck, newBuckets)) => {
           println(s">>>>>>>>>>>>buck in unary are $buck")   // HERE EMPTY ARRAY
@@ -565,6 +566,7 @@ class Transform[T[_[_]]: Recursive: Corecursive: FunctorT: EqualT: ShowT, F[_]: 
             QC.inj(Map(a1, mf)))).right
         }
         case None =>
+          scala.Predef.println(s"|||||||||||||||stuff is ${QC.inj(Map(a1, Free.roll(MapFunc.translateUnaryMapping(func)(HoleF[T])))).show}")
           EnvT((
             EmptyAnn[T],
             QC.inj(Map(a1, Free.roll(MapFunc.translateUnaryMapping(func)(HoleF[T])))))).right

--- a/core/src/main/scala/quasar/qscript/package.scala
+++ b/core/src/main/scala/quasar/qscript/package.scala
@@ -94,6 +94,7 @@ package object qscript {
     buckets match {
       case Nil => None
       case head :: tail =>
+        scala.Predef.println(s"buckets are $buckets")
         (ConcatArraysN(buckets.map(b => Free.roll(MakeArray[T, FreeMap[T]](b)))),
           NEL(head, tail).zipWithIndex.map(p =>
             Free.roll(ProjectIndex[T, FreeMap[T]](
@@ -113,11 +114,15 @@ package object qscript {
 
   def concat3[T[_[_]]: Corecursive, A](
     l: Free[MapFunc[T, ?], A], c: Free[MapFunc[T, ?], A], r: Free[MapFunc[T, ?], A]):
-      (Free[MapFunc[T, ?], A], FreeMap[T], FreeMap[T], FreeMap[T]) =
+      (Free[MapFunc[T, ?], A], FreeMap[T], FreeMap[T], FreeMap[T]) = {
+    scala.Predef.println(s"l2 is ${l}")
+    scala.Predef.println(s"c2 is ${c}")
+    scala.Predef.println(s"r2 is ${r}")
     (Free.roll(ConcatArrays(Free.roll(ConcatArrays(Free.roll(MakeArray(l)), Free.roll(MakeArray(c)))), Free.roll(MakeArray(r)))),
       Free.roll(ProjectIndex(HoleF[T], IntLit[T, Hole](0))),
       Free.roll(ProjectIndex(HoleF[T], IntLit[T, Hole](1))),
       Free.roll(ProjectIndex(HoleF[T], IntLit[T, Hole](2))))
+  }
 
   // TODO: move to matryoshka
 

--- a/core/src/test/scala/quasar/qscript/QScript.scala
+++ b/core/src/test/scala/quasar/qscript/QScript.scala
@@ -197,17 +197,52 @@ class QScriptSpec extends CompilerHelpers with QScriptHelpers with ScalazMatcher
           Free.roll(MakeMap(StrLit("loc"), Free.point(RightSide))))).embed.some)
     }
 
-    "convert a constant shift array" in pending {
+    "convert a constant shift array of size one" in {
       // this query never makes it to LP->QS transform because it's a constant value
-      // "foo := (1,2,3); select * from foo"
+      // "foo := (7); select * from foo"
+      QueryFile.convertToQScript(
+        identity.Squash[FLP](
+          structural.ShiftArray[FLP](
+            structural.MakeArrayN[Fix](LP.Constant(Data.Int(7)))))).toOption must
+      equal(
+        SP.inj(LeftShift(
+          RootR,
+          Free.roll(Nullary(
+            CommonEJson.inj(ejson.Arr(List(
+              ExtEJson.inj(ejson.Int[Fix[ejson.EJson]](7)).embed))).embed)),
+          Free.point(RightSide))).embed.some)
+    }
+
+    "convert a constant shift array of size two" in {
+      // this query never makes it to LP->QS transform because it's a constant value
+      // "foo := (7,8); select * from foo"
+      QueryFile.convertToQScript(
+        identity.Squash[FLP](
+          structural.ShiftArray[FLP](
+            structural.ArrayConcat[FLP](
+              structural.MakeArrayN[Fix](LP.Constant(Data.Int(7))),
+              structural.MakeArrayN[Fix](LP.Constant(Data.Int(8))))))).toOption must
+      equal(
+        SP.inj(LeftShift(
+          RootR,
+          Free.roll(Nullary(
+            CommonEJson.inj(ejson.Arr(List(
+              ExtEJson.inj(ejson.Int[Fix[ejson.EJson]](7)).embed,
+              ExtEJson.inj(ejson.Int[Fix[ejson.EJson]](8)).embed))).embed)),
+          Free.point(RightSide))).embed.some)
+    }
+
+    "convert a constant shift array of size three" in {
+      // this query never makes it to LP->QS transform because it's a constant value
+      // "foo := (7,8,9); select * from foo"
       QueryFile.convertToQScript(
         identity.Squash[FLP](
           structural.ShiftArray[FLP](
             structural.ArrayConcat[FLP](
               structural.ArrayConcat[FLP](
-                structural.MakeArrayN[Fix](LP.Constant(Data.Int(1))),
-                structural.MakeArrayN[Fix](LP.Constant(Data.Int(2)))),
-              structural.MakeArrayN[Fix](LP.Constant(Data.Int(3))))))).toOption must
+                structural.MakeArrayN[Fix](LP.Constant(Data.Int(7))),
+                structural.MakeArrayN[Fix](LP.Constant(Data.Int(8)))),
+              structural.MakeArrayN[Fix](LP.Constant(Data.Int(9))))))).toOption must
       equal(
         SP.inj(LeftShift(
           RootR,


### PR DESCRIPTION
wip PR

- no longer generates empty arrays in `concatBuckets`
- traces extra `MakeArray` most likely to `translateUnaryMapping` - investigation ongoing
- adds more tests for constant arrays

TODO before merge:

- fix the `MakeArray` bug
- remove printlns
- optimization to remove concatted `MakeArray` and to use `Nullary(Arr)` instead