### PR TITLE
Generate new operators in MongoDB 3.0

### DIFF
--- a/CHANGELOG/feature.md
+++ b/CHANGELOG/feature.md
@@ -1,0 +1,2 @@
+- [#1310] evaluate `time_of_day` in the aggregation pipeline on MongoDB 3.0 or later
+- along with much machinery to support generating version-specific aggregation ops

--- a/foundation/src/main/scala/quasar/fp/package.scala
+++ b/foundation/src/main/scala/quasar/fp/package.scala
@@ -601,7 +601,7 @@ package object fp
       T[F] =
     f(t).fold(ι, FunctorT[T].map(_)(_.map(transApoT(_)(f))))
 
-  def freeCata[F[_]: Traverse, E, A](free: Free[F, E])(φ: Algebra[CoEnv[E, F, ?], A]): A =
+  def freeCata[F[_]: Functor, E, A](free: Free[F, E])(φ: Algebra[CoEnv[E, F, ?], A]): A =
     free.hylo(φ, CoEnv.freeIso[E, F].reverseGet)
 
   def freeCataM[M[_]: Monad, F[_]: Traverse, E, A](free: Free[F, E])(φ: AlgebraM[M, CoEnv[E, F, ?], A]): M[A] =

--- a/foundation/src/main/scala/quasar/fp/tree/package.scala
+++ b/foundation/src/main/scala/quasar/fp/tree/package.scala
@@ -21,33 +21,31 @@ import quasar.Predef._
 import matryoshka._
 import scalaz._
 
+/** "Generic" types for building partially-constructed trees in some
+  * "functorized" type. */
+// TODO: submit to matryoshka?
 package object tree {
-  /** A tree structure with one kind of hole. See `eval1`. */
+  /** A tree structure with one kind of hole. See [[UnaryOps.eval]]. */
   type Unary[F[_]] = Free[F, UnaryArg]
   object Unary {
     def arg[F[_]]: Unary[F] = Free.pure(UnaryArg._1)
   }
-
-  /** A tree structure with two kinds of holes. See `eval2`. */
-  type Binary[F[_]] = Free[F, BinaryArg]
-  object Binary {
-    def arg1[F[_]]: Binary[F] = Free.pure(BinaryArg._1)
-    def arg2[F[_]]: Binary[F] = Free.pure(BinaryArg._2)
-  }
-
-  /** A tree structure with three kinds of holes. See `eval3`. */
-  type Ternary[F[_]] = Free[F, TernaryArg]
-  object Ternary {
-    def arg1[F[_]]: Ternary[F] = Free.pure(TernaryArg._1)
-    def arg2[F[_]]: Ternary[F] = Free.pure(TernaryArg._2)
-    def arg3[F[_]]: Ternary[F] = Free.pure(TernaryArg._3)
-  }
-
   trait UnaryArg {
     def fold[A](arg1: A): A = arg1
   }
   object UnaryArg {
     case object _1 extends UnaryArg
+  }
+  implicit class UnaryOps[F[_]](self: Unary[F]) {
+    def eval[T[_[_]]: Corecursive](arg: T[F])(implicit F: Functor[F]): T[F] =
+      freeCata[F, UnaryArg, T[F]](self)(interpret(_.fold(arg), _.embed))
+  }
+
+  /** A tree structure with two kinds of holes. See [[BinaryOps.eval]]. */
+  type Binary[F[_]] = Free[F, BinaryArg]
+  object Binary {
+    def arg1[F[_]]: Binary[F] = Free.pure(BinaryArg._1)
+    def arg2[F[_]]: Binary[F] = Free.pure(BinaryArg._2)
   }
   trait BinaryArg {
     def fold[A](arg1: A, arg2: A): A = this match {
@@ -58,6 +56,18 @@ package object tree {
   object BinaryArg {
     case object _1 extends BinaryArg
     case object _2 extends BinaryArg
+  }
+  implicit class BinaryOps[F[_]](self: Binary[F]) {
+    def eval[T[_[_]]: Corecursive](arg1: T[F], arg2: T[F])(implicit F: Functor[F]): T[F] =
+      freeCata[F, BinaryArg, T[F]](self)(interpret(_.fold(arg1, arg2), _.embed))
+  }
+
+  /** A tree structure with three kinds of holes. See [[TernaryOps.eval]]. */
+  type Ternary[F[_]] = Free[F, TernaryArg]
+  object Ternary {
+    def arg1[F[_]]: Ternary[F] = Free.pure(TernaryArg._1)
+    def arg2[F[_]]: Ternary[F] = Free.pure(TernaryArg._2)
+    def arg3[F[_]]: Ternary[F] = Free.pure(TernaryArg._3)
   }
   trait TernaryArg {
     def fold[A](arg1: A, arg2: A, arg3: A): A = this match {
@@ -71,16 +81,8 @@ package object tree {
     case object _2 extends TernaryArg
     case object _3 extends TernaryArg
   }
-
-  def eval1[T[_[_]]: Corecursive, F[_]: Traverse](t: Unary[F]): T[F] => T[F] =
-    arg => freeCata[F, UnaryArg, T[F]](t)(interpret(_.fold(arg), _.embed))
-
-  def eval2[T[_[_]]: Corecursive, F[_]: Traverse](t: Binary[F]): (T[F], T[F]) => T[F] =
-    (arg1, arg2) => freeCata[F, BinaryArg, T[F]](t)(interpret(_.fold(arg1, arg2), _.embed))
-
-  def eval3[T[_[_]]: Corecursive, F[_]: Traverse](t: Ternary[F]): (T[F], T[F], T[F]) => T[F] =
-    (arg1, arg2, arg3) => freeCata[F, TernaryArg, T[F]](t)(interpret(_.fold(arg1, arg2, arg3), _.embed))
-
-  // TODO
-  // implicit def unaryRenderTree(implicit Delay[RenderTree, ???]): RenderTree[Unary[F]]
+  implicit class TernaryOps[F[_]](self: Ternary[F]) {
+    def eval[T[_[_]]: Corecursive](arg1: T[F], arg2: T[F], arg3: T[F])(implicit F: Functor[F]): T[F] =
+      freeCata[F, TernaryArg, T[F]](self)(interpret(_.fold(arg1, arg2, arg3), _.embed))
+  }
 }

--- a/foundation/src/main/scala/quasar/fp/tree/package.scala
+++ b/foundation/src/main/scala/quasar/fp/tree/package.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.fp
+
+import quasar.Predef._
+
+import matryoshka._
+import scalaz._
+
+package object tree {
+  /** A tree structure with one kind of hole. See `eval1`. */
+  type Unary[F[_]] = Free[F, UnaryArg]
+  object Unary {
+    def arg[F[_]]: Unary[F] = Free.pure(UnaryArg._1)
+  }
+
+  /** A tree structure with two kinds of holes. See `eval2`. */
+  type Binary[F[_]] = Free[F, BinaryArg]
+  object Binary {
+    def arg1[F[_]]: Binary[F] = Free.pure(BinaryArg._1)
+    def arg2[F[_]]: Binary[F] = Free.pure(BinaryArg._2)
+  }
+
+  /** A tree structure with three kinds of holes. See `eval3`. */
+  type Ternary[F[_]] = Free[F, TernaryArg]
+  object Ternary {
+    def arg1[F[_]]: Ternary[F] = Free.pure(TernaryArg._1)
+    def arg2[F[_]]: Ternary[F] = Free.pure(TernaryArg._2)
+    def arg3[F[_]]: Ternary[F] = Free.pure(TernaryArg._3)
+  }
+
+  trait UnaryArg {
+    def fold[A](arg1: A): A = arg1
+  }
+  object UnaryArg {
+    case object _1 extends UnaryArg
+  }
+  trait BinaryArg {
+    def fold[A](arg1: A, arg2: A): A = this match {
+      case BinaryArg._1 => arg1
+      case BinaryArg._2 => arg2
+    }
+  }
+  object BinaryArg {
+    case object _1 extends BinaryArg
+    case object _2 extends BinaryArg
+  }
+  trait TernaryArg {
+    def fold[A](arg1: A, arg2: A, arg3: A): A = this match {
+      case TernaryArg._1 => arg1
+      case TernaryArg._2 => arg2
+      case TernaryArg._3 => arg3
+    }
+  }
+  object TernaryArg {
+    case object _1 extends TernaryArg
+    case object _2 extends TernaryArg
+    case object _3 extends TernaryArg
+  }
+
+  def eval1[T[_[_]]: Corecursive, F[_]: Traverse](t: Unary[F]): T[F] => T[F] =
+    arg => freeCata[F, UnaryArg, T[F]](t)(interpret(_.fold(arg), _.embed))
+
+  def eval2[T[_[_]]: Corecursive, F[_]: Traverse](t: Binary[F]): (T[F], T[F]) => T[F] =
+    (arg1, arg2) => freeCata[F, BinaryArg, T[F]](t)(interpret(_.fold(arg1, arg2), _.embed))
+
+  def eval3[T[_[_]]: Corecursive, F[_]: Traverse](t: Ternary[F]): (T[F], T[F], T[F]) => T[F] =
+    (arg1, arg2, arg3) => freeCata[F, TernaryArg, T[F]](t)(interpret(_.fold(arg1, arg2, arg3), _.embed))
+
+  // TODO
+  // implicit def unaryRenderTree(implicit Delay[RenderTree, ???]): RenderTree[Unary[F]]
+}

--- a/frontend/src/test/scala/quasar/std/StdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/StdLibSpec.scala
@@ -22,6 +22,7 @@ import quasar.{Data, LogicalPlan, Qspec}, LogicalPlan._
 import matryoshka._
 import org.specs2.execute._
 import org.scalacheck.{Arbitrary, Gen}
+import org.threeten.bp.{Instant, ZoneOffset}
 
 trait StdLibTestRunner {
   def nullary(
@@ -215,6 +216,18 @@ abstract class StdLibSpec extends Qspec {
         // "interval" >> prop { (x: Duration) =>
         //   unary(ToString(_).embed, Data.Interval(x), Data.Str(x.toString))
         // }
+      }
+    }
+
+    "DateLib" >> {
+      import DateLib._
+
+      "TimeOfDay" >> {
+        "timestamp" >> {
+          val now = Instant.now
+          val expected = now.atZone(ZoneOffset.UTC).toLocalTime
+          unary(TimeOfDay(_).embed, Data.Timestamp(now), Data.Time(expected))
+        }
       }
     }
   }

--- a/it/src/main/resources/tests/temporal/time.test
+++ b/it/src/main/resources/tests/temporal/time.test
@@ -2,7 +2,6 @@
   "name": "filter on time_of_day",
 
   "backends": {
-    "mongodb_read_only": "pending",
     "postgresql":        "pending"
   },
 

--- a/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
@@ -23,6 +23,7 @@ import quasar.fp._
 import quasar.fs.DataCursor
 import quasar.std.{StdLibSpec, StdLibTestRunner}
 import quasar.physical.mongodb.fs._, bsoncursor._
+import quasar.physical.mongodb.planner.MongoDbPlanner
 import quasar.physical.mongodb.workflow._
 import WorkflowExecutor.WorkflowCursor
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/accumulator/accumop.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/accumulator/accumop.scala
@@ -17,12 +17,12 @@
 package quasar.physical.mongodb.accumulator
 
 import quasar.Predef._
-import quasar.RenderTree
+import quasar.{RenderTree, Terminal}
 import quasar.fp._
-import quasar.physical.mongodb.expression.ExprOp
+import quasar.physical.mongodb.expression.ExprOpOps
 
 import matryoshka.Fix
-import scalaz._
+import scalaz._, Scalaz._
 
 sealed trait AccumOp[A]
 object AccumOp {
@@ -67,8 +67,11 @@ object AccumOp {
         }
     }
 
-  implicit val AccumOpRenderTree: RenderTree[AccumOp[Fix[ExprOp]]] =
-    RenderTree.fromToString[AccumOp[Fix[ExprOp]]]("AccumOp")
+  implicit def AccumOpRenderTree[EX[_]: Functor](implicit exprOps: ExprOpOps.Uni[EX])
+      : RenderTree[AccumOp[Fix[EX]]] =
+    new RenderTree[AccumOp[Fix[EX]]] {
+      def render(v: AccumOp[Fix[EX]]) = Terminal(List("AccumOp"), groupBson(v).toJs.pprint(0).some)
+    }
 }
 
 object $addToSet {

--- a/mongodb/src/main/scala/quasar/physical/mongodb/accumulator/accumop.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/accumulator/accumop.scala
@@ -19,7 +19,9 @@ package quasar.physical.mongodb.accumulator
 import quasar.Predef._
 import quasar.RenderTree
 import quasar.fp._
+import quasar.physical.mongodb.expression.ExprOp
 
+import matryoshka.Fix
 import scalaz._
 
 sealed trait AccumOp[A]
@@ -65,8 +67,8 @@ object AccumOp {
         }
     }
 
-  implicit val AccumOpRenderTree: RenderTree[Accumulator] =
-    RenderTree.fromToString[Accumulator]("AccumOp")
+  implicit val AccumOpRenderTree: RenderTree[AccumOp[Fix[ExprOp]]] =
+    RenderTree.fromToString[AccumOp[Fix[ExprOp]]]("AccumOp")
 }
 
 object $addToSet {

--- a/mongodb/src/main/scala/quasar/physical/mongodb/accumulator/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/accumulator/package.scala
@@ -25,10 +25,8 @@ import scalaz._, Scalaz._
 
 package object accumulator {
 
-  type Accumulator = AccumOp[Fix[ExprOpCoreF]]
-
-  def rewriteGroupRefs(t: Accumulator)(applyVar: PartialFunction[DocVar, DocVar])
-      (implicit exprOps: ExprOpOps.Uni[ExprOpCoreF]): Accumulator =
+  def rewriteGroupRefs[EX[_]: Functor](t: AccumOp[Fix[EX]])(applyVar: PartialFunction[DocVar, DocVar])
+      (implicit exprOps: ExprOpOps.Uni[EX]): AccumOp[Fix[EX]] =
     t.map(_.cata(exprOps.rewriteRefs(applyVar)))
 
   val groupBsonƒ: AccumOp[Bson] => Bson = {
@@ -42,6 +40,6 @@ package object accumulator {
     case $sum(value)      => Bson.Doc("$sum" -> value)
   }
 
-  def groupBson(g: Accumulator)(implicit exprOps: ExprOpOps.Uni[ExprOpCoreF]) =
+  def groupBson[EX[_]: Functor](g: AccumOp[Fix[EX]])(implicit exprOps: ExprOpOps.Uni[EX]) =
     groupBsonƒ(g.map(_.cata(exprOps.bson)))
 }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/execution.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/execution.scala
@@ -46,8 +46,8 @@ private[mongodb] object execution {
 
   // NB: need to construct core exprs in the type used for pipeline ops.
   // FIXME: For now, that's just the core type itself.
-  private val coreFp = ExprOpCoreF.fixpoint[Fix, ExprOpCoreF]
-  import coreFp._
+  private val exprCoreFp = ExprOpCoreF.fixpoint[Fix, ExprOp]
+  import exprCoreFp._
 
   /** Extractor to determine whether a `$GroupF` represents a simple `count()`. */
   object Countable {

--- a/mongodb/src/main/scala/quasar/physical/mongodb/expression/ExprOpCore.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/expression/ExprOpCore.scala
@@ -378,16 +378,6 @@ object ExprOpCoreF {
     }
   }
 
-  implicit val renderTree: Delay[RenderTree, ExprOpCoreF] =
-    new Delay[RenderTree, ExprOpCoreF] {
-      def apply[A](r: RenderTree[A]) =
-        new RenderTree[ExprOpCoreF[A]] {
-          def render(expr: ExprOpCoreF[A]) = expr match {
-            case _ => Terminal(List("ExprOpCore"), Some(expr.toString))
-          }
-        }
-    }
-
   /** "Fixed" constructors, with the corecursive type and the coproduct type
     * captured when an instance is created. */
   final case class fixpoint[T[_[_]]: Corecursive, EX[_]: Functor](implicit I: ExprOpCoreF :<: EX) {

--- a/mongodb/src/main/scala/quasar/physical/mongodb/fs/queryfile.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/fs/queryfile.scala
@@ -24,6 +24,7 @@ import quasar.fp.kleisli._
 import quasar.fs._
 import quasar.javascript._
 import quasar.physical.mongodb._, WorkflowExecutor.WorkflowCursor
+import quasar.physical.mongodb.planner.MongoDbPlanner
 
 import argonaut.JsonObject, JsonObject.{single => jSingle}
 import argonaut.JsonIdentity._

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/FuncHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/FuncHandler.scala
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.mongodb.planner
+
+import quasar.Predef._
+import quasar.{UnaryFunc, BinaryFunc, TernaryFunc}
+import quasar.fp.tree._
+import quasar.physical.mongodb.Bson
+import quasar.physical.mongodb.expression._
+import quasar.std.StdLib._
+
+import org.threeten.bp.Instant
+import matryoshka._
+import scalaz._
+
+trait FuncHandler[EX[_]] {
+  def translateUnary(func: UnaryFunc): Option[Unary[EX]]
+  def translateBinary(func: BinaryFunc): Option[Binary[EX]]
+  def translateTernary(func: TernaryFunc): Option[Ternary[EX]]
+}
+
+object FuncHandler {
+  def fromPartial[EX[_]](
+    unary: PartialFunction[UnaryFunc, Unary[EX]],
+    binary: PartialFunction[BinaryFunc, Binary[EX]],
+    ternary: PartialFunction[TernaryFunc, Ternary[EX]]): FuncHandler[EX] =
+    new FuncHandler[EX] {
+      def translateUnary(func: UnaryFunc) = unary.lift(func)
+      def translateBinary(func: BinaryFunc) = binary.lift(func)
+      def translateTernary(func: TernaryFunc) = ternary.lift(func)
+    }
+
+  val handle2_6: FuncHandler[Expr2_6] = FuncHandler.fromPartial[Expr2_6](
+    {
+      val coreFp = ExprOpCoreF.fixpoint[Unary, Expr2_6]
+      import coreFp._
+      import Unary._
+      {
+        case math.Negate        => $multiply($literal(Bson.Int32(-1)), arg)
+
+        case string.Lower       => $toLower(arg)
+        case string.Upper       => $toUpper(arg)
+
+        case relations.Not      => $not(arg)
+
+        case string.Null        =>
+          $cond($eq(arg, $literal(Bson.Text("null"))),
+            $literal(Bson.Null),
+            $literal(Bson.Undefined))
+
+        case string.Boolean     =>
+          $cond($eq(arg, $literal(Bson.Text("true"))),
+            $literal(Bson.Bool(true)),
+            $cond($eq(arg, $literal(Bson.Text("false"))),
+              $literal(Bson.Bool(false)),
+              $literal(Bson.Undefined)))
+
+        case date.ToTimestamp   => $add($literal(Bson.Date(Instant.ofEpochMilli(0))), arg)
+      }
+    },
+    {
+      val coreFp = ExprOpCoreF.fixpoint[Binary, Expr2_6]
+      import coreFp._
+      import Binary._
+      {
+        case set.Constantly     => arg1
+
+        case math.Add           => $add(arg1, arg2)
+        case math.Multiply      => $multiply(arg1, arg2)
+        case math.Subtract      => $subtract(arg1, arg2)
+        case math.Divide        => $divide(arg1, arg2)
+        case math.Modulo        => $mod(arg1, arg2)
+
+        case relations.Eq       => $eq(arg1, arg2)
+        case relations.Neq      => $neq(arg1, arg2)
+        case relations.Lt       => $lt(arg1, arg2)
+        case relations.Lte      => $lte(arg1, arg2)
+        case relations.Gt       => $gt(arg1, arg2)
+        case relations.Gte      => $gte(arg1, arg2)
+
+        case relations.Coalesce => $ifNull(arg1, arg2)
+
+        case string.Concat      => $concat(arg1, arg2)
+
+        case relations.Or       => $or(arg1, arg2)
+        case relations.And      => $and(arg1, arg2)
+      }
+    },
+    {
+      val coreFp = ExprOpCoreF.fixpoint[Ternary, Expr2_6]
+      import coreFp._
+      import Ternary._
+      {
+        case string.Substring   => $substr(arg1, arg2, arg3)
+
+        case relations.Cond     => $cond(arg1, arg2, arg3)
+
+        case relations.Between  => $and($lte(arg2, arg1), $lte(arg1, arg3))
+      }
+    })
+
+  def handle3_0(implicit I: Expr2_6 :<: Expr3_0): FuncHandler[Expr3_0] = new FuncHandler[Expr3_0] {
+    // TODO
+    def translateUnary(func: UnaryFunc) = handle2_6.translateUnary(func).map(_.mapSuspension(I))
+    def translateBinary(func: BinaryFunc) = handle2_6.translateBinary(func).map(_.mapSuspension(I))
+    def translateTernary(func: TernaryFunc) = handle2_6.translateTernary(func).map(_.mapSuspension(I))
+  }
+
+  def handle3_2(implicit I: Expr2_6 :<: Expr3_2): FuncHandler[Expr3_2] = new FuncHandler[Expr3_2] {
+    // TODO
+    def translateUnary(func: UnaryFunc) = handle2_6.translateUnary(func).map(_.mapSuspension(I))
+    def translateBinary(func: BinaryFunc) = handle2_6.translateBinary(func).map(_.mapSuspension(I))
+    def translateTernary(func: TernaryFunc) = handle2_6.translateTernary(func).map(_.mapSuspension(I))
+  }
+}

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/InputFinder.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/InputFinder.scala
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-// TODO: move to .planner package
-package quasar.physical.mongodb
+package quasar.physical.mongodb.planner
 
 import quasar.Predef._
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/JoinHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/JoinHandler.scala
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-// TOOD: move to .planner package
-package quasar.physical.mongodb
+package quasar.physical.mongodb.planner
 
 import quasar.Predef._
 import quasar.fp._
 import quasar.javascript._
 import quasar.jscore, jscore.{JsCore, JsFn}
-import quasar.namegen._
 import quasar.std.StdLib._
+import quasar.physical.mongodb._
 import quasar.physical.mongodb.accumulator._
 import quasar.physical.mongodb.expression._
 import quasar.physical.mongodb.workflow._

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/MongoDbPlanner.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/MongoDbPlanner.scala
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 
-package quasar.physical.mongodb
+package quasar.physical.mongodb.planner
 
 import quasar.Predef._
-import quasar._, Type._
+import quasar.{fs => _, _}, Type._
 import quasar.contrib.pathy.mkAbsolute
 import quasar.contrib.shapeless._
 import quasar.fp._
 import quasar.javascript._
 import quasar.jscore, jscore.{JsCore, JsFn}
 import quasar.namegen._
+import quasar.physical.mongodb._
 import quasar.physical.mongodb.javascript._
 import quasar.physical.mongodb.workflow._
 import quasar.qscript._
@@ -1117,11 +1118,11 @@ object MongoDbPlanner {
     case x => \/-(Fix(x))
   }
 
-  def plan0[F[_]: Functor: Coalesce: Crush: Crystallize]
-    (joinHandler: JoinHandler[F, WorkflowBuilder.M])
+  def plan0[WF[_]: Functor: Coalesce: Crush: Crystallize]
+    (joinHandler: JoinHandler[WF, WorkflowBuilder.M])
     (logical: Fix[LogicalPlan])
-    (implicit ev0: WorkflowOpCoreF :<: F, ev1: Show[Fix[WorkflowBuilderF[F, ?]]], ev2: RenderTree[Fix[F]])
-      : EitherT[Writer[PhaseResults, ?], PlannerError, Crystallized[F]] = {
+    (implicit ev0: WorkflowOpCoreF :<: WF, ev1: Show[Fix[WorkflowBuilderF[WF, ?]]], ev2: RenderTree[Fix[WF]])
+      : EitherT[Writer[PhaseResults, ?], PlannerError, Crystallized[WF]] = {
 
     // NB: Locally add state on top of the result monad so everything
     //     can be done in a single for comprehension.
@@ -1143,7 +1144,7 @@ object MongoDbPlanner {
     def liftError[A](ea: PlannerError \/ A): M[A] =
       EitherT(ea.point[W]).liftM[GenT]
 
-    val wfƒ = workflowƒ[F](joinHandler) ⋙ (_ ∘ (_ ∘ (_ ∘ normalize[F])))
+    val wfƒ = workflowƒ[WF](joinHandler) ⋙ (_ ∘ (_ ∘ (_ ∘ normalize[WF])))
 
     (for {
       cleaned <- log("Logical Plan (reduced typechecks)")(liftError(logical.cataM[PlannerError \/ ?, Fix[LogicalPlan]](assumeReadObjƒ)))
@@ -1151,7 +1152,7 @@ object MongoDbPlanner {
       prep <- log("Logical Plan (projections preferred)")(Optimizer.preferProjections(align).point[M])
       wb   <- log("Workflow Builder")                    (swizzle(swapM(lpParaZygoHistoS(prep)(annotateƒ, wfƒ))))
       wf1  <- log("Workflow (raw)")                      (swizzle(build(wb)))
-      wf2  <- log("Workflow (crystallized)")             (Crystallize[F].crystallize(wf1).point[M])
+      wf2  <- log("Workflow (crystallized)")             (Crystallize[WF].crystallize(wf1).point[M])
     } yield wf2).evalZero
   }
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -27,6 +27,7 @@ import quasar.physical.mongodb.WorkflowBuilder._
 import quasar.physical.mongodb.accumulator._
 import quasar.physical.mongodb.expression._
 import quasar.physical.mongodb.fs.listContents
+import quasar.physical.mongodb.planner.{JoinHandler, JoinSource, InputFinder, Here, There}
 import quasar.physical.mongodb.workflow._
 import quasar.qscript._
 import quasar.std.StdLib._, string._ // TODO: remove this

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflow/WorkflowOpCore.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflow/WorkflowOpCore.scala
@@ -943,7 +943,7 @@ object WorkflowOpCoreF {
           val nt = "$GroupF" :: wfType
           NonTerminal(nt, None,
             grouped.render ::
-              Terminal("By" :: nt, Some(expr.toString)) ::
+              expr.render.retype(κ("By" :: nt)) ::
               Nil)
         case $SortF(_, value)   =>
           val nt = "$SortF" :: wfType

--- a/mongodb/src/test/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutionSpec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutionSpec.scala
@@ -32,7 +32,7 @@ import scalaz.syntax.either._
 class JavaScriptWorkflowExecutionSpec extends quasar.Qspec {
   import CollectionUtil._
 
-  private val exprFp: ExprOpCoreF.fixpoint[Fix, ExprOpCoreF] = ExprOpCoreF.fixpoint[Fix, ExprOpCoreF]
+  private val exprFp: ExprOpCoreF.fixpoint[Fix, ExprOp] = ExprOpCoreF.fixpoint[Fix, ExprOp]
   import exprFp._
 
   def toJS(wf: Workflow): WorkflowExecutionError \/ String =

--- a/mongodb/src/test/scala/quasar/physical/mongodb/optimize.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/optimize.scala
@@ -30,7 +30,7 @@ import scalaz._, Scalaz._
 class OptimizeSpecs extends quasar.Qspec with TreeMatchers {
   import CollectionUtil._
 
-  val exprCoreFp: ExprOpCoreF.fixpoint[Fix, ExprOpCoreF] = ExprOpCoreF.fixpoint[Fix, ExprOpCoreF]
+  val exprCoreFp: ExprOpCoreF.fixpoint[Fix, ExprOp] = ExprOpCoreF.fixpoint[Fix, ExprOp]
   import exprCoreFp._
 
   "simplifyGroupƒ" should {

--- a/mongodb/src/test/scala/quasar/physical/mongodb/pipeline.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/pipeline.scala
@@ -31,7 +31,7 @@ class PipelineSpec extends quasar.Qspec with ArbBsonField {
   import CollectionUtil._
   import ArbitraryExprOp._
 
-  val exprCoreFp: ExprOpCoreF.fixpoint[Fix, ExprOpCoreF] = ExprOpCoreF.fixpoint[Fix, ExprOpCoreF]
+  val exprCoreFp: ExprOpCoreF.fixpoint[Fix, ExprOp] = ExprOpCoreF.fixpoint[Fix, ExprOp]
   import exprCoreFp._
 
   implicit def arbitraryOp: Arbitrary[PipelineOp] = Arbitrary { Gen.resize(5, Gen.sized { size =>
@@ -48,13 +48,13 @@ class PipelineSpec extends quasar.Qspec with ArbBsonField {
 
       field = c.toString + cs
 
-      value <- if (size <= 0) genExpr.map(\/-(_))
+      value <- if (size <= 0) genExpr3_2.map(\/-(_))
       else Gen.oneOf(
         genProject(size - 1).map(p => -\/(p.shape)),
-        genExpr.map(\/-(_)))
+        genExpr3_2.map(\/-(_)))
     } yield BsonField.Name(field) -> value)
     id <- Gen.oneOf(ExcludeId, IncludeId)
-  } yield $ProjectF((), Reshape[ExprOpCoreF](ListMap(fields: _*)), id)
+  } yield $ProjectF((), Reshape[ExprOp](ListMap(fields: _*)), id)
 
   implicit def arbProject = Arbitrary[$ProjectF[Unit]](Gen.resize(5, Gen.sized(genProject)))
 

--- a/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -71,6 +71,8 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
 
   val exprCoreFp: ExprOpCoreF.fixpoint[Fix, ExprOp] = ExprOpCoreF.fixpoint[Fix, ExprOp]
   import exprCoreFp._
+  val expr3_0Fp: ExprOp3_0F.fixpoint[Fix, ExprOp] = ExprOp3_0F.fixpoint[Fix, ExprOp]
+  import expr3_0Fp._
 
   val basePath = rootDir[Sandboxed] </> dir("db")
 
@@ -96,6 +98,9 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
 
   def plan2_6(query: String): Either[CompilationError, Crystallized[WorkflowF]] =
     plan0(query, MongoQueryModel.`2.6`, κ(None), κ(None))
+
+  def plan3_0(query: String): Either[CompilationError, Crystallized[WorkflowF]] =
+    plan0(query, MongoQueryModel.`3.0`, κ(None), κ(None))
 
   def plan3_2(query: String,
     stats: Collection => Option[CollectionStatistics],
@@ -2516,9 +2521,26 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
             ExcludeId)))
     }
 
-    "plan time_of_day" in {
-      plan("select time_of_day(ts) from foo") must
+    "plan time_of_day (JS)" in {
+      plan("select time_of_day(ts) from days") must
         beRight // NB: way too complicated to spell out here, and will change as JS generation improves
+    }
+
+    "plan time_of_day (pipeline)" in {
+      import FormatSpecifier._
+
+      plan3_0("select time_of_day(ts) from days") must
+        beWorkflow(chain[Workflow](
+          $read(collection("db", "days")),
+          $project(
+            reshape("0" ->
+              $cond(
+                $and(
+                  $lte($literal(Bson.Date(Instant.parse("1970-01-01T00:00:00Z"))), $field("ts")),
+                  $lt($field("ts"), $literal(Bson.Regex("", "")))),
+                $dateToString(Hour :: ":" :: Minute :: ":" :: Second :: "." :: Millisecond :: FormatString.empty, $field("ts")),
+                $literal(Bson.Undefined))),
+            IgnoreId)))
     }
 
     "plan filter on date" in {

--- a/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -22,6 +22,7 @@ import quasar.fp._
 import quasar.javascript._
 import quasar.physical.mongodb.accumulator._
 import quasar.physical.mongodb.expression._
+import quasar.physical.mongodb.planner._
 import quasar.physical.mongodb.workflow._
 import quasar.qscript.SortDir
 import quasar.sql.{fixpoint => sql, _}

--- a/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -69,7 +69,7 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
     }
   }
 
-  val exprCoreFp: ExprOpCoreF.fixpoint[Fix, ExprOpCoreF] = ExprOpCoreF.fixpoint[Fix, ExprOpCoreF]
+  val exprCoreFp: ExprOpCoreF.fixpoint[Fix, ExprOp] = ExprOpCoreF.fixpoint[Fix, ExprOp]
   import exprCoreFp._
 
   val basePath = rootDir[Sandboxed] </> dir("db")
@@ -132,8 +132,8 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
   def beWorkflow(wf: Workflow) = beRight(equalToWorkflow(wf))
 
   implicit def toBsonField(name: String) = BsonField.Name(name)
-  implicit def toLeftShape(shape: Reshape[ExprOpCoreF]): Reshape.Shape[ExprOpCoreF] = -\/ (shape)
-  implicit def toRightShape(exprOp: Fix[ExprOpCoreF]):   Reshape.Shape[ExprOpCoreF] =  \/-(exprOp)
+  implicit def toLeftShape(shape: Reshape[ExprOp]): Reshape.Shape[ExprOp] = -\/ (shape)
+  implicit def toRightShape(exprOp: Fix[ExprOp]):   Reshape.Shape[ExprOp] =  \/-(exprOp)
 
   def isNumeric(field: BsonField): Selector =
     Selector.Or(
@@ -1536,10 +1536,10 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
         $read(collection("db", "zips")),
         $project(
           reshape(
-            "__tmp3" -> reshape[ExprOpCoreF](
+            "__tmp3" -> reshape(
               "city"  -> $field("city"),
               "state" -> $field("state")),
-            "__tmp4" -> reshape[ExprOpCoreF](
+            "__tmp4" -> reshape(
               "__tmp2" ->
                 $cond(
                   $and(
@@ -1650,7 +1650,7 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
         $read (collection("db", "zips")),
         $project(
           reshape(
-            "__tmp5" -> reshape[ExprOpCoreF](
+            "__tmp5" -> reshape(
               "pop" -> $field("pop"),
               "2"   ->
                 $cond(
@@ -1663,7 +1663,7 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
                       $lt($field("pop"), $literal(Bson.Regex("", ""))))),
                   $divide($field("pop"), $literal(Bson.Int32(1000))),
                   $literal(Bson.Undefined))),
-            "__tmp6" -> reshape[ExprOpCoreF](
+            "__tmp6" -> reshape(
               "__tmp2" ->
                 $cond(
                   $and(
@@ -2632,15 +2632,15 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
     }
 
     def joinStructure0(
-      left: Workflow, leftName: String, leftBase: Fix[ExprOpCoreF], right: Workflow,
-      leftKey: Reshape.Shape[ExprOpCoreF], rightKey: (String, Fix[ExprOpCoreF], Reshape.Shape[ExprOpCoreF]) \/ JsCore,
+      left: Workflow, leftName: String, leftBase: Fix[ExprOp], right: Workflow,
+      leftKey: Reshape.Shape[ExprOp], rightKey: (String, Fix[ExprOp], Reshape.Shape[ExprOp]) \/ JsCore,
       fin: FixOp[WorkflowF],
       swapped: Boolean) = {
 
       val (leftLabel, rightLabel) =
         if (swapped) ("right", "left") else ("left", "right")
       def initialPipeOps(
-        src: Workflow, name: String, base: Fix[ExprOpCoreF], key: Reshape.Shape[ExprOpCoreF], mainLabel: String, otherLabel: String):
+        src: Workflow, name: String, base: Fix[ExprOp], key: Reshape.Shape[ExprOp], mainLabel: String, otherLabel: String):
           Workflow =
         chain[Workflow](
           src,
@@ -2689,8 +2689,8 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
     }
 
     def joinStructure(
-        left: Workflow, leftName: String, leftBase: Fix[ExprOpCoreF], right: Workflow,
-        leftKey: Reshape.Shape[ExprOpCoreF], rightKey: (String, Fix[ExprOpCoreF], Reshape.Shape[ExprOpCoreF]) \/ JsCore,
+        left: Workflow, leftName: String, leftBase: Fix[ExprOp], right: Workflow,
+        leftKey: Reshape.Shape[ExprOp], rightKey: (String, Fix[ExprOp], Reshape.Shape[ExprOp]) \/ JsCore,
         fin: FixOp[WorkflowF],
         swapped: Boolean) =
       Crystallize[WorkflowF].crystallize(joinStructure0(left, leftName, leftBase, right, leftKey, rightKey, fin, swapped))
@@ -2701,7 +2701,7 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
           joinStructure(
             $read(collection("db", "zips")), "__tmp0", $$ROOT,
             $read(collection("db", "zips2")),
-            reshape[ExprOpCoreF]("0" -> $field("_id")),
+            reshape("0" -> $field("_id")),
             Obj(ListMap(Name("0") -> Select(ident("value"), "_id"))).right,
             chain[Workflow](_,
               $match(Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
@@ -2843,7 +2843,7 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
         joinStructure(
           $read(collection("db", "foo")), "__tmp0", $$ROOT,
           $read(collection("db", "bar")),
-          reshape[ExprOpCoreF]("0" -> $field("id")),
+          reshape("0" -> $field("id")),
           Obj(ListMap(Name("0") -> Select(ident("value"), "foo_id"))).right,
           chain[Workflow](_,
             $match(Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
@@ -2992,7 +2992,7 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
         joinStructure(
           $read(collection("db", "foo")), "__tmp0", $$ROOT,
           $read(collection("db", "bar")),
-          reshape[ExprOpCoreF]("0" -> $field("id")),
+          reshape("0" -> $field("id")),
           Obj(ListMap(Name("0") -> Select(ident("value"), "foo_id"))).right,
           chain[Workflow](_,
             $project(
@@ -3043,7 +3043,7 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
         joinStructure(
           $read(collection("db", "foo")), "__tmp0", $$ROOT,
           $read(collection("db", "bar")),
-          reshape[ExprOpCoreF]("0" -> $field("id")),
+          reshape("0" -> $field("id")),
           Obj(ListMap(Name("0") -> Select(ident("value"), "foo_id"))).right,
           chain[Workflow](_,
             $match(Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
@@ -3155,7 +3155,7 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
           joinStructure0(
             $read(collection("db", "foo")), "__tmp0", $$ROOT,
             $read(collection("db", "bar")),
-            reshape[ExprOpCoreF]("0" -> $field("id")),
+            reshape("0" -> $field("id")),
             Obj(ListMap(Name("0") -> Select(ident("value"), "foo_id"))).right,
             chain[Workflow](_,
               $match(Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
@@ -3164,7 +3164,7 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
               $unwind(DocField(BsonField.Name("left"))),
               $unwind(DocField(BsonField.Name("right")))),
             false),
-          reshape[ExprOpCoreF]("0" -> $field("bar_id")),
+          reshape("0" -> $field("bar_id")),
           Obj(ListMap(Name("0") -> Select(Select(ident("value"), "right"), "id"))).right,
           chain[Workflow](_,
             $match(Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
@@ -3294,7 +3294,7 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
               ListMap())),
           "__tmp7", $field("__tmp5"),
           $read(collection("db", "slamengine_commits")),
-          reshape[ExprOpCoreF](
+          reshape(
             "0" -> $field("__tmp4"),
             "1" -> $field("__tmp6")),
           obj(
@@ -3371,8 +3371,8 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
                 "__tmp4" -> $$ROOT),
               IgnoreId),
             $unwind(DocField(BsonField.Name("__tmp3")))),
-          reshape[ExprOpCoreF]("0" -> $field("__tmp0")),
-          ("__tmp5", $field("__tmp4"), reshape[ExprOpCoreF](
+          reshape("0" -> $field("__tmp0")),
+          ("__tmp5", $field("__tmp4"), reshape(
             "0" -> $field("__tmp3")).left).left,
           chain[Workflow](_,
             $match(Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](

--- a/mongodb/src/test/scala/quasar/physical/mongodb/workflowbuilder.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/workflowbuilder.scala
@@ -654,12 +654,12 @@ class WorkflowBuilderSpec extends quasar.Qspec {
           |│  ├─ CollectionBuilder(Root())
           |│  │  ├─ $ReadF(db; zips)
           |│  │  ╰─ Schema(None)
-          |│  ╰─ ExprOpCore($varF(DocField(BsonField.Name("pop"))))
+          |│  ╰─ ExprOp("$pop")
           |├─ By
           |│  ╰─ ValueBuilder(Int32(1))
           |╰─ Content
           |   ╰─ -\/
-          |      ╰─ AccumOp($sum(Fix($varF(DocVar.ROOT()))))""".stripMargin)
+          |      ╰─ AccumOp({ "$sum": "$$ROOT" })""".stripMargin)
     }
 
   }

--- a/mongodb/src/test/scala/quasar/physical/mongodb/workflowbuilder.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/workflowbuilder.scala
@@ -36,7 +36,7 @@ class WorkflowBuilderSpec extends quasar.Qspec {
   val builder = WorkflowBuilder.Ops[WorkflowF]
   import builder._
 
-  private val exprCoreFp: ExprOpCoreF.fixpoint[Fix, ExprOpCoreF] = ExprOpCoreF.fixpoint[Fix, ExprOpCoreF]
+  private val exprCoreFp: ExprOpCoreF.fixpoint[Fix, ExprOp] = ExprOpCoreF.fixpoint[Fix, ExprOp]
   import exprCoreFp._
 
   val readZips = read(collection("db", "zips"))

--- a/mongodb/src/test/scala/quasar/physical/mongodb/workflowop.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/workflowop.scala
@@ -56,7 +56,7 @@ class WorkflowFSpec extends org.specs2.scalaz.Spec {
 class WorkflowSpec extends quasar.Qspec with TreeMatchers {
   import CollectionUtil._
 
-  val exprCoreFp: ExprOpCoreF.fixpoint[Fix, ExprOpCoreF] = ExprOpCoreF.fixpoint[Fix, ExprOpCoreF]
+  val exprCoreFp: ExprOpCoreF.fixpoint[Fix, ExprOp] = ExprOpCoreF.fixpoint[Fix, ExprOp]
   import exprCoreFp._
 
   val readFoo = $read[WorkflowF](collection("db", "foo"))


### PR DESCRIPTION
Closes #1310.

The upshot here is just that `time_of_day` can now be evaluated in the aggregation pipeline. More interestingly, this lays the groundwork for the 3.2 ops to be generated as well.