### PR TITLE
decode MongoDB index with Double instead of Integer

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- more lenient decoding of MongoDB indexes

--- a/mongodb/src/main/scala/quasar/physical/mongodb/MongoDbIO.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/MongoDbIO.scala
@@ -323,9 +323,9 @@ object MongoDbIO {
     def decodeField(s: String): BsonField = BsonField.Name(s)
 
     val decodeType: PartialFunction[java.lang.Object, IndexType] = {
-      case x: java.lang.Integer if x.intValue ≟ 1  => IndexType.Ascending
-      case x: java.lang.Integer if x.intValue ≟ -1 => IndexType.Descending
-      case "hashed"                                => IndexType.Hashed
+      case x: java.lang.Number if x.intValue ≟ 1  => IndexType.Ascending
+      case x: java.lang.Number if x.intValue ≟ -1 => IndexType.Descending
+      case "hashed"                               => IndexType.Hashed
     }
 
     def decodeIndex(doc: Document): Option[Index] =


### PR DESCRIPTION
Ran into this when preparing for the 3.1 demo. No idea why I didn't see it previously using the same version of MongoDB.