### PR TITLE
Cut time to compile QScriptCore from 155 seconds to 20 seconds.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- Compilation time improvement.


### PR DESCRIPTION
The dramatic impact of this change means we should immediately
investigate the other especially slow-to-compile files for
similar opportunities. Every call to freeTransCata is a likely
candidate, but not only those.