### PR TITLE
Disable sbt-header plugin for marklogic-validation until exclusion is available

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+-Disable sbt-header plugin for marklogic-validation until exclusion is available.

--- a/build.sbt
+++ b/build.sbt
@@ -271,7 +271,9 @@ lazy val marklogicValidation = project.in(file("marklogic-validation"))
   .settings(name := "quasar-marklogic-validation-internal")
   .settings(commonSettings)
   .settings(libraryDependencies ++= Dependencies.marklogicValidation)
-  .enablePlugins(AutomateHeaderPlugin)
+  // TODO: Disabled until a new release of sbt-headers with exclusion is available
+  //       as we don't want our headers applied to XMLChar.java
+  //.enablePlugins(AutomateHeaderPlugin)
 
 lazy val marklogic = project
   .settings(name := "quasar-marklogic-internal")


### PR DESCRIPTION
Disables the `AutomateHeaderPlugin` config for the `marklogic-validation` project until a the exclusion support for `sbt-header` is released.

This will prevent the `XMLChar.java` file from continually showing as modified via the on-compile header updates.