### PR TITLE
Two fixes related to joining sub-selects

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- [#1371] two fixes related to joining sub-selects

--- a/it/src/main/resources/tests/joins/joinSubSelects.test
+++ b/it/src/main/resources/tests/joins/joinSubSelects.test
@@ -1,0 +1,26 @@
+{
+  "name": "join the results of a pair of sub-queries",
+
+  "backends": {
+    "mongodb_read_only": "pending",
+    "postgresql":        "pending"
+  },
+
+  "data": "../zips.data",
+
+  "query": "select t1.city, t1.popCA, t2.popMA from
+            (select city, sum(pop) as popCA from `../zips`
+              where state = \"CA\" group by city
+              order by sum(pop) desc limit 200) as t1
+            join
+            (select city, sum(pop) as popMA from `../zips`
+              where state = \"MA\" group by city
+              order by sum(pop) desc limit 200) as t2
+            on t1.city = t2.city",
+
+  "predicate": "containsExactly",
+  "expected": [
+    { "city": "CONCORD",    "popCA": 115027, "popMA": 17076 },
+    { "city": "WILMINGTON", "popCA":  49178, "popMA": 17647 }
+  ]
+}

--- a/js/src/main/scala/quasar/jscore/jsfn.scala
+++ b/js/src/main/scala/quasar/jscore/jsfn.scala
@@ -25,7 +25,7 @@ import scalaz._, Scalaz._
   * @param param The free parameter to the expression
   */
 final case class JsFn(param: Name, expr: JsCore) {
-  def apply(x: JsCore) = expr.substitute(Ident(param), x)
+  def apply(x: JsCore): JsCore = expr.substitute(Ident(param), x)
 
   def >>>(that: JsFn): JsFn =
     if (this == JsFn.identity) that

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflow/WorkflowOpCore.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflow/WorkflowOpCore.scala
@@ -491,11 +491,9 @@ object $MapF {
     mapKeyVal(("key", ident), Js.Ident("key"), transform)
   val mapNOP = mapMap("value", Js.Ident("value"))
 
-  def finalizerFn(fn: Js.Expr) =
+  def finalizerFn(fn: JsFn) =
     Js.AnonFunDecl(List("key", "value"),
-      List(Js.Return(Js.Access(
-        Js.Call(fn, List(Js.Ident("key"), Js.Ident("value"))),
-        Js.Num(1, false)))))
+      List(Js.Return(fn(jscore.Ident(jscore.Name("value"))).toJs)))
 
   def mapFn(fn: Js.Expr) =
     Js.AnonFunDecl(Nil,

--- a/mongodb/src/test/scala/quasar/physical/mongodb/workflowop.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/workflowop.scala
@@ -656,7 +656,7 @@ class WorkflowSpec extends quasar.Qspec with TreeMatchers {
           Js.Access(Js.Ident("value"), Js.Num(0, false))),
           ListMap()),
         $reduce($ReduceF.reduceFoldLeft, ListMap()),
-        $map($MapF.mapMap("value", Js.Ident("value")), ListMap())))) must
+        $simpleMap(NonEmptyList(MapExpr(JsFn.identity)), ListMap())))) must
       beTree[WorkflowTask](
         MapReduceTask(
           ReadTask(collection("db", "zips")),
@@ -670,8 +670,7 @@ class WorkflowSpec extends quasar.Qspec with TreeMatchers {
             inputSort =
               Some(NonEmptyList(BsonField.Name("city") -> SortDir.Descending)),
             limit = Some(100),
-            finalizer = Some($MapF.finalizerFn($MapF.mapMap("value",
-              Js.Ident("value"))))),
+            finalizer = Some($MapF.finalizerFn(JsFn.identity))),
           None))
     }
 
@@ -688,7 +687,7 @@ class WorkflowSpec extends quasar.Qspec with TreeMatchers {
             Js.AnonElem(List(Js.Ident("key"), Js.Ident("value"))))))),
           ListMap()),
         $reduce($ReduceF.reduceFoldLeft, ListMap()),
-        $map($MapF.mapMap("value", Js.Ident("value")), ListMap())))) must
+        $simpleMap(NonEmptyList(MapExpr(JsFn.identity)), ListMap())))) must
       beTree[WorkflowTask](
         MapReduceTask(
           ReadTask(collection("db", "zips")),
@@ -703,8 +702,7 @@ class WorkflowSpec extends quasar.Qspec with TreeMatchers {
             inputSort =
               Some(NonEmptyList(BsonField.Name("city") -> SortDir.Descending)),
             limit = Some(100),
-            finalizer = Some($MapF.finalizerFn($MapF.mapMap("value",
-              Js.Ident("value"))))),
+            finalizer = Some($MapF.finalizerFn(JsFn.identity))),
           None))
     }
 
@@ -717,7 +715,7 @@ class WorkflowSpec extends quasar.Qspec with TreeMatchers {
         $sort(NonEmptyList(BsonField.Name("city") -> SortDir.Descending)),
         $limit(100),
         $reduce($ReduceF.reduceFoldLeft, ListMap()),
-        $map($MapF.mapMap("value", Js.Ident("value")), ListMap())))) must
+        $simpleMap(NonEmptyList(MapExpr(JsFn.identity)), ListMap())))) must
       beTree[WorkflowTask](
         MapReduceTask(
           ReadTask(collection("db", "zips")),
@@ -730,8 +728,7 @@ class WorkflowSpec extends quasar.Qspec with TreeMatchers {
             inputSort =
               Some(NonEmptyList(BsonField.Name("city") -> SortDir.Descending)),
             limit = Some(100),
-            finalizer = Some($MapF.finalizerFn($MapF.mapMap("value",
-              Js.Ident("value"))))),
+            finalizer = Some($MapF.finalizerFn(JsFn.identity))),
           None))
     }
 


### PR DESCRIPTION
Fixes #1371.

One was related to applying InputFinders to the wrong nodes. The other was blindly re-writing `$Map` ops even if they where trying to alter the key; a side-effect of that fix is more comprehensible JS for the resulting finalizer fns.

With this, we can now handle some very fancy-looking and perhaps even useful queries, such as the one in the new regression test.

@sellout: assigning this to you mostly so you can be aware of the bugs that appeared here, because there are probably more of them lurking in this code and I'm sure you have ideas about how we can improve it down the road.

@drostron: feel free to have a look. You saw all of these changes but I cleaned up the code a lot since we were looking at it.