### PR TITLE
Centralize creation of common value.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- Centralize creation of common value.

--- a/mongodb/src/main/scala/quasar/physical/mongodb/execution.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/execution.scala
@@ -23,7 +23,6 @@ import quasar.physical.mongodb.expression._
 import quasar.physical.mongodb.workflow._
 import quasar.qscript.SortDir
 
-import matryoshka.Fix
 import scalaz._, Scalaz._
 
 private[mongodb] object execution {
@@ -46,8 +45,7 @@ private[mongodb] object execution {
 
   // NB: need to construct core exprs in the type used for pipeline ops.
   // FIXME: For now, that's just the core type itself.
-  private val exprCoreFp = ExprOpCoreF.fixpoint[Fix, ExprOp]
-  import exprCoreFp._
+  import fixExprOp._
 
   /** Extractor to determine whether a `$GroupF` represents a simple `count()`. */
   object Countable {

--- a/mongodb/src/main/scala/quasar/physical/mongodb/expression/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/expression/package.scala
@@ -38,6 +38,8 @@ package object expression {
   /** The type for expressions supporting the most advanced capabilities. */
   type ExprOp[A] = Expr3_2[A]
 
+  val fixExprOp = ExprOpCoreF.fixpoint[Fix, ExprOp]
+
   val DocField = Prism.partial[DocVar, BsonField] {
     case DocVar.ROOT(Some(tail)) => tail
   } (DocVar.ROOT(_))

--- a/mongodb/src/main/scala/quasar/physical/mongodb/optimize/optimize.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/optimize/optimize.scala
@@ -28,8 +28,7 @@ import scalaz._, Scalaz._
 
 package object optimize {
   object pipeline {
-    private val exprCoreFp = ExprOpCoreF.fixpoint[Fix, ExprOp]
-    import exprCoreFp._
+    import fixExprOp._
 
     private def deleteUnusedFields0[F[_]: Functor: Refs](op: Fix[F], usedRefs: Option[Set[DocVar]])
       (implicit I: WorkflowOpCoreF :<: F): Fix[F] = {

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/JoinHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/JoinHandler.scala
@@ -48,8 +48,7 @@ object JoinHandler {
 
   // NB: it's only safe to emit "core" expr ops here, but we always use the
   // largest type in WorkflowOp, so they're immediately injected into ExprOp.
-  private val exprCoreFp = ExprOpCoreF.fixpoint[Fix, ExprOp]
-  import exprCoreFp._
+  import fixExprOp._
 
   def fallback[WF[_], F[_]: Monad](
       first: JoinHandler[WF, OptionT[F, ?]],

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/MongoDbPlanner.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/MongoDbPlanner.scala
@@ -639,8 +639,7 @@ object MongoDbPlanner {
 
     // NB: it's only safe to emit "core" expr ops here, but we always use the
     // largest type in WorkflowOp, so they're immediately injected into ExprOp.
-    val exprFp = ExprOpCoreF.fixpoint[Fix, ExprOp]
-    import exprFp.{I => _, _}
+    import fixExprOp.{ I => _, _ }
     val check = Check[Fix, ExprOp]
 
     object HasData {
@@ -1018,8 +1017,6 @@ object MongoDbPlanner {
         State(s => v.run(s).fold(e => s -> -\/(e), t => t._1 -> \/-(t._2)))
     }
   }
-
-  import Planner._
 
   val annotateƒ =
     GAlgebraZip[(Fix[LogicalPlan], ?), LogicalPlan].zip(

--- a/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -42,8 +42,7 @@ object MongoDbQScriptPlanner {
 
   type OutputM[A] = PlannerError \/ A
 
-  val exprFp = ExprOpCoreF.fixpoint[Fix, ExprOp]
-  import exprFp._
+  import fixExprOp._
 
   def generateTypeCheck[In, Out](or: (Out, Out) => Out)(f: PartialFunction[Type, In => Out]):
       Type => Option[In => Out] =

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflow/WorkflowOpCore.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflow/WorkflowOpCore.scala
@@ -116,7 +116,7 @@ final case class $ProjectF[A](src: A, shape: Reshape[ExprOp], idExclusion: IdHan
     idExclusion match {
       case IncludeId => all.collectFirst {
         case (IdName, _) => all
-      }.getOrElse((IdName, ExprOpCoreF.fixpoint[Fix, ExprOp].$include()) :: all)
+      }.getOrElse((IdName, fixExprOp.$include()) :: all)
       case _         => all
     }
   }
@@ -147,7 +147,7 @@ final case class $ProjectF[A](src: A, shape: Reshape[ExprOp], idExclusion: IdHan
             case (k, v) =>
               v.fold(
                 r => -\/(loop(Some(nest(k)), $ProjectF(p.src, r, p.idExclusion)).shape),
-                κ(\/-(ExprOpCoreF.fixpoint[Fix, ExprOp].$var(DocVar.ROOT(nest(k))))))
+                κ(\/-(fixExprOp.$var(DocVar.ROOT(nest(k))))))
           }),
         p.idExclusion)
     }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflow/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflow/package.scala
@@ -82,8 +82,7 @@ package object workflow {
 
   // NB: it's only safe to emit "core" expr ops here, but we always use the
   // largest type here, so they're immediately injected into ExprOp.
-  private val exprFp: ExprOpCoreF.fixpoint[Fix, ExprOp] = ExprOpCoreF.fixpoint[Fix, ExprOp]
-  import exprFp._
+  import fixExprOp._
 
   def task[F[_]: Functor](fop: Crystallized[F])(implicit C: Crush[F]): WorkflowTask =
     (finish(_, _)).tupled(fop.op.para(C.crush[Fix]))._2.transAna(normalize)

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
@@ -52,8 +52,7 @@ object WorkflowBuilder {
     def render(x: Expr) = x.fold(_.render, _.render)
   }
 
-  private val exprFp: ExprOpCoreF.fixpoint[Fix, ExprOp] = ExprOpCoreF.fixpoint[Fix, ExprOp]
-  import exprFp._
+  import fixExprOp._
 
   /**
    * Like ValueBuilder, this is a Leaf node which can be used to construct a more complicated WorkflowBuilder.

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflowtask/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflowtask/package.scala
@@ -31,8 +31,7 @@ package object workflowtask {
 
   // NB: it's only safe to emit "core" expr ops here, but we always use the
   // largest type here, so they're immediately injected into ExprOp.
-  private val exprCoreFp = ExprOpCoreF.fixpoint[Fix, ExprOp]
-  import exprCoreFp._
+  import fixExprOp._
 
   val simplifyProject: WorkflowOpCoreF[Unit] => Option[PipelineF[WorkflowOpCoreF, Unit]] =
     {

--- a/mongodb/src/test/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutionSpec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutionSpec.scala
@@ -25,15 +25,12 @@ import quasar.qscript.SortDir
 
 import scala.collection.immutable.ListMap
 
-import matryoshka._
 import scalaz._
 import scalaz.syntax.either._
 
 class JavaScriptWorkflowExecutionSpec extends quasar.Qspec {
   import CollectionUtil._
-
-  private val exprFp: ExprOpCoreF.fixpoint[Fix, ExprOp] = ExprOpCoreF.fixpoint[Fix, ExprOp]
-  import exprFp._
+  import fixExprOp._
 
   def toJS(wf: Workflow): WorkflowExecutionError \/ String =
     WorkflowExecutor.toJS(Crystallize[WorkflowF].crystallize(wf))

--- a/mongodb/src/test/scala/quasar/physical/mongodb/expression/spec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/expression/spec.scala
@@ -83,9 +83,7 @@ object ArbitraryExprOp {
 }
 
 class ExpressionSpec extends quasar.Qspec {
-
-  val fpCore = ExprOpCoreF.fixpoint[Fix, ExprOp]
-  import fpCore._
+  import fixExprOp._
   val fp3_0 = ExprOp3_0F.fixpoint[Fix, ExprOp]
   import fp3_0._
 

--- a/mongodb/src/test/scala/quasar/physical/mongodb/optimize.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/optimize.scala
@@ -29,9 +29,7 @@ import scalaz._, Scalaz._
 
 class OptimizeSpecs extends quasar.Qspec with TreeMatchers {
   import CollectionUtil._
-
-  val exprCoreFp: ExprOpCoreF.fixpoint[Fix, ExprOp] = ExprOpCoreF.fixpoint[Fix, ExprOp]
-  import exprCoreFp._
+  import fixExprOp._
 
   "simplifyGroupƒ" should {
     "elide useless reduction" in {

--- a/mongodb/src/test/scala/quasar/physical/mongodb/pipeline.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/pipeline.scala
@@ -23,16 +23,13 @@ import quasar.physical.mongodb.expression._
 import quasar.physical.mongodb.workflow._
 import quasar.qscript.SortDir
 
-import matryoshka.Fix
 import org.scalacheck._
 import scalaz._
 
 class PipelineSpec extends quasar.Qspec with ArbBsonField {
   import CollectionUtil._
   import ArbitraryExprOp._
-
-  val exprCoreFp: ExprOpCoreF.fixpoint[Fix, ExprOp] = ExprOpCoreF.fixpoint[Fix, ExprOp]
-  import exprCoreFp._
+  import fixExprOp._
 
   implicit def arbitraryOp: Arbitrary[PipelineOp] = Arbitrary { Gen.resize(5, Gen.sized { size =>
     // Note: Gen.oneOf is overridden and this variant requires two explicit args

--- a/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -69,8 +69,7 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
     }
   }
 
-  val exprCoreFp: ExprOpCoreF.fixpoint[Fix, ExprOp] = ExprOpCoreF.fixpoint[Fix, ExprOp]
-  import exprCoreFp._
+  import fixExprOp._
   val expr3_0Fp: ExprOp3_0F.fixpoint[Fix, ExprOp] = ExprOp3_0F.fixpoint[Fix, ExprOp]
   import expr3_0Fp._
 

--- a/mongodb/src/test/scala/quasar/physical/mongodb/workflowbuilder.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/workflowbuilder.scala
@@ -35,9 +35,7 @@ class WorkflowBuilderSpec extends quasar.Qspec {
 
   val builder = WorkflowBuilder.Ops[WorkflowF]
   import builder._
-
-  private val exprCoreFp: ExprOpCoreF.fixpoint[Fix, ExprOp] = ExprOpCoreF.fixpoint[Fix, ExprOp]
-  import exprCoreFp._
+  import fixExprOp._
 
   val readZips = read(collection("db", "zips"))
   def pureInt(n: Int) = pure(Bson.Int32(n))

--- a/mongodb/src/test/scala/quasar/physical/mongodb/workflowop.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/workflowop.scala
@@ -55,9 +55,7 @@ class WorkflowFSpec extends org.specs2.scalaz.Spec {
 
 class WorkflowSpec extends quasar.Qspec with TreeMatchers {
   import CollectionUtil._
-
-  val exprCoreFp: ExprOpCoreF.fixpoint[Fix, ExprOp] = ExprOpCoreF.fixpoint[Fix, ExprOp]
-  import exprCoreFp._
+  import fixExprOp._
 
   val readFoo = $read[WorkflowF](collection("db", "foo"))
 


### PR DESCRIPTION
The value ExprOpCoreF.fixpoint[Fix, ExprOp] was being created
from 17 distinct call sites.