### PR TITLE
Use typelevel compiler.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- Switch to using typelevel scala compiler.

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ lazy val buildSettings = Seq(
     ("scala", Apache2_0("2014–2016", "SlamData Inc.")),
     ("java",  Apache2_0("2014–2016", "SlamData Inc."))),
   scalaVersion := "2.11.8",
+  scalaOrganization := "org.typelevel",
   outputStrategy := Some(StdoutOutput),
   initialize := {
     val version = sys.props("java.specification.version")
@@ -51,7 +52,6 @@ lazy val buildSettings = Seq(
     "bintray/non" at "http://dl.bintray.com/non/maven"),
   addCompilerPlugin("org.spire-math" %% "kind-projector"   % "0.8.0"),
   addCompilerPlugin("org.scalamacros" % "paradise"         % "2.1.0" cross CrossVersion.full),
-  addCompilerPlugin("com.milessabin"  % "si2712fix-plugin" % "1.2.0" cross CrossVersion.full),
 
   ScoverageKeys.coverageHighlighting := true,
 
@@ -60,6 +60,8 @@ lazy val buildSettings = Seq(
     "-target:jvm-1.8",
     "-Ybackend:GenBCode",
     "-Ydelambdafy:method",
+    "-Ypartial-unification",
+    "-Yliteral-types",
     "-Ywarn-unused-import"),
   scalacOptions in (Test, console) --= Seq(
     "-Yno-imports",

--- a/effect/src/main/scala/quasar/errors.scala
+++ b/effect/src/main/scala/quasar/errors.scala
@@ -50,22 +50,22 @@ object Errors {
     type G[F[_], A] = EitherT[F, E, A]
     liftMT[Task, G]
   }
+}
 
-  /** Given a function A => B, returns a natural transformation from
-    * EitherT[F, A, ?] ~> EitherT[F, B, ?].
-    *
-    * Partially applies the monad, `F`, for better inference, so use like
-    *   `convertError[F](f)`
-    */
-  object convertError {
-    def apply[F[_]]: Aux[F] =
-      new Aux[F]
+/** Given a function A => B, returns a natural transformation from
+  * EitherT[F, A, ?] ~> EitherT[F, B, ?].
+  *
+  * Partially applies the monad, `F`, for better inference, so use like
+  *   `convertError[F](f)`
+  */
+object convertError {
+  def apply[F[_]]: Aux[F] =
+    new Aux[F]
 
-    final class Aux[F[_]] {
-      def apply[A, B](f: A => B)(implicit F: Functor[F]): EitherT[F, A, ?] ~> EitherT[F, B, ?] =
-        new (EitherT[F, A, ?] ~> EitherT[F, B, ?]) {
-          def apply[C](ea: EitherT[F, A, C]) = ea.leftMap(f)
-        }
-    }
+  final class Aux[F[_]] {
+    def apply[A, B](f: A => B)(implicit F: Functor[F]): EitherT[F, A, ?] ~> EitherT[F, B, ?] =
+      new (EitherT[F, A, ?] ~> EitherT[F, B, ?]) {
+        def apply[C](ea: EitherT[F, A, C]) = ea.leftMap(f)
+      }
   }
 }

--- a/foundation/src/main/scala/quasar/Predef.scala
+++ b/foundation/src/main/scala/quasar/Predef.scala
@@ -21,8 +21,15 @@ import scala.{collection => C}
 import scala.collection.{immutable => I}
 import scala.{runtime => R}
 
+object Predef extends Predef
 
-object Predef extends LowPriorityImplicits {
+class Predef extends LowPriorityImplicits {
+  /** The typelevel Predef additions which makes literal
+   *  types more reasonable to use.
+   */
+  type ValueOf[A]                           = scala.ValueOf[A]
+  def valueOf[A](implicit z: ValueOf[A]): A = z.value
+
   type deprecated = scala.deprecated
   type tailrec = scala.annotation.tailrec
   type SuppressWarnings = java.lang.SuppressWarnings

--- a/foundation/src/test/scala/quasar/TypelevelSpec.scala
+++ b/foundation/src/test/scala/quasar/TypelevelSpec.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar
+
+import quasar.Predef._
+
+/** A small smoke test for the presence of the typelevel compiler.
+ */
+class TypelevelSpec extends quasar.Qspec {
+  "typelevel compiler features" >> {
+    "should exist" >> (valueOf[5] must_=== 5)
+  }
+}

--- a/mongodb/src/main/scala/quasar/physical/mongodb/fs/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/fs/package.scala
@@ -169,7 +169,7 @@ package object fs {
   )(implicit
     S0: Task :<: S
   ): DefErrT[Free[S, ?], MongoClient] = {
-    import quasar.Errors.convertError
+    import quasar.convertError
     type M[A] = Free[S, A]
     type ME[A, B] = EitherT[M, A, B]
     type MEEnvErr[A] = ME[EnvironmentError,A]

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.13-M1

--- a/web/src/main/scala/quasar/api/package.scala
+++ b/web/src/main/scala/quasar/api/package.scala
@@ -17,7 +17,6 @@
 package quasar
 
 import quasar.Predef._
-import quasar.Errors.convertError
 import quasar.api.ToQResponse.ops._
 import quasar.effect.Failure
 import quasar.fp._


### PR DESCRIPTION
The immediate consequence is the elimination of si2712fix-plugin.
A subsequent commit will exploit type literals and singleton inference
to eliminate the currently extensive reliance on shapeless's Nat.

The apparently unrelated change to move the convertError object
outside of the Errors object is actually necessary for things to
work with the typelevel options. This is life with the scala
compiler: any change at all is likely to alter the profile of
when types get forced, and you never know how it will materialize.
In fact it's very encouraging that only the one change was needed.