### PR TITLE
Efficient execution of simple counts with appended limit/skip ops

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- [#1376] use mongodb's `count` command for `select count(*)` with `limit` (as is the case when a simple `count(*)` is saved as a view or run in the REPL)

--- a/mongodb/src/main/scala/quasar/physical/mongodb/WorkflowExecutor.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/WorkflowExecutor.scala
@@ -294,11 +294,13 @@ private[mongodb] abstract class WorkflowExecutor[F[_]: Monad, C] {
         find(src, Find(None, bson.some, keys.some, skip, limit)) map (_.right)
       case (List(PipelineOpCore($MatchF((), sel)), Projectable(bson), PipelineOpCore($SortF((), keys))), Nil) =>
         find(src, Find(sel.some, bson.some, keys.some, skip, limit)) map (_.right)
-      case (List(Countable(field)), Nil) if skip ≟ None && limit ≟ None =>
+      case (List(Countable(field)), Nil)
+          if skip.getOrElse(0) == 0 && limit.cata(_ >= 1, true) =>
         labeledCount(src, Count(None, None, None), field) map (_.left)
       case (Nil, List(Countable(field))) =>
         labeledCount(src, Count(None, skip, limit), field) map (_.left)
-      case (List(PipelineOpCore($MatchF((), sel)), Countable(field)), Nil) if skip ≟ None && limit ≟ None =>
+      case (List(PipelineOpCore($MatchF((), sel)), Countable(field)), Nil)
+          if skip.getOrElse(0) == 0 && limit.cata(_ >= 1, true) =>
         labeledCount(src, Count(sel.some, None, None), field) map (_.left)
       case (List(PipelineOpCore($MatchF((), sel))), List(Countable(field))) =>
         labeledCount(src, Count(sel.some, skip, limit), field) map (_.left)

--- a/mongodb/src/main/scala/quasar/physical/mongodb/WorkflowExecutor.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/WorkflowExecutor.scala
@@ -295,12 +295,12 @@ private[mongodb] abstract class WorkflowExecutor[F[_]: Monad, C] {
       case (List(PipelineOpCore($MatchF((), sel)), Projectable(bson), PipelineOpCore($SortF((), keys))), Nil) =>
         find(src, Find(sel.some, bson.some, keys.some, skip, limit)) map (_.right)
       case (List(Countable(field)), Nil)
-          if skip.getOrElse(0) == 0 && limit.cata(_ >= 1, true) =>
+          if skip.getOrElse(0L) ≟ 0L && limit.cata(_ >= 1L, true) =>
         labeledCount(src, Count(None, None, None), field) map (_.left)
       case (Nil, List(Countable(field))) =>
         labeledCount(src, Count(None, skip, limit), field) map (_.left)
       case (List(PipelineOpCore($MatchF((), sel)), Countable(field)), Nil)
-          if skip.getOrElse(0) == 0 && limit.cata(_ >= 1, true) =>
+          if skip.getOrElse(0L) ≟ 0L && limit.cata(_ >= 1L, true) =>
         labeledCount(src, Count(sel.some, None, None), field) map (_.left)
       case (List(PipelineOpCore($MatchF((), sel))), List(Countable(field))) =>
         labeledCount(src, Count(sel.some, skip, limit), field) map (_.left)

--- a/mongodb/src/test/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutionSpec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutionSpec.scala
@@ -125,6 +125,20 @@ class JavaScriptWorkflowExecutionSpec extends quasar.Qspec {
           |""".stripMargin)
     }
 
+    "write count followed by limit to JS" in {
+      val wf = chain(
+        $read[WorkflowF](collection("db", "zips")),
+        $group[WorkflowF](
+          Grouped(ListMap(
+            BsonField.Name("num") -> $sum($literal(Bson.Int32(1))))),
+          $literal(Bson.Null).right),
+        $limit[WorkflowF](11))
+
+      toJS(wf) must beRightDisjunction(
+        """db.zips.count();
+          |""".stripMargin)
+    }
+
     "write simple distinct to JS" in {
       val wf = chain(
         $read[WorkflowF](collection("db", "zips")),


### PR DESCRIPTION
Fixes #1376.

When a simple `select count(*) from foo` is executed in the REPL, or saved as a view and then read with offset/limit parameters, `limit` and/or `offset` clauses are effectively added before the query is executed. Because the query always produces a single result, those clauses have no effect, but they were not being recognized when the query was executed, and so quasar was doing `aggregate` rather than `count`, which is potentially much slower. This commit just recognizes that pattern and disregards any skip/limit after a count operation, as long as they wouldn't affect the single result.