### PR TITLE
Avoid creating unnecessary autojoins.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,5 +1,1 @@
-- have Coalesce push Take/Drop later, rather than earlier
-- add an `optimize` transformation to finalize QScript (which pulls Take/Drop earlier)
-- implement Mergable for ProjectBucket
-- fix conversions of Take and Drop from LP
-- eliminate many ThetaJoins from queries
+- avoid creating unnecessary autojoins

--- a/connector/src/main/scala/quasar/qscript/package.scala
+++ b/connector/src/main/scala/quasar/qscript/package.scala
@@ -115,9 +115,6 @@ package object qscript {
   import MapFunc._
   import MapFuncs._
 
-  def EquiJF[T[_[_]]]: JoinFunc[T] =
-    Free.roll(Eq(Free.point(LeftSide), Free.point(RightSide)))
-
   def concatBuckets[T[_[_]]: Recursive: Corecursive](buckets: List[FreeMap[T]]):
       Option[(FreeMap[T], NEL[FreeMap[T]])] =
     buckets match {

--- a/connector/src/test/scala/quasar/qscript/QScript.scala
+++ b/connector/src/test/scala/quasar/qscript/QScript.scala
@@ -108,6 +108,54 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
               Free.roll(Undefined())))))))).some)
     }
 
+    "convert a basic reduction" in {
+      val lp = fullCompileExp("select sum(pop) from bar")
+      val qs = convert(listContents.some, lp)
+      qs must equal(chain(
+        ReadR(rootDir </> file("bar")),
+        QC.inj(LeftShift((), HoleF, RightSideF)),
+        QC.inj(Reduce((),
+          NullLit(),
+          List(ReduceFuncs.Sum(
+            Free.roll(Guard(
+              HoleF, Type.Obj(ScalaMap(), Type.Top.some),
+              Free.roll(Guard(
+                ProjectFieldR(HoleF, StrLit("pop")),
+                Type.Coproduct(Type.Coproduct(Type.Int, Type.Dec), Type.Interval),
+                ProjectFieldR(HoleF, StrLit("pop")),
+                Free.roll(Undefined()))),
+              Free.roll(Undefined()))))),
+          Free.roll(MakeMap(StrLit("0"), ReduceIndexF(0)))))).some)
+    }
+
+    "convert a multi-field select" in {
+      val lp = fullCompileExp("select city, state from bar")
+      val qs = convert(listContents.some, lp)
+      qs must equal(chain(
+        ReadR(rootDir </> file("bar")),
+        QC.inj(LeftShift((),
+          HoleF,
+          Free.roll(ConcatMaps(
+            Free.roll(MakeMap(
+              StrLit("city"),
+              ProjectFieldR(
+                Free.roll(Guard(
+                  RightSideF,
+                  Type.Obj(ScalaMap(),Some(Type.Top)),
+                  RightSideF,
+                  Free.roll(Undefined()))),
+                StrLit("city")))),
+            Free.roll(MakeMap(
+              StrLit("state"),
+              ProjectFieldR(
+                Free.roll(Guard(
+                  RightSideF,
+                  Type.Obj(ScalaMap(),Some(Type.Top)),
+                  RightSideF,
+                  Free.roll(Undefined()))),
+                StrLit("state"))))))))).some)
+    }
+
     "convert a simple take" in pending {
       convert(listContents.some, StdLib.set.Take(lpRead("/foo/bar"), LP.Constant(Data.Int(10))).embed) must
       equal(


### PR DESCRIPTION
Many more ThetaJoins are avoided in QScript with this.

This is based on #1514.