### PR TITLE
Use java's builtin facilities for URI encoding.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- Use java's built-in facilities for URI escaping.

--- a/web/src/main/scala/quasar/api/package.scala
+++ b/web/src/main/scala/quasar/api/package.scala
@@ -154,24 +154,25 @@ package object api {
     }
   }
 
-  val UriPathCodec = {
+  def uriEncodeUtf8(s: String): String = java.net.URLEncoder.encode(s, "UTF-8")
+  def uriDecodeUtf8(s: String): String = java.net.URLDecoder.decode(s, "UTF-8")
 
-    val $dot$ = "$dot$"
+  val UriPathCodec = {
+    val $dot$    = "$dot$"
     val $dotdot$ = "$dotdot$"
 
-    val escapeRel = (s: String) =>
-      if (s == "..") $dotdot$ else if (s == ".") $dot$ else s
+    val escapeRel: String => String = {
+      case ".." => $dotdot$
+      case "."  => $dot$
+      case s    => uriEncodeUtf8(s)
+    }
+    val unescapeRel: String => String = {
+      case `$dotdot$` => ".."
+      case `$dot$`    => "."
+      case s          => uriDecodeUtf8(s)
+    }
 
-    val unescapeRel = (s: String) =>
-      if (s == $dotdot$) ".." else if (s == $dot$) "." else s
-
-    val encode = (s: String) =>
-      UrlCodingUtils.urlEncode(s, toSkip = HPath.pathUnreserved)
-
-    val decode = (s: String) =>
-      UrlCodingUtils.urlDecode(s)
-
-    PathCodec('/', encode compose escapeRel, decode compose unescapeRel)
+    PathCodec('/', escapeRel, unescapeRel)
   }
 
   // NB: oddly, every path is prefixed with '/', except "".
@@ -208,7 +209,7 @@ package object api {
   def decodedPath(encodedPath: String): ApiError \/ APath =
     AsPath.unapply(HPath(encodedPath)) \/> ApiError.fromMsg(
       BadRequest withReason "Malformed path.",
-      s"Failed to parse '${UrlCodingUtils.urlDecode(encodedPath)}' as an absolute path.",
+      s"Failed to parse '${uriDecodeUtf8(encodedPath)}' as an absolute path.",
       "encodedPath" := encodedPath)
 
   def transcode(from: PathCodec, to: PathCodec): String => String =


### PR DESCRIPTION
There is a bug in http4s where %xx sequences are rendered
upper case if the xx characters might be hex digits. But it's
not clear why we're using NIH URI facilities in any case.