### PR TITLE
fix a flaky test of Config encoding

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- fix a flaky Config test by cleaning up the generator

--- a/connector/src/test/scala/quasar/scalacheck/package.scala
+++ b/connector/src/test/scala/quasar/scalacheck/package.scala
@@ -38,4 +38,25 @@ package object scalacheck {
 
   implicit def shrinkISet[A: Order](implicit s: Shrink[Set[A]]): Shrink[ISet[A]] =
     Shrink(as => s.shrink(as.toSet).map(ISet.fromFoldable(_)))
+
+  /** Resize a generator, applying a scale factor so that the resulting
+    * values still respond to the incoming size value (which is controlled by
+    * the `maxSize` parameter), but typically scaled down to produce more
+    * modestly-sized values. */
+  def scaleSize[A](gen: Gen[A], f: Int => Int): Gen[A] =
+    Gen.sized(size => Gen.resize(f(size), gen))
+
+  /** Scaling function raising the incoming size to some power, typically less
+    * than 1. If your generator constructs values with dimension 2 (e.g.
+    * `List[List[Int]]`), then 0.5 is a good choice. */
+  def scalePow(exp: Double): Int => Int =
+    size => scala.math.pow(size.toDouble, exp).toInt
+
+  /** Scaling function which just adjusts the size so as to use at most
+    * `desiredLimit`, assuming the default `maxSize` is in effect. */
+  def scaleLinear(desiredLimit: Int): Int => Int = {
+    val externalLimit = 200
+    val factor = externalLimit/desiredLimit
+    _/factor
+  }
 }

--- a/core/src/test/scala/quasar/fs/mount/MountingsConfigArbitrary.scala
+++ b/core/src/test/scala/quasar/fs/mount/MountingsConfigArbitrary.scala
@@ -23,13 +23,18 @@ import quasar.contrib.pathy.{APath, PathArbitrary}
 //     for scala collections.
 import scala.Predef._
 
-import org.scalacheck.Arbitrary, Arbitrary.arbitrary
+import org.scalacheck.{Arbitrary, Gen}, Arbitrary.arbitrary
 
 trait MountingsConfigArbitrary {
   import MountConfigArbitrary._, PathArbitrary._
 
+  private def scaleSize[A](gen: Gen[A]): Gen[A] =
+    Gen.sized(size => Gen.resize(size/40 + 1, gen))
+
   implicit val mountingsConfigArbitrary: Arbitrary[MountingsConfig] =
-    Arbitrary(arbitrary[Map[APath, MountConfig]] map (MountingsConfig(_)))
+    // NB: this is a map, and MountConfig contains a map, so if the size isn't
+    // reigned in we get gigantic configs.
+    Arbitrary(scaleSize(arbitrary[Map[APath, MountConfig]]) map (MountingsConfig(_)))
 }
 
 object MountingsConfigArbitrary extends MountingsConfigArbitrary

--- a/core/src/test/scala/quasar/fs/mount/MountingsConfigArbitrary.scala
+++ b/core/src/test/scala/quasar/fs/mount/MountingsConfigArbitrary.scala
@@ -18,23 +18,21 @@ package quasar.fs.mount
 
 import quasar.Predef.Map
 import quasar.contrib.pathy.{APath, PathArbitrary}
+import quasar.scalacheck._
 
 // NB: Something in here is needed by scalacheck's Arbitrary defs
 //     for scala collections.
 import scala.Predef._
 
-import org.scalacheck.{Arbitrary, Gen}, Arbitrary.arbitrary
+import org.scalacheck.Arbitrary, Arbitrary.arbitrary
 
 trait MountingsConfigArbitrary {
   import MountConfigArbitrary._, PathArbitrary._
 
-  private def scaleSize[A](gen: Gen[A]): Gen[A] =
-    Gen.sized(size => Gen.resize(size/40 + 1, gen))
-
   implicit val mountingsConfigArbitrary: Arbitrary[MountingsConfig] =
     // NB: this is a map, and MountConfig contains a map, so if the size isn't
-    // reigned in we get gigantic configs.
-    Arbitrary(scaleSize(arbitrary[Map[APath, MountConfig]]) map (MountingsConfig(_)))
+    // reined in we get gigantic configs.
+    Arbitrary(scaleSize(arbitrary[Map[APath, MountConfig]], scaleLinear(5)) map (MountingsConfig(_)))
 }
 
 object MountingsConfigArbitrary extends MountingsConfigArbitrary

--- a/frontend/src/test/scala/quasar/VariablesArbitrary.scala
+++ b/frontend/src/test/scala/quasar/VariablesArbitrary.scala
@@ -26,7 +26,7 @@ trait VariablesArbitrary {
     Arbitrary(arb[String].map(VarName(_)))
 
   implicit val arbitraryVarValue: Arbitrary[VarValue] =
-    Arbitrary(ExprArbitrary.constExprGen.map(expr => VarValue(expr.toString)))
+    Arbitrary(ExprArbitrary.constExprGen.map(expr => VarValue(sql.pprint(expr))))
 
   implicit val arbitraryVariables: Arbitrary[Variables] =
     Arbitrary(arb[Map[VarName, VarValue]].map(Variables(_)))

--- a/interface/src/test/scala/quasar/config/CoreConfigSpec.scala
+++ b/interface/src/test/scala/quasar/config/CoreConfigSpec.scala
@@ -57,6 +57,6 @@ class CoreConfigSpec extends ConfigSpec[CoreConfig] {
       val json = CoreConfig.codec.encode(cfg)
       val cfg2 = CoreConfig.codec.decode(json.hcursor)
       cfg2.result must beRight(cfg)
-    }.set(minTestsOk = 5)
+    }
   }
 }


### PR DESCRIPTION
A random failure occurred in a build of #1474.

As far as I can tell, this was very unlikely to happen just because `minTestsOk` was set so low that we were only testing small inputs, except when we got very lucky.

It was easy to reproduce by increasing that param, but the results were impossible to analyze because they were simply huge. After limiting the size in the generator, I've run thousands of tests without a failure, and we're certainly testing non-trivial configs of several mounts and variables, based on printing some of them out.