### PR TITLE
delete nested views when a mount is deleted

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- [#1448] delete nested mounts (i.e. views) when a mount is deleted

--- a/core/src/test/scala/quasar/fs/mount/MountingSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/MountingSpec.scala
@@ -436,6 +436,19 @@ abstract class MountingSpec[S[_]](
         r map (_ must beNone)
       }
 
+      "should remove a nested view mount" >>* {
+        val d = rootDir </> dir("tounmount")
+        val f = d </> file("nested")
+
+        val r =
+          mountFileSystem(d, dbType, uriB) *>
+          mountViewNoVars(f, exprA)        *>
+          unmount(d)                       *>
+          lookupConfig(f).run
+
+        r map (_ must beNone)
+      }
+
       "should fail when nothing mounted at path" >>* {
         val f = rootDir </> dir("nothing") </> file("there")
         mntErr.attempt(unmount(f)) map (dj => maybeNotFound(dj) must beSome(f))


### PR DESCRIPTION
This is the first, simpler, part of the fix for #1448, cleaning up when a mount is deleted so that no strange directory is left behind containing only the views.

Wanted to get this merged since this is the part that impacts the frontend most directly. Another PR will follow with the change to move nested views when a mounts is `MOVE`d. That change will be  a bit more involved because it will require a new term in the `Mounting` algebra.