### PR TITLE
Fix corner case in URI encoding.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- Fix space-to-plus encoding in URIs.

--- a/web/src/main/scala/quasar/api/package.scala
+++ b/web/src/main/scala/quasar/api/package.scala
@@ -153,7 +153,10 @@ package object api {
     }
   }
 
-  def uriEncodeUtf8(s: String): String = java.net.URLEncoder.encode(s, "UTF-8")
+  /** This encoder translates spaces into pluses, but we want the
+   *  more rigorous encoding %20.
+   */
+  def uriEncodeUtf8(s: String): String = java.net.URLEncoder.encode(s, "UTF-8").replace("+", "%20")
   def uriDecodeUtf8(s: String): String = java.net.URLDecoder.decode(s, "UTF-8")
 
   val UriPathCodec = {

--- a/web/src/test/scala/quasar/api/UriPathCodecSpec.scala
+++ b/web/src/test/scala/quasar/api/UriPathCodecSpec.scala
@@ -41,7 +41,9 @@ class UriPathCodecSpec extends quasar.Qspec {
     "."   -> "$dot$",
     ".."  -> "$dotdot$",
     "..." -> "...",
-    "/"   -> "%2F"
+    "/"   -> "%2F",
+    " "   -> "%20",
+    "+ "  -> "%2B%20"
   )
 
   private def encodingFragments = Fragments(


### PR DESCRIPTION
The jre native encoder translates ' ' into '+' which, although
legal, is not what we want or expect. I discovered this through
a test failure.