### PR TITLE
Replace transformers with mtl classes in `convertToQScript` and `ConvertPath`

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- Replace monad trans with mtl classes in ConvertPath

--- a/core/src/main/scala/quasar/fs/QueryFile.scala
+++ b/core/src/main/scala/quasar/fs/QueryFile.scala
@@ -65,31 +65,43 @@ object QueryFile {
     [T[_[_]]: Recursive: Corecursive: EqualT: ShowT, S[_]]
     (lp: T[LogicalPlan])
     (implicit QF: QueryFile.Ops[S]):
-      EitherT[WriterT[Free[S, ?], PhaseResults, ?], FileSystemError, T[QS[T, ?]]] =
-    convertToQScript[T, Free[S, ?]]((QF.ls(_: ADir)).some)(lp)
+      EitherT[WriterT[Free[S, ?], PhaseResults, ?], FileSystemError, T[QS[T, ?]]] = {
+
+    val lc = (d: ADir) => EitherT(QF.ls(d).run.liftM[WriterT[?[_], PhaseResults, ?]])
+
+    convertToQScript(some(lc))(lp)
+  }
 
   /** This is a stop-gap function that QScript-based backends should use until
     * LogicalPlan no longer needs to be exposed.
     */
-  def convertToQScript[T[_[_]]: Recursive: Corecursive: EqualT: ShowT, M[_]: Monad](
+  def convertToQScript[T[_[_]]: Recursive: Corecursive: EqualT: ShowT, M[_]](
     listContents: Option[ConvertPath.ListContents[M]])(
-    lp: T[LogicalPlan]):
-      EitherT[WriterT[M, PhaseResults, ?], FileSystemError, T[QS[T, ?]]] = {
+    lp: T[LogicalPlan])(
+    implicit
+    merr: MonadError[M, FileSystemError],
+    mtell: MonadTell[M, PhaseResults]
+  ): M[T[QS[T, ?]]] = {
     val transform = new Transform[T, QS[T, ?]]
     val optimize = new Optimize[T]
 
+    val rawQS =
+      optimizeEval(lp)(optimize.applyAll).fold(
+        perr => merr.raiseError(FileSystemError.planningFailed(lp.convertTo[Fix], perr)),
+        merr.point(_))
+
+    val withoutProj =
+      merr.bind(rawQS)(optimize.eliminateProjections[M, QS[T, ?]](listContents))
+
     // TODO: Rather than explicitly applying multiple times, we should apply
     //       repeatedly until unchanged.
-    val qs =
-      (EitherT(optimizeEval(lp)(optimize.applyAll).leftMap(FileSystemError.planningFailed(lp.convertTo[Fix], _)).point[M]) >>=
-        optimize.eliminateProjections[M, QS[T, ?]](listContents)).map(
-          _.transCata(optimize.applyAll).transCata(optimize.applyAll))
+    val optimized =
+      merr.map(withoutProj)(_.transCata(optimize.applyAll).transCata(optimize.applyAll))
 
-    EitherT(WriterT(qs.run.map(qq => (
-      qq.fold(
-        κ(Vector()),
-        a => Vector(PhaseResult.Tree("QScript", a.cata(transform.linearize).reverse.render))),
-      qq))))
+    mtell.bind(optimized) { qs =>
+      val renderedTree = qs.cata(transform.linearize).reverse.render
+      mtell.writer(Vector(PhaseResult.Tree("QScript", renderedTree)), qs)
+    }
   }
 
   /** The result of the query is stored in an output file
@@ -150,9 +162,6 @@ object QueryFile {
   /** This operation should return whether a file exists in the filesystem.*/
   final case class FileExists(file: AFile)
     extends QueryFile[Boolean]
-
-  // TODO[scalaz]: Shadow the scalaz.Monad.monadMTMAB SI-2712 workaround
-  import EitherT.eitherTMonad
 
   final class Ops[S[_]](implicit S: QueryFile :<: S)
     extends LiftedOps[QueryFile, S] {

--- a/core/src/main/scala/quasar/fs/package.scala
+++ b/core/src/main/scala/quasar/fs/package.scala
@@ -62,6 +62,7 @@ package object fs extends PhysicalErrorPrisms {
 
   type FileSystemFailure[A] = Failure[FileSystemError, A]
   type FileSystemErrT[F[_], A] = EitherT[F, FileSystemError, A]
+  type MonadFsErr[F[_]] = MonadError[F, FileSystemError]
 
   type PhysErr[A] = Failure[PhysicalError, A]
 

--- a/core/src/main/scala/quasar/qscript/Optimize.scala
+++ b/core/src/main/scala/quasar/qscript/Optimize.scala
@@ -18,7 +18,7 @@ package quasar.qscript
 
 import quasar.Predef._
 import quasar.fp._
-import quasar.fs.FileSystemError
+import quasar.fs.MonadFsErr
 import quasar.qscript.MapFunc._
 import quasar.qscript.MapFuncs._
 
@@ -534,29 +534,26 @@ class Optimize[T[_[_]]: Recursive: Corecursive: EqualT: ShowT] {
     * `f` takes QScript representing a _potential_ path to a file, converts
     * [[Root]] and its children to path, with the operations post-file remaining.
     */
-  def pathify[M[_]: Monad, F[_]: Traverse](
+  def pathify[M[_]: MonadFsErr, F[_]: Traverse](
     ls: ConvertPath.ListContents[M])(
     implicit FS: StaticPath.Aux[T, F],
              F: Pathable[T, ?] :<: F,
              QC: QScriptCore[T, ?] :<: F,
              FI: F :<: QScriptTotal[T, ?],
              CP: ConvertPath.Aux[T, Pathable[T, ?], F]):
-      T[F] => EitherT[M,  FileSystemError, T[QScriptTotal[T, ?]]] =
-    _.cataM[EitherT[M, FileSystemError, ?], T[QScriptTotal[T, ?]] \/ T[Pathable[T, ?]]](FS.pathifyƒ[M, F](ls)) >>=
-      (_.fold(qt => EitherT(qt.right.point[M]), FS.toRead[M, F, QScriptTotal[T, ?]](ls)))
+      T[F] => M[T[QScriptTotal[T, ?]]] =
+    _.cataM[M, T[QScriptTotal[T, ?]] \/ T[Pathable[T, ?]]](FS.pathifyƒ[M, F](ls))
+      .flatMap(_.fold(_.point[M], FS.toRead[M, F, QScriptTotal[T, ?]](ls)))
 
-  def eliminateProjections[M[_]: Monad, F[_]: Traverse](
+  def eliminateProjections[M[_]: MonadFsErr, F[_]: Traverse](
     lsOpt: Option[ConvertPath.ListContents[M]])(
     implicit FS: StaticPath.Aux[T, F],
              F: Pathable[T, ?] :<: F,
              QC: QScriptCore[T, ?] :<: F,
              FI: F :<: QScriptTotal[T, ?],
              CP: ConvertPath.Aux[T, Pathable[T, ?], F]):
-      T[F] => EitherT[M, FileSystemError, T[QScriptTotal[T, ?]]] = qs => {
-    val res = lsOpt.fold(EitherT(qs.transAna(FI.inj).right[FileSystemError].point[M]))(pathify[M, F](_).apply(qs))
-
-    res.map(
-      _.transAna(SimplifyProjection[QScriptTotal[T, ?], QScriptTotal[T, ?]].simplifyProjection))
+      T[F] => M[T[QScriptTotal[T, ?]]] = {
+    val simplifyProj = SimplifyProjection[QScriptTotal[T, ?], QScriptTotal[T, ?]].simplifyProjection
+    qs => lsOpt.fold(qs.transAna(FI.inj).point[M])(pathify[M, F](_).apply(qs)) map (_.transAna(simplifyProj))
   }
-
 }

--- a/core/src/main/scala/quasar/qscript/StaticPath.scala
+++ b/core/src/main/scala/quasar/qscript/StaticPath.scala
@@ -19,7 +19,7 @@ package quasar.qscript
 import quasar.Predef._
 import quasar.Planner.PlannerError
 import quasar.fp._
-import quasar.fs.{ADir, FileSystemError}
+import quasar.fs.{ADir, FileSystemError, MonadFsErr}
 import quasar.qscript.ConvertPath.{ListContents, Pathed, postPathify}
 
 import matryoshka._, TraverseT.ops._
@@ -30,7 +30,7 @@ import simulacrum.typeclass
 @typeclass trait StaticPath[F[_]] {
   type IT[F[_]]
 
-  def pathifyƒ[M[_]: Monad, G[_]: Traverse]
+  def pathifyƒ[M[_]: MonadFsErr, G[_]: Traverse]
     (ls: ListContents[M])
     (implicit
       TC: Corecursive[IT],
@@ -41,9 +41,9 @@ import simulacrum.typeclass
       FI: G :<: QScriptTotal[IT, ?],
       F: Traverse[F],
       CP: ConvertPath.Aux[IT, Pathable[IT, ?], G])
-      : AlgebraM[EitherT[M, FileSystemError, ?], F, IT[QScriptTotal[IT, ?]] \/ IT[Pathable[IT, ?]]]
+      : AlgebraM[M, F, IT[QScriptTotal[IT, ?]] \/ IT[Pathable[IT, ?]]]
 
-  def toRead[M[_]: Monad, F[_]: Traverse, G[_]: Functor]
+  def toRead[M[_]: MonadFsErr, F[_]: Traverse, G[_]: Functor]
     (ls: ListContents[M])
     (implicit
       TC: Corecursive[IT],
@@ -55,12 +55,13 @@ import simulacrum.typeclass
       QC: QScriptCore[IT, ?] :<: G,
       FI: G :<: QScriptTotal[IT, ?],
       CP: ConvertPath.Aux[IT, Pathable[IT, ?], F])
-      : IT[Pathable[IT, ?]] => EitherT[M, FileSystemError, IT[G]] = {
+      : IT[Pathable[IT, ?]] => M[IT[G]] = {
     implicit val pathedTraverse: Traverse[Pathed[F, ?]] =
       Traverse[List].compose(Traverse[CoEnv[ADir, F, ?]])
 
-    _.transCataM[EitherT[M, FileSystemError, ?], Pathed[F, ?]](CP.convertPath[M](ls)) >>=
-      (TraverseT[IT].transCataM[EitherT[M, PlannerError, ?], Pathed[F, ?], G](_)(postPathify[IT, M, F, G](ls)).leftMap(FileSystemError.qscriptPlanningFailed(_)))
+    _.transCataM[M, Pathed[F, ?]](CP.convertPath[M](ls)) >>=
+      (TraverseT[IT].transCataM[EitherT[M, PlannerError, ?], Pathed[F, ?], G](_)(postPathify[IT, M, F, G](ls)).run) >>=
+      (_.fold(FileSystemError.qscriptPlanningFailed(_).raiseError[M, IT[G]], _.point[M]))
     }
 }
 
@@ -72,7 +73,7 @@ object StaticPath extends LowPriorityStaticPathInstances {
     new StaticPath[F] {
       type IT[F[_]] = T[F]
 
-      def pathifyƒ[M[_]: Monad, G[_]: Traverse](ls: ListContents[M])(
+      def pathifyƒ[M[_]: MonadFsErr, G[_]: Traverse](ls: ListContents[M])(
         implicit TC: Corecursive[T],
                  TR: Recursive[T],
                  PF: Pathable[IT, ?] ~> G,
@@ -81,9 +82,10 @@ object StaticPath extends LowPriorityStaticPathInstances {
                  FI: G :<: QScriptTotal[T, ?],
                  T: Traverse[F],
                  CP: ConvertPath.Aux[IT, Pathable[IT, ?], G]):
-          // AlgebraM[FileSystemError \/ ?, F, T[QScriptTotal[T, ?]] \/ T[Pathable[T, ?]]]
-          F[T[QScriptTotal[T, ?]] \/ T[Pathable[T, ?]]] => EitherT[M, FileSystemError, T[QScriptTotal[T, ?]] \/ T[Pathable[T, ?]]] =
-        fa => EitherT(fa.sequence.bimap(qt => FI(F(fa.as(qt))).embed, Path(_).embed).right.point[M])
+          // AlgebraM[M, F, IT[QScriptTotal[IT, ?]] \/ IT[Pathable[IT, ?]]]
+          F[T[QScriptTotal[T, ?]] \/ T[Pathable[T, ?]]] => M[T[QScriptTotal[T, ?]] \/ T[Pathable[T, ?]]] =
+
+        fa => fa.sequence.bimap(qt => FI(F(fa.as(qt))).embed, Path(_).embed).point[M]
     }
 
   implicit def coproduct[T[_[_]], H[_]: Traverse, I[_]: Traverse](
@@ -92,7 +94,7 @@ object StaticPath extends LowPriorityStaticPathInstances {
     new StaticPath[Coproduct[H, I, ?]] {
       type IT[F[_]] = T[F]
 
-      def pathifyƒ[M[_]: Monad, G[_]: Traverse](ls: ListContents[M])(
+      def pathifyƒ[M[_]: MonadFsErr, G[_]: Traverse](ls: ListContents[M])(
         implicit TC: Corecursive[T],
                  TR: Recursive[T],
                  PF: Pathable[IT, ?] ~> G,
@@ -101,10 +103,11 @@ object StaticPath extends LowPriorityStaticPathInstances {
                  FI: G :<: QScriptTotal[T, ?],
                  T: Traverse[Coproduct[H, I, ?]],
                  CP: ConvertPath.Aux[IT, Pathable[IT, ?], G]):
-          AlgebraM[EitherT[M, FileSystemError, ?], Coproduct[H, I, ?], T[QScriptTotal[T, ?]] \/ T[Pathable[T, ?]]] =
+          AlgebraM[M, Coproduct[H, I, ?], IT[QScriptTotal[IT, ?]] \/ IT[Pathable[IT, ?]]] =
+
         _.run.fold(
-          FS.pathifyƒ(ls)(Monad[M], Traverse[G], TC, TR, PF, QC, F.compose(Inject[H, Coproduct[H, I, ?]]), FI, Traverse[H], CP),
-          GS.pathifyƒ(ls)(Monad[M], Traverse[G], TC, TR, PF, QC, F.compose(Inject[I, Coproduct[H, I, ?]]), FI, Traverse[I], CP))
+          FS.pathifyƒ(ls)(MonadError[M, FileSystemError], Traverse[G], TC, TR, PF, QC, F.compose(Inject[H, Coproduct[H, I, ?]]), FI, Traverse[H], CP),
+          GS.pathifyƒ(ls)(MonadError[M, FileSystemError], Traverse[G], TC, TR, PF, QC, F.compose(Inject[I, Coproduct[H, I, ?]]), FI, Traverse[I], CP))
     }
 }
 
@@ -113,7 +116,7 @@ sealed trait LowPriorityStaticPathInstances {
     new StaticPath[F] {
       type IT[F[_]] = T[F]
 
-      def pathifyƒ[M[_]: Monad, G[_]: Traverse](ls: ListContents[M])(
+      def pathifyƒ[M[_]: MonadFsErr, G[_]: Traverse](ls: ListContents[M])(
         implicit TC: Corecursive[T],
                  TR: Recursive[T],
                  PF: Pathable[IT, ?] ~> G,
@@ -122,10 +125,8 @@ sealed trait LowPriorityStaticPathInstances {
                  FI: G :<: QScriptTotal[T, ?],
                  T: Traverse[F],
                  CP: ConvertPath.Aux[IT, Pathable[IT, ?], G]):
-          AlgebraM[EitherT[M, FileSystemError, ?], F, T[QScriptTotal[T, ?]] \/ T[Pathable[T, ?]]]=
-        _.traverse(_.fold(
-          qt => EitherT(qt.right[FileSystemError].point[M]),
-          toRead[M, G, QScriptTotal[T, ?]](ls)))
+          AlgebraM[M, F, IT[QScriptTotal[IT, ?]] \/ IT[Pathable[IT, ?]]] =
+        _.traverse(_.fold(_.point[M], toRead[M, G, QScriptTotal[T, ?]](ls)))
           .map(x => FI(F(x)).embed.left)
     }
 }

--- a/core/src/test/scala/quasar/fs/QueryFileSpec.scala
+++ b/core/src/test/scala/quasar/fs/QueryFileSpec.scala
@@ -30,9 +30,6 @@ class QueryFileSpec extends quasar.Qspec with FileSystemFixture {
   import InMemory._, FileSystemError._, PathError._, DataArbitrary._
   import query._, transforms.ExecM
 
-  // TODO[scalaz]: Shadow the scalaz.Monad.monadMTMAB SI-2712 workaround
-  import EitherT.eitherTMonad
-
   "QueryFile" should {
     "descendantFiles" >> {
       "returns all descendants of the given directory" >> prop {

--- a/core/src/test/scala/quasar/qscript/QScriptHelpers.scala
+++ b/core/src/test/scala/quasar/qscript/QScriptHelpers.scala
@@ -17,7 +17,7 @@
 package quasar.qscript
 
 import quasar.Predef._
-import quasar.{LogicalPlan => LP}
+import quasar.{LogicalPlan => LP, PhaseResultT}
 import quasar.fp._
 import quasar.fs._
 import quasar.qscript.MapFuncs._
@@ -58,9 +58,8 @@ trait QScriptHelpers {
       T[F] =
     ops.foldLeft(op.embed)((acc, elem) => elem.as(acc).embed)
 
-  // NB: This is the same type as QueryFile.ListContents
-  def listContents: ConvertPath.ListContents[Id] =
-    d => EitherT((
+  val listContents: ConvertPath.ListContents[Id] =
+    d =>
       if (d ≟ rootDir)
         Set(
           DirName("foo").left,
@@ -84,10 +83,11 @@ trait QScriptHelpers {
           FileName("city").right,
           FileName("person").right,
           FileName("zips").right,
-          FileName("car").right)).right.point[Id])
-    
+          FileName("car").right)
 
   def convert(lc: Option[ConvertPath.ListContents[Id]], lp: Fix[LP]):
-      Option[Fix[QScriptTotal[Fix, ?]]] =
-    QueryFile.convertToQScript[Fix, Id](lc)(lp).toOption.run.copoint
+      Option[Fix[QScriptTotal[Fix, ?]]] = {
+    val lc1 = lc map (_.andThen(_.liftM[PhaseResultT].liftM[FileSystemErrT]))
+    QueryFile.convertToQScript(lc1)(lp).toOption.run.copoint
+  }
 }

--- a/foundation/src/main/scala/quasar/fp/eitherT.scala
+++ b/foundation/src/main/scala/quasar/fp/eitherT.scala
@@ -46,7 +46,7 @@ trait EitherTInstances extends EitherTInstances0 {
     }
 }
 
-trait EitherTInstances0 {
+trait EitherTInstances0 extends EitherTInstances1 {
   implicit def eitherTMonadReader[F[_], R, E](implicit F: MonadReader[F, R]): MonadReader[EitherT[F, E, ?], R] =
     new MonadReader[EitherT[F, E, ?], R] {
       def ask = EitherT.right(F.ask)
@@ -55,6 +55,11 @@ trait EitherTInstances0 {
       def bind[A, B](fa: EitherT[F, E, A])(f: A => EitherT[F, E, B]) = fa flatMap f
       def point[A](a: => A) = F.point(a).liftM[EitherT[?[_], E, ?]]
     }
+}
+
+trait EitherTInstances1 {
+  implicit def eitherTMonadTell[F[_], W, E](implicit F: MonadTell[F, W]): MonadTell[EitherT[F, E, ?], W] =
+    EitherT.monadTell[F, W, E]
 }
 
 object eitherT extends EitherTInstances

--- a/it/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
@@ -215,9 +215,6 @@ class MongoDbFileSystemSpec extends FileSystemTest[FileSystemIO](mongoFsUT map (
 
           import xform._
 
-          // TODO[scalaz]: Shadow the scalaz.Monad.monadMTMAB SI-2712 workaround
-          import EitherT.eitherTMonad
-
           val runExec: CompExecM ~> FileSystemErrT[PhaseResultT[Task, ?], ?] = {
             type X0[A] = PhaseResultT[Task, A]
             type X1[A] = FileSystemErrT[X0, A]

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -144,9 +144,6 @@ abstract class QueryRegressionTest[S[_]](
     run: Run
   ): Task[Result] = {
     val liftRun: CompExecM ~> Task = {
-      // TODO[scalaz]: Shadow the scalaz.Monad.monadMTMAB SI-2712 workaround
-      import EitherT.eitherTMonad
-
       type H1[A] = PhaseResultT[Task, A]
       type H2[A] = SemanticErrsT[H1, A]
       type H3[A] = FileSystemErrT[H2, A]

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner.scala
@@ -1108,9 +1108,6 @@ object MongoDbPlanner {
     (logical: Fix[LogicalPlan])
     (implicit ev0: WorkflowOpCoreF :<: F, ev1: Show[Fix[WorkflowBuilderF[F, ?]]], ev2: RenderTree[Fix[F]])
       : EitherT[Writer[PhaseResults, ?], PlannerError, Crystallized[F]] = {
-    // TODO[scalaz]: Shadow the scalaz.Monad.monadMTMAB SI-2712 workaround
-    import EitherT.eitherTMonad
-    import StateT.stateTMonadState
 
     // NB: Locally add state on top of the result monad so everything
     //     can be done in a single for comprehension.

--- a/repl/src/main/scala/quasar/repl/Repl.scala
+++ b/repl/src/main/scala/quasar/repl/Repl.scala
@@ -97,9 +97,6 @@ object Repl {
   ): Free[S, Unit] = {
     import Command._
 
-    // TODO[scalaz]: Shadow the scalaz.Monad.monadMTMAB SI-2712 workaround
-    import EitherT.eitherTMonad
-
     val RS = AtomicRef.Ops[RunState, S]
     val DF = Failure.Ops[String, S]
 


### PR DESCRIPTION
Replaces the explicit choices of `WriterT[?[_], PhaseResults, ?]` and `EitherT[?[_], FileSystemError, ?]` in `QueryFile.convertToQScript` with their equivalent "mtl" class. Also does the same in `ConvertPath`.

This expresses the required capabilities more directly, trading data types for constraints, and makes them easier to use with other transformer stacks (or algebraic effects) that satisfy the constraints.