### PR TITLE
Fix handling of “result” pointers.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,4 @@
+- use “result pointers” properly
+- expand `Coalesce` to cover cases with different constraints on the coproduct
+- generalize `coalesceSR` (née `transformIncludeToExclude`) to handle branches and Reduce nodes
+- convert many more normalizations to return `Option` (and be applied repeatedly)

--- a/connector/src/main/scala/quasar/fs/QueryFile.scala
+++ b/connector/src/main/scala/quasar/fs/QueryFile.scala
@@ -64,7 +64,7 @@ object QueryFile {
     //       so we don’t duplicate work.
     lp.transCata[LogicalPlan](orOriginal(Optimizer.elideLets[T]))
       .cataM[PlannerError \/ ?, (Ann[T], T[QS])](newLP => transform.lpToQScript(newLP.map(_ ∘ (_.transCata(eval)))))
-      .map(qs => QC.inj(quasar.qscript.Map(qs._2, qs._1.values)).embed.transCata(eval))
+      .map(qs => QC.inj((transform.reifyResult(qs._1, qs._2))).embed.transCata(eval))
   }
 
   def simplifyAndNormalize

--- a/connector/src/main/scala/quasar/qscript/ShiftRead.scala
+++ b/connector/src/main/scala/quasar/qscript/ShiftRead.scala
@@ -50,11 +50,14 @@ object ShiftRead {
 
   def apply[T[_[_]], F[_], G[_]](implicit ev: ShiftRead.Aux[T, F, G]) = ev
 
+  private def ShiftTotal[T[_[_]]: Recursive: Corecursive] =
+    ShiftRead[T, QScriptTotal[T, ?], QScriptTotal[T, ?]]
+
   def applyToBranch[T[_[_]]: Recursive: Corecursive](branch: FreeQS[T]):
       FreeQS[T] =
     freeTransFutu(branch)((co: CoEnv[Hole, QScriptTotal[T, ?], T[CoEnv[Hole, QScriptTotal[T, ?], ?]]]) => co.run.fold(
       κ(co.map(Free.point[CoEnv[Hole, QScriptTotal[T, ?], ?], T[CoEnv[Hole, QScriptTotal[T, ?], ?]]])),
-      ShiftRead[T, QScriptTotal[T, ?], QScriptTotal[T, ?]].shiftRead(coenvPrism[QScriptTotal[T, ?], Hole].reverseGet)(_)))
+      ShiftTotal.shiftRead(coenvPrism[QScriptTotal[T, ?], Hole].reverseGet)(_)))
 
   implicit def read[T[_[_]]: Recursive: Corecursive, F[_]]
     (implicit SR: Const[ShiftedRead, ?] :<: F, QC: QScriptCore[T, ?] :<: F)

--- a/connector/src/test/scala/quasar/qscript/QScript.scala
+++ b/connector/src/test/scala/quasar/qscript/QScript.scala
@@ -128,6 +128,15 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           Free.roll(MakeMap(StrLit("0"), ReduceIndexF(0)))))).some)
     }
 
+    "convert a basic take" in {
+      val lp = fullCompileExp("select * from bar limit 10")
+      val qs = convert(listContents.some, lp)
+      qs must equal(
+        QC.inj(Take(QC.inj(Unreferenced[Fix, Fix[QS]]()).embed,
+          Free.roll(QCT.inj(LeftShift(Free.roll(RT.inj(Const[Read, FreeQS[Fix]](Read(rootDir </> file("bar"))))), HoleF, RightSideF))),
+          Free.roll(QCT.inj(Map(Free.roll(QCT.inj(Unreferenced())), IntLit(10)))))).embed.some)
+    }
+
     "convert a multi-field select" in {
       val lp = fullCompileExp("select city, state from bar")
       val qs = convert(listContents.some, lp)


### PR DESCRIPTION
Sometimes we would throw away necessary information for finding the
result of a QScript node. We now apply it properly.

This also has some other improvements to simplifying `ShiftedRead` nodes
and normalization in general.