### PR TITLE
Improve the names of parameters to some `MapFuncs`

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+Improve the names of parameters to some `MapFuncs`

--- a/core/src/main/scala/quasar/qscript/MapFunc.scala
+++ b/core/src/main/scala/quasar/qscript/MapFunc.scala
@@ -548,7 +548,11 @@ object MapFuncs {
   @Lenses final case class Or[T[_[_]], A](a1: A, a2: A) extends Binary[T, A]
   @Lenses final case class Coalesce[T[_[_]], A](a1: A, a2: A) extends Binary[T, A]
   @Lenses final case class Between[T[_[_]], A](a1: A, a2: A, a3: A) extends Ternary[T, A]
-  @Lenses final case class Cond[T[_[_]], A](a1: A, a2: A, a3: A) extends Ternary[T, A]
+  @Lenses final case class Cond[T[_[_]], A](cond: A, then_ : A, else_ : A) extends Ternary[T, A] {
+    def a1 = cond
+    def a2 = then_
+    def a3 = else_
+  }
 
   // set
   @Lenses final case class Within[T[_[_]], A](a1: A, a2: A) extends Binary[T, A]
@@ -562,16 +566,32 @@ object MapFuncs {
   @Lenses final case class Null[T[_[_]], A](a1: A) extends Unary[T, A]
   @Lenses final case class ToString[T[_[_]], A](a1: A) extends Unary[T, A]
   @Lenses final case class Search[T[_[_]], A](a1: A, a2: A, a3: A) extends Ternary[T, A]
-  @Lenses final case class Substring[T[_[_]], A](a1: A, a2: A, a3: A) extends Ternary[T, A]
+  @Lenses final case class Substring[T[_[_]], A](string: A, from: A, count: A) extends Ternary[T, A] {
+    def a1 = string
+    def a2 = from
+    def a3 = count
+  }
 
   // structural
   @Lenses final case class MakeArray[T[_[_]], A](a1: A) extends Unary[T, A]
-  @Lenses final case class MakeMap[T[_[_]], A](a1: A, a2: A) extends Binary[T, A]
+  @Lenses final case class MakeMap[T[_[_]], A](key: A, value: A) extends Binary[T, A] {
+    def a1 = key
+    def a2 = value
+  }
   @Lenses final case class ConcatArrays[T[_[_]], A](a1: A, a2: A) extends Binary[T, A]
   @Lenses final case class ConcatMaps[T[_[_]], A](a1: A, a2: A) extends Binary[T, A]
-  @Lenses final case class ProjectIndex[T[_[_]], A](a1: A, a2: A) extends Binary[T, A]
-  @Lenses final case class ProjectField[T[_[_]], A](a1: A, a2: A) extends Binary[T, A]
-  @Lenses final case class DeleteField[T[_[_]], A](a1: A, a2: A) extends Binary[T, A]
+  @Lenses final case class ProjectIndex[T[_[_]], A](src: A, index: A) extends Binary[T, A] {
+    def a1 = src
+    def a2 = index
+  }
+  @Lenses final case class ProjectField[T[_[_]], A](src: A, field: A) extends Binary[T, A] {
+    def a1 = src
+    def a2 = field
+  }
+  @Lenses final case class DeleteField[T[_[_]], A](src: A, field: A) extends Binary[T, A] {
+    def a1 = src
+    def a2 = field
+  }
 
   // helpers & QScript-specific
   /** Turns a map of `{ k1: v1, k2: v2, ...}` into a map of
@@ -589,7 +609,10 @@ object MapFuncs {
     * `[[0, v1], [1, v2], ...]`.
     */
   @Lenses final case class ZipArrayIndices[T[_[_]], A](a1: A) extends Unary[T, A]
-  @Lenses final case class Range[T[_[_]], A](a1: A, a2: A) extends Binary[T, A]
+  @Lenses final case class Range[T[_[_]], A](from: A, to: A) extends Binary[T, A] {
+    def a1 = from
+    def a2 = to
+  }
   /** A conditional specifically for checking that `a1` satisfies `pattern`.
     */
   @Lenses final case class Guard[T[_[_]], A](a1: A, pattern: Type, a2: A, a3: A)

--- a/web/src/test/scala/quasar/api/services/MountServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/MountServiceSpec.scala
@@ -491,7 +491,7 @@ class MountServiceSpec extends quasar.Qspec with Http4s {
               (mntd must beEmpty)
             }
           }
-        }
+        }.flakyTest("ARG_0: FileIn(Current,FileName(%7b9DyymB.g.x.kk쉛rpf1Waff\uFD4B⣹thqxslkuv/8x.op))\n[error]        > ARG_1: DirIn(DirIn(DirIn(DirIn(DirIn(Root,DirName(qaverlryzkrd6s/cw.btn\uECF6h0/▖i.hOdK윾g㳩lnc7.hglCsuml)),DirName(dx/gpkMjhim1)),DirName(juycm)),DirName(y)),DirName(9))\n[error]        > object[(path,\"/qaverlryzkrd6s$sep$cw.btn\uECF6h0$sep$▖i.hOdK윾g㳩lnc7.hglCsuml/dx$sep$gpkMjhim1/juycm/y/9/%7B9DyymB.g.x.kk쉛rpf1Waff\uFD4B⣹thqxslkuv$sep$8x.op\")] !== object[(path,\"/qaverlryzkrd6s$sep$cw.btn\uECF6h0$sep$▖i.hOdK윾g㳩lnc7.hglCsuml/dx$sep$gpkMjhim1/juycm/y/9/%7b9DyymB.g.x.kk쉛rpf1Waff\uFD4B⣹thqxslkuv$sep$8x.op\")]")
 
         "be 400 with view config and dir path in X-File-Name header" >> prop { (parent: ADir, viewDir: RDir) =>
           runTest { service =>


### PR DESCRIPTION
Happy to do the same thing for more of them. Some of them it didn't feel like it was worth the effort to name cuz they were really obvious. Of course, these ones were obvious enough since I was able to guess them from the name of the function, although I wouldn't be surprised if I got one or two of them wrong. Others (like `Between` and `Coalesce`) I wasn't able to guess so it would probably be a good idea to give them names actually 😄 .