### PR TITLE
Limit concurrent tasks in Travis to 2

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- improve build stability by hard-coding the concurrent task limit when running in Travis

--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,8 @@ import scoverage._
 
 val BothScopes = "test->test;compile->compile"
 
+def isTravis: Boolean = sys.env contains "TRAVIS"
+
 // Exclusive execution settings
 lazy val ExclusiveTests = config("exclusive") extend Test
 
@@ -84,8 +86,6 @@ lazy val buildSettings = Seq(
   testOptions in Test := Seq(Tests.Argument(Specs2, "exclude", "exclusive")),
   // Exclusive tests include only those tagged with 'exclusive'.
   testOptions in ExclusiveTests := Seq(Tests.Argument(Specs2, "include", "exclusive")),
-  // Tasks tagged with `ExclusiveTest` should be run exclusively.
-  concurrentRestrictions in Global := Seq(Tags.exclusive(ExclusiveTest)),
 
   console <<= console in Test, // console alias test:console
 
@@ -95,6 +95,20 @@ lazy val buildSettings = Seq(
     if ((createHeaders in Compile).value.nonEmpty)
       sys.error("headers not all present")
   })
+
+// In Travis, the processor count is reported as 32, but only ~2 cores are
+// actually available to run.
+concurrentRestrictions in Global := {
+  val maxTasks = 2
+  if (isTravis)
+    // Recreate the default rules with the task limit hard-coded:
+    Seq(Tags.limitAll(maxTasks), Tags.limit(Tags.ForkedTestGroup, 1))
+  else
+    (concurrentRestrictions in Global).value
+}
+
+// Tasks tagged with `ExclusiveTest` should be run exclusively.
+concurrentRestrictions in Global += Tags.exclusive(ExclusiveTest)
 
 lazy val publishSettings = Seq(
   organizationName := "SlamData Inc.",
@@ -209,7 +223,7 @@ lazy val foundation = project
   .settings(commonSettings)
   .settings(publishTestsSettings)
   .settings(libraryDependencies ++= Dependencies.foundation,
-    isCIBuild := sys.env contains "TRAVIS",
+    isCIBuild := isTravis,
     isIsolatedEnv := java.lang.Boolean.parseBoolean(java.lang.System.getProperty("isIsolatedEnv")),
     exclusiveTestTag := "exclusive",
     buildInfoKeys := Seq[BuildInfoKey](version, ScoverageKeys.coverageEnabled, isCIBuild, isIsolatedEnv, exclusiveTestTag),

--- a/connector/src/main/scala/quasar/fs/QueryFile.scala
+++ b/connector/src/main/scala/quasar/fs/QueryFile.scala
@@ -174,7 +174,7 @@ object QueryFile {
     val transforms = Transforms[F]
     import transforms._
 
-    /** Returns the path to the result of executing the given [[LogicalPlan]],
+    /** Returns the path to the result of executing the given `LogicalPlan`,
       * using the provided path if possible.
       *
       * Execution of certain plans may return a result file other than the
@@ -185,7 +185,7 @@ object QueryFile {
       EitherT(WriterT(lift(ExecutePlan(plan, out))): G[FileSystemError \/ AFile])
 
     /** Returns an enumerator of data resulting from evaluating the given
-      * [[LogicalPlan]].
+      * `LogicalPlan`.
       */
     def enumerate(plan: Fix[LogicalPlan]): EnumeratorT[Data, ExecM] = {
       import Iteratee._
@@ -209,7 +209,7 @@ object QueryFile {
     }
 
     /** Returns the stream of data resulting from evaluating the given
-      * [[LogicalPlan]].
+      * `LogicalPlan`.
       */
     def evaluate(plan: Fix[LogicalPlan]): Process[ExecM, Data] = {
       // TODO: use DataCursor.process for the appropriate cursor type
@@ -290,7 +290,7 @@ object QueryFile {
     val transforms = Transforms[F]
     import transforms._
 
-    /** Returns a handle to the results of evaluating the given [[LogicalPlan]]
+    /** Returns a handle to the results of evaluating the given `LogicalPlan`
       * that can be used to read chunks of result data.
       *
       * Care must be taken to `close` the returned handle in order to avoid

--- a/connector/src/main/scala/quasar/fs/WriteFile.scala
+++ b/connector/src/main/scala/quasar/fs/WriteFile.scala
@@ -75,7 +75,7 @@ object WriteFile {
       Process.bracket(unsafe.open(dst))(closeHandle)(h => channel.lift(writeChunk(h)))
     }
 
-    /** Same as `append` but accepts chunked [[Data]]. */
+    /** Same as `append` but accepts chunked `Data`. */
     def appendChunked(dst: AFile, src: Process[F, Vector[Data]]): Process[M, FileSystemError] = {
       val accumPartialWrites =
         process1.id[FileSystemError]
@@ -112,7 +112,7 @@ object WriteFile {
       // NB: the handle will be closed even if `write` produces errors in its value
       unsafe.open(dst) flatMapF (h => unsafe.write(h, data) <* unsafe.close(h) map (_.right))
 
-    /** Same as `save` but accepts chunked [[Data]]. */
+    /** Same as `save` but accepts chunked `Data`. */
     def saveChunked(dst: AFile, src: Process[F, Vector[Data]])
                    (implicit MF: ManageFile.Ops[S])
                    : Process[M, FileSystemError] = {
@@ -142,7 +142,7 @@ object WriteFile {
       saveThese0(dst, data, MoveSemantics.Overwrite)
     }
 
-    /** Same as `create` but accepts chunked [[Data]]. */
+    /** Same as `create` but accepts chunked `Data`. */
     def createChunked(dst: AFile, src: Process[F, Vector[Data]])
                      (implicit QF: QueryFile.Ops[S], MF: ManageFile.Ops[S])
                      : Process[M, FileSystemError] = {
@@ -170,7 +170,7 @@ object WriteFile {
         saveThese0(dst, data, MoveSemantics.FailIfExists))
     }
 
-    /** Same as `replace` but accepts chunked [[Data]]. */
+    /** Same as `replace` but accepts chunked `Data`. */
     def replaceChunked(dst: AFile, src: Process[F, Vector[Data]])
                       (implicit QF: QueryFile.Ops[S], MF: ManageFile.Ops[S])
                       : Process[M, FileSystemError] = {


### PR DESCRIPTION
SBT normally limits tasks overall to the reported number of processors/cores. Come to find out, that number is 32(!) when running in Travis.

Since we believe Travis only uses 1-2 CPUs worth of processor time, resetting the parallel task limit to 2 should preserve any actual parallelism while reducing memory footprint and thrashing.

Running on another branch, this change made the `doc` task complete reliably. It's less clear what it does to the build time.