### PR TITLE
Handle join with arbitrary expression on one side of the condition

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- [#1364] use $lookup for joins where one side has an expression in the key

--- a/core/src/main/scala/quasar/logicalplan.scala
+++ b/core/src/main/scala/quasar/logicalplan.scala
@@ -85,13 +85,13 @@ object LogicalPlan {
         }
     }
   implicit val RenderTreeLogicalPlan:
-      RenderTree ~> λ[α => RenderTree[LogicalPlan[α]]] =
-    new (RenderTree ~> λ[α => RenderTree[LogicalPlan[α]]]) {
-      def apply[α](ra: RenderTree[α]): RenderTree[LogicalPlan[α]] =
-        new RenderTree[LogicalPlan[α]] {
+      Delay[RenderTree, LogicalPlan] =
+    new Delay[RenderTree, LogicalPlan] {
+      def apply[A](ra: RenderTree[A]): RenderTree[LogicalPlan[A]] =
+        new RenderTree[LogicalPlan[A]] {
           val nodeType = "LogicalPlan" :: Nil
 
-          def render(v: LogicalPlan[α]) = v match {
+          def render(v: LogicalPlan[A]) = v match {
             // NB: a couple of special cases for readability
             case ConstantF(Data.Str(str)) => Terminal("Str" :: "Constant" :: nodeType, Some(str.shows))
             case InvokeFUnapply(structural.ObjectProject, Sized(expr, name)) =>

--- a/foundation/src/main/scala/quasar/RenderTree.scala
+++ b/foundation/src/main/scala/quasar/RenderTree.scala
@@ -376,7 +376,7 @@ object RenderTree extends RenderTreeInstances {
       def render(v: Fix[F]) = RF(fix[F]).render(v.unFix)
     }
 
-  implicit def cofree[F[_], A: RenderTree](implicit RF: RenderTree ~> λ[α => RenderTree[F[α]]]):
+  implicit def cofree[F[_], A: RenderTree](implicit RF: Delay[RenderTree, F]):
       RenderTree[Cofree[F, A]] =
     new RenderTree[Cofree[F, A]] {
       def render(t: Cofree[F, A]) = {

--- a/mongodb/src/main/scala/quasar/physical/mongodb/JoinHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/JoinHandler.scala
@@ -46,6 +46,11 @@ object JoinHandler {
   val LeftName: BsonField.Name = BsonField.Name("left")
   val RightName: BsonField.Name = BsonField.Name("right")
 
+  def fallback[WF[_], F[_]: Monad](
+      first: JoinHandler[WF, OptionT[F, ?]],
+      second: JoinHandler[WF, F]): JoinHandler[WF, F] =
+    JoinHandler((tpe, l, r) => first(tpe, l, r) getOrElseF second(tpe, l, r))
+
   /** When possible, plan a join using the more efficient \$lookup operator in
     * the aggregation pipeline.
     */

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner.scala
@@ -1151,12 +1151,9 @@ object MongoDbPlanner {
 
     queryContext.model match {
       case `3.2` =>
-        val pl = JoinHandler.pipeline[Workflow3_2F](queryContext.statistics)
-        val mr = JoinHandler.mapReduce[Workflow3_2F]
-        val joinHandler =
-          JoinHandler[Workflow3_2F, WorkflowBuilder.M]((tpe, l, r) =>
-            pl(tpe, l, r) getOrElseF mr(tpe, l, r))
-
+        val joinHandler = JoinHandler.fallback(
+          JoinHandler.pipeline[Workflow3_2F](queryContext.statistics),
+          JoinHandler.mapReduce[Workflow3_2F])
         plan0[Workflow3_2F](joinHandler)(logical)
 
       case _     =>

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner.scala
@@ -1100,7 +1100,7 @@ object MongoDbPlanner {
   def plan0[F[_]: Functor: Coalesce: Crush: Crystallize]
     (joinHandler: JoinHandler[F, WorkflowBuilder.M])
     (logical: Fix[LogicalPlan])
-    (implicit ev0: WorkflowOpCoreF :<: F, ev1: Show[Fix[WorkflowBuilderF[F, ?]]], ev2: Delay[RenderTree, F])
+    (implicit ev0: WorkflowOpCoreF :<: F, ev1: Show[Fix[WorkflowBuilderF[F, ?]]], ev2: RenderTree[Fix[F]])
       : EitherT[Writer[PhaseResults, ?], PlannerError, Crystallized[F]] = {
     // TODO[scalaz]: Shadow the scalaz.Monad.monadMTMAB SI-2712 workaround
     import EitherT.eitherTMonad

--- a/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -756,7 +756,7 @@ object MongoDbQScriptPlanner {
     implicit I: WorkflowOpCoreF :<: WF,
              ev: Show[WorkflowBuilder[WF]],
              WB: WorkflowBuilder.Ops[WF],
-             R: Delay[RenderTree, WF]):
+             R: RenderTree[Fix[WF]]):
       EitherT[Writer[PhaseResults, ?], PlannerError, Crystallized[WF]] = {
     val optimize = new Optimize[T]
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -815,13 +815,12 @@ object MongoDbQScriptPlanner {
 
     queryContext.model match {
       case `3.2` =>
-        val pl = JoinHandler.pipeline[Workflow3_2F](queryContext.statistics)
-        val mr = JoinHandler.mapReduce[Workflow3_2F]
         val joinHandler =
-          JoinHandler[Workflow3_2F, WorkflowBuilder.M]((tpe, l, r) =>
-            pl(tpe, l, r) getOrElseF mr(tpe, l, r))
-
+          JoinHandler.fallback(
+            JoinHandler.pipeline[Workflow3_2F](queryContext.statistics),
+            JoinHandler.mapReduce[Workflow3_2F])
         plan0[T, Workflow3_2F](joinHandler)(logical)
+
       case _     =>
         val joinHandler = JoinHandler.mapReduce[Workflow2_6F]
         plan0[T, Workflow2_6F](joinHandler)(logical).map(_.inject[WorkflowF])

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflow/Crystallized.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflow/Crystallized.scala
@@ -28,7 +28,7 @@ final case class Crystallized[F[_]](op: Fix[F]) {
 }
 
 object Crystallized {
-  implicit def renderTree[F[_]](implicit R: Delay[RenderTree, F]):
+  implicit def renderTree[F[_]](implicit R: RenderTree[Fix[F]]):
       RenderTree[Crystallized[F]] =
     new RenderTree[Crystallized[F]] {
       def render(v: Crystallized[F]) = v.op.render

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflow/WorkflowOp3_2.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflow/WorkflowOp3_2.scala
@@ -131,17 +131,15 @@ object WorkflowOp3_2F {
       }
     }
 
-  implicit def renderTree: Delay[RenderTree, WorkflowOp3_2F] =
-    new Delay[RenderTree, WorkflowOp3_2F] {
-      def apply[A](fa: RenderTree[A]) = new RenderTree[WorkflowOp3_2F[A]] {
-        val wfType = "Workflow3.2" :: Nil
+  implicit def renderTree: RenderTree[WorkflowOp3_2F[Unit]] =
+    new RenderTree[WorkflowOp3_2F[Unit]] {
+      val wfType = "Workflow3.2" :: Nil
 
-        def render(v: WorkflowOp3_2F[A]) = v match {
-          case $LookupF(_, from, localField, foreignField, as) =>
-            Terminal("$LookupF" :: wfType, s"from ${from.value} with (this).${localField.asText} = (that).${foreignField.asText} as ${as.asText}".some)
-          case $SampleF(_, size) =>
-            Terminal("$SampleF" :: wfType, size.toString.some)
-        }
+      def render(v: WorkflowOp3_2F[Unit]) = v match {
+        case $LookupF(_, from, localField, foreignField, as) =>
+          Terminal("$LookupF" :: wfType, s"from ${from.value} with (this).${localField.asText} = (that).${foreignField.asText} as ${as.asText}".some)
+        case $SampleF(_, size) =>
+          Terminal("$SampleF" :: wfType, size.toString.some)
       }
     }
 }

--- a/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -3047,6 +3047,44 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
           IgnoreId)))
     }
 
+    "plan simple inner equi-join with expression ($lookup)" in {
+      plan(
+        "select foo.name, bar.address from foo join bar on lower(foo.id) = bar.foo_id") must
+      beWorkflow(chain[Workflow](
+        $read(collection("db", "foo")),
+        $project(reshape(
+          "left" -> $$ROOT,
+          "__tmp0" -> $toLower($field("id"))),
+          IgnoreId),
+        $match(Selector.Doc(
+          BsonField.Name("__tmp0") -> Selector.Neq(Bson.Null))),
+        $lookup(
+          CollectionName("bar"),
+          BsonField.Name("__tmp0"),
+          BsonField.Name("foo_id"),
+          BsonField.Name("right")),
+        $project(reshape(
+          "left" -> $field("left"),
+          "right" -> $field("right"))),
+        $unwind(DocField(BsonField.Name("right"))),
+        $project(reshape(
+          "name" ->
+            $cond(
+              $and(
+                $lte($literal(Bson.Doc(ListMap())), $field("left")),
+                $lt($field("left"), $literal(Bson.Arr(Nil)))),
+              $field("left", "name"),
+              $literal(Bson.Undefined)),
+          "address" ->
+            $cond(
+              $and(
+                $lte($literal(Bson.Doc(ListMap())), $field("right")),
+                $lt($field("right"), $literal(Bson.Arr(Nil)))),
+              $field("right", "address"),
+              $literal(Bson.Undefined))),
+          IgnoreId)))
+    }
+
     "plan simple outer equi-join with wildcard" in {
       plan("select * from foo full join bar on foo.id = bar.foo_id") must
       beWorkflow(
@@ -3096,7 +3134,7 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
           false).op)
     }
 
-    "plan simple left equi-join" in {
+    "plan simple left equi-join (map-reduce)" in {
       plan(
         "select foo.name, bar.address " +
           "from foo left join bar on foo.id = bar.foo_id") must
@@ -3138,6 +3176,68 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
               IgnoreId)),
           false).op)
     }
+
+    "plan simple left equi-join ($lookup)" in {
+      plan(
+        "select foo.name, bar.address " +
+          "from foo left join bar on foo.id = bar.foo_id") must
+      beWorkflow(chain[Workflow](
+        $read(collection("db", "foo")),
+        $project(reshape("left" -> $$ROOT)),
+        $lookup(
+          CollectionName("bar"),
+          BsonField.Name("left") \ BsonField.Name("id"),
+          BsonField.Name("foo_id"),
+          BsonField.Name("right")),
+        $unwind(DocField(BsonField.Name("right"))),  // FIXME: need to preserve docs with no match
+        $project(reshape(
+          "name" ->
+            $cond(
+              $and(
+                $lte($literal(Bson.Doc(ListMap())), $field("left")),
+                $lt($field("left"), $literal(Bson.Arr(Nil)))),
+              $field("left", "name"),
+              $literal(Bson.Undefined)),
+          "address" ->
+            $cond(
+              $and(
+                $lte($literal(Bson.Doc(ListMap())), $field("right")),
+                $lt($field("right"), $literal(Bson.Arr(Nil)))),
+              $field("right", "address"),
+              $literal(Bson.Undefined))),
+          IgnoreId)))
+    }.pendingUntilFixed("TODO: left/right joins in $lookup")
+
+    "plan simple right equi-join ($lookup)" in {
+      plan(
+        "select foo.name, bar.address " +
+          "from foo right join bar on foo.id = bar.foo_id") must
+      beWorkflow(chain[Workflow](
+        $read(collection("db", "bar")),
+        $project(reshape("right" -> $$ROOT)),
+        $lookup(
+          CollectionName("foo"),
+          BsonField.Name("right") \ BsonField.Name("foo_id"),
+          BsonField.Name("id"),
+          BsonField.Name("left")),
+        $unwind(DocField(BsonField.Name("left"))),  // FIXME: need to preserve docs with no match
+        $project(reshape(
+          "name" ->
+            $cond(
+              $and(
+                $lte($literal(Bson.Doc(ListMap())), $field("left")),
+                $lt($field("left"), $literal(Bson.Arr(Nil)))),
+              $field("left", "name"),
+              $literal(Bson.Undefined)),
+          "address" ->
+            $cond(
+              $and(
+                $lte($literal(Bson.Doc(ListMap())), $field("right")),
+                $lt($field("right"), $literal(Bson.Arr(Nil)))),
+              $field("right", "address"),
+              $literal(Bson.Undefined))),
+          IgnoreId)))
+    }.pendingUntilFixed("TODO: left/right joins in $lookup")
 
     "plan 3-way right equi-join (map-reduce)" in {
       plan2_6(
@@ -3209,6 +3309,66 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
                     $literal(Bson.Undefined))),
               IgnoreId)),
           true).op)
+    }
+
+    "plan 3-way equi-join ($lookup)" in {
+      plan(
+        "select foo.name, bar.address, baz.zip " +
+          "from foo join bar on foo.id = bar.foo_id " +
+          "join baz on bar.id = baz.bar_id") must
+        beWorkflow(chain[Workflow](
+          $read(collection("db", "foo")),
+          $match(Selector.Doc(
+            BsonField.Name("id") -> Selector.Neq(Bson.Null))),
+          $project(reshape("left" -> $$ROOT)),
+          $lookup(
+            CollectionName("bar"),
+            BsonField.Name("left") \ BsonField.Name("id"),
+            BsonField.Name("foo_id"),
+            BsonField.Name("right")),
+          $unwind(DocField(BsonField.Name("right"))),
+          $match(Selector.Doc(
+            BsonField.Name("right") \ BsonField.Name("id") -> Selector.Neq(Bson.Null))),
+          $project(reshape("left" -> $$ROOT)),
+          $lookup(
+            CollectionName("baz"),
+            BsonField.Name("left") \ BsonField.Name("right") \ BsonField.Name("id"),
+            BsonField.Name("bar_id"),
+            BsonField.Name("right")),
+          $unwind(DocField(BsonField.Name("right"))),
+          $project(reshape(
+            "name" ->
+              $cond(
+                $and(
+                  $lte($literal(Bson.Doc(ListMap())), $field("left")),
+                  $lt($field("left"), $literal(Bson.Arr(Nil)))),
+                $cond(
+                  $and(
+                    $lte($literal(Bson.Doc(ListMap())), $field("left", "left")),
+                    $lt($field("left", "left"), $literal(Bson.Arr(Nil)))),
+                  $field("left", "left", "name"),
+                  $literal(Bson.Undefined)),
+                $literal(Bson.Undefined)),
+            "address" ->
+              $cond(
+                $and(
+                  $lte($literal(Bson.Doc(ListMap())), $field("left")),
+                  $lt($field("left"), $literal(Bson.Arr(Nil)))),
+                $cond(
+                  $and(
+                    $lte($literal(Bson.Doc(ListMap())), $field("left", "right")),
+                    $lt($field("left", "right"), $literal(Bson.Arr(Nil)))),
+                  $field("left", "right", "address"),
+                  $literal(Bson.Undefined)),
+                $literal(Bson.Undefined)),
+            "zip" ->
+              $cond(
+                $and(
+                  $lte($literal(Bson.Doc(ListMap())), $field("right")),
+                  $lt($field("right"), $literal(Bson.Arr(Nil)))),
+                $field("right", "zip"),
+                $literal(Bson.Undefined))),
+            IgnoreId)))
     }
 
     "plan join with multiple conditions" in {

--- a/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -2876,7 +2876,7 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
         beWorkflow(chain[Workflow](
           $read(collection("db", "zips")),
           $match(Selector.Doc(
-            BsonField.Name("_id") -> Selector.Neq(Bson.Null))),
+            BsonField.Name("_id") -> Selector.Exists(true))),
           $project(reshape("left" -> $$ROOT)),
           $lookup(
             CollectionName("zips2"),
@@ -3021,7 +3021,7 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
       beWorkflow(chain[Workflow](
         $read(collection("db", "foo")),
         $match(Selector.Doc(
-          BsonField.Name("id") -> Selector.Neq(Bson.Null))),
+          BsonField.Name("id") -> Selector.Exists(true))),
         $project(reshape("left" -> $$ROOT)),
         $lookup(
           CollectionName("bar"),
@@ -3056,8 +3056,6 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
           "left" -> $$ROOT,
           "__tmp0" -> $toLower($field("id"))),
           IgnoreId),
-        $match(Selector.Doc(
-          BsonField.Name("__tmp0") -> Selector.Neq(Bson.Null))),
         $lookup(
           CollectionName("bar"),
           BsonField.Name("__tmp0"),
@@ -3319,7 +3317,7 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
         beWorkflow(chain[Workflow](
           $read(collection("db", "foo")),
           $match(Selector.Doc(
-            BsonField.Name("id") -> Selector.Neq(Bson.Null))),
+            BsonField.Name("id") -> Selector.Exists(true))),
           $project(reshape("left" -> $$ROOT)),
           $lookup(
             CollectionName("bar"),
@@ -3328,7 +3326,7 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
             BsonField.Name("right")),
           $unwind(DocField(BsonField.Name("right"))),
           $match(Selector.Doc(
-            BsonField.Name("right") \ BsonField.Name("id") -> Selector.Neq(Bson.Null))),
+            BsonField.Name("right") \ BsonField.Name("id") -> Selector.Exists(true))),
           $project(reshape("left" -> $$ROOT)),
           $lookup(
             CollectionName("baz"),


### PR DESCRIPTION
This is a first step for #1364, handling joins where one source is a trivial read and the other source is a pipeline without filtering. Notably this allows a simple 3-way join to run in `aggregate`, which is pretty impressive:

```
 $ select a.foo, b.bar, c.baz from abc as a join abc as b on b.a_id = a._id join abc as c on c.b_id = b._id
MongoDB
db.abc.aggregate(
  [
    { "$match": { "_id": { "$ne": null } } },
    { "$project": { "left": "$$ROOT" } },
    {
      "$lookup": {
        "from": "abc",
        "localField": "left._id",
        "foreignField": "a_id",
        "as": "right"
      }
    },
    { "$unwind": "$right" },
    { "$match": { "right._id": { "$ne": null } } },
    { "$project": { "left": "$$ROOT" } },
    {
      "$lookup": {
        "from": "abc",
        "localField": "left.right._id",
        "foreignField": "b_id",
        "as": "right"
      }
    },
    { "$unwind": "$right" },
    { "$limit": NumberLong("11") },
    {
      "$project": {
        "foo": {
```
