### PR TITLE
Fix bug in autojoin3.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+Fix bug in autojoin3 where sources were being referenced incorrectly.

--- a/connector/src/main/scala/quasar/qscript/Transform.scala
+++ b/connector/src/main/scala/quasar/qscript/Transform.scala
@@ -236,7 +236,10 @@ class Transform[T[_[_]]: Recursive: Corecursive: FunctorT: EqualT: ShowT, F[_]: 
     val (fullSrc, fullBuckets, bval, rval) =
       autojoin(EnvT((Ann[T](lbuckets, HoleF), lsrc)).embed, right)
 
-    (fullSrc, fullBuckets, bval >> lval, bval >> cval, rval)
+    // the holes in `bval` reference `fullSrc`
+    // so we replace the holes in `lval` with `bval` because the holes in `lval >> bval` must reference `fullSrc`
+    // and `bval` applied to `fullSrc` gives us access to `lsrc`, so we apply `lval` after `bval`
+    (fullSrc, fullBuckets, lval >> bval, cval >> bval, rval)
   }
 
   def merge2Map(


### PR DESCRIPTION
This bug would affect any query that autojoins 3 sources, for example, any query with a `Guard` node.

This PR now produces correct (though not yet fully optimized) qscript for the query `select foo from bar`.