### PR TITLE
Lazily load regression test data

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,2 @@
+- Lazily load regression test data when missing rather than eagerly at suite start.
+  - Add a 'run_' prefix to the random dir segment used for test data

--- a/it/src/main/resources/tests/letInSelectProjection.test
+++ b/it/src/main/resources/tests/letInSelectProjection.test
@@ -3,7 +3,7 @@
 
     "backends": { "postgresql": "pending", "marklogic": "pending" },
 
-    "data": "zips.data",
+    "data": ["cars.data", "zips.data"],
 
     "query": "select (zips := select * from cars; select * from zips) from zips",
 

--- a/it/src/main/resources/tests/literalReductionWithNegative.test
+++ b/it/src/main/resources/tests/literalReductionWithNegative.test
@@ -1,8 +1,5 @@
 {
     "name": "reduce a literal set with negatives",
-    "backends": {
-            "marklogic":         "pending"
-    },
     "data": "zips.data",
     "query": "select max((0, 1, -2, 5)) from zips",
     "predicate": "equalsExactly",

--- a/it/src/test/scala/quasar/TestConfig.scala
+++ b/it/src/test/scala/quasar/TestConfig.scala
@@ -106,7 +106,7 @@ object TestConfig {
       } yield FileSystemUT(n,
           embed(testRef.get.map(_._1)),
           embed(setupRef.get.map(_._1)),
-          p </> dir(s),
+          p </> dir("run_" + s),
           testRef.release *> setupRef.release)
     }
 

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -89,7 +89,7 @@ abstract class QueryRegressionTest[S[_]](
   fileSystemShould { fs =>
     suiteName should {
       tests.toList foreach { case (f, t) =>
-        regressionExample(f, t, fs.name, fs.testInterpM)
+        regressionExample(f, t, fs.name, fs.setupInterpM, fs.testInterpM)
       }
 
       step(runT(fs.setupInterpM)(manage.delete(DataDir)).runVoid)
@@ -103,12 +103,13 @@ abstract class QueryRegressionTest[S[_]](
     loc: RFile,
     test: RegressionTest,
     backendName: BackendName,
+    setup: Run,
     run: Run
   ): Fragment = {
     def runTest: Result = {
       val data = testQuery(DataDir </> fileParent(loc), test.query, test.variables)
 
-      (ensureTestData(loc, test, run) *> verifyResults(test.expected, data, run))
+      (ensureTestData(loc, test, setup) *> verifyResults(test.expected, data, run))
         .timed(5.minutes)
         .unsafePerformSync
     }

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -37,7 +37,7 @@ import org.specs2.specification.core.Fragment
 import pathy.Path, Path._
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
-import scalaz.stream.{merge => pmerge, _}
+import scalaz.stream._
 
 abstract class QueryRegressionTest[S[_]](
   fileSystems: Task[IList[FileSystemUT[S]]])(
@@ -88,8 +88,6 @@ abstract class QueryRegressionTest[S[_]](
 
   fileSystemShould { fs =>
     suiteName should {
-      step(prepareTestData(tests, fs.setupInterpM).unsafePerformSync)
-
       tests.toList foreach { case (f, t) =>
         regressionExample(f, t, fs.name, fs.testInterpM)
       }
@@ -107,15 +105,13 @@ abstract class QueryRegressionTest[S[_]](
     backendName: BackendName,
     run: Run
   ): Fragment = {
-    def runTest = (for {
-      _    <- run(test.data.traverse[F,Result](
-                relFile => injectTask(resolveData(loc, relFile).fold(
-                          err => Task.fail(new RuntimeException(err)),
-                          Task.now)) >>=
-                        (p => verifyDataExists(dataFile(p)))))
-      data =  testQuery(DataDir </> fileParent(loc), test.query, test.variables)
-      res  <- verifyResults(test.expected, data, run)
-    } yield res).timed(5.minutes).unsafePerformSync
+    def runTest: Result = {
+      val data = testQuery(DataDir </> fileParent(loc), test.query, test.variables)
+
+      (ensureTestData(loc, test, run) *> verifyResults(test.expected, data, run))
+        .timed(5.minutes)
+        .unsafePerformSync
+    }
 
     s"${test.name} [${posixCodec.printPath(loc)}]" >> {
       test.backends.get(backendName) match {
@@ -132,11 +128,19 @@ abstract class QueryRegressionTest[S[_]](
     }
   }
 
-  /** Verify that the given data file exists in the filesystem. */
-  def verifyDataExists(file: AFile): F[org.specs2.execute.Result] =
-    query.fileExists(file).map(exists =>
-      if (exists) org.specs2.execute.Success(s"data file exists: ${fileName(file).value}")
-      else org.specs2.execute.Failure(s"data file does not exist: ${fileName(file).value}"))
+  /** Ensures the data for the given test exists in the Quasar filesystem, inserting
+    * it if not. Returns whether any data was inserted.
+    */
+  def ensureTestData(testLoc: RFile, test: RegressionTest, run: Run): Task[Boolean] = {
+    def ensureTestFile(loc: RFile): Task[Boolean] =
+      run(query.fileExists(dataFile(loc))).ifM(
+        false.point[Task],
+        loadTestData(loc, run).as(true))
+
+    val locs: Set[RFile] = test.data.flatMap(resolveData(testLoc, _).toOption).toSet
+
+    Task.gatherUnordered(locs.toList map ensureTestFile) map (_ any ι)
+  }
 
   /** Verify the given results according to the provided expectation. */
   def verifyResults(
@@ -186,24 +190,20 @@ abstract class QueryRegressionTest[S[_]](
     f(parseTask).liftM[Process] flatMap (queryResults(_, Variables.fromMap(vars), loc))
   }
 
-  /** Loads all the test data needed by the given tests into the filesystem. */
-  def prepareTestData(tests: Map[RFile, RegressionTest], run: Run): Task[Unit] = {
+  /** Load the contents of the test data file into the filesytem under test at
+    * the same path, relative to the test `DataDir`.
+    *
+    * Any failures during loading will result in a failed `Task`.
+    */
+  def loadTestData(dataLoc: RFile, run: Run): Task[Unit] = {
     val throwFsError = rethrow[Task, FileSystemError]
 
-    val dataLoc: ((RFile, RegressionTest)) => Set[RFile] = {
-      case (f, t) =>
-        t.data.flatMap(resolveData(f, _).toOption).toSet
-    }
+    val load = write.createChunked(
+      dataFile(dataLoc),
+      testData(dataLoc).chunk(500).translate(injectTask)
+    ).translate[Task](throwFsError.compose[FsErr](runT(run)))
 
-    val loads: Process[Task, Process[Task, FileSystemError]] =
-      Process.emitAll(tests.toList.foldMap(dataLoc).toVector) map { file =>
-        write.createChunked(
-          dataFile(file),
-          testData(file).chunk(500).translate(injectTask)
-        ).translate[Task](throwFsError.compose[FsErr](runT(run)))
-      }
-
-    throwFsError(EitherT(pmerge.mergeN(loads).take(1).runLast.map(_ <\/ (()))))
+    throwFsError(EitherT(load.take(1).runLast map (_ <\/ (()))))
   }
 
   /** Returns a stream of `Data` representing the lines of the given data file. */

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -204,7 +204,11 @@ abstract class QueryRegressionTest[S[_]](
       testData(dataLoc).chunk(500).translate(injectTask)
     ).translate[Task](throwFsError.compose[FsErr](runT(run)))
 
-    throwFsError(EitherT(load.take(1).runLast map (_ <\/ (()))))
+    throwFsError(EitherT(load.take(1).runLast map (_ <\/ (())))) handleWith {
+      case err =>
+        val msg = s"Failed loading test data '${posixCodec.printPath(dataLoc)}': ${err.getMessage}"
+        Task.fail(new RuntimeException(msg, err))
+    }
   }
 
   /** Returns a stream of `Data` representing the lines of the given data file. */


### PR DESCRIPTION
Instead of eagerly loading all regression test data at suite start, this PR changes the behavior to load test data on-demand, if it is missing. This makes it nicer when running a subset of the regression suite as only the required data is loaded.