### PR TITLE
Tests for date, math, and relations, and fixes for JavaScript

### DIFF
--- a/CHANGELOG/feature.md
+++ b/CHANGELOG/feature.md
@@ -1,0 +1,9 @@
+- much more correct and consistent behavior for date functions on MongoDB
+    - much of date_part was just plain wrong in map-reduce
+    - implement `epoch` in map-reduce
+    - correct decade, century, and millennium to be integers and mostly the right ones
+- fix `TIME_OF_DAY` when running in map-reduce
+- implement `POWER` on MongoDB (requiring map-reduce for now)
+- alternative syntax, e.g. `DATE_PART("year", ts)` is now equivalent to `EXTRACT_YEAR(ts)`
+- fairly complete tests for `math`, `relations`, and `date` libraries
+- move compilation for MongoDB map-reduce out to a common `JsFuncHandler`, reducing duplication betweeen the two planners

--- a/connector/src/main/scala/quasar/qscript/MapFunc.scala
+++ b/connector/src/main/scala/quasar/qscript/MapFunc.scala
@@ -302,6 +302,9 @@ object MapFunc {
         case ExtractMonth(a1) => f(a1) ∘ (ExtractMonth(_))
         case ExtractQuarter(a1) => f(a1) ∘ (ExtractQuarter(_))
         case ExtractSecond(a1) => f(a1) ∘ (ExtractSecond(_))
+        case ExtractTimezone(a1) => f(a1) ∘ (ExtractTimezone(_))
+        case ExtractTimezoneHour(a1) => f(a1) ∘ (ExtractTimezoneHour(_))
+        case ExtractTimezoneMinute(a1) => f(a1) ∘ (ExtractTimezoneMinute(_))
         case ExtractWeek(a1) => f(a1) ∘ (ExtractWeek(_))
         case ExtractYear(a1) => f(a1) ∘ (ExtractYear(_))
         case Date(a1) => f(a1) ∘ (Date(_))
@@ -386,6 +389,9 @@ object MapFunc {
         case (ExtractMonth(a1), ExtractMonth(a2)) => in.equal(a1, a2)
         case (ExtractQuarter(a1), ExtractQuarter(a2)) => in.equal(a1, a2)
         case (ExtractSecond(a1), ExtractSecond(a2)) => in.equal(a1, a2)
+        case (ExtractTimezone(a1), ExtractTimezone(a2)) => in.equal(a1, a2)
+        case (ExtractTimezoneHour(a1), ExtractTimezoneHour(a2)) => in.equal(a1, a2)
+        case (ExtractTimezoneMinute(a1), ExtractTimezoneMinute(a2)) => in.equal(a1, a2)
         case (ExtractWeek(a1), ExtractWeek(a2)) => in.equal(a1, a2)
         case (ExtractYear(a1), ExtractYear(a2)) => in.equal(a1, a2)
         case (Date(a1), Date(b1)) => in.equal(a1, b1)
@@ -475,6 +481,9 @@ object MapFunc {
           case ExtractMonth(a1) => shz("ExtractMonth", a1)
           case ExtractQuarter(a1) => shz("ExtractQuarter", a1)
           case ExtractSecond(a1) => shz("ExtractSecond", a1)
+          case ExtractTimezone(a1) => shz("ExtractTimezone", a1)
+          case ExtractTimezoneHour(a1) => shz("ExtractTimezoneHour", a1)
+          case ExtractTimezoneMinute(a1) => shz("ExtractTimezoneMinute", a1)
           case ExtractWeek(a1) => shz("ExtractWeek", a1)
           case ExtractYear(a1) => shz("ExtractYear", a1)
           case Date(a1) => shz("Date", a1)
@@ -558,6 +567,9 @@ object MapFunc {
       case date.ExtractMonth => ExtractMonth(_)
       case date.ExtractQuarter => ExtractQuarter(_)
       case date.ExtractSecond => ExtractSecond(_)
+      case date.ExtractTimezone => ExtractTimezone(_)
+      case date.ExtractTimezoneHour => ExtractTimezoneHour(_)
+      case date.ExtractTimezoneMinute => ExtractTimezoneMinute(_)
       case date.ExtractWeek => ExtractWeek(_)
       case date.ExtractYear => ExtractYear(_)
       case date.Date => Date(_)
@@ -656,6 +668,9 @@ object MapFuncs {
   @Lenses final case class ExtractMonth[T[_[_]], A](a1: A) extends Unary[T, A]
   @Lenses final case class ExtractQuarter[T[_[_]], A](a1: A) extends Unary[T, A]
   @Lenses final case class ExtractSecond[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ExtractTimezone[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ExtractTimezoneHour[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ExtractTimezoneMinute[T[_[_]], A](a1: A) extends Unary[T, A]
   @Lenses final case class ExtractWeek[T[_[_]], A](a1: A) extends Unary[T, A]
   @Lenses final case class ExtractYear[T[_[_]], A](a1: A) extends Unary[T, A]
   @Lenses final case class Date[T[_[_]], A](a1: A) extends Unary[T, A]

--- a/connector/src/main/scala/quasar/qscript/MapFunc.scala
+++ b/connector/src/main/scala/quasar/qscript/MapFunc.scala
@@ -294,6 +294,24 @@ object MapFunc {
         case Now() => G.point(Now[T, B]())
 
         // unary
+        case ExtractCentury(a1) => f(a1) ∘ (ExtractCentury(_))
+        case ExtractDayOfMonth(a1) => f(a1) ∘ (ExtractDayOfMonth(_))
+        case ExtractDecade(a1) => f(a1) ∘ (ExtractDecade(_))
+        case ExtractDayOfWeek(a1) => f(a1) ∘ (ExtractDayOfWeek(_))
+        case ExtractDayOfYear(a1) => f(a1) ∘ (ExtractDayOfYear(_))
+        case ExtractEpoch(a1) => f(a1) ∘ (ExtractEpoch(_))
+        case ExtractHour(a1) => f(a1) ∘ (ExtractHour(_))
+        case ExtractIsoDayOfWeek(a1) => f(a1) ∘ (ExtractIsoDayOfWeek(_))
+        case ExtractIsoYear(a1) => f(a1) ∘ (ExtractIsoYear(_))
+        case ExtractMicroseconds(a1) => f(a1) ∘ (ExtractMicroseconds(_))
+        case ExtractMillenium(a1) => f(a1) ∘ (ExtractMillenium(_))
+        case ExtractMilliseconds(a1) => f(a1) ∘ (ExtractMilliseconds(_))
+        case ExtractMinute(a1) => f(a1) ∘ (ExtractMinute(_))
+        case ExtractMonth(a1) => f(a1) ∘ (ExtractMonth(_))
+        case ExtractQuarter(a1) => f(a1) ∘ (ExtractQuarter(_))
+        case ExtractSecond(a1) => f(a1) ∘ (ExtractSecond(_))
+        case ExtractWeek(a1) => f(a1) ∘ (ExtractWeek(_))
+        case ExtractYear(a1) => f(a1) ∘ (ExtractYear(_))
         case Date(a1) => f(a1) ∘ (Date(_))
         case Time(a1) => f(a1) ∘ (Time(_))
         case Timestamp(a1) => f(a1) ∘ (Timestamp(_))
@@ -317,7 +335,6 @@ object MapFunc {
         case ZipMapKeys(a1) => f(a1) ∘ (ZipMapKeys(_))
 
         // binary
-        case Extract(a1, a2) => (f(a1) ⊛ f(a2))(Extract(_, _))
         case Add(a1, a2) => (f(a1) ⊛ f(a2))(Add(_, _))
         case Multiply(a1, a2) => (f(a1) ⊛ f(a2))(Multiply(_, _))
         case Subtract(a1, a2) => (f(a1) ⊛ f(a2))(Subtract(_, _))
@@ -361,6 +378,24 @@ object MapFunc {
         case (Now(), Now()) => true
 
         // unary
+        case (ExtractCentury(a1), ExtractCentury(a2)) => in.equal(a1, a2)
+        case (ExtractDayOfMonth(a1), ExtractDayOfMonth(a2)) => in.equal(a1, a2)
+        case (ExtractDecade(a1), ExtractDecade(a2)) => in.equal(a1, a2)
+        case (ExtractDayOfWeek(a1), ExtractDayOfWeek(a2)) => in.equal(a1, a2)
+        case (ExtractDayOfYear(a1), ExtractDayOfYear(a2)) => in.equal(a1, a2)
+        case (ExtractEpoch(a1), ExtractEpoch(a2)) => in.equal(a1, a2)
+        case (ExtractHour(a1), ExtractHour(a2)) => in.equal(a1, a2)
+        case (ExtractIsoDayOfWeek(a1), ExtractIsoDayOfWeek(a2)) => in.equal(a1, a2)
+        case (ExtractIsoYear(a1), ExtractIsoYear(a2)) => in.equal(a1, a2)
+        case (ExtractMicroseconds(a1), ExtractMicroseconds(a2)) => in.equal(a1, a2)
+        case (ExtractMillenium(a1), ExtractMillenium(a2)) => in.equal(a1, a2)
+        case (ExtractMilliseconds(a1), ExtractMilliseconds(a2)) => in.equal(a1, a2)
+        case (ExtractMinute(a1), ExtractMinute(a2)) => in.equal(a1, a2)
+        case (ExtractMonth(a1), ExtractMonth(a2)) => in.equal(a1, a2)
+        case (ExtractQuarter(a1), ExtractQuarter(a2)) => in.equal(a1, a2)
+        case (ExtractSecond(a1), ExtractSecond(a2)) => in.equal(a1, a2)
+        case (ExtractWeek(a1), ExtractWeek(a2)) => in.equal(a1, a2)
+        case (ExtractYear(a1), ExtractYear(a2)) => in.equal(a1, a2)
         case (Date(a1), Date(b1)) => in.equal(a1, b1)
         case (Time(a1), Time(b1)) => in.equal(a1, b1)
         case (Timestamp(a1), Timestamp(b1)) => in.equal(a1, b1)
@@ -383,7 +418,6 @@ object MapFunc {
         case (ZipArrayIndices(a1), ZipArrayIndices(b1)) => in.equal(a1, b1)
         case (ZipMapKeys(a1), ZipMapKeys(b1)) => in.equal(a1, b1)
 
-        case (Extract(a1, a2), Extract(b1, b2)) => in.equal(a1, b1) && in.equal(a2, b2)
         case (Add(a1, a2), Add(b1, b2)) => in.equal(a1, b1) && in.equal(a2, b2)
         case (Multiply(a1, a2), Multiply(b1, b2)) => in.equal(a1, b1) && in.equal(a2, b2)
         case (Subtract(a1, a2), Subtract(b1, b2)) => in.equal(a1, b1) && in.equal(a2, b2)
@@ -422,73 +456,118 @@ object MapFunc {
 
   implicit def show[T[_[_]]: ShowT]: Delay[Show, MapFunc[T, ?]] =
     new Delay[Show, MapFunc[T, ?]] {
-      def apply[A](sh: Show[A]): Show[MapFunc[T, A]] = Show.show {
-        // nullary
-        case Constant(v) => Cord("Constant(") ++ v.show ++ Cord(")")
-        case Undefined() => Cord("Undefined()")
-        case Now() => Cord("Now()")
+      def apply[A](sh: Show[A]): Show[MapFunc[T, A]] = {
+        def shz(label: String, a: A*) =
+          Cord(label) ++ Cord("(") ++ a.map(sh.show).toList.intercalate(Cord(", ")) ++ Cord(")")
 
-        // unary
-        case Date(a1) => Cord("Date(") ++ sh.show(a1) ++ Cord(")")
-        case Time(a1) => Cord("Time(") ++ sh.show(a1) ++ Cord(")")
-        case Timestamp(a1) => Cord("Timestamp(") ++ sh.show(a1) ++ Cord(")")
-        case Interval(a1) => Cord("Interval(") ++ sh.show(a1) ++ Cord(")")
-        case TimeOfDay(a1) => Cord("TimeOfDay(") ++ sh.show(a1) ++ Cord(")")
-        case ToTimestamp(a1) => Cord("ToTimestamp(") ++ sh.show(a1) ++ Cord(")")
-        case Negate(a1) => Cord("Negate(") ++ sh.show(a1) ++ Cord(")")
-        case Not(a1) => Cord("Not(") ++ sh.show(a1) ++ Cord(")")
-        case Length(a1) => Cord("Length(") ++ sh.show(a1) ++ Cord(")")
-        case Lower(a1) => Cord("Lower(") ++ sh.show(a1) ++ Cord(")")
-        case Upper(a1) => Cord("Upper(") ++ sh.show(a1) ++ Cord(")")
-        case Bool(a1) => Cord("Bool(") ++ sh.show(a1) ++ Cord(")")
-        case Integer(a1) => Cord("Integer(") ++ sh.show(a1) ++ Cord(")")
-        case Decimal(a1) => Cord("Decimal(") ++ sh.show(a1) ++ Cord(")")
-        case Null(a1) => Cord("Null(") ++ sh.show(a1) ++ Cord(")")
-        case ToString(a1) => Cord("ToString(") ++ sh.show(a1) ++ Cord(")")
-        case MakeArray(a1) => Cord("MakeArray(") ++ sh.show(a1) ++ Cord(")")
-        case DupArrayIndices(a1) => Cord("DupArrayIndices(") ++ sh.show(a1) ++ Cord(")")
-        case DupMapKeys(a1) => Cord("DupMapKeys(") ++ sh.show(a1) ++ Cord(")")
-        case ZipArrayIndices(a1) => Cord("ZipArrayIndices(") ++ sh.show(a1) ++ Cord(")")
-        case ZipMapKeys(a1) => Cord("ZipMapKeys(") ++ sh.show(a1) ++ Cord(")")
+        Show.show {
+          // nullary
+          case Constant(v) => Cord("Constant(") ++ v.show ++ Cord(")")
+          case Undefined() => Cord("Undefined()")
+          case Now() => Cord("Now()")
 
-        // binary
-        case Extract(a1, a2) => Cord("Extract(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case Add(a1, a2) => Cord("Add(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case Multiply(a1, a2) => Cord("Multiply(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case Subtract(a1, a2) => Cord("Subtract(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case Divide(a1, a2) => Cord("Divide(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case Modulo(a1, a2) => Cord("Modulo(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case Power(a1, a2) => Cord("Power(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case Eq(a1, a2) => Cord("Eq(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case Neq(a1, a2) => Cord("Neq(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case Lt(a1, a2) => Cord("Lt(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case Lte(a1, a2) => Cord("Lte(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case Gt(a1, a2) => Cord("Gt(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case Gte(a1, a2) => Cord("Gte(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case IfUndefined(a1, a2) => Cord("IfUndefined(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case And(a1, a2) => Cord("And(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case Or(a1, a2) => Cord("Or(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case Coalesce(a1, a2) => Cord("Coalesce(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case Within(a1, a2) => Cord("Within(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case MakeMap(a1, a2) => Cord("MakeMap(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case ConcatMaps(a1, a2) => Cord("ConcatMaps(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case ProjectIndex(a1, a2) => Cord("ProjectIndex(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case ProjectField(a1, a2) => Cord("ProjectField(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case DeleteField(a1, a2) => Cord("DeleteField(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case ConcatArrays(a1, a2) => Cord("ConcatArrays(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
-        case Range(a1, a2) => Cord("Range(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2)  ++ Cord(")")
+          // unary
+          case ExtractCentury(a1) => shz("ExtractCentury", a1)
+          case ExtractDayOfMonth(a1) => shz("ExtractDayOfMonth", a1)
+          case ExtractDecade(a1) => shz("ExtractDecade", a1)
+          case ExtractDayOfWeek(a1) => shz("ExtractDayOfWeek", a1)
+          case ExtractDayOfYear(a1) => shz("ExtractDayOfYear", a1)
+          case ExtractEpoch(a1) => shz("ExtractEpoch", a1)
+          case ExtractHour(a1) => shz("ExtractHour", a1)
+          case ExtractIsoDayOfWeek(a1) => shz("ExtractIsoDayOfWeek", a1)
+          case ExtractIsoYear(a1) => shz("ExtractIsoYear", a1)
+          case ExtractMicroseconds(a1) => shz("ExtractMicroseconds", a1)
+          case ExtractMillenium(a1) => shz("ExtractMillenium", a1)
+          case ExtractMilliseconds(a1) => shz("ExtractMilliseconds", a1)
+          case ExtractMinute(a1) => shz("ExtractMinute", a1)
+          case ExtractMonth(a1) => shz("ExtractMonth", a1)
+          case ExtractQuarter(a1) => shz("ExtractQuarter", a1)
+          case ExtractSecond(a1) => shz("ExtractSecond", a1)
+          case ExtractWeek(a1) => shz("ExtractWeek", a1)
+          case ExtractYear(a1) => shz("ExtractYear", a1)
+          case Date(a1) => shz("Date", a1)
+          case Time(a1) => shz("Time", a1)
+          case Timestamp(a1) => shz("Timestamp", a1)
+          case Interval(a1) => shz("Interval", a1)
+          case TimeOfDay(a1) => shz("TimeOfDay", a1)
+          case ToTimestamp(a1) => shz("ToTimestamp", a1)
+          case Negate(a1) => shz("Negate", a1)
+          case Not(a1) => shz("Not", a1)
+          case Length(a1) => shz("Length", a1)
+          case Lower(a1) => shz("Lower", a1)
+          case Upper(a1) => shz("Upper", a1)
+          case Bool(a1) => shz("Bool", a1)
+          case Integer(a1) => shz("Integer", a1)
+          case Decimal(a1) => shz("Decimal", a1)
+          case Null(a1) => shz("Null", a1)
+          case ToString(a1) => shz("ToString", a1)
+          case MakeArray(a1) => shz("MakeArray", a1)
+          case DupArrayIndices(a1) => shz("DupArrayIndices", a1)
+          case DupMapKeys(a1) => shz("DupMapKeys", a1)
+          case ZipArrayIndices(a1) => shz("ZipArrayIndices", a1)
+          case ZipMapKeys(a1) => shz("ZipMapKeys", a1)
 
-        //  ternary
-        case Between(a1, a2, a3) => Cord("Between(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2) ++ Cord(", ") ++ sh.show(a3) ++ Cord(")")
-        case Cond(a1, a2, a3) => Cord("Cond(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2) ++ Cord(", ") ++ sh.show(a3) ++ Cord(")")
-        case Search(a1, a2, a3) => Cord("Search(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2) ++ Cord(", ") ++ sh.show(a3) ++ Cord(")")
-        case Substring(a1, a2, a3) => Cord("Substring(") ++ sh.show(a1) ++ Cord(", ") ++ sh.show(a2) ++ Cord(", ") ++ sh.show(a3) ++ Cord(")")
-        case Guard(a1, tpe, a2, a3) => Cord("Guard(") ++ sh.show(a1) ++ Cord(", ") ++ tpe.show ++ Cord(", ") ++ sh.show(a2) ++ Cord(", ") ++ sh.show(a3) ++ Cord(")")
+          // binary
+          case Add(a1, a2) => shz("Add", a1, a2)
+          case Multiply(a1, a2) => shz("Multiply", a1, a2)
+          case Subtract(a1, a2) => shz("Subtract", a1, a2)
+          case Divide(a1, a2) => shz("Divide", a1, a2)
+          case Modulo(a1, a2) => shz("Modulo", a1, a2)
+          case Power(a1, a2) => shz("Power", a1, a2)
+          case Eq(a1, a2) => shz("Eq", a1, a2)
+          case Neq(a1, a2) => shz("Neq", a1, a2)
+          case Lt(a1, a2) => shz("Lt", a1, a2)
+          case Lte(a1, a2) => shz("Lte", a1, a2)
+          case Gt(a1, a2) => shz("Gt", a1, a2)
+          case Gte(a1, a2) => shz("Gte", a1, a2)
+          case IfUndefined(a1, a2) => shz("IfUndefined", a1, a2)
+          case And(a1, a2) => shz("And", a1, a2)
+          case Or(a1, a2) => shz("Or", a1, a2)
+          case Coalesce(a1, a2) => shz("Coalesce", a1, a2)
+          case Within(a1, a2) => shz("Within", a1, a2)
+          case MakeMap(a1, a2) => shz("MakeMap", a1, a2)
+          case ConcatMaps(a1, a2) => shz("ConcatMaps", a1, a2)
+          case ProjectIndex(a1, a2) => shz("ProjectIndex", a1, a2)
+          case ProjectField(a1, a2) => shz("ProjectField", a1, a2)
+          case DeleteField(a1, a2) => shz("DeleteField", a1, a2)
+          case ConcatArrays(a1, a2) => shz("ConcatArrays", a1, a2)
+          case Range(a1, a2) => shz("Range", a1, a2)
+
+          //  ternary
+          case Between(a1, a2, a3) => shz("Between", a1, a2, a3)
+          case Cond(a1, a2, a3) => shz("Cond", a1, a2, a3)
+          case Search(a1, a2, a3) => shz("Search", a1, a2, a3)
+          case Substring(a1, a2, a3) => shz("Substring", a1, a2, a3)
+          case Guard(a1, tpe, a2, a3) =>
+            Cord("Guard(") ++
+              sh.show(a1) ++ Cord(", ") ++
+              tpe.show ++ Cord(", ") ++
+              sh.show(a2) ++ Cord(", ") ++
+              sh.show(a3) ++ Cord(")")
+        }
       }
     }
 
   def translateUnaryMapping[T[_[_]], A]: UnaryFunc => A => MapFunc[T, A] = {
     {
+      case date.ExtractCentury => ExtractCentury(_)
+      case date.ExtractDayOfMonth => ExtractDayOfMonth(_)
+      case date.ExtractDecade => ExtractDecade(_)
+      case date.ExtractDayOfWeek => ExtractDayOfWeek(_)
+      case date.ExtractDayOfYear => ExtractDayOfYear(_)
+      case date.ExtractEpoch => ExtractEpoch(_)
+      case date.ExtractHour => ExtractHour(_)
+      case date.ExtractIsoDayOfWeek => ExtractIsoDayOfWeek(_)
+      case date.ExtractIsoYear => ExtractIsoYear(_)
+      case date.ExtractMicroseconds => ExtractMicroseconds(_)
+      case date.ExtractMillenium => ExtractMillenium(_)
+      case date.ExtractMilliseconds => ExtractMilliseconds(_)
+      case date.ExtractMinute => ExtractMinute(_)
+      case date.ExtractMonth => ExtractMonth(_)
+      case date.ExtractQuarter => ExtractQuarter(_)
+      case date.ExtractSecond => ExtractSecond(_)
+      case date.ExtractWeek => ExtractWeek(_)
+      case date.ExtractYear => ExtractYear(_)
       case date.Date => Date(_)
       case date.Time => Time(_)
       case date.Timestamp => Timestamp(_)
@@ -514,7 +593,6 @@ object MapFunc {
       // NB: ArrayLength takes 2 params because of SQL, but we really don’t care
       //     about the second. And it shouldn’t even have two in LP.
       case array.ArrayLength => (a, b) => Length(a)
-      case date.Extract => Extract(_, _)
       case math.Add => Add(_, _)
       case math.Multiply => Multiply(_, _)
       case math.Subtract => Subtract(_, _)
@@ -569,17 +647,33 @@ object MapFuncs {
   @Lenses final case class Length[T[_[_]], A](a1: A) extends Unary[T, A]
 
   // date
+  // See https://www.postgresql.org/docs/9.2/static/functions-datetime.html#FUNCTIONS-DATETIME-EXTRACT
+  @Lenses final case class ExtractCentury[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ExtractDayOfMonth[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ExtractDecade[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ExtractDayOfWeek[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ExtractDayOfYear[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ExtractEpoch[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ExtractHour[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ExtractIsoDayOfWeek[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ExtractIsoYear[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ExtractMicroseconds[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ExtractMillenium[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ExtractMilliseconds[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ExtractMinute[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ExtractMonth[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ExtractQuarter[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ExtractSecond[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ExtractWeek[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ExtractYear[T[_[_]], A](a1: A) extends Unary[T, A]
   @Lenses final case class Date[T[_[_]], A](a1: A) extends Unary[T, A]
   @Lenses final case class Time[T[_[_]], A](a1: A) extends Unary[T, A]
   @Lenses final case class Timestamp[T[_[_]], A](a1: A) extends Unary[T, A]
   @Lenses final case class Interval[T[_[_]], A](a1: A) extends Unary[T, A]
   @Lenses final case class TimeOfDay[T[_[_]], A](a1: A) extends Unary[T, A]
   @Lenses final case class ToTimestamp[T[_[_]], A](a1: A) extends Unary[T, A]
-  /** @see https://www.postgresql.org/docs/9.2/static/functions-datetime.html#FUNCTIONS-DATETIME-EXTRACT */
-  @Lenses final case class Extract[T[_[_]], A](a1: A, a2: A) extends Binary[T, A]
   /** Fetches the [[quasar.Type.Timestamp]] for the current instant in time. */
   @Lenses final case class Now[T[_[_]], A]() extends Nullary[T, A]
-
 
   // math
   @Lenses final case class Negate[T[_[_]], A](a1: A) extends Unary[T, A]

--- a/connector/src/main/scala/quasar/qscript/MapFunc.scala
+++ b/connector/src/main/scala/quasar/qscript/MapFunc.scala
@@ -296,7 +296,7 @@ object MapFunc {
         case ExtractIsoDayOfWeek(a1) => f(a1) ∘ (ExtractIsoDayOfWeek(_))
         case ExtractIsoYear(a1) => f(a1) ∘ (ExtractIsoYear(_))
         case ExtractMicroseconds(a1) => f(a1) ∘ (ExtractMicroseconds(_))
-        case ExtractMillenium(a1) => f(a1) ∘ (ExtractMillenium(_))
+        case ExtractMillennium(a1) => f(a1) ∘ (ExtractMillennium(_))
         case ExtractMilliseconds(a1) => f(a1) ∘ (ExtractMilliseconds(_))
         case ExtractMinute(a1) => f(a1) ∘ (ExtractMinute(_))
         case ExtractMonth(a1) => f(a1) ∘ (ExtractMonth(_))
@@ -383,7 +383,7 @@ object MapFunc {
         case (ExtractIsoDayOfWeek(a1), ExtractIsoDayOfWeek(a2)) => in.equal(a1, a2)
         case (ExtractIsoYear(a1), ExtractIsoYear(a2)) => in.equal(a1, a2)
         case (ExtractMicroseconds(a1), ExtractMicroseconds(a2)) => in.equal(a1, a2)
-        case (ExtractMillenium(a1), ExtractMillenium(a2)) => in.equal(a1, a2)
+        case (ExtractMillennium(a1), ExtractMillennium(a2)) => in.equal(a1, a2)
         case (ExtractMilliseconds(a1), ExtractMilliseconds(a2)) => in.equal(a1, a2)
         case (ExtractMinute(a1), ExtractMinute(a2)) => in.equal(a1, a2)
         case (ExtractMonth(a1), ExtractMonth(a2)) => in.equal(a1, a2)
@@ -475,7 +475,7 @@ object MapFunc {
           case ExtractIsoDayOfWeek(a1) => shz("ExtractIsoDayOfWeek", a1)
           case ExtractIsoYear(a1) => shz("ExtractIsoYear", a1)
           case ExtractMicroseconds(a1) => shz("ExtractMicroseconds", a1)
-          case ExtractMillenium(a1) => shz("ExtractMillenium", a1)
+          case ExtractMillennium(a1) => shz("ExtractMillennium", a1)
           case ExtractMilliseconds(a1) => shz("ExtractMilliseconds", a1)
           case ExtractMinute(a1) => shz("ExtractMinute", a1)
           case ExtractMonth(a1) => shz("ExtractMonth", a1)
@@ -561,7 +561,7 @@ object MapFunc {
       case date.ExtractIsoDayOfWeek => ExtractIsoDayOfWeek(_)
       case date.ExtractIsoYear => ExtractIsoYear(_)
       case date.ExtractMicroseconds => ExtractMicroseconds(_)
-      case date.ExtractMillenium => ExtractMillenium(_)
+      case date.ExtractMillennium => ExtractMillennium(_)
       case date.ExtractMilliseconds => ExtractMilliseconds(_)
       case date.ExtractMinute => ExtractMinute(_)
       case date.ExtractMonth => ExtractMonth(_)
@@ -662,7 +662,7 @@ object MapFuncs {
   @Lenses final case class ExtractIsoDayOfWeek[T[_[_]], A](a1: A) extends Unary[T, A]
   @Lenses final case class ExtractIsoYear[T[_[_]], A](a1: A) extends Unary[T, A]
   @Lenses final case class ExtractMicroseconds[T[_[_]], A](a1: A) extends Unary[T, A]
-  @Lenses final case class ExtractMillenium[T[_[_]], A](a1: A) extends Unary[T, A]
+  @Lenses final case class ExtractMillennium[T[_[_]], A](a1: A) extends Unary[T, A]
   @Lenses final case class ExtractMilliseconds[T[_[_]], A](a1: A) extends Unary[T, A]
   @Lenses final case class ExtractMinute[T[_[_]], A](a1: A) extends Unary[T, A]
   @Lenses final case class ExtractMonth[T[_[_]], A](a1: A) extends Unary[T, A]

--- a/core/src/test/scala/quasar/sql/compiler.scala
+++ b/core/src/test/scala/quasar/sql/compiler.scala
@@ -365,8 +365,7 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
         Squash(
           makeObj(
             "0" ->
-              Extract[FLP](
-                Constant(Data.Str("day")),
+              ExtractDayOfMonth[FLP](
                 ObjectProject(read("foo"), Constant(Data.Str("baz")))))))
     }
 

--- a/frontend/src/main/scala/quasar/SemanticError.scala
+++ b/frontend/src/main/scala/quasar/SemanticError.scala
@@ -90,6 +90,9 @@ object SemanticError {
   final case class InvalidPathError(path: Path[_, File, _], hint: Option[String]) extends SemanticError {
     def message = "Invalid path: " + posixCodec.unsafePrintPath(path) + hint.map(" (" + _ + ")").getOrElse("")
   }
+  final case class UnexpectedDatePart(part: String) extends SemanticError {
+    def message = "Invalid selector for DATE_PART: " + part + " (expected \"century\", \"day\", etc.)"
+  }
 
   // TODO: Add other prisms when necessary (unless we enable the "No Any" wart first)
   val genericError: Prism[SemanticError, String] =

--- a/frontend/src/main/scala/quasar/std/date.scala
+++ b/frontend/src/main/scala/quasar/std/date.scala
@@ -17,8 +17,9 @@
 package quasar.std
 
 import quasar.Predef._
-import quasar.{Data, Func, UnaryFunc, BinaryFunc, GenericFunc, Mapping, Type, SemanticError}, SemanticError._
+import quasar.{Data, Func, UnaryFunc, GenericFunc, Mapping, Type, SemanticError}, SemanticError._
 import quasar.fp.ski._
+
 import org.threeten.bp.{Duration, Instant, LocalDate, LocalTime, Period, ZoneOffset}
 import scalaz._, Validation.success
 import shapeless.{Data => _, _}
@@ -57,15 +58,58 @@ trait DateLib extends Library {
   // NB: SQL specifies a function called `extract`, but that doesn't have comma-
   //     separated arguments. `date_part` is Postgres’ name for the same thing
   //     with commas.
-  val Extract = BinaryFunc(
-    Mapping,
-    "date_part",
-    "Pulls out a part of the date. The first argument is one of the strings defined for Postgres’ `date_type function. This is a partial function – using an unsupported string has undefined results.",
-    Type.Numeric,
-    Func.Input2(Type.Str, Type.Temporal),
-    noSimplification,
-    constTyper[nat._2](Type.Numeric),
-    basicUntyper)
+
+  private def extract(name: String, help: String) =
+    UnaryFunc(
+      Mapping, name, help,
+      Type.Numeric,
+      Func.Input1(Type.Temporal),
+      noSimplification,
+      constTyper[nat._1](Type.Numeric),
+      basicUntyper)
+
+  val ExtractCentury      = extract("extract_century",
+    "Pulls out the century subfield from a date/time value (currently year/100).")
+  val ExtractDayOfMonth   = extract("extract_day_of_month",
+    "Pulls out the day of month (`day`) subfield from a date/time value (1-31).")
+  val ExtractDecade       = extract("extract_decade",
+    "Pulls out the decade subfield from a date/time value (year/10).")
+  val ExtractDayOfWeek    = extract("extract_day_of_week",
+    "Pulls out the day of week (`dow`) subfield from a date/time value " +
+    "(Sunday: 0 to Saturday: 7).")
+  val ExtractDayOfYear    = extract("extract_day_of_year",
+    "Pulls out the day of year (`doy`) subfield from a date/time value.")
+  val ExtractEpoch        = extract("extract_epoch",
+    "Pulls out the epoch subfield from a date/time value. For dates and " +
+    "timestamps, this is the number of seconds since midnight, 1970-01-01. " +
+    "For intervals, the number of seconds in the interval.")
+  val ExtractHour         = extract("extract_hour",
+    "Pulls out the hour subfield from a date/time value (0-23).")
+  val ExtractIsoDayOfWeek       = extract("extract_iso_day_of_week",
+    "Pulls out the ISO day of week (`isodow`) subfield from a date/time value " +
+    "(Monday: 1 to Sunday: 7).")
+  val ExtractIsoYear      = extract("extract_iso_year",
+    "Pulls out the ISO year (`isoyear`) subfield from a date/time value (based " +
+    "on the first week containing Jan. 4).")
+  val ExtractMicroseconds = extract("extract_microseconds",
+    "Pulls out the microseconds subfield from a date/time value (including seconds).")
+  val ExtractMillenium    = extract("extract_millenium",
+    "Pulls out the millenium subfield from a date/time value (currently year/1000).")
+  val ExtractMilliseconds = extract("extract_milliseconds",
+    "Pulls out the milliseconds subfield from a date/time value (including seconds).")
+  val ExtractMinute       = extract("extract_minute",
+    "Pulls out the minute subfield from a date/time value (0-59).")
+  val ExtractMonth        = extract("extract_month",
+    "Pulls out the month subfield from a date/time value (1-12).")
+  val ExtractQuarter      = extract("extract_quarter",
+    "Pulls out the quarter subfield from a date/time value (1-4).")
+  val ExtractSecond = extract("extract_second",
+    "Pulls out the second subfield from a date/time value (0-59, with fractional parts).")
+  // TODO: Timezone, TimezoneHour, TimezoneMinute
+  val ExtractWeek = extract("extract_week",
+    "Pulls out the week subfield from a date/time value (1-53).")
+  val ExtractYear = extract("extract_year",
+    "Pulls out the year subfield from a date/time value.")
 
   val Date = UnaryFunc(
     Mapping,
@@ -146,9 +190,14 @@ trait DateLib extends Library {
     basicUntyper)
 
   def unaryFunctions: List[GenericFunc[nat._1]] =
+    ExtractCentury :: ExtractDayOfMonth :: ExtractDecade :: ExtractDayOfWeek ::
+    ExtractDayOfYear :: ExtractEpoch :: ExtractHour :: ExtractIsoDayOfWeek ::
+    ExtractIsoYear :: ExtractMicroseconds :: ExtractMillenium ::
+    ExtractMilliseconds :: ExtractMinute :: ExtractMonth :: ExtractQuarter ::
+    ExtractSecond :: ExtractWeek :: ExtractYear ::
     Date :: Time :: Timestamp :: Interval :: TimeOfDay :: ToTimestamp :: Nil
 
-  def binaryFunctions: List[GenericFunc[nat._2]] = Extract :: Nil
+  def binaryFunctions: List[GenericFunc[nat._2]] = Nil
   def ternaryFunctions: List[GenericFunc[nat._3]] = Nil
 }
 

--- a/frontend/src/main/scala/quasar/std/date.scala
+++ b/frontend/src/main/scala/quasar/std/date.scala
@@ -78,7 +78,7 @@ trait DateLib extends Library {
     "Pulls out the day of week (`dow`) subfield from a date/time value " +
     "(Sunday: 0 to Saturday: 7).")
   val ExtractDayOfYear    = extract("extract_day_of_year",
-    "Pulls out the day of year (`doy`) subfield from a date/time value.")
+    "Pulls out the day of year (`doy`) subfield from a date/time value (1-365 or -366).")
   val ExtractEpoch        = extract("extract_epoch",
     "Pulls out the epoch subfield from a date/time value. For dates and " +
     "timestamps, this is the number of seconds since midnight, 1970-01-01. " +

--- a/frontend/src/main/scala/quasar/std/date.scala
+++ b/frontend/src/main/scala/quasar/std/date.scala
@@ -93,8 +93,8 @@ trait DateLib extends Library {
     "on the first week containing Jan. 4).")
   val ExtractMicroseconds = extract("extract_microseconds",
     "Pulls out the microseconds subfield from a date/time value (including seconds).")
-  val ExtractMillenium    = extract("extract_millenium",
-    "Pulls out the millenium subfield from a date/time value (currently year/1000).")
+  val ExtractMillennium    = extract("extract_millennium",
+    "Pulls out the millennium subfield from a date/time value (currently year/1000).")
   val ExtractMilliseconds = extract("extract_milliseconds",
     "Pulls out the milliseconds subfield from a date/time value (including seconds).")
   val ExtractMinute       = extract("extract_minute",
@@ -197,7 +197,7 @@ trait DateLib extends Library {
   def unaryFunctions: List[GenericFunc[nat._1]] =
     ExtractCentury :: ExtractDayOfMonth :: ExtractDecade :: ExtractDayOfWeek ::
     ExtractDayOfYear :: ExtractEpoch :: ExtractHour :: ExtractIsoDayOfWeek ::
-    ExtractIsoYear :: ExtractMicroseconds :: ExtractMillenium ::
+    ExtractIsoYear :: ExtractMicroseconds :: ExtractMillennium ::
     ExtractMilliseconds :: ExtractMinute :: ExtractMonth :: ExtractQuarter ::
     ExtractSecond :: ExtractWeek :: ExtractYear ::
     Date :: Time :: Timestamp :: Interval :: TimeOfDay :: ToTimestamp :: Nil

--- a/frontend/src/main/scala/quasar/std/date.scala
+++ b/frontend/src/main/scala/quasar/std/date.scala
@@ -105,7 +105,12 @@ trait DateLib extends Library {
     "Pulls out the quarter subfield from a date/time value (1-4).")
   val ExtractSecond = extract("extract_second",
     "Pulls out the second subfield from a date/time value (0-59, with fractional parts).")
-  // TODO: Timezone, TimezoneHour, TimezoneMinute
+  val ExtractTimezone = extract("extract_timezone",
+    "Pulls out the timezone subfield from a date/time value (in seconds east of UTC).")
+  val ExtractTimezoneHour = extract("extract_timezone_hour",
+    "Pulls out the hour component of the timezone subfield from a date/time value.")
+  val ExtractTimezoneMinute = extract("extract_timezone_minute",
+    "Pulls out the minute component of the timezone subfield from a date/time value.")
   val ExtractWeek = extract("extract_week",
     "Pulls out the week subfield from a date/time value (1-53).")
   val ExtractYear = extract("extract_year",

--- a/frontend/src/main/scala/quasar/std/math.scala
+++ b/frontend/src/main/scala/quasar/std/math.scala
@@ -233,7 +233,7 @@ trait MathLib extends Library {
       case Sized(v1, TOne() ) => success(v1)
       case Sized(v1, TZero()) => failure(NonEmptyList(GenericError("Division by zero")))
 
-      case Sized(Type.Const(Data.Int(v1)), Type.Const(Data.Int(v2)))       => success(Type.Const(Data.Int(v1 / v2)))
+      case Sized(Type.Const(Data.Int(v1)), Type.Const(Data.Int(v2)))       => success(Type.Const(Data.Dec(BigDecimal(v1) / BigDecimal(v2))))
       case Sized(Type.Const(Data.Number(v1)), Type.Const(Data.Number(v2))) => success(Type.Const(Data.Dec(v1 / v2)))
 
       // TODO: handle interval divided by Dec (not provided by threeten). See SD-582.
@@ -256,7 +256,7 @@ trait MathLib extends Library {
     Mapping,
     "-",
     "Reverses the sign of a numeric or interval value",
-    MathRel, 
+    MathRel,
     Func.Input1(MathRel),
     noSimplification,
     partialTyperV[nat._1] {
@@ -272,16 +272,16 @@ trait MathLib extends Library {
     })
 
   val Modulo = BinaryFunc(
-    Mapping, 
+    Mapping,
     "(%)",
     "Finds the remainder of one number divided by another",
     MathRel,
     Func.Input2(MathRel, Type.Numeric),
     noSimplification,
     (partialTyperV[nat._2] {
-      case Sized(v1, TOne())  => success(v1)
       case Sized(v1, TZero()) => failure(NonEmptyList(GenericError("Division by zero")))
 
+      case Sized(v1 @ Type.Const(Data.Int(_)), TOne())                     => success(TZero())
       case Sized(Type.Const(Data.Int(v1)), Type.Const(Data.Int(v2)))       => success(Type.Const(Data.Int(v1 % v2)))
       case Sized(Type.Const(Data.Number(v1)), Type.Const(Data.Number(v2))) => success(Type.Const(Data.Dec(v1 % v2)))
     }) ||| numericWidening,

--- a/frontend/src/test/scala/quasar/std/SimplifyStdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/SimplifyStdLibSpec.scala
@@ -46,7 +46,7 @@ class SimplifyStdLibSpec extends StdLibSpec {
     case (date.ExtractIsoDayOfWeek, _) => notHandled
     case (date.ExtractIsoYear, _) => notHandled
     case (date.ExtractMicroseconds, _) => notHandled
-    case (date.ExtractMillenium, _) => notHandled
+    case (date.ExtractMillennium, _) => notHandled
     case (date.ExtractMilliseconds, _) => notHandled
     case (date.ExtractMinute, _) => notHandled
     case (date.ExtractMonth, _) => notHandled

--- a/frontend/src/test/scala/quasar/std/SimplifyStdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/SimplifyStdLibSpec.scala
@@ -19,6 +19,7 @@ package quasar.std
 import quasar.Predef._
 import quasar.{Data, GenericFunc, LogicalPlan}, LogicalPlan._
 import quasar.fp._
+import quasar.std.StdLib._
 
 import matryoshka._, Recursive.ops._
 import org.specs2.execute._
@@ -29,7 +30,11 @@ import shapeless.Nat
 /** Test the typers and simplifiers defined in the std lib functions themselves.
   */
 class SimplifyStdLibSpec extends StdLibSpec {
+  val notHandled: Result \/ Unit = Skipped("not simplified").left
+
   def shortCircuit[N <: Nat](func: GenericFunc[N], args: List[Data]): Result \/ Unit = (func, args) match {
+    case (relations.Between, _) => notHandled
+
     case _ => ().right
   }
 

--- a/frontend/src/test/scala/quasar/std/SimplifyStdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/SimplifyStdLibSpec.scala
@@ -36,6 +36,25 @@ class SimplifyStdLibSpec extends StdLibSpec {
   def shortCircuit[N <: Nat](func: GenericFunc[N], args: List[Data]): Result \/ Unit = (func, args) match {
     case (relations.Between, _) => notHandled
 
+    case (date.ExtractCentury, _) => notHandled
+    case (date.ExtractDayOfMonth, _) => notHandled
+    case (date.ExtractDecade, _) => notHandled
+    case (date.ExtractDayOfWeek, _) => notHandled
+    case (date.ExtractDayOfYear, _) => notHandled
+    case (date.ExtractEpoch, _) => notHandled
+    case (date.ExtractHour, _) => notHandled
+    case (date.ExtractIsoDayOfWeek, _) => notHandled
+    case (date.ExtractIsoYear, _) => notHandled
+    case (date.ExtractMicroseconds, _) => notHandled
+    case (date.ExtractMillenium, _) => notHandled
+    case (date.ExtractMilliseconds, _) => notHandled
+    case (date.ExtractMinute, _) => notHandled
+    case (date.ExtractMonth, _) => notHandled
+    case (date.ExtractQuarter, _) => notHandled
+    case (date.ExtractSecond, _) => notHandled
+    case (date.ExtractWeek, _) => notHandled
+    case (date.ExtractYear, _) => notHandled
+
     case _ => ().right
   }
 

--- a/frontend/src/test/scala/quasar/std/SimplifyStdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/SimplifyStdLibSpec.scala
@@ -18,7 +18,8 @@ package quasar.std
 
 import quasar.Predef._
 import quasar.{Data, GenericFunc, LogicalPlan}, LogicalPlan._
-import quasar.fp._
+import quasar.RenderTree.ops._
+import quasar.fp.ski._
 import quasar.std.StdLib._
 
 import matryoshka._, Recursive.ops._
@@ -51,7 +52,7 @@ class SimplifyStdLibSpec extends StdLibSpec {
   def run(lp: Fix[LogicalPlan], expected: Data): Result =
     ensureCorrectTypes(lp).disjunction match {
       case  \/-(Fix(LogicalPlan.ConstantF(d))) => (d must closeTo(expected)).toResult
-      case  \/-(v) => Failure("not a constant", v.shows)
+      case  \/-(v) => Failure("not a constant", v.render.shows)
       case -\/ (err) => Failure("simplification failed", err.toString)
     }
 

--- a/frontend/src/test/scala/quasar/std/SimplifyStdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/SimplifyStdLibSpec.scala
@@ -17,41 +17,64 @@
 package quasar.std
 
 import quasar.Predef._
-import quasar.{Data, LogicalPlan}, LogicalPlan._
+import quasar.{Data, GenericFunc, LogicalPlan}, LogicalPlan._
+import quasar.fp._
 
-import matryoshka._
+import matryoshka._, Recursive.ops._
 import org.specs2.execute._
 import org.scalacheck.Arbitrary, Arbitrary._
+import scalaz.{Failure => _, _}, Scalaz._
+import shapeless.Nat
 
 /** Test the typers and simplifiers defined in the std lib functions themselves.
   */
 class SimplifyStdLibSpec extends StdLibSpec {
-  def run(lp: Fix[LogicalPlan], expected: Data): Result = {
-    val simple = ensureCorrectTypes(lp).disjunction
-    (simple must beRightDisjunction(LogicalPlan.Constant(expected))).toResult
+  def shortCircuit[N <: Nat](func: GenericFunc[N], args: List[Data]): Result \/ Unit = (func, args) match {
+    case _ => ().right
   }
 
+  /** Identify constructs that are expected not to be implemented. */
+  def shortCircuitLP(args: List[Data]): AlgebraM[Result \/ ?, LogicalPlan, Unit] = {
+    case LogicalPlan.InvokeF(func, _) => shortCircuit(func, args)
+    case _ => ().right
+  }
+
+  def check(args: List[Data], prg: List[Fix[LogicalPlan]] => Fix[LogicalPlan]): Option[Result] =
+    prg((0 until args.length).toList.map(idx => LogicalPlan.Free(Symbol("arg" + idx))))
+      .cataM[Result \/ ?, Unit](shortCircuitLP(args)).swap.toOption
+
+  def run(lp: Fix[LogicalPlan], expected: Data): Result =
+    ensureCorrectTypes(lp).disjunction match {
+      case  \/-(Fix(LogicalPlan.ConstantF(d))) => (d must closeTo(expected)).toResult
+      case  \/-(v) => Failure("not a constant", v.shows)
+      case -\/ (err) => Failure("simplification failed", err.toString)
+    }
+
   val runner = new StdLibTestRunner {
-      def nullary(prg: Fix[LogicalPlan], expected: Data) =
+    def nullary(prg: Fix[LogicalPlan], expected: Data) =
+      check(Nil, κ(prg)) getOrElse
         run(prg, expected)
 
-      def unary(prg: Fix[LogicalPlan] => Fix[LogicalPlan], arg: Data, expected: Data) =
+    def unary(prg: Fix[LogicalPlan] => Fix[LogicalPlan], arg: Data, expected: Data) =
+      check(List(arg), { case List(arg1) => prg(arg1) }) getOrElse
         run(prg(LogicalPlan.Constant(arg)), expected)
 
-      def binary(prg: (Fix[LogicalPlan], Fix[LogicalPlan]) => Fix[LogicalPlan], arg1: Data, arg2: Data, expected: Data) =
+    def binary(prg: (Fix[LogicalPlan], Fix[LogicalPlan]) => Fix[LogicalPlan], arg1: Data, arg2: Data, expected: Data) =
+      check(List(arg1, arg2), { case List(arg1, arg2) => prg(arg1, arg2) }) getOrElse
         run(prg(LogicalPlan.Constant(arg1), LogicalPlan.Constant(arg2)), expected)
 
-      def ternary(prg: (Fix[LogicalPlan], Fix[LogicalPlan], Fix[LogicalPlan]) => Fix[LogicalPlan], arg1: Data, arg2: Data, arg3: Data, expected: Data) =
+    def ternary(prg: (Fix[LogicalPlan], Fix[LogicalPlan], Fix[LogicalPlan]) => Fix[LogicalPlan], arg1: Data, arg2: Data, arg3: Data, expected: Data) =
+      check(List(arg1, arg2, arg3), { case List(arg1, arg2, arg3) => prg(arg1, arg2, arg3) }) getOrElse
         run(prg(LogicalPlan.Constant(arg1), LogicalPlan.Constant(arg2), LogicalPlan.Constant(arg3)), expected)
 
-      def intDomain = arbitrary[BigInt]
+    def intDomain = arbitrary[BigInt]
 
-      // NB: BigDecimal parsing cannot handle values that are too close to the
-      // edges of its range.
-      def decDomain = arbitrary[BigDecimal].filter(i => i.scale > Int.MinValue && i.scale < Int.MaxValue)
+    // NB: BigDecimal parsing cannot handle values that are too close to the
+    // edges of its range.
+    def decDomain = arbitrary[BigDecimal].filter(i => i.scale > Int.MinValue && i.scale < Int.MaxValue)
 
-      def stringDomain = arbitrary[String]
-    }
+    def stringDomain = arbitrary[String]
+  }
 
   tests(runner)
 }

--- a/frontend/src/test/scala/quasar/std/StdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/StdLibSpec.scala
@@ -559,6 +559,10 @@ abstract class StdLibSpec extends Qspec {
         }
       }
 
+      // TODO: ExtractTimezone
+      // TODO: ExtractTimezoneHour
+      // TODO: ExtractTimezoneMinute
+
       "ExtractWeek" >> {
         // NB: current implementation, which is not consistent with IsoYear
 

--- a/frontend/src/test/scala/quasar/std/StdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/StdLibSpec.scala
@@ -787,8 +787,11 @@ abstract class StdLibSpec extends Qspec {
           binary(Eq(_, _).embed, x, x, Data.Bool(true))
         }
 
-        "any non-numeric values with different types" >> prop { (x: Data, y: Data) =>
-          x.dataType != y.dataType ==>
+        "any values with different types" >> prop { (x: Data, y: Data) =>
+          // ...provide they are not both Numeric (Int | Dec)
+          (x.dataType != y.dataType &&
+            !((Type.Numeric contains x.dataType) &&
+              (Type.Numeric contains y.dataType))) ==>
             binary(Eq(_, _).embed, x, y, Data.Bool(false))
         }
 
@@ -824,7 +827,7 @@ abstract class StdLibSpec extends Qspec {
           binary(Neq(_, _).embed, x, x, Data.Bool(false))
         }
 
-        "anyvalues with different types" >> prop { (x: Data, y: Data) =>
+        "any values with different types" >> prop { (x: Data, y: Data) =>
           // ...provide they are not both Numeric (Int | Dec)
           (x.dataType != y.dataType &&
             !((Type.Numeric contains x.dataType) &&

--- a/frontend/src/test/scala/quasar/std/StdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/StdLibSpec.scala
@@ -197,6 +197,9 @@ abstract class StdLibSpec extends Qspec {
         }
 
         "dec" >> prop { (x: BigDecimal) =>
+          // TODO: re-parse and compare the resulting value approximately. It's
+          // not reasonable to expect a perfect match on formatted values,
+          // because of trailing zeros, round-off, and choive of notation.
           unary(ToString(_).embed, Data.Dec(x), Data.Str(x.toString))
         }
 

--- a/frontend/src/test/scala/quasar/std/StdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/StdLibSpec.scala
@@ -17,7 +17,7 @@
 package quasar.std
 
 import quasar.Predef._
-import quasar.{Data, LogicalPlan, Qspec}, LogicalPlan._
+import quasar.{Data, LogicalPlan, Qspec, Type}, LogicalPlan._
 
 import matryoshka._
 import org.specs2.execute._
@@ -824,8 +824,11 @@ abstract class StdLibSpec extends Qspec {
           binary(Neq(_, _).embed, x, x, Data.Bool(false))
         }
 
-        "any non-numeric values with different types" >> prop { (x: Data, y: Data) =>
-          x.dataType != y.dataType ==>
+        "anyvalues with different types" >> prop { (x: Data, y: Data) =>
+          // ...provide they are not both Numeric (Int | Dec)
+          (x.dataType != y.dataType &&
+            !((Type.Numeric contains x.dataType) &&
+              (Type.Numeric contains y.dataType))) ==>
             binary(Neq(_, _).embed, x, y, Data.Bool(true))
         }
 

--- a/frontend/src/test/scala/quasar/std/StdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/StdLibSpec.scala
@@ -91,6 +91,12 @@ abstract class StdLibSpec extends Qspec {
     implicit val arbBigInt = Arbitrary[BigInt] { runner.intDomain }
     implicit val arbBigDecimal = Arbitrary[BigDecimal] { runner.decDomain }
     implicit val arbString = Arbitrary[String] { runner.stringDomain }
+    implicit val arbData = Arbitrary[Data] {
+      Gen.oneOf(
+        runner.intDomain.map(Data.Int(_)),
+        runner.decDomain.map(Data.Dec(_)),
+        runner.stringDomain.map(Data.Str(_)))
+    }
 
     def commute(
         prg: (Fix[LogicalPlan], Fix[LogicalPlan]) => Fix[LogicalPlan],
@@ -404,6 +410,290 @@ abstract class StdLibSpec extends Qspec {
         // "mixed int/double" >> prop { (x: Int, y: Double) =>
         //   commute(Modulo(_, _).embed, Data.Int(x), Data.Dec(y), Data.Dec(x % y))
         // }
+      }
+    }
+
+    "RelationsLib" >> {
+      import RelationsLib._
+
+      "Eq" >> {
+        "any Int with self" >> prop { (x: BigInt) =>
+          binary(Eq(_, _).embed, Data.Int(x), Data.Int(x), Data.Bool(true))
+        }
+
+        "any two Ints" >> prop { (x: BigInt, y: BigInt) =>
+          binary(Eq(_, _).embed, Data.Int(x), Data.Int(y), Data.Bool(x == y))
+        }
+
+        "any Dec with self" >> prop { (x: BigDecimal) =>
+          binary(Eq(_, _).embed, Data.Dec(x), Data.Dec(x), Data.Bool(true))
+        }
+
+        "any two Decs" >> prop { (x: BigDecimal, y: BigDecimal) =>
+          binary(Eq(_, _).embed, Data.Dec(x), Data.Dec(y), Data.Bool(x == y))
+        }
+
+        "any Str with self" >> prop { (x: String) =>
+          binary(Eq(_, _).embed, Data.Str(x), Data.Str(x), Data.Bool(true))
+        }
+
+        "any two Strs" >> prop { (x: String, y: String) =>
+          binary(Eq(_, _).embed, Data.Str(x), Data.Str(y), Data.Bool(x == y))
+        }
+
+        "any value with self" >> prop { (x: Data) =>
+          binary(Eq(_, _).embed, x, x, Data.Bool(true))
+        }
+
+        "any non-numeric values with different types" >> prop { (x: Data, y: Data) =>
+          x.dataType != y.dataType ==>
+            binary(Eq(_, _).embed, x, y, Data.Bool(false))
+        }
+
+        // TODO: the rest of the types
+      }
+
+      "Neq" >> {
+        "any Int with self" >> prop { (x: BigInt) =>
+          binary(Neq(_, _).embed, Data.Int(x), Data.Int(x), Data.Bool(false))
+        }
+
+        "any two Ints" >> prop { (x: BigInt, y: BigInt) =>
+          binary(Neq(_, _).embed, Data.Int(x), Data.Int(y), Data.Bool(x != y))
+        }
+
+        "any Dec with self" >> prop { (x: BigDecimal) =>
+          binary(Neq(_, _).embed, Data.Dec(x), Data.Dec(x), Data.Bool(false))
+        }
+
+        "any two Decs" >> prop { (x: BigDecimal, y: BigDecimal) =>
+          binary(Neq(_, _).embed, Data.Dec(x), Data.Dec(y), Data.Bool(x != y))
+        }
+
+        "any Str with self" >> prop { (x: String) =>
+          binary(Neq(_, _).embed, Data.Str(x), Data.Str(x), Data.Bool(false))
+        }
+
+        "any two Strs" >> prop { (x: String, y: String) =>
+          binary(Neq(_, _).embed, Data.Str(x), Data.Str(y), Data.Bool(x != y))
+        }
+
+        "any value with self" >> prop { (x: Data) =>
+          binary(Neq(_, _).embed, x, x, Data.Bool(false))
+        }
+
+        "any non-numeric values with different types" >> prop { (x: Data, y: Data) =>
+          x.dataType != y.dataType ==>
+            binary(Neq(_, _).embed, x, y, Data.Bool(true))
+        }
+
+        // TODO: the rest of the types
+      }
+
+      "Lt" >> {
+        "any Int with self" >> prop { (x: BigInt) =>
+          binary(Lt(_, _).embed, Data.Int(x), Data.Int(x), Data.Bool(false))
+        }
+
+        "any two Ints" >> prop { (x: BigInt, y: BigInt) =>
+          binary(Lt(_, _).embed, Data.Int(x), Data.Int(y), Data.Bool(x < y))
+        }
+
+        "any Dec with self" >> prop { (x: BigDecimal) =>
+          binary(Lt(_, _).embed, Data.Dec(x), Data.Dec(x), Data.Bool(false))
+        }
+
+        "any two Decs" >> prop { (x: BigDecimal, y: BigDecimal) =>
+          binary(Lt(_, _).embed, Data.Dec(x), Data.Dec(y), Data.Bool(x < y))
+        }
+
+        "any Str with self" >> prop { (x: String) =>
+          binary(Lt(_, _).embed, Data.Str(x), Data.Str(x), Data.Bool(false))
+        }
+
+        "any two Strs" >> prop { (x: String, y: String) =>
+          binary(Lt(_, _).embed, Data.Str(x), Data.Str(y), Data.Bool(x < y))
+        }
+
+        // TODO: Timestamp, Interval, cross-type comparison
+      }
+
+      "Lte" >> {
+        "any Int with self" >> prop { (x: BigInt) =>
+          binary(Lte(_, _).embed, Data.Int(x), Data.Int(x), Data.Bool(true))
+        }
+
+        "any two Ints" >> prop { (x: BigInt, y: BigInt) =>
+          binary(Lte(_, _).embed, Data.Int(x), Data.Int(y), Data.Bool(x <= y))
+        }
+
+        "any Dec with self" >> prop { (x: BigDecimal) =>
+          binary(Lte(_, _).embed, Data.Dec(x), Data.Dec(x), Data.Bool(true))
+        }
+
+        "any two Decs" >> prop { (x: BigDecimal, y: BigDecimal) =>
+          binary(Lte(_, _).embed, Data.Dec(x), Data.Dec(y), Data.Bool(x <= y))
+        }
+
+        "any Str with self" >> prop { (x: String) =>
+          binary(Lte(_, _).embed, Data.Str(x), Data.Str(x), Data.Bool(true))
+        }
+
+        "any two Strs" >> prop { (x: String, y: String) =>
+          binary(Lte(_, _).embed, Data.Str(x), Data.Str(y), Data.Bool(x <= y))
+        }
+
+        // TODO: Timestamp, Interval, cross-type comparison
+      }
+
+      "Gt" >> {
+        "any Int with self" >> prop { (x: BigInt) =>
+          binary(Gt(_, _).embed, Data.Int(x), Data.Int(x), Data.Bool(false))
+        }
+
+        "any two Ints" >> prop { (x: BigInt, y: BigInt) =>
+          binary(Gt(_, _).embed, Data.Int(x), Data.Int(y), Data.Bool(x > y))
+        }
+
+        "any Dec with self" >> prop { (x: BigDecimal) =>
+          binary(Gt(_, _).embed, Data.Dec(x), Data.Dec(x), Data.Bool(false))
+        }
+
+        "any two Decs" >> prop { (x: BigDecimal, y: BigDecimal) =>
+          binary(Gt(_, _).embed, Data.Dec(x), Data.Dec(y), Data.Bool(x > y))
+        }
+
+        "any Str with self" >> prop { (x: String) =>
+          binary(Gt(_, _).embed, Data.Str(x), Data.Str(x), Data.Bool(false))
+        }
+
+        "any two Strs" >> prop { (x: String, y: String) =>
+          binary(Gt(_, _).embed, Data.Str(x), Data.Str(y), Data.Bool(x > y))
+        }
+
+        // TODO: Timestamp, Interval, cross-type comparison
+      }
+
+      "Gte" >> {
+        "any Int with self" >> prop { (x: BigInt) =>
+          binary(Gte(_, _).embed, Data.Int(x), Data.Int(x), Data.Bool(true))
+        }
+
+        "any two Ints" >> prop { (x: BigInt, y: BigInt) =>
+          binary(Gte(_, _).embed, Data.Int(x), Data.Int(y), Data.Bool(x >= y))
+        }
+
+        "any Dec with self" >> prop { (x: BigDecimal) =>
+          binary(Gte(_, _).embed, Data.Dec(x), Data.Dec(x), Data.Bool(true))
+        }
+
+        "any two Decs" >> prop { (x: BigDecimal, y: BigDecimal) =>
+          binary(Gte(_, _).embed, Data.Dec(x), Data.Dec(y), Data.Bool(x >= y))
+        }
+
+        "any Str with self" >> prop { (x: String) =>
+          binary(Gte(_, _).embed, Data.Str(x), Data.Str(x), Data.Bool(true))
+        }
+
+        "any two Strs" >> prop { (x: String, y: String) =>
+          binary(Gte(_, _).embed, Data.Str(x), Data.Str(y), Data.Bool(x >= y))
+        }
+
+        // TODO: Timestamp, Interval, cross-type comparison
+      }
+
+      "Between" >> {
+        "any Int with self" >> prop { (x: BigInt) =>
+          ternary(Between(_, _, _).embed, Data.Int(x), Data.Int(x), Data.Int(x), Data.Bool(true))
+        }
+
+        "any three Ints" >> prop { (x1: BigInt, x2: BigInt, x3: BigInt) =>
+          val xs = List(x1, x2, x3).sorted
+          ternary(Between(_, _, _).embed, Data.Int(xs(0)), Data.Int(xs(1)), Data.Int(xs(2)), Data.Bool(true))
+        }
+
+        "any Dec with self" >> prop { (x: BigDecimal) =>
+          ternary(Between(_, _, _).embed, Data.Dec(x), Data.Dec(x), Data.Dec(x), Data.Bool(true))
+        }
+
+        "any three Decs" >> prop { (x1: BigDecimal, x2: BigDecimal, x3: BigDecimal) =>
+          val xs = List(x1, x2, x3).sorted
+          ternary(Between(_, _, _).embed, Data.Dec(xs(0)), Data.Dec(xs(1)), Data.Dec(xs(2)), Data.Bool(true))
+        }
+
+        "any Str with self" >> prop { (x: String) =>
+          ternary(Between(_, _, _).embed, Data.Str(x), Data.Str(x), Data.Str(x), Data.Bool(true))
+        }
+
+        "any three Strs" >> prop { (x1: String, x2: String, x3: String) =>
+          val xs = List(x1, x2, x3).sorted
+          ternary(Between(_, _, _).embed, Data.Str(xs(0)), Data.Str(xs(1)), Data.Str(xs(2)), Data.Bool(true))
+        }
+
+        // TODO: Timestamp, Interval, cross-type comparison
+      }
+
+      // TODO: can this be tested?
+      // "IfUndefined" >> {
+      // }
+
+      "And" >> {
+        "false, false" >> {
+          binary(And(_, _).embed, Data.Bool(false), Data.Bool(false), Data.Bool(false))
+        }
+
+        "false, true" >> {
+          commute(And(_, _).embed, Data.Bool(false), Data.Bool(true), Data.Bool(false))
+        }
+
+        "true, true" >> {
+          binary(And(_, _).embed, Data.Bool(true), Data.Bool(true), Data.Bool(true))
+        }
+      }
+
+      "Or" >> {
+        "false, false" >> {
+          binary(Or(_, _).embed, Data.Bool(false), Data.Bool(false), Data.Bool(false))
+        }
+
+        "false, true" >> {
+          commute(Or(_, _).embed, Data.Bool(false), Data.Bool(true), Data.Bool(true))
+        }
+
+        "true, true" >> {
+          binary(Or(_, _).embed, Data.Bool(true), Data.Bool(true), Data.Bool(true))
+        }
+      }
+
+      "Not" >> {
+        "false" >> {
+          unary(Not(_).embed, Data.Bool(false), Data.Bool(true))
+        }
+
+        "true" >> {
+          unary(Not(_).embed, Data.Bool(true), Data.Bool(false))
+        }
+      }
+
+      "Cond" >> {
+        "true" >> prop { (x: Data, y: Data) =>
+          ternary(Cond(_, _, _).embed, Data.Bool(true), x, y, x)
+        }
+
+        "false" >> prop { (x: Data, y: Data) =>
+          ternary(Cond(_, _, _).embed, Data.Bool(false), x, y, y)
+        }
+      }
+
+      "Coalesce" >> {
+        "null" >> prop { (x: Data) =>
+          binary(Coalesce(_, _).embed, Data.Null, x, x)
+        }
+
+        "non-null" >> prop { (x: Data, y: Data) =>
+          x != Data.Null ==>
+            binary(Coalesce(_, _).embed, x, y, x)
+        }
       }
     }
   }

--- a/frontend/src/test/scala/quasar/std/StdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/StdLibSpec.scala
@@ -642,10 +642,12 @@ abstract class StdLibSpec extends Qspec {
           binary(Multiply(_, _).embed, Data.Int(x), Data.Int(y), Data.Int(x.toLong * y.toLong))
         }
 
+        // TODO: figure out what domain can be tested here (tends to overflow)
         // "any doubles" >> prop { (x: Double, y: Double) =>
         //   binary(Multiply(_, _).embed, Data.Dec(x), Data.Dec(y), Data.Dec(x * y))
         // }
 
+        // TODO: figure out what domain can be tested here
         // "mixed int/double" >> prop { (x: Int, y: Double) =>
         //   commute(Multiply(_, _).embed, Data.Int(x), Data.Dec(y), Data.Dec(x * y))
         // }
@@ -676,6 +678,7 @@ abstract class StdLibSpec extends Qspec {
             binary(Power(_, _).embed, Data.Int(0), Data.Int(y), Data.Int(0))
         }
 
+        // TODO: figure out what domain can be tested here (negatives?)
         // "0 to Dec" >> prop { (y: BigDecimal) =>
         //   y != 0 ==>
         //     binary(Power(_, _).embed, Data.Int(0), Data.Dec(y), Data.Int(0))
@@ -714,10 +717,12 @@ abstract class StdLibSpec extends Qspec {
             binary(Divide(_, _).embed, Data.Int(x), Data.Int(y), Data.Dec(x.toDouble / y.toDouble))
         }
 
+        // TODO: figure out what domain can be tested here
         // "any doubles" >> prop { (x: Double, y: Double) =>
         //   binary(Divide(_, _).embed, Data.Dec(x), Data.Dec(y), Data.Dec(x / y))
         // }
 
+        // TODO: figure out what domain can be tested here
         // "mixed int/double" >> prop { (x: Int, y: Double) =>
         //   commute(Divide(_, _).embed, Data.Int(x), Data.Dec(y), Data.Dec(x / y))
         // }
@@ -749,10 +754,12 @@ abstract class StdLibSpec extends Qspec {
             binary(Modulo(_, _).embed, Data.Int(x), Data.Int(y), Data.Int(BigInt(x) % BigInt(y)))
         }
 
+        // TODO: figure out what domain can be tested here
         // "any doubles" >> prop { (x: Double, y: Double) =>
         //   binary(Modulo(_, _).embed, Data.Dec(x), Data.Dec(y), Data.Dec(x % y))
         // }
 
+        // TODO: figure out what domain can be tested here
         // "mixed int/double" >> prop { (x: Int, y: Double) =>
         //   commute(Modulo(_, _).embed, Data.Int(x), Data.Dec(y), Data.Dec(x % y))
         // }
@@ -792,7 +799,7 @@ abstract class StdLibSpec extends Qspec {
         }
 
         "any values with different types" >> prop { (x: Data, y: Data) =>
-          // ...provide they are not both Numeric (Int | Dec)
+          // ...provided they are not both Numeric (Int | Dec)
           (x.dataType != y.dataType &&
             !((Type.Numeric contains x.dataType) &&
               (Type.Numeric contains y.dataType))) ==>
@@ -832,7 +839,7 @@ abstract class StdLibSpec extends Qspec {
         }
 
         "any values with different types" >> prop { (x: Data, y: Data) =>
-          // ...provide they are not both Numeric (Int | Dec)
+          // ...provided they are not both Numeric (Int | Dec)
           (x.dataType != y.dataType &&
             !((Type.Numeric contains x.dataType) &&
               (Type.Numeric contains y.dataType))) ==>

--- a/frontend/src/test/scala/quasar/std/StdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/StdLibSpec.scala
@@ -23,7 +23,7 @@ import matryoshka._
 import org.specs2.execute._
 import org.specs2.matcher._
 import org.scalacheck.{Arbitrary, Gen}
-import org.threeten.bp.{Instant, ZoneOffset}
+import org.threeten.bp.{Instant, LocalDate, ZoneOffset}
 import scala.math.abs
 
 trait StdLibTestRunner {
@@ -73,10 +73,10 @@ abstract class StdLibSpec extends Qspec {
     def apply[S <: Data](s: Expectable[S]) = {
       val v = s.value
       (v, expected) match {
-        case (Data.Dec(x), Data.Dec(exp)) =>
+        case (Data.Number(x), Data.Number(exp)) =>
           result(isClose(x, exp, 1e-9),
-            s"$x is Dec and matches $exp",
-            s"$x is Dec but does not match $exp", s)
+            s"$x is a Number and matches $exp",
+            s"$x is a Number but does not match $exp", s)
         case _ =>
           result(v == expected,
             s"$v matches $expected",
@@ -258,6 +258,339 @@ abstract class StdLibSpec extends Qspec {
     "DateLib" >> {
       import DateLib._
 
+      "ExtractCentury" >> {
+        "0001-01-01" >> {
+          unary(ExtractCentury(_).embed, Data.Date(LocalDate.parse("0001-01-01")), Data.Int(1))
+        }
+
+        "2000-01-01" >> {
+          unary(ExtractCentury(_).embed, Data.Date(LocalDate.parse("2000-01-01")), Data.Int(20))
+        }
+
+        "2001-01-01" >> {
+          unary(ExtractCentury(_).embed, Data.Date(LocalDate.parse("2001-01-01")), Data.Int(21))
+        }
+
+        "midnight 0001-01-01" >> {
+          unary(ExtractCentury(_).embed, Data.Timestamp(Instant.parse("0001-01-01T00:00:00.000Z")), Data.Int(1))
+        }
+
+        "midnight 2000-01-01" >> {
+          unary(ExtractCentury(_).embed, Data.Timestamp(Instant.parse("2000-01-01T00:00:00.000Z")), Data.Int(20))
+        }
+
+        "midnight 2001-01-01" >> {
+          unary(ExtractCentury(_).embed, Data.Timestamp(Instant.parse("2001-01-01T00:00:00.000Z")), Data.Int(21))
+        }
+      }
+
+      "ExtractDayOfMonth" >> {
+        "2016-01-01" >> {
+          unary(ExtractDayOfMonth(_).embed, Data.Date(LocalDate.parse("2016-01-01")), Data.Int(1))
+        }
+
+        "midnight 2016-01-01" >> {
+          unary(ExtractDayOfMonth(_).embed, Data.Timestamp(Instant.parse("2016-01-01T00:00:00.000Z")), Data.Int(1))
+        }
+
+        "2016-02-29" >> {
+          unary(ExtractDayOfMonth(_).embed, Data.Date(LocalDate.parse("2016-02-29")), Data.Int(29))
+        }
+
+        "midnight 2016-02-29" >> {
+          unary(ExtractDayOfMonth(_).embed, Data.Timestamp(Instant.parse("2016-02-29T00:00:00.000Z")), Data.Int(29))
+        }
+      }
+
+      "ExtractDecade" >> {
+        "1999-12-31" >> {
+          unary(ExtractDecade(_).embed, Data.Date(LocalDate.parse("1999-12-31")), Data.Int(199))
+        }
+
+        "midnight 1999-12-31" >> {
+          unary(ExtractDecade(_).embed, Data.Timestamp(Instant.parse("1999-12-31T00:00:00.000Z")), Data.Int(199))
+        }
+      }
+
+      "ExtractDayOfWeek" >> {
+        "2016-09-28" >> {
+          unary(ExtractDayOfWeek(_).embed, Data.Date(LocalDate.parse("2016-09-28")), Data.Int(3))
+        }
+
+        "midnight 2016-09-28" >> {
+          unary(ExtractDayOfWeek(_).embed, Data.Timestamp(Instant.parse("2016-09-28T00:00:00.000Z")), Data.Int(3))
+        }
+
+        "2016-10-02" >> {
+          unary(ExtractDayOfWeek(_).embed, Data.Date(LocalDate.parse("2016-10-02")), Data.Int(0))
+        }
+
+        "midnight 2016-10-02" >> {
+          unary(ExtractDayOfWeek(_).embed, Data.Timestamp(Instant.parse("2016-10-02T00:00:00.000Z")), Data.Int(0))
+        }
+      }
+
+      "ExtractDayOfYear" >> {
+        "2016-03-01" >> {
+          unary(ExtractDayOfYear(_).embed, Data.Date(LocalDate.parse("2016-03-01")), Data.Int(61))
+        }
+
+        "midnight 2016-03-01" >> {
+          unary(ExtractDayOfYear(_).embed, Data.Timestamp(Instant.parse("2016-03-01T00:00:00.000Z")), Data.Int(61))
+        }
+
+        "2017-03-01" >> {
+          unary(ExtractDayOfYear(_).embed, Data.Date(LocalDate.parse("2017-03-01")), Data.Int(60))
+        }
+
+        "midnight 2017-03-01" >> {
+          unary(ExtractDayOfYear(_).embed, Data.Timestamp(Instant.parse("2017-03-01T00:00:00.000Z")), Data.Int(60))
+        }
+      }
+
+      "ExtractEpoch" >> {
+        "2016-09-29" >> {
+          unary(ExtractEpoch(_).embed, Data.Date(LocalDate.parse("2016-09-29")), Data.Dec(1475107200.0))
+        }
+
+        "2016-09-29 12:34:56.789" >> {
+          unary(ExtractEpoch(_).embed, Data.Timestamp(Instant.parse("2016-09-29T12:34:56.789Z")), Data.Dec(1475152496.789))
+        }
+      }
+
+      "ExtractHour" >> {
+        "2016-09-29" >> {
+          unary(ExtractHour(_).embed, Data.Date(LocalDate.parse("2016-09-29")), Data.Int(0))
+        }
+
+        "midnight 2016-09-29" >> {
+          unary(ExtractHour(_).embed, Data.Timestamp(Instant.parse("2016-03-01T00:00:00.000Z")), Data.Int(0))
+        }
+
+        "2016-09-29 12:34:56.789" >> {
+          unary(ExtractHour(_).embed, Data.Timestamp(Instant.parse("2016-03-01T12:34:56.789Z")), Data.Int(12))
+        }
+      }
+
+      "ExtractIsoDayOfWeek" >> {
+        "2016-09-28" >> {
+          unary(ExtractIsoDayOfWeek(_).embed, Data.Date(LocalDate.parse("2016-09-28")), Data.Int(3))
+        }
+
+        "midnight 2016-09-28" >> {
+          unary(ExtractIsoDayOfWeek(_).embed, Data.Timestamp(Instant.parse("2016-09-28T00:00:00.000Z")), Data.Int(3))
+        }
+
+        "2016-10-02" >> {
+          unary(ExtractIsoDayOfWeek(_).embed, Data.Date(LocalDate.parse("2016-10-02")), Data.Int(7))
+        }
+
+        "midnight 2016-10-02" >> {
+          unary(ExtractIsoDayOfWeek(_).embed, Data.Timestamp(Instant.parse("2016-10-02T00:00:00.000Z")), Data.Int(7))
+        }
+      }
+
+      "ExtractIsoYear" >> {
+        "2006-01-01" >> {
+          unary(ExtractIsoYear(_).embed, Data.Date(LocalDate.parse("2006-01-01")), Data.Int(2005))
+        }
+
+        "midnight 2006-01-01" >> {
+          unary(ExtractIsoYear(_).embed, Data.Timestamp(Instant.parse("2006-01-01T00:00:00.000Z")), Data.Int(2005))
+        }
+
+        "2006-01-02" >> {
+          unary(ExtractIsoYear(_).embed, Data.Date(LocalDate.parse("2006-01-02")), Data.Int(2006))
+        }
+
+        "midnight 2006-01-02" >> {
+          unary(ExtractIsoYear(_).embed, Data.Timestamp(Instant.parse("2006-01-02T00:00:00.000Z")), Data.Int(2006))
+        }
+      }
+
+      "ExtractMicroseconds" >> {
+        "2016-09-29" >> {
+          unary(ExtractMicroseconds(_).embed, Data.Date(LocalDate.parse("2016-09-29")), Data.Dec(0))
+        }
+
+        "midnight 2016-09-29" >> {
+          unary(ExtractMicroseconds(_).embed, Data.Timestamp(Instant.parse("2016-03-01T00:00:00.000Z")), Data.Dec(0))
+        }
+
+        "2016-09-29 12:34:56.789" >> {
+          unary(ExtractMicroseconds(_).embed, Data.Timestamp(Instant.parse("2016-03-01T12:34:56.789Z")), Data.Dec(56.789e6))
+        }
+      }
+
+
+      "ExtractMillenium" >> {
+        "0001-01-01" >> {
+          unary(ExtractMillenium(_).embed, Data.Date(LocalDate.parse("0001-01-01")), Data.Int(1))
+        }
+
+        "2000-01-01" >> {
+          unary(ExtractMillenium(_).embed, Data.Date(LocalDate.parse("2000-01-01")), Data.Int(2))
+        }
+
+        "2001-01-01" >> {
+          unary(ExtractMillenium(_).embed, Data.Date(LocalDate.parse("2001-01-01")), Data.Int(3))
+        }
+
+        "midnight 0001-01-01" >> {
+          unary(ExtractMillenium(_).embed, Data.Timestamp(Instant.parse("0001-01-01T00:00:00.000Z")), Data.Int(1))
+        }
+
+        "midnight 2000-01-01" >> {
+          unary(ExtractMillenium(_).embed, Data.Timestamp(Instant.parse("2000-01-01T00:00:00.000Z")), Data.Int(2))
+        }
+
+        "midnight 2001-01-01" >> {
+          unary(ExtractMillenium(_).embed, Data.Timestamp(Instant.parse("2001-01-01T00:00:00.000Z")), Data.Int(3))
+        }
+      }
+
+      "ExtractMilliseconds" >> {
+        "2016-09-29" >> {
+          unary(ExtractMilliseconds(_).embed, Data.Date(LocalDate.parse("2016-09-29")), Data.Dec(0))
+        }
+
+        "midnight 2016-09-29" >> {
+          unary(ExtractMilliseconds(_).embed, Data.Timestamp(Instant.parse("2016-03-01T00:00:00.000Z")), Data.Dec(0))
+        }
+
+        "2016-09-29 12:34:56.789" >> {
+          unary(ExtractMilliseconds(_).embed, Data.Timestamp(Instant.parse("2016-03-01T12:34:56.789Z")), Data.Dec(56.789e3))
+        }
+      }
+
+      "ExtractMinute" >> {
+        "2016-09-29" >> {
+          unary(ExtractMinute(_).embed, Data.Date(LocalDate.parse("2016-09-29")), Data.Int(0))
+        }
+
+        "midnight 2016-09-29" >> {
+          unary(ExtractMinute(_).embed, Data.Timestamp(Instant.parse("2016-03-01T00:00:00.000Z")), Data.Int(0))
+        }
+
+        "2016-09-29 12:34:56.789" >> {
+          unary(ExtractMinute(_).embed, Data.Timestamp(Instant.parse("2016-03-01T12:34:56.789Z")), Data.Int(34))
+        }
+      }
+
+      "ExtractMonth" >> {
+        "2016-01-01" >> {
+          unary(ExtractMonth(_).embed, Data.Date(LocalDate.parse("2016-01-01")), Data.Int(1))
+        }
+
+        "midnight 2016-01-01" >> {
+          unary(ExtractMonth(_).embed, Data.Timestamp(Instant.parse("2016-01-01T00:00:00.000Z")), Data.Int(1))
+        }
+
+        "2016-02-29" >> {
+          unary(ExtractMonth(_).embed, Data.Date(LocalDate.parse("2016-02-29")), Data.Int(2))
+        }
+
+        "midnight 2016-02-29" >> {
+          unary(ExtractMonth(_).embed, Data.Timestamp(Instant.parse("2016-02-29T00:00:00.000Z")), Data.Int(2))
+        }
+      }
+
+      "ExtractQuarter" >> {
+        "2016-10-03" >> {
+          unary(ExtractQuarter(_).embed, Data.Date(LocalDate.parse("2016-10-03")), Data.Int(4))
+        }
+
+        "midnight 2016-10-03" >> {
+          unary(ExtractQuarter(_).embed, Data.Timestamp(Instant.parse("2016-10-03T00:00:00.000Z")), Data.Int(4))
+        }
+
+        "2016-03-31 (leap year)" >> {
+          unary(ExtractQuarter(_).embed, Data.Date(LocalDate.parse("2016-03-31")), Data.Int(1))
+        }
+
+        "midnight 2016-03-31 (leap year)" >> {
+          unary(ExtractQuarter(_).embed, Data.Timestamp(Instant.parse("2016-03-31T00:00:00.000Z")), Data.Int(1))
+        }
+
+        "2016-04-01 (leap year)" >> {
+          unary(ExtractQuarter(_).embed, Data.Date(LocalDate.parse("2016-04-01")), Data.Int(2))
+        }
+
+        "midnight 2016-04-01 (leap year)" >> {
+          unary(ExtractQuarter(_).embed, Data.Timestamp(Instant.parse("2016-04-01T00:00:00.000Z")), Data.Int(2))
+        }
+
+        "2017-03-31" >> {
+          unary(ExtractQuarter(_).embed, Data.Date(LocalDate.parse("2017-03-31")), Data.Int(1))
+        }
+
+        "midnight 2017-03-31" >> {
+          unary(ExtractQuarter(_).embed, Data.Timestamp(Instant.parse("2017-03-31T00:00:00.000Z")), Data.Int(1))
+        }
+
+        "2017-04-01" >> {
+          unary(ExtractQuarter(_).embed, Data.Date(LocalDate.parse("2017-04-01")), Data.Int(2))
+        }
+
+        "midnight 2017-04-01" >> {
+          unary(ExtractQuarter(_).embed, Data.Timestamp(Instant.parse("2017-04-01T00:00:00.000Z")), Data.Int(2))
+        }
+      }
+
+      "ExtractSecond" >> {
+        "2016-09-29" >> {
+          unary(ExtractSecond(_).embed, Data.Date(LocalDate.parse("2016-09-29")), Data.Dec(0))
+        }
+
+        "midnight 2016-09-29" >> {
+          unary(ExtractSecond(_).embed, Data.Timestamp(Instant.parse("2016-03-01T00:00:00.000Z")), Data.Dec(0))
+        }
+
+        "2016-09-29 12:34:56.789" >> {
+          unary(ExtractSecond(_).embed, Data.Timestamp(Instant.parse("2016-03-01T12:34:56.789Z")), Data.Dec(56.789))
+        }
+      }
+
+      "ExtractWeek" >> {
+        // NB: current implementation, which is not consistent with IsoYear
+
+        "2016-01-01" >> {
+          unary(ExtractWeek(_).embed, Data.Date(LocalDate.parse("2016-01-01")), Data.Int(0))
+        }
+
+        "midnight 2016-01-01" >> {
+          unary(ExtractWeek(_).embed, Data.Timestamp(Instant.parse("2016-01-01T00:00:00.000Z")), Data.Int(0))
+        }
+
+        // These examples illustrate the "correct", ISO-compliant behavior:
+
+        "2001-02-16" >> {
+          unary(ExtractWeek(_).embed, Data.Date(LocalDate.parse("2001-02-16")), Data.Int(7))
+        }.pendingUntilFixed
+
+        "midnight 2016-10-03" >> {
+          unary(ExtractWeek(_).embed, Data.Timestamp(Instant.parse("2001-02-16T00:00:00.000Z")), Data.Int(7))
+        }.pendingUntilFixed
+
+        "2005-01-01" >> {
+          unary(ExtractWeek(_).embed, Data.Date(LocalDate.parse("2005-01-01")), Data.Int(53))
+        }.pendingUntilFixed
+
+        "midnight 2005-01-01" >> {
+          unary(ExtractWeek(_).embed, Data.Timestamp(Instant.parse("2005-01-01T00:00:00.000Z")), Data.Int(53))
+        }.pendingUntilFixed
+      }
+
+      "ExtractYear" >> {
+        "1999-12-31" >> {
+          unary(ExtractYear(_).embed, Data.Date(LocalDate.parse("1999-12-31")), Data.Int(1999))
+        }
+
+        "midnight 1999-12-31" >> {
+          unary(ExtractYear(_).embed, Data.Timestamp(Instant.parse("1999-12-31T00:00:00.000Z")), Data.Int(1999))
+        }
+      }
+
       "TimeOfDay" >> {
         "timestamp" >> {
           val now = Instant.now
@@ -325,17 +658,18 @@ abstract class StdLibSpec extends Qspec {
           binary(Power(_, _).embed, Data.Dec(x), Data.Int(1), Data.Dec(x))
         }
 
-        "0 to Int" >> prop { (y: BigInt) =>
+        "0 to small positive int" >> prop { (y0: Int) =>
+          val y = abs(y0 % 10)
           y != 0 ==>
             binary(Power(_, _).embed, Data.Int(0), Data.Int(y), Data.Int(0))
         }
 
-        "0 to Dec" >> prop { (y: BigDecimal) =>
-          y != 0 ==>
-            binary(Power(_, _).embed, Data.Int(0), Data.Dec(y), Data.Int(0))
-        }
+        // "0 to Dec" >> prop { (y: BigDecimal) =>
+        //   y != 0 ==>
+        //     binary(Power(_, _).embed, Data.Int(0), Data.Dec(y), Data.Int(0))
+        // }
 
-        "Int to small Int" >> prop { (x: Int) =>
+        "Int squared" >> prop { (x: Int) =>
           binary(Power(_, _).embed, Data.Int(x), Data.Int(2), Data.Int(x.toLong * x.toLong))
         }
 
@@ -365,7 +699,7 @@ abstract class StdLibSpec extends Qspec {
       "Divide" >> {
         "any ints" >> prop { (x: Int, y: Int) =>
           y != 0 ==>
-            binary(Divide(_, _).embed, Data.Int(x), Data.Int(y), Data.Int(x.toLong / y.toLong))
+            binary(Divide(_, _).embed, Data.Int(x), Data.Int(y), Data.Dec(x.toDouble / y.toDouble))
         }
 
         // "any doubles" >> prop { (x: Double, y: Double) =>
@@ -393,7 +727,7 @@ abstract class StdLibSpec extends Qspec {
 
       "Modulo" >> {
         "any int by 1" >> prop { (x: Int) =>
-            binary(Modulo(_, _).embed, Data.Int(x), Data.Int(1), Data.Int(x))
+            binary(Modulo(_, _).embed, Data.Int(x), Data.Int(1), Data.Int(0))
         }
 
         "any positive ints" >> prop { (x0: Int, y0: Int) =>
@@ -609,7 +943,7 @@ abstract class StdLibSpec extends Qspec {
 
         "any three Ints" >> prop { (x1: BigInt, x2: BigInt, x3: BigInt) =>
           val xs = List(x1, x2, x3).sorted
-          ternary(Between(_, _, _).embed, Data.Int(xs(0)), Data.Int(xs(1)), Data.Int(xs(2)), Data.Bool(true))
+          ternary(Between(_, _, _).embed, Data.Int(xs(1)), Data.Int(xs(0)), Data.Int(xs(2)), Data.Bool(true))
         }
 
         "any Dec with self" >> prop { (x: BigDecimal) =>
@@ -618,7 +952,7 @@ abstract class StdLibSpec extends Qspec {
 
         "any three Decs" >> prop { (x1: BigDecimal, x2: BigDecimal, x3: BigDecimal) =>
           val xs = List(x1, x2, x3).sorted
-          ternary(Between(_, _, _).embed, Data.Dec(xs(0)), Data.Dec(xs(1)), Data.Dec(xs(2)), Data.Bool(true))
+          ternary(Between(_, _, _).embed, Data.Dec(xs(1)), Data.Dec(xs(0)), Data.Dec(xs(2)), Data.Bool(true))
         }
 
         "any Str with self" >> prop { (x: String) =>
@@ -627,7 +961,7 @@ abstract class StdLibSpec extends Qspec {
 
         "any three Strs" >> prop { (x1: String, x2: String, x3: String) =>
           val xs = List(x1, x2, x3).sorted
-          ternary(Between(_, _, _).embed, Data.Str(xs(0)), Data.Str(xs(1)), Data.Str(xs(2)), Data.Bool(true))
+          ternary(Between(_, _, _).embed, Data.Str(xs(1)), Data.Str(xs(0)), Data.Str(xs(2)), Data.Bool(true))
         }
 
         // TODO: Timestamp, Interval, cross-type comparison

--- a/frontend/src/test/scala/quasar/std/StdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/StdLibSpec.scala
@@ -68,7 +68,7 @@ trait StdLibTestRunner {
 abstract class StdLibSpec extends Qspec {
   def closeTo(expected: Data): Matcher[Data] = new Matcher[Data] {
     def isClose(x: BigDecimal, y: BigDecimal, err: Double): Boolean =
-      x == y || ((x - y)/y).abs.toDouble < err
+      x == y || ((x - y).abs/(y.abs max err)).toDouble < err
 
     def apply[S <: Data](s: Expectable[S]) = {
       val v = s.value

--- a/frontend/src/test/scala/quasar/std/StdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/StdLibSpec.scala
@@ -328,6 +328,14 @@ abstract class StdLibSpec extends Qspec {
         "midnight 2016-10-02" >> {
           unary(ExtractDayOfWeek(_).embed, Data.Timestamp(Instant.parse("2016-10-02T00:00:00.000Z")), Data.Int(0))
         }
+
+        "2016-10-08" >> {
+          unary(ExtractDayOfWeek(_).embed, Data.Date(LocalDate.parse("2016-10-08")), Data.Int(6))
+        }
+
+        "noon 2016-10-08" >> {
+          unary(ExtractDayOfWeek(_).embed, Data.Timestamp(Instant.parse("2016-10-08T12:00:00.000Z")), Data.Int(6))
+        }
       }
 
       "ExtractDayOfYear" >> {

--- a/frontend/src/test/scala/quasar/std/StdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/StdLibSpec.scala
@@ -431,29 +431,29 @@ abstract class StdLibSpec extends Qspec {
       }
 
 
-      "ExtractMillenium" >> {
+      "ExtractMillennium" >> {
         "0001-01-01" >> {
-          unary(ExtractMillenium(_).embed, Data.Date(LocalDate.parse("0001-01-01")), Data.Int(1))
+          unary(ExtractMillennium(_).embed, Data.Date(LocalDate.parse("0001-01-01")), Data.Int(1))
         }
 
         "2000-01-01" >> {
-          unary(ExtractMillenium(_).embed, Data.Date(LocalDate.parse("2000-01-01")), Data.Int(2))
+          unary(ExtractMillennium(_).embed, Data.Date(LocalDate.parse("2000-01-01")), Data.Int(2))
         }
 
         "2001-01-01" >> {
-          unary(ExtractMillenium(_).embed, Data.Date(LocalDate.parse("2001-01-01")), Data.Int(3))
+          unary(ExtractMillennium(_).embed, Data.Date(LocalDate.parse("2001-01-01")), Data.Int(3))
         }
 
         "midnight 0001-01-01" >> {
-          unary(ExtractMillenium(_).embed, Data.Timestamp(Instant.parse("0001-01-01T00:00:00.000Z")), Data.Int(1))
+          unary(ExtractMillennium(_).embed, Data.Timestamp(Instant.parse("0001-01-01T00:00:00.000Z")), Data.Int(1))
         }
 
         "midnight 2000-01-01" >> {
-          unary(ExtractMillenium(_).embed, Data.Timestamp(Instant.parse("2000-01-01T00:00:00.000Z")), Data.Int(2))
+          unary(ExtractMillennium(_).embed, Data.Timestamp(Instant.parse("2000-01-01T00:00:00.000Z")), Data.Int(2))
         }
 
         "midnight 2001-01-01" >> {
-          unary(ExtractMillenium(_).embed, Data.Timestamp(Instant.parse("2001-01-01T00:00:00.000Z")), Data.Int(3))
+          unary(ExtractMillennium(_).embed, Data.Timestamp(Instant.parse("2001-01-01T00:00:00.000Z")), Data.Int(3))
         }
       }
 

--- a/frontend/src/test/scala/quasar/std/math.scala
+++ b/frontend/src/test/scala/quasar/std/math.scala
@@ -97,9 +97,9 @@ class MathSpec extends quasar.Qspec with TypeArbitrary {
       expr should beSuccessful(Const(Int(2)))
     }
 
-    "fold truncating division" in {
+    "fold non-truncating division" in {
       val expr = Divide.tpe(Func.Input2(Const(Int(5)), Const(Int(2))))
-      expr should beSuccessful(Const(Int(2)))
+      expr should beSuccessful(Const(Dec(2.5)))
     }
 
     "fold simple division (dec)" in {

--- a/it/src/main/resources/tests/temporal/datePartsConverted.test
+++ b/it/src/main/resources/tests/temporal/datePartsConverted.test
@@ -15,7 +15,7 @@
   "nb": "Currently pending for Mongo because the shape is somehow not handled for JS.
          Also `doy` and `week` are missing because we currently have no JS implementation.",
   "query": "select
-              date_part(\"millenium\", timestamp(commit.committer.date)) as millenium,
+              date_part(\"millennium\", timestamp(commit.committer.date)) as millenium,
               date_part(\"century\", timestamp(commit.committer.date)) as century,
               date_part(\"decade\", timestamp(commit.committer.date)) as decade,
               date_part(\"year\", timestamp(commit.committer.date)) as year,
@@ -37,7 +37,7 @@
   "expected": [
     {
       "id": "33031",
-      "millenium": 2, "century": 20, "decade": 201, "year": 2015,
+      "millennium": 2, "century": 20, "decade": 201, "year": 2015,
       "doy": 1
     }
   ]

--- a/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
@@ -43,7 +43,7 @@ class MongoDbExprStdLibSpec extends MongoDbStdLibSpec {
   val notHandled = Skipped("not implemented in aggregation")
 
   /** Identify constructs that are expected not to be implemented in the pipeline. */
-  def shortCircuit[N <: Nat](backend: BackendName, func: GenericFunc[N]): Result \/ Unit = func match {
+  def shortCircuit[N <: Nat](backend: BackendName, func: GenericFunc[N], args: List[Data]): Result \/ Unit = func match {
     case StringLib.Length   => notHandled.left
     case StringLib.Integer  => notHandled.left
     case StringLib.Decimal  => notHandled.left

--- a/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
@@ -19,11 +19,8 @@ package quasar.physical.mongodb
 import quasar.Predef._
 import quasar._, Planner.{PlannerError, InternalError}
 import quasar.std.StdLib._
-import quasar.fp._
 import quasar.fp.ski._
-import quasar.fs.DataCursor
-import quasar.std.{StdLibSpec, StdLibTestRunner}
-import quasar.physical.mongodb.fs._, bsoncursor._
+import quasar.physical.mongodb.fs._
 import quasar.physical.mongodb.planner.MongoDbPlanner
 import quasar.physical.mongodb.workflow._
 

--- a/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
@@ -18,7 +18,7 @@ package quasar.physical.mongodb
 
 import quasar.Predef._
 import quasar._, Planner.{PlannerError, InternalError}
-import quasar.std._
+import quasar.std.StdLib._
 import quasar.fp._
 import quasar.fp.ski._
 import quasar.fs.DataCursor
@@ -44,18 +44,17 @@ class MongoDbExprStdLibSpec extends MongoDbStdLibSpec {
 
   /** Identify constructs that are expected not to be implemented in the pipeline. */
   def shortCircuit[N <: Nat](backend: BackendName, func: GenericFunc[N], args: List[Data]): Result \/ Unit = (func, args) match {
-    case (StringLib.Length, _)   => notHandled.left
-    case (StringLib.Integer, _)  => notHandled.left
-    case (StringLib.Decimal, _)  => notHandled.left
-    case (StringLib.ToString, _) => notHandled.left
+    case (string.Length, _)   => notHandled.left
+    case (string.Integer, _)  => notHandled.left
+    case (string.Decimal, _)  => notHandled.left
+    case (string.ToString, _) => notHandled.left
 
-    case (DateLib.TimeOfDay, _) if is2_6(backend) => Skipped("not implemented in aggregation on MongoDB 2.6").left
+    case (date.ExtractIsoYear, _) => notHandled.left
+    case (date.ExtractQuarter, _) => Skipped("TODO").left
 
-    case (MathLib.Power, _) if !is3_2(backend) => Skipped("not implemented in aggregation on MongoDB < 3.2").left
+    case (date.TimeOfDay, _) if is2_6(backend) => Skipped("not implemented in aggregation on MongoDB 2.6").left
 
-    case (MathLib.Power, Data.Number(x) :: Data.Number(y) :: Nil)
-        if x == 0 && y < 0 =>
-      Skipped("Zero to a negative powere is a runtime error").left
+    case (math.Power, _) if !is3_2(backend) => Skipped("not implemented in aggregation on MongoDB < 3.2").left
 
     case _                  => ().right
   }
@@ -63,7 +62,7 @@ class MongoDbExprStdLibSpec extends MongoDbStdLibSpec {
   def compile(queryModel: MongoQueryModel, coll: Collection, lp: Fix[LogicalPlan])
       : PlannerError \/ (Crystallized[WorkflowF], BsonField.Name) = {
     val wrapped =
-      Fix(StructuralLib.MakeObject(
+      Fix(structural.MakeObject(
         LogicalPlan.Constant(Data.Str("result")),
         lp))
 

--- a/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
@@ -26,14 +26,11 @@ import quasar.std.{StdLibSpec, StdLibTestRunner}
 import quasar.physical.mongodb.fs._, bsoncursor._
 import quasar.physical.mongodb.planner.MongoDbPlanner
 import quasar.physical.mongodb.workflow._
-import WorkflowExecutor.WorkflowCursor
 
 import matryoshka._, Recursive.ops._
 import org.specs2.execute._
-import org.specs2.main.ArgProperty
 import scalaz._, Scalaz._
-import scalaz.concurrent.Task
-import shapeless.{Nat}
+import shapeless.Nat
 
 /** Test the implementation of the standard library for MongoDb's aggregation
   * pipeline (aka ExprOp).
@@ -42,128 +39,39 @@ import shapeless.{Nat}
   * from the rest of the MongoDb planner, this test runs the whole planner and
   * then simply fails if it finds that the generated plan required map-reduce.
   */
-class MongoDbExprStdLibSpec extends StdLibSpec {
-  args.report(showtimes = ArgProperty(true))
+class MongoDbExprStdLibSpec extends MongoDbStdLibSpec {
+  val notHandled = Skipped("not implemented in aggregation")
 
-  MongoDbSpec.clientShould { (backend, prefix, setupClient, testClient) =>
-    import MongoDbIO._
+  /** Identify constructs that are expected not to be implemented in the pipeline. */
+  def shortCircuit[N <: Nat](backend: BackendName, func: GenericFunc[N]): Result \/ Unit = func match {
+    case StringLib.Length   => notHandled.left
+    case StringLib.Integer  => notHandled.left
+    case StringLib.Decimal  => notHandled.left
+    case StringLib.ToString => notHandled.left
 
-    val notHandled = Skipped("not implemented in aggregation")
+    case DateLib.TimeOfDay if is2_6(backend) => Skipped("not implemented for in aggregation on MongoDB 2.6").left
 
-    def is2_6 = backend == TestConfig.MONGO_2_6
+    case _                  => ().right
+  }
 
-    /** Identify constructs that are expected not to be implemented in the pipeline. */
-    def shortCircuitInvoke[N <: Nat](func: GenericFunc[N]): Result \/ Unit = func match {
-      case StringLib.Length   => notHandled.left
-      case StringLib.Integer  => notHandled.left
-      case StringLib.Decimal  => notHandled.left
-      case StringLib.ToString => notHandled.left
+  def compile(queryModel: MongoQueryModel, coll: Collection, lp: Fix[LogicalPlan])
+      : PlannerError \/ (Crystallized[WorkflowF], BsonField.Name) = {
+    val wrapped =
+      Fix(StructuralLib.MakeObject(
+        LogicalPlan.Constant(Data.Str("result")),
+        lp))
 
-      case DateLib.TimeOfDay if is2_6 => Skipped("not implemented for MongoDB 2.6").left
+    val ctx = QueryContext(queryModel, κ(None), κ(None))
 
-      case _                  => ().right
-    }
-
-    /** Identify constructs that are expected not to be implemented in the pipeline. */
-    def shortCircuit: AlgebraM[Result \/ ?, LogicalPlan, Unit] = {
-      case LogicalPlan.InvokeF(func, _) => shortCircuitInvoke(func)
-      case _ => ().right
-    }
-
-    /** Intercept and transform expected values into the form that's actually
-      * produced by the MongoDB backend, in cases where MongoDB cannot represent
-      * the type natively. */
-    def massage(expected: Data): Data = expected match {
-      case Data.Time(time) => Data.Str(time.toString)
-      case _               => expected
-    }
-
-
-    def evaluate(wf: Crystallized[WorkflowF], tmp: Collection): MongoDbIO[List[Data]] =
-      for {
-        exc <- WorkflowExecutor.mongoDb.run.unattempt
-        v   <- exc.evaluate(wf, None).run.run(tmp.collection).eval(0).unattempt
-        rez <- v.fold(
-                _.map(BsonCodec.toData(_)).point[MongoDbIO],
-                c => DataCursor[MongoDbIO, WorkflowCursor[BsonCursor]].process(c).runLog.map(_.toList))
-      } yield rez
-
-    // TODO: this should probably have access to the arguments so it can inspect them as well
-    def check(arity: Int, prg: List[Fix[LogicalPlan]] => Fix[LogicalPlan]): Option[Result] =
-      prg((0 until arity).toList.map(idx => LogicalPlan.Free(Symbol("arg" + idx))))
-        .cataM[Result \/ ?, Unit](shortCircuit).swap.toOption
-
-    def compile(queryModel: MongoQueryModel, coll: Collection, arity: Int, prg: List[Fix[LogicalPlan]] => Fix[LogicalPlan], resultField: BsonField.Name)
-        : PlannerError \/ Crystallized[WorkflowF] = {
-      val lp =
-        Fix(StructuralLib.MakeObject(
-          LogicalPlan.Constant(Data.Str("result")),
-          prg(
-            (0 until arity).toList.map(idx =>
-              Fix(StructuralLib.ObjectProject(
-                LogicalPlan.Read(coll.asFile),
-                LogicalPlan.Constant(Data.Str("arg" + idx))))))))
-
-      val ctx = QueryContext(queryModel, κ(None), κ(None))
-
-      MongoDbPlanner.plan(lp, ctx).run.value
-        .flatMap { wf =>
-          val singlePipeline = wf.op.cata[Boolean] {
-            case IsSource(_)   => true
-            case IsPipeline(p) => p.src
-            case _             => false
-          }
-          if (singlePipeline) wf.right else InternalError("compiled to map-reduce").left
+    MongoDbPlanner.plan(wrapped, ctx).run.value
+      .flatMap { wf =>
+        val singlePipeline = wf.op.cata[Boolean] {
+          case IsSource(_)   => true
+          case IsPipeline(p) => p.src
+          case _             => false
         }
-    }
-
-    def run(args: List[Data], prg: List[Fix[LogicalPlan]] => Fix[LogicalPlan], expected: Data): Result =
-      check(args.length, prg).getOrElse(
-        (for {
-          coll <- MongoDbSpec.tempColl(prefix)
-          argsBson <- args.zipWithIndex.traverse { case (arg, idx) =>
-                      BsonCodec.fromData(arg).point[Task].unattempt.strengthL("arg" + idx) }
-          _     <- insert(
-                    coll,
-                    List(Bson.Doc(argsBson.toListMap)).map(_.repr)).run(setupClient)
-
-          qm  <- serverVersion.map(MongoQueryModel(_)).run(testClient)
-
-          wf  <- compile(qm, coll, args.length, prg, BsonField.Name("result")).point[Task].unattempt
-
-          rez <- evaluate(wf, coll).run(testClient)
-
-          _     <- dropCollection(coll).run(setupClient)
-        } yield {
-          rez must_= List(Data.Obj(ListMap("result" -> massage(expected))))
-        }).unsafePerformSync.toResult)
-
-
-    val runner = new StdLibTestRunner with MongoDbDomain {
-      def nullary(
-        prg: Fix[LogicalPlan],
-        expected: Data): Result =
-        run(Nil, { case Nil => prg; case _ => scala.sys.error("") }, expected)
-
-      def unary(
-        prg: Fix[LogicalPlan] => Fix[LogicalPlan],
-        arg: Data,
-        expected: Data): Result =
-        run(List(arg), { case List(arg) => prg(arg) }, expected)
-
-      def binary(
-        prg: (Fix[LogicalPlan], Fix[LogicalPlan]) => Fix[LogicalPlan],
-        arg1: Data, arg2: Data,
-        expected: Data): Result =
-        run(List(arg1, arg2), { case List(arg1, arg2) => prg(arg1, arg2) }, expected)
-
-      def ternary(
-        prg: (Fix[LogicalPlan], Fix[LogicalPlan], Fix[LogicalPlan]) => Fix[LogicalPlan],
-        arg1: Data, arg2: Data, arg3: Data,
-        expected: Data): Result =
-        run(List(arg1, arg2, arg3), { case List(arg1, arg2, arg3) => prg(arg1, arg2, arg3) }, expected)
-    }
-
-    backend.name should tests(runner)
+        if (singlePipeline) wf.right else InternalError("compiled to map-reduce").left
+      }
+      .strengthR(BsonField.Name("result"))
   }
 }

--- a/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
@@ -49,7 +49,9 @@ class MongoDbExprStdLibSpec extends MongoDbStdLibSpec {
     case StringLib.Decimal  => notHandled.left
     case StringLib.ToString => notHandled.left
 
-    case DateLib.TimeOfDay if is2_6(backend) => Skipped("not implemented for in aggregation on MongoDB 2.6").left
+    case DateLib.TimeOfDay if is2_6(backend) => Skipped("not implemented in aggregation on MongoDB 2.6").left
+
+    case MathLib.Power if !is3_2(backend) => Skipped("not implemented in aggregation on MongoDB < 3.2").left
 
     case _                  => ().right
   }

--- a/it/src/test/scala/quasar/physical/mongodb/JsStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/JsStdLibSpec.scala
@@ -18,7 +18,7 @@ package quasar.physical.mongodb
 
 import quasar.Predef._
 import quasar._, Planner.{PlannerError, InternalError}
-import quasar.std._
+import quasar.std.StdLib._
 import quasar.jscore._
 import quasar.physical.mongodb.planner.MongoDbPlanner
 import quasar.physical.mongodb.workflow._
@@ -36,15 +36,18 @@ class MongoDbJsStdLibSpec extends MongoDbStdLibSpec {
 
   /** Identify constructs that are expected not to be implemented in JS. */
   def shortCircuit[N <: Nat](backend: BackendName, func: GenericFunc[N], args: List[Data]): Result \/ Unit = (func, args) match {
-    case (StringLib.Lower, _)   => notHandled.left
-    case (StringLib.Upper, _)   => notHandled.left
+    case (string.Lower, _)   => notHandled.left
+    case (string.Upper, _)   => notHandled.left
 
-    case (StringLib.ToString, Data.Dec(_) :: Nil) =>
+    case (string.ToString, Data.Dec(_) :: Nil) =>
       Skipped("Dec printing doesn't match precisely").left
 
-    case (MathLib.Power, Data.Number(x) :: Data.Number(y) :: Nil)
+    case (math.Power, Data.Number(x) :: Data.Number(y) :: Nil)
         if x == 0 && y < 0 =>
       Skipped("Infinity is not translated properly?").left
+
+    case (relations.Cond, _) => notHandled.left
+    case (relations.Coalesce, _) => notHandled.left
 
     case _                  => ().right
   }

--- a/it/src/test/scala/quasar/physical/mongodb/JsStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/JsStdLibSpec.scala
@@ -36,8 +36,8 @@ class MongoDbJsStdLibSpec extends MongoDbStdLibSpec {
 
   /** Identify constructs that are expected not to be implemented in JS. */
   def shortCircuit[N <: Nat](backend: BackendName, func: GenericFunc[N], args: List[Data]): Result \/ Unit = (func, args) match {
-    case (string.Lower, _)   => notHandled.left
-    case (string.Upper, _)   => notHandled.left
+    case (string.Lower, _)   => Skipped("TODO").left
+    case (string.Upper, _)   => Skipped("TODO").left
 
     case (string.ToString, Data.Dec(_) :: Nil) =>
       Skipped("Dec printing doesn't match precisely").left
@@ -46,8 +46,14 @@ class MongoDbJsStdLibSpec extends MongoDbStdLibSpec {
         if x == 0 && y < 0 =>
       Skipped("Infinity is not translated properly?").left
 
-    case (relations.Cond, _) => notHandled.left
-    case (relations.Coalesce, _) => notHandled.left
+    case (relations.Cond, _)     => Skipped("TODO").left
+    case (relations.Coalesce, _) => Skipped("TODO").left
+
+    case (date.ExtractDayOfYear, _)    => Skipped("TODO").left
+    // case (date.ExtractIsoDayOfWeek, _) => Skipped("TODO").left
+    case (date.ExtractIsoYear, _)      => Skipped("TODO").left
+    case (date.ExtractWeek, _)         => Skipped("TODO").left
+    case (date.ExtractQuarter, _)      => Skipped("TODO").left
 
     case _                  => ().right
   }

--- a/it/src/test/scala/quasar/physical/mongodb/JsStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/JsStdLibSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.mongodb
+
+import quasar.Predef._
+import quasar._, Planner.{PlannerError, InternalError}
+import quasar.std._
+import quasar.jscore._
+import quasar.physical.mongodb.planner.MongoDbPlanner
+import quasar.physical.mongodb.workflow._
+
+import matryoshka._, Recursive.ops._
+import org.specs2.execute._
+import scalaz.{Name => _, _}, Scalaz._
+import shapeless.Nat
+
+/** Test the implementation of the standard library for MongoDb's map-reduce
+  * (i.e. JavaScript).
+  */
+class MongoDbJsStdLibSpec extends MongoDbStdLibSpec {
+  val notHandled = Skipped("not implemented in JS")
+
+  /** Identify constructs that are expected not to be implemented in JS. */
+  def shortCircuit[N <: Nat](backend: BackendName, func: GenericFunc[N]): Result \/ Unit = func match {
+    case StringLib.Lower   => notHandled.left
+    case StringLib.Upper   => notHandled.left
+
+    case _                  => ().right
+  }
+
+  def compile(queryModel: MongoQueryModel, coll: Collection, lp: Fix[LogicalPlan])
+      : PlannerError \/ (Crystallized[WorkflowF], BsonField.Name) = {
+
+    for {
+      t  <- lp.cata(MongoDbPlanner.jsExprƒ)
+      (pj, ifs) = t
+      js <- pj.lift(List.fill(ifs.length)(JsFn.identity)) \/> InternalError("no JS compilation")
+      wf =  chain[Fix[WorkflowF]](
+              $read(coll),
+              $simpleMap(NonEmptyList(MapExpr(js)), ListMap.empty))
+    } yield (Crystallize[WorkflowF].crystallize(wf), BsonField.Name("value"))
+  }
+}

--- a/it/src/test/scala/quasar/physical/mongodb/JsStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/JsStdLibSpec.scala
@@ -35,9 +35,11 @@ class MongoDbJsStdLibSpec extends MongoDbStdLibSpec {
   val notHandled = Skipped("not implemented in JS")
 
   /** Identify constructs that are expected not to be implemented in JS. */
-  def shortCircuit[N <: Nat](backend: BackendName, func: GenericFunc[N]): Result \/ Unit = func match {
-    case StringLib.Lower   => notHandled.left
-    case StringLib.Upper   => notHandled.left
+  def shortCircuit[N <: Nat](backend: BackendName, func: GenericFunc[N], args: List[Data]): Result \/ Unit = (func, args) match {
+    case (StringLib.Lower, _)   => notHandled.left
+    case (StringLib.Upper, _)   => notHandled.left
+
+    case (StringLib.ToString, Data.Dec(_) :: Nil) => Skipped("Dec printing doesn't match precisely").left
 
     case _                  => ().right
   }

--- a/it/src/test/scala/quasar/physical/mongodb/JsStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/JsStdLibSpec.scala
@@ -39,7 +39,12 @@ class MongoDbJsStdLibSpec extends MongoDbStdLibSpec {
     case (StringLib.Lower, _)   => notHandled.left
     case (StringLib.Upper, _)   => notHandled.left
 
-    case (StringLib.ToString, Data.Dec(_) :: Nil) => Skipped("Dec printing doesn't match precisely").left
+    case (StringLib.ToString, Data.Dec(_) :: Nil) =>
+      Skipped("Dec printing doesn't match precisely").left
+
+    case (MathLib.Power, Data.Number(x) :: Data.Number(y) :: Nil)
+        if x == 0 && y < 0 =>
+      Skipped("Infinity is not translated properly?").left
 
     case _                  => ().right
   }

--- a/it/src/test/scala/quasar/physical/mongodb/MongoDbDomain.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/MongoDbDomain.scala
@@ -19,12 +19,16 @@ package quasar.physical.mongodb
 import quasar.Predef._
 
 import org.scalacheck.{Arbitrary, Gen}, Arbitrary._
+import scalaz._, Scalaz._
 
 /** Defines the domains of values for which the MongoDb connector is expected
   * to behave properly. May be mixed in when implementing `StdLibTestRunner`.
 */
 trait MongoDbDomain {
-  val intDomain = arbitrary[Long].filter(_ != Long.MinValue).map(BigInt(_))
+  // NB: in the pipeline, the entire 64-bit range works, but in map-reduce,
+  // only about 53 bits of integer resolution are available.
+  // TODO: use `Long` in the Expr test, and this domain for JS.
+  val intDomain = arbitrary[Int].filter(_ ≠ Int.MinValue).map(BigInt(_))
   val decDomain = arbitrary[Double].map(BigDecimal(_))
 
   // NB: restricted to printable ASCII only because most functions are not

--- a/it/src/test/scala/quasar/physical/mongodb/MongoDbDomain.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/MongoDbDomain.scala
@@ -27,7 +27,7 @@ trait MongoDbDomain {
   val intDomain = arbitrary[Long].map(BigInt(_))
   val decDomain = arbitrary[Double].map(BigDecimal(_))
 
-  // NB: restricted to ASCII only because most functions are not well-defined
-  // for the rest (e.g. $toLower, $toUpper, $substr)
-  val stringDomain = Gen.listOf(Gen.choose('\u0000', '\u007f')).map(_.mkString)
+  // NB: restricted to printable ASCII only because most functions are not
+  // well-defined for the rest (e.g. $toLower, $toUpper, $substr)
+  val stringDomain = Gen.listOf(Gen.choose('\u0020', '\u007e')).map(_.mkString)
 }

--- a/it/src/test/scala/quasar/physical/mongodb/MongoDbDomain.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/MongoDbDomain.scala
@@ -24,7 +24,7 @@ import org.scalacheck.{Arbitrary, Gen}, Arbitrary._
   * to behave properly. May be mixed in when implementing `StdLibTestRunner`.
 */
 trait MongoDbDomain {
-  val intDomain = arbitrary[Long].map(BigInt(_))
+  val intDomain = arbitrary[Long].filter(_ != Long.MinValue).map(BigInt(_))
   val decDomain = arbitrary[Double].map(BigDecimal(_))
 
   // NB: restricted to printable ASCII only because most functions are not

--- a/it/src/test/scala/quasar/physical/mongodb/MongoDbStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/MongoDbStdLibSpec.scala
@@ -20,8 +20,8 @@ import quasar.Predef._
 import quasar._, Planner.PlannerError
 import quasar.std._
 import quasar.fp._
+import quasar.fp.ski._
 import quasar.fs.DataCursor
-import quasar.std.{StdLibSpec, StdLibTestRunner}
 import quasar.physical.mongodb.fs._, bsoncursor._
 import quasar.physical.mongodb.workflow._
 import WorkflowExecutor.WorkflowCursor

--- a/it/src/test/scala/quasar/physical/mongodb/MongoDbStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/MongoDbStdLibSpec.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.mongodb
+
+import quasar.Predef._
+import quasar._, Planner.PlannerError
+import quasar.std._
+import quasar.fp._
+import quasar.fs.DataCursor
+import quasar.std.{StdLibSpec, StdLibTestRunner}
+import quasar.physical.mongodb.fs._, bsoncursor._
+import quasar.physical.mongodb.workflow._
+import WorkflowExecutor.WorkflowCursor
+
+import matryoshka._, Recursive.ops._
+import org.specs2.execute._
+import org.specs2.main.ArgProperty
+import scalaz._, Scalaz._
+import scalaz.concurrent.Task
+import shapeless.{Nat}
+
+/** Test the implementation of the standard library for one of MongoDb's
+  * evaluators.
+  */
+abstract class MongoDbStdLibSpec extends StdLibSpec {
+  args.report(showtimes = ArgProperty(true))
+
+  def shortCircuit[N <: Nat](backend: BackendName, func: GenericFunc[N]): Result \/ Unit
+
+  def compile(queryModel: MongoQueryModel, coll: Collection, lp: Fix[LogicalPlan])
+      : PlannerError \/ (Crystallized[WorkflowF], BsonField.Name)
+
+  def is2_6(backend: BackendName): Boolean = backend == TestConfig.MONGO_2_6
+
+  MongoDbSpec.clientShould { (backend, prefix, setupClient, testClient) =>
+    import MongoDbIO._
+
+    /** Intercept and transform expected values into the form that's actually
+      * produced by the MongoDB backend, in cases where MongoDB cannot represent
+      * the type natively. */
+    def massage(expected: Data): Data = expected match {
+      case Data.Time(time) => Data.Str(time.toString)
+      case _               => expected
+    }
+
+    /** Identify constructs that are expected not to be implemented. */
+    def shortCircuitLP: AlgebraM[Result \/ ?, LogicalPlan, Unit] = {
+      case LogicalPlan.InvokeF(func, _) => shortCircuit(backend, func)
+      case _ => ().right
+    }
+
+    def evaluate(wf: Crystallized[WorkflowF], tmp: Collection): MongoDbIO[List[Data]] =
+      for {
+        exc <- WorkflowExecutor.mongoDb.run.unattempt
+        v   <- exc.evaluate(wf, None).run.run(tmp.collection).eval(0).unattempt
+        rez <- v.fold(
+                _.map(BsonCodec.toData(_)).point[MongoDbIO],
+                c => DataCursor[MongoDbIO, WorkflowCursor[BsonCursor]].process(c).runLog.map(_.toList))
+      } yield rez
+
+    // TODO: this should probably have access to the arguments so it can inspect them as well
+    def check(arity: Int, prg: List[Fix[LogicalPlan]] => Fix[LogicalPlan]): Option[Result] =
+      prg((0 until arity).toList.map(idx => LogicalPlan.Free(Symbol("arg" + idx))))
+        .cataM[Result \/ ?, Unit](shortCircuitLP).swap.toOption
+
+    def run(args: List[Data], prg: List[Fix[LogicalPlan]] => Fix[LogicalPlan], expected: Data): Result =
+      check(args.length, prg).getOrElse(
+        (for {
+          coll <- MongoDbSpec.tempColl(prefix)
+          argsBson <- args.zipWithIndex.traverse { case (arg, idx) =>
+                      BsonCodec.fromData(arg).point[Task].unattempt.strengthL("arg" + idx) }
+          _     <- insert(
+                    coll,
+                    List(Bson.Doc(argsBson.toListMap)).map(_.repr)).run(setupClient)
+
+          qm  <- serverVersion.map(MongoQueryModel(_)).run(testClient)
+
+          lp = prg(
+                (0 until args.length).toList.map(idx =>
+                  Fix(StructuralLib.ObjectProject(
+                    LogicalPlan.Read(coll.asFile),
+                    LogicalPlan.Constant(Data.Str("arg" + idx))))))
+          t  <- compile(qm, coll, lp).point[Task].unattempt
+          (wf, resultField) = t
+
+          rez <- evaluate(wf, coll).run(testClient)
+
+          _     <- dropCollection(coll).run(setupClient)
+        } yield {
+          rez must_= List(Data.Obj(ListMap(resultField.asText -> massage(expected))))
+        }).unsafePerformSync.toResult)
+
+
+    val runner = new StdLibTestRunner with MongoDbDomain {
+      def nullary(
+        prg: Fix[LogicalPlan],
+        expected: Data): Result =
+        run(Nil, { case Nil => prg; case _ => scala.sys.error("") }, expected)
+
+      def unary(
+        prg: Fix[LogicalPlan] => Fix[LogicalPlan],
+        arg: Data,
+        expected: Data): Result =
+        run(List(arg), { case List(arg) => prg(arg) }, expected)
+
+      def binary(
+        prg: (Fix[LogicalPlan], Fix[LogicalPlan]) => Fix[LogicalPlan],
+        arg1: Data, arg2: Data,
+        expected: Data): Result =
+        run(List(arg1, arg2), { case List(arg1, arg2) => prg(arg1, arg2) }, expected)
+
+      def ternary(
+        prg: (Fix[LogicalPlan], Fix[LogicalPlan], Fix[LogicalPlan]) => Fix[LogicalPlan],
+        arg1: Data, arg2: Data, arg3: Data,
+        expected: Data): Result =
+        run(List(arg1, arg2, arg3), { case List(arg1, arg2, arg3) => prg(arg1, arg2, arg3) }, expected)
+    }
+
+    backend.name should tests(runner)
+  }
+}

--- a/it/src/test/scala/quasar/physical/mongodb/MongoDbStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/MongoDbStdLibSpec.scala
@@ -45,6 +45,7 @@ abstract class MongoDbStdLibSpec extends StdLibSpec {
       : PlannerError \/ (Crystallized[WorkflowF], BsonField.Name)
 
   def is2_6(backend: BackendName): Boolean = backend == TestConfig.MONGO_2_6
+  def is3_2(backend: BackendName): Boolean = backend == TestConfig.MONGO_3_2
 
   MongoDbSpec.clientShould { (backend, prefix, setupClient, testClient) =>
     import MongoDbIO._

--- a/it/src/test/scala/quasar/physical/mongodb/MongoDbStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/MongoDbStdLibSpec.scala
@@ -30,8 +30,9 @@ import matryoshka._, Recursive.ops._
 import org.specs2.execute._
 import org.specs2.matcher._
 import org.specs2.main.ArgProperty
+import scala.concurrent.duration._
 import scalaz._, Scalaz._
-import scalaz.concurrent.Task
+import scalaz.concurrent.{Strategy, Task}
 import shapeless.{Nat}
 
 /** Test the implementation of the standard library for one of MongoDb's
@@ -116,7 +117,7 @@ abstract class MongoDbStdLibSpec extends StdLibSpec {
           _     <- dropCollection(coll).run(setupClient)
         } yield {
           rez must beSingleResult(closeTo(massage(expected)))
-        }).unsafePerformSync.toResult)
+        }).timed(5.seconds)(Strategy.DefaultTimeoutScheduler).unsafePerformSync.toResult)
 
     val runner = new StdLibTestRunner with MongoDbDomain {
       def nullary(

--- a/js/src/main/scala/quasar/jscore/fixpoint.scala
+++ b/js/src/main/scala/quasar/jscore/fixpoint.scala
@@ -19,7 +19,36 @@ package quasar.jscore
 import quasar.Predef._
 import quasar.javascript.Js
 
-import matryoshka.Fix
+import matryoshka._
+
+final case class fixpoint[T[_[_]]: Corecursive]() {
+  type R = T[JsCoreF]
+
+  @inline private implicit def convert(x: JsCoreF[R]): R =
+    x.embed
+
+  def Literal(value: Js.Lit): R                          = LiteralF[R](value)
+  def Ident(value: Name): R                              = IdentF[R](value)
+  def Access(expr: R, key: R): R                         = AccessF(expr, key)
+  def Call(callee: R, args: List[R]): R                  = CallF(callee, args)
+  def New(name: Name, args: List[R]): R                  = NewF(name, args)
+  def If(condition: R, consequent: R, alternative: R): R = IfF(condition, consequent, alternative)
+  def UnOp(op: UnaryOperator, arg: R): R                 = UnOpF(op, arg)
+  def BinOp(op: BinaryOperator, left: R, right: R): R    = BinOpF(op, left, right)
+  def Arr(values: List[R]): R                            = ArrF(values)
+  def Fun(params: List[Name], body: R): R                = FunF(params, body)
+  def Obj(values: ListMap[Name, R]): R                   = ObjF(values)
+  def Let(name: Name, expr: R, body: R): R               = LetF(name, expr, body)
+  def SpliceObjects(srcs: List[R]): R                    = SpliceObjectsF(srcs)
+  def SpliceArrays(srcs: List[R]): R                     = SpliceArraysF(srcs)
+
+  def ident(name: String): R = Ident(Name(name))
+  def select(expr: R, name: String): R = Access(expr, Literal(Js.Str(name)))
+  def binop(op: BinaryOperator, a1: R, args: R*): R = args.toList match {
+    case Nil    => a1
+    case h :: t => BinOp(op, a1, binop(op, h, t: _*))
+  }
+}
 
 object Literal {
   def apply(value: Js.Lit): JsCore = Fix(LiteralF(value))

--- a/marklogic/src/main/scala/quasar/physical/marklogic/fs/queryfile.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/fs/queryfile.scala
@@ -19,7 +19,6 @@ package quasar.physical.marklogic.fs
 import quasar.Predef._
 import quasar.{Data, LogicalPlan, Planner => QPlanner}
 import quasar.{PhaseResult, PhaseResults, PhaseResultT}
-import quasar.Func.Input2
 import quasar.contrib.matryoshka._
 import quasar.contrib.pathy._
 import quasar.effect.MonotonicSeq
@@ -34,7 +33,6 @@ import quasar.physical.marklogic.qscript._
 import quasar.physical.marklogic.xcc._
 import quasar.physical.marklogic.xquery._
 import quasar.qscript._
-import quasar.std.DateLib.Extract
 
 import matryoshka._, Recursive.ops._
 import scalaz._, Scalaz._, concurrent._
@@ -72,8 +70,8 @@ object queryfile {
         Vector(PhaseResult.detail("XQuery", main.render))
 
       def extractErr(partName: String, msg: String): FileSystemError =
-        FileSystemError.planningFailed(lp, QPlanner.UnsupportedPlan(
-          LogicalPlan.InvokeF(Extract, Input2(partName, "<date/time>")), Some(msg)))
+        FileSystemError.planningFailed(lp, QPlanner.UnsupportedFunction(
+          partName, "in planner".some))
 
       val listContents: DiscoverPath.ListContents[QPlan] =
         adir => lift(ops.ls(adir)).into[S].liftM[PhaseResultT].liftM[FileSystemErrT]
@@ -96,9 +94,6 @@ object queryfile {
                        FileSystemError.planningFailed(lp, QPlanner.UnsupportedPlan(
                          // TODO: Change to include the QScript context when supported
                          LogicalPlan.ConstantF(Data.Str(s)), Some(mlerr.shows)))
-
-                     case UnrecognizedDatePart(n) =>
-                       extractErr(n, mlerr.shows)
 
                      case UnrepresentableEJson(ejs, _) =>
                        FileSystemError.planningFailed(lp, QPlanner.NonRepresentableEJson(ejs.shows))

--- a/marklogic/src/main/scala/quasar/physical/marklogic/fs/queryfile.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/fs/queryfile.scala
@@ -69,10 +69,6 @@ object queryfile {
       def phase(main: MainModule): PhaseResults =
         Vector(PhaseResult.detail("XQuery", main.render))
 
-      def extractErr(partName: String, msg: String): FileSystemError =
-        FileSystemError.planningFailed(lp, QPlanner.UnsupportedFunction(
-          partName, "in planner".some))
-
       val listContents: DiscoverPath.ListContents[QPlan] =
         adir => lift(ops.ls(adir)).into[S].liftM[PhaseResultT].liftM[FileSystemErrT]
 
@@ -99,7 +95,8 @@ object queryfile {
                        FileSystemError.planningFailed(lp, QPlanner.NonRepresentableEJson(ejs.shows))
 
                      case UnsupportedDatePart(n) =>
-                       extractErr(n, mlerr.shows)
+                       FileSystemError.planningFailed(lp, QPlanner.UnsupportedFunction(
+                         n, "in planner".some))
                    })
         a       <- WriterT.put(lift(f(mod)).into[S])(phase(mod)).liftM[FileSystemErrT]
       } yield a

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MapFuncPlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MapFuncPlanner.scala
@@ -58,30 +58,27 @@ object MapFuncPlanner {
     case ToTimestamp(millis) => qscript.timestampToDateTime[F] apply (millis)
     case Now()               => fn.currentDateTime.point[F]
 
-    case Extract(XQuery.StringLit(part), time) => part match {
-      case "century"         => fn.ceiling(fn.yearFromDateTime(xs.dateTime(time)) div 100.xqy).point[F]
-      case "day"             => fn.dayFromDateTime(xs.dateTime(time)).point[F]
-      case "decade"          => fn.floor(fn.yearFromDateTime(xs.dateTime(time)) div 10.xqy).point[F]
-      case "dow"             => mkSeq_(xdmp.weekdayFromDate(xs.date(time)) - 1.xqy).point[F]
-      case "doy"             => xdmp.yeardayFromDate(xs.date(time)).point[F]
-      case "epoch"           => qscript.secondsSinceEpoch[F] apply (xs.dateTime(time))
-      case "hour"            => fn.hoursFromDateTime(xs.dateTime(time)).point[F]
-      case "isodow"          => xdmp.weekdayFromDate(xs.date(time)).point[F]
-      case "isoyear"         => MonadPlanErr[F].raiseError(MarkLogicPlannerError.unsupportedDatePart("isoyear"))
-      case "microseconds"    => mkSeq_(fn.secondsFromDateTime(xs.dateTime(time)) * 1000000.xqy).point[F]
-      case "millennium"      => mkSeq_(mkSeq_(fn.yearFromDateTime(xs.dateTime(time)) mod 1000.xqy) + 1.xqy).point[F]
-      case "milliseconds"    => mkSeq_(fn.secondsFromDateTime(xs.dateTime(time)) * 1000.xqy).point[F]
-      case "minute"          => fn.minutesFromDateTime(xs.dateTime(time)).point[F]
-      case "month"           => fn.monthFromDateTime(xs.dateTime(time)).point[F]
-      case "quarter"         => xdmp.quarterFromDate(xs.date(time)).point[F]
-      case "second"          => fn.secondsFromDateTime(xs.dateTime(time)).point[F]
-      case "timezone"        => qscript.timezoneOffsetSeconds[F] apply (xs.dateTime(time))
-      case "timezone_hour"   => fn.hoursFromDuration(fn.timezoneFromDateTime(xs.dateTime(time))).point[F]
-      case "timezone_minute" => fn.minutesFromDuration(fn.timezoneFromDateTime(xs.dateTime(time))).point[F]
-      case "week"            => xdmp.weekFromDate(xs.date(time)).point[F]
-      case "year"            => fn.yearFromDateTime(xs.dateTime(time)).point[F]
-      case other             => MonadPlanErr[F].raiseError(MarkLogicPlannerError.unrecognizedDatePart(other))
-    }
+    case ExtractCentury(time)         => fn.ceiling(fn.yearFromDateTime(xs.dateTime(time)) div 100.xqy).point[F]
+    case ExtractDayOfMonth(time)      => fn.dayFromDateTime(xs.dateTime(time)).point[F]
+    case ExtractDecade(time)          => fn.floor(fn.yearFromDateTime(xs.dateTime(time)) div 10.xqy).point[F]
+    case ExtractDayOfWeek(time)       => mkSeq_(xdmp.weekdayFromDate(xs.date(time)) - 1.xqy).point[F]
+    case ExtractDayOfYear(time)       => xdmp.yeardayFromDate(xs.date(time)).point[F]
+    case ExtractEpoch(time)           => qscript.secondsSinceEpoch[F] apply (xs.dateTime(time))
+    case ExtractHour(time)            => fn.hoursFromDateTime(xs.dateTime(time)).point[F]
+    case ExtractIsoDayOfWeek(time)    => xdmp.weekdayFromDate(xs.date(time)).point[F]
+    case ExtractIsoYear(time)         => MonadPlanErr[F].raiseError(MarkLogicPlannerError.unsupportedDatePart("isoyear"))
+    case ExtractMicroseconds(time)    => mkSeq_(fn.secondsFromDateTime(xs.dateTime(time)) * 1000000.xqy).point[F]
+    case ExtractMillenium(time)       => mkSeq_(mkSeq_(fn.yearFromDateTime(xs.dateTime(time)) mod 1000.xqy) + 1.xqy).point[F]
+    case ExtractMilliseconds(time)    => mkSeq_(fn.secondsFromDateTime(xs.dateTime(time)) * 1000.xqy).point[F]
+    case ExtractMinute(time)          => fn.minutesFromDateTime(xs.dateTime(time)).point[F]
+    case ExtractMonth(time)           => fn.monthFromDateTime(xs.dateTime(time)).point[F]
+    case ExtractQuarter(time)         => xdmp.quarterFromDate(xs.date(time)).point[F]
+    case ExtractSecond(time)          => fn.secondsFromDateTime(xs.dateTime(time)).point[F]
+    // case ExtractTimezone(time)       => qscript.timezoneOffsetSeconds[F] apply (xs.dateTime(time))
+    // case ExtractTimezoneHour(time)   => fn.hoursFromDuration(fn.timezoneFromDateTime(xs.dateTime(time))).point[F]
+    // case ExtractTimezoneMinute(time) => fn.minutesFromDuration(fn.timezoneFromDateTime(xs.dateTime(time))).point[F]
+    case ExtractWeek(time)            => xdmp.weekFromDate(xs.date(time)).point[F]
+    case ExtractYear(time)            => fn.yearFromDateTime(xs.dateTime(time)).point[F]
 
     // math
     case Negate(x)      => (-x).point[F]

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MapFuncPlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MapFuncPlanner.scala
@@ -74,9 +74,9 @@ object MapFuncPlanner {
     case ExtractMonth(time)           => fn.monthFromDateTime(xs.dateTime(time)).point[F]
     case ExtractQuarter(time)         => xdmp.quarterFromDate(xs.date(time)).point[F]
     case ExtractSecond(time)          => fn.secondsFromDateTime(xs.dateTime(time)).point[F]
-    // case ExtractTimezone(time)       => qscript.timezoneOffsetSeconds[F] apply (xs.dateTime(time))
-    // case ExtractTimezoneHour(time)   => fn.hoursFromDuration(fn.timezoneFromDateTime(xs.dateTime(time))).point[F]
-    // case ExtractTimezoneMinute(time) => fn.minutesFromDuration(fn.timezoneFromDateTime(xs.dateTime(time))).point[F]
+    case ExtractTimezone(time)       => qscript.timezoneOffsetSeconds[F] apply (xs.dateTime(time))
+    case ExtractTimezoneHour(time)   => fn.hoursFromDuration(fn.timezoneFromDateTime(xs.dateTime(time))).point[F]
+    case ExtractTimezoneMinute(time) => fn.minutesFromDuration(fn.timezoneFromDateTime(xs.dateTime(time))).point[F]
     case ExtractWeek(time)            => xdmp.weekFromDate(xs.date(time)).point[F]
     case ExtractYear(time)            => fn.yearFromDateTime(xs.dateTime(time)).point[F]
 

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MapFuncPlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MapFuncPlanner.scala
@@ -68,7 +68,7 @@ object MapFuncPlanner {
     case ExtractIsoDayOfWeek(time)    => xdmp.weekdayFromDate(xs.date(time)).point[F]
     case ExtractIsoYear(time)         => MonadPlanErr[F].raiseError(MarkLogicPlannerError.unsupportedDatePart("isoyear"))
     case ExtractMicroseconds(time)    => mkSeq_(fn.secondsFromDateTime(xs.dateTime(time)) * 1000000.xqy).point[F]
-    case ExtractMillenium(time)       => mkSeq_(mkSeq_(fn.yearFromDateTime(xs.dateTime(time)) mod 1000.xqy) + 1.xqy).point[F]
+    case ExtractMillennium(time)       => mkSeq_(mkSeq_(fn.yearFromDateTime(xs.dateTime(time)) mod 1000.xqy) + 1.xqy).point[F]
     case ExtractMilliseconds(time)    => mkSeq_(fn.secondsFromDateTime(xs.dateTime(time)) * 1000.xqy).point[F]
     case ExtractMinute(time)          => fn.minutesFromDateTime(xs.dateTime(time)).point[F]
     case ExtractMonth(time)           => fn.monthFromDateTime(xs.dateTime(time)).point[F]

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MarkLogicPlannerError.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MarkLogicPlannerError.scala
@@ -32,18 +32,12 @@ sealed abstract class MarkLogicPlannerError
 
 object MarkLogicPlannerError {
   final case class InvalidQName(strLit: String) extends MarkLogicPlannerError
-  // TODO: If we had an enum for the date parts, this wouldn't be necessary.
-  final case class UnrecognizedDatePart(name: String) extends MarkLogicPlannerError
   final case class UnrepresentableEJson(ejson: Fix[EJson], msgs: ErrorMessages) extends MarkLogicPlannerError
   final case class UnsupportedDatePart(name: String) extends MarkLogicPlannerError
 
   val invalidQName = Prism.partial[MarkLogicPlannerError, String] {
     case InvalidQName(s) => s
   } (InvalidQName)
-
-  val unrecognizedDatePart = Prism.partial[MarkLogicPlannerError, String] {
-    case UnrecognizedDatePart(name) => name
-  } (UnrecognizedDatePart)
 
   val unrepresentableEJson = Prism.partial[MarkLogicPlannerError, (Fix[EJson], ErrorMessages)] {
     case UnrepresentableEJson(ejs, msgs) => (ejs, msgs)
@@ -57,9 +51,6 @@ object MarkLogicPlannerError {
     Show.shows {
       case InvalidQName(s) =>
         s"'$s' is not a valid XML QName."
-
-      case UnrecognizedDatePart(n) =>
-        s"'$n' is not recognized as a date/time part."
 
       case UnrepresentableEJson(ejs, msgs) =>
         s"'${ejs.shows}' does not have an XQuery representation: ${msgs.intercalate(", ")}"

--- a/mongodb/src/main/scala/quasar/physical/mongodb/expression/ExprOpCore.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/expression/ExprOpCore.scala
@@ -22,7 +22,6 @@ import quasar.fp._
 import quasar.javascript._
 import quasar.jscore, jscore.{JsCore, JsFn}
 import quasar.physical.mongodb.{Bson, BsonField}
-import quasar.physical.mongodb.javascript._
 
 import matryoshka._
 import scalaz._, Scalaz._
@@ -293,6 +292,9 @@ object ExprOpCoreF {
     // FIXME: Define a proper `Show[ExprOpCoreF]` instance.
     @SuppressWarnings(Array("org.wartremover.warts.ToString"))
     def toJsSimple: AlgebraM[PlannerError \/ ?, ExprOpCoreF, JsFn] = {
+      val mjs = quasar.physical.mongodb.javascript[Fix]
+      import mjs._
+
       def expr1(x1: JsFn)(f: JsCore => JsCore): PlannerError \/ JsFn =
         \/-(JsFn(JsFn.defaultName, f(x1(jscore.Ident(JsFn.defaultName)))))
       def expr2(x1: JsFn, x2: JsFn)(f: (JsCore, JsCore) => JsCore): PlannerError \/ JsFn =

--- a/mongodb/src/main/scala/quasar/physical/mongodb/expression/ExprOpCore.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/expression/ExprOpCore.scala
@@ -366,12 +366,15 @@ object ExprOpCoreF {
         case $toLowerF(a)            => invoke(a, "toLowerCase")
         case $toUpperF(a)            => invoke(a, "toUpperCase")
 
-        case $yearF(a)               => invoke(a, "getFullYear")
+        case $yearF(a)               => invoke(a, "getUTCFullYear")
         // case $dayOfYear(a)           => // TODO: no JS equivalent
-        case $monthF(a)              => invoke(a, "getMonth")
-        case $dayOfMonthF(a)         => invoke(a, "getDate")
+        case $monthF(a)              => invoke(a, "getUTCMonth")
+        case $dayOfMonthF(a)         => invoke(a, "getUTCDate")
         // case $week(a)                => // TODO: no JS equivalent
-        case $dayOfWeekF(a)          => invoke(a, "getDay")
+        case $dayOfWeekF(a)          => expr1(a)(x =>
+          jscore.BinOp(jscore.Add,
+            jscore.Call(jscore.Select(x, "getUTCDay"), Nil),
+            jscore.Literal(Js.Num(1, false))))
         case $hourF(a)               => invoke(a, "getUTCHours")
         case $minuteF(a)             => invoke(a, "getUTCMinutes")
         case $secondF(a)             => invoke(a, "getUTCSeconds")

--- a/mongodb/src/main/scala/quasar/physical/mongodb/expression/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/expression/package.scala
@@ -20,7 +20,6 @@ import quasar.Predef._
 import quasar.{Type, RenderTree, Terminal}, Type.⨿
 import quasar.jscore, jscore.{JsCore, JsFn}
 import quasar.Planner.{PlannerError, UnsupportedJS}
-import quasar.physical.mongodb.javascript._
 
 import matryoshka._, Recursive.ops._
 import monocle.Prism
@@ -53,6 +52,9 @@ package object expression {
       ev0: Equal[T[EX]],
       ev1: ExprOpOps.Uni[EX])
       : PartialFunction[T[EX], PlannerError \/ JsFn] = {
+    val mjs = quasar.physical.mongodb.javascript[Fix]
+    import mjs._
+
     def app(x: T[EX], tc: JsCore => JsCore): PlannerError \/ JsFn =
       Recursive[T].para(x)(toJs[T, EX]).map(f => JsFn(JsFn.defaultName, tc(f(jscore.Ident(JsFn.defaultName)))))
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/javascript/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/javascript/package.scala
@@ -22,55 +22,65 @@ import quasar._
 import quasar.jscore._
 import quasar.javascript.{Js}
 
-package object javascript {
+import matryoshka._
+
+final case class javascript[T[_[_]]: Corecursive]() {
+  private type R = T[JsCoreF]
+
+  @inline private implicit def convert(x: JsCoreF[R]): R =
+    x.embed
+
+  private val jsFp = jscore.fixpoint[T]
+  import jsFp._
+
   /** Convert a `Bson.Date` to a JavaScript `Date`. */
-  def toJsDate(value: Bson.Date): JsCore =
+  def toJsDate(value: Bson.Date): R =
     New(Name("Date"), List(Literal(Js.Str(value.value.toString))))
 
   /** Convert a `Bson.ObjectId` to a JavaScript `ObjectId`. */
-  def toJsObjectId(value: Bson.ObjectId): JsCore =
+  def toJsObjectId(value: Bson.ObjectId): R =
     New(Name("ObjectId"), List(Literal(Js.Str(value.str))))
 
-  def isNull(expr: JsCore): JsCore =
+  def isNull(expr: R): R =
     BinOp(Eq, Literal(Js.Null), expr)
 
-  def isAnyNumber(expr: JsCore): JsCore =
+  def isAnyNumber(expr: R): R =
     BinOp(Or, isDec(expr), isInt(expr))
 
-  def isInt(expr: JsCore): JsCore =
+  def isInt[A](expr: R): R =
     BinOp(Or,
       BinOp(Instance, expr, ident("NumberInt")),
       BinOp(Instance, expr, ident("NumberLong")))
 
-  def isDec(expr: JsCore): JsCore =
+  def isDec(expr: R): R =
     Call(ident("isNumber"), List(expr))
 
-  def isString(expr: JsCore): JsCore =
+  def isString(expr: R): R =
     Call(ident("isString"), List(expr))
 
-  def isObjectOrArray(expr: JsCore): JsCore =
+  def isObjectOrArray(expr: R): R =
     Call(ident("isObject"), List(expr))
 
-  def isArray(expr: JsCore): JsCore =
-    Call(Select(ident("Array"), "isArray"), List(expr))
+  def isArray(expr: R): R =
+    Call(select(ident("Array"), "isArray"), List(expr))
 
-  def isObject(expr: JsCore): JsCore =
+  def isObject(expr: R): R =
     BinOp(And,
       isObjectOrArray(expr),
       UnOp(Not, isArray(expr)))
 
-  def isBoolean(expr: JsCore): JsCore =
-    BinOp(Eq, UnOp(TypeOf, expr), jscore.Literal(Js.Str("boolean")))
+  def isBoolean(expr: R): R =
+    BinOp(Eq, UnOp(TypeOf, expr), Literal(Js.Str("boolean")))
 
-  def isTimestamp(expr: JsCore): JsCore =
-    jscore.BinOp(jscore.Instance, expr, jscore.ident("Timestamp"))
+  def isTimestamp(expr: R): R =
+    BinOp(Instance, expr, ident("Timestamp"))
 
-  def isDate(expr: JsCore): JsCore =
-    jscore.BinOp(jscore.Instance, expr, jscore.ident("Date"))
+  def isDate(expr: R): R =
+    BinOp(Instance, expr, ident("Date"))
 
-  def isBinary(expr: JsCore): JsCore =
-    jscore.BinOp(jscore.Instance, expr, jscore.ident("Binary"))
+  def isBinary(expr: R): R =
+    BinOp(Instance, expr, ident("Binary"))
 
-  def isObjectId(expr: JsCore): JsCore =
-    jscore.BinOp(jscore.Instance, expr, jscore.ident("ObjectId"))
+  def isObjectId(expr: R): R =
+    BinOp(Instance, expr, ident("ObjectId"))
 }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/FuncHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/FuncHandler.scala
@@ -108,7 +108,7 @@ object FuncHandler {
                 $multiply($second(a1), $literal(Bson.Int32(1000))),
                 $millisecond(a1)),
               $literal(Bson.Int32(1000)))
-          case ExtractMillenium(a1) =>
+          case ExtractMillennium(a1) =>
             trunc($divide($add($year(a1), $literal(Bson.Int32(999))), $literal(Bson.Int32(1000))))
           case ExtractMilliseconds(a1) =>
             $add(

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/FuncHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/FuncHandler.scala
@@ -112,9 +112,16 @@ object FuncHandler {
   }
 
   def handleOps3_2[T[_[_]]]: FuncHandler[T, ExprOp3_2F] = {
+    def hole[D](d: D): Free[ExprOp3_2F, D] = Free.pure(d)
     new FuncHandler[T, ExprOp3_2F](new (MapFunc[T, ?] ~> M[ExprOp3_2F, ?]) {
       def apply[A](fa: MapFunc[T, A]): M[ExprOp3_2F, A] = {
-        None
+        val fp = ExprOp3_2F.fixpoint[Free[?[_], A], ExprOp3_2F]
+        import fp._
+
+        fa.some collect {
+          case Power(a1, a2) =>
+            $pow(hole(a1), hole(a2))
+        }
       }
     })
   }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/FuncHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/FuncHandler.scala
@@ -38,7 +38,7 @@ object FuncHandler {
   type M[F[_], A] = Option[Free[F, A]]
 
   def handleOpsCore[T[_[_]]]: FuncHandler[T, ExprOpCoreF] = {
-    def hole[D](d: D): Free[ExprOpCoreF, D] = Free.pure(d)
+    implicit def hole[D](d: D): Free[ExprOpCoreF, D] = Free.pure(d)
 
     new FuncHandler[T, ExprOpCoreF](new (MapFunc[T, ?] ~> M[ExprOpCoreF, ?]) {
       def apply[A](fa: MapFunc[T, A]): M[ExprOpCoreF, A] = {
@@ -46,57 +46,88 @@ object FuncHandler {
         import fp._
 
         fa.some collect {
-          case Add(a1, a2)           => $add(hole(a1), hole(a2))
-          case Multiply(a1, a2)      => $multiply(hole(a1), hole(a2))
-          case Subtract(a1, a2)      => $subtract(hole(a1), hole(a2))
-          case Divide(a1, a2)        => $divide(hole(a1), hole(a2))
-          case Modulo(a1, a2)        => $mod(hole(a1), hole(a2))
-          case Negate(a1)            => $multiply($literal(Bson.Int32(-1)), hole(a1))
+          case Add(a1, a2)           => $add(a1, a2)
+          case Multiply(a1, a2)      => $multiply(a1, a2)
+          case Subtract(a1, a2)      => $subtract(a1, a2)
+          case Divide(a1, a2)        => $divide(a1, a2)
+          case Modulo(a1, a2)        => $mod(a1, a2)
+          case Negate(a1)            => $multiply($literal(Bson.Int32(-1)), a1)
 
-          case Eq(a1, a2)            => $eq(hole(a1), hole(a2))
-          case Neq(a1, a2)           => $neq(hole(a1), hole(a2))
-          case Lt(a1, a2)            => $lt(hole(a1), hole(a2))
-          case Lte(a1, a2)           => $lte(hole(a1), hole(a2))
-          case Gt(a1, a2)            => $gt(hole(a1), hole(a2))
-          case Gte(a1, a2)           => $gte(hole(a1), hole(a2))
+          case Eq(a1, a2)            => $eq(a1, a2)
+          case Neq(a1, a2)           => $neq(a1, a2)
+          case Lt(a1, a2)            => $lt(a1, a2)
+          case Lte(a1, a2)           => $lte(a1, a2)
+          case Gt(a1, a2)            => $gt(a1, a2)
+          case Gte(a1, a2)           => $gte(a1, a2)
 
-          case Coalesce(a1, a2)      => $ifNull(hole(a1), hole(a2))
+          case Coalesce(a1, a2)      => $ifNull(a1, a2)
 
-          case ConcatArrays(a1, a2)  => $concat(hole(a1), hole(a2))  // NB: this is valid for strings only
-          case Lower(a1)             => $toLower(hole(a1))
-          case Upper(a1)             => $toUpper(hole(a1))
-          case Substring(a1, a2, a3) => $substr(hole(a1), hole(a2), hole(a3))
+          case ConcatArrays(a1, a2)  => $concat(a1, a2)  // NB: this is valid for strings only
+          case Lower(a1)             => $toLower(a1)
+          case Upper(a1)             => $toUpper(a1)
+          case Substring(a1, a2, a3) => $substr(a1, a2, a3)
 
-          case Cond(a1, a2, a3)      => $cond(hole(a1), hole(a2), hole(a3))
+          case Cond(a1, a2, a3)      => $cond(a1, a2, a3)
 
-          case Or(a1, a2)            => $or(hole(a1), hole(a2))
-          case And(a1, a2)           => $and(hole(a1), hole(a2))
-          case Not(a1)               => $not(hole(a1))
+          case Or(a1, a2)            => $or(a1, a2)
+          case And(a1, a2)           => $and(a1, a2)
+          case Not(a1)               => $not(a1)
 
           case Null(a1) =>
-            $cond($eq(hole(a1), $literal(Bson.Text("null"))),
+            $cond($eq(a1, $literal(Bson.Text("null"))),
               $literal(Bson.Null),
               $literal(Bson.Undefined))
 
           case Bool(a1) =>
-            $cond($eq(hole(a1), $literal(Bson.Text("true"))),
+            $cond($eq(a1, $literal(Bson.Text("true"))),
               $literal(Bson.Bool(true)),
-              $cond($eq(hole(a1), $literal(Bson.Text("false"))),
+              $cond($eq(a1, $literal(Bson.Text("false"))),
                 $literal(Bson.Bool(false)),
                 $literal(Bson.Undefined)))
 
-          case ToTimestamp(a1) =>
-            $add($literal(Bson.Date(Instant.ofEpochMilli(0))), hole(a1))
+          case ExtractCentury(a1) =>
+            $divide($year(a1), $literal(Bson.Int32(100)))  // FIXME
+          case ExtractDayOfMonth(a1) => $dayOfMonth(a1)
+          case ExtractDecade(a1) => $divide($year(a1), $literal(Bson.Int32(10)))
+          case ExtractDayOfWeek(a1) => $add($dayOfWeek(a1), $literal(Bson.Int32(-1)))
+          case ExtractDayOfYear(a1) => $dayOfYear(a1)
+          case ExtractEpoch(a1) =>
+            $divide(
+              $subtract(a1, $literal(Bson.Date(Instant.ofEpochMilli(0)))),
+              $literal(Bson.Int32(1000)))
+          case ExtractHour(a1) => $hour(a1)
+          case ExtractIsoDayOfWeek(a1) =>
+            $cond($eq($dayOfWeek(a1), $literal(Bson.Int32(1))),
+              $literal(Bson.Int32(7)),
+              $add($dayOfWeek(a1), $literal(Bson.Int32(-1))))
+          // TODO: case ExtractIsoYear(a1) =>
+          case ExtractMicroseconds(a1) =>
+            $multiply($millisecond(a1), $literal(Bson.Int32(1000)))  // FIXME
+          case ExtractMillenium(a1) =>
+            $divide($year(a1), $literal(Bson.Int32(1000)))  // FIXME
+          case ExtractMilliseconds(a1) => $millisecond(a1)  // FIXME
+          case ExtractMinute(a1) => $minute(a1)
+          case ExtractMonth(a1) => $month(a1)
+          case ExtractQuarter(a1) =>
+            $add(
+              $divide($dayOfYear(a1), $literal(Bson.Int32(92))),
+              $literal(Bson.Int32(1)))  // FIXME
+          case ExtractSecond(a1) => $second(a1)
+          case ExtractWeek(a1) => $week(a1)
+          case ExtractYear(a1) => $year(a1)
 
-          case Between(a1, a2, a3)   => $and($lte(hole(a2), hole(a1)),
-                                              $lte(hole(a1), hole(a3)))
+          case ToTimestamp(a1) =>
+            $add($literal(Bson.Date(Instant.ofEpochMilli(0))), a1)
+
+          case Between(a1, a2, a3)   => $and($lte(a2, a1),
+                                              $lte(a1, a3))
         }
       }
     })
   }
 
   def handleOps3_0[T[_[_]]]: FuncHandler[T, ExprOp3_0F] = {
-    def hole[D](d: D): Free[ExprOp3_0F, D] = Free.pure(d)
+    implicit def hole[D](d: D): Free[ExprOp3_0F, D] = Free.pure(d)
     new FuncHandler[T, ExprOp3_0F](new (MapFunc[T, ?] ~> M[ExprOp3_0F, ?]) {
       def apply[A](fa: MapFunc[T, A]): M[ExprOp3_0F, A] = {
         val fp = ExprOp3_0F.fixpoint[Free[?[_], A], ExprOp3_0F]
@@ -105,14 +136,14 @@ object FuncHandler {
 
         fa.some collect {
           case TimeOfDay(a1) =>
-            $dateToString(Hour :: ":" :: Minute :: ":" :: Second :: "." :: Millisecond :: FormatString.empty, hole(a1))
+            $dateToString(Hour :: ":" :: Minute :: ":" :: Second :: "." :: Millisecond :: FormatString.empty, a1)
         }
       }
     })
   }
 
   def handleOps3_2[T[_[_]]]: FuncHandler[T, ExprOp3_2F] = {
-    def hole[D](d: D): Free[ExprOp3_2F, D] = Free.pure(d)
+    implicit def hole[D](d: D): Free[ExprOp3_2F, D] = Free.pure(d)
     new FuncHandler[T, ExprOp3_2F](new (MapFunc[T, ?] ~> M[ExprOp3_2F, ?]) {
       def apply[A](fa: MapFunc[T, A]): M[ExprOp3_2F, A] = {
         val fp = ExprOp3_2F.fixpoint[Free[?[_], A], ExprOp3_2F]
@@ -120,7 +151,7 @@ object FuncHandler {
 
         fa.some collect {
           case Power(a1, a2) =>
-            $pow(hole(a1), hole(a2))
+            $pow(a1, a2)
         }
       }
     })

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/JsFuncHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/JsFuncHandler.scala
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.mongodb.planner
+
+import quasar.Predef._
+import quasar.javascript.Js
+import quasar.jscore, jscore.{Name, JsCoreF}
+import quasar.std.StdLib._
+import quasar.qscript.MapFunc
+import quasar.qscript.MapFuncs._
+
+import scalaz.{Free, Scalaz}, Scalaz._
+
+object JsFuncHandler {
+  def apply[T[_[_]], A](func: MapFunc[T, A]): Option[Free[JsCoreF, A]] = {
+    implicit def hole(a: A): Free[JsCoreF, A] = Free.pure(a)
+
+    val js = quasar.jscore.fixpoint[Free[?[_], A]]
+    import js._
+    val mjs = quasar.physical.mongodb.javascript[Free[?[_], A]]
+    import mjs._
+
+    func.some collect {
+      case Add(a1, a2)      => BinOp(jscore.Add, a1, a2)
+      case Multiply(a1, a2) => BinOp(jscore.Mult, a1, a2)
+      case Power(a1, a2) =>
+        Call(select(ident("Math"), "pow"), List(a1, a2))
+      case Subtract(a1, a2) => BinOp(jscore.Sub, a1, a2)
+      case Divide(a1, a2)   => BinOp(jscore.Div, a1, a2)
+      case Modulo(a1, a2)   => BinOp(jscore.Mod, a1, a2)
+      case Negate(a1)       => UnOp(jscore.Neg, a1)
+
+      case Eq(a1, a2)  => BinOp(jscore.Eq, a1, a2)
+      case Neq(a1, a2) => BinOp(jscore.Neq, a1, a2)
+      case Lt(a1, a2)  => BinOp(jscore.Lt, a1, a2)
+      case Lte(a1, a2) => BinOp(jscore.Lte, a1, a2)
+      case Gt(a1, a2)  => BinOp(jscore.Gt, a1, a2)
+      case Gte(a1, a2) => BinOp(jscore.Gte, a1, a2)
+      case Not(a1)     => UnOp(jscore.Not, a1)
+      case And(a1, a2) => BinOp(jscore.And, a1, a2)
+      case Or(a1, a2)  => BinOp(jscore.Or, a1, a2)
+      case Between(value, min, max) =>
+          BinOp(jscore.And,
+            BinOp(jscore.Lte, min, value),
+            BinOp(jscore.Lte, value, max))
+
+      case ConcatArrays(a1, a2) => BinOp(jscore.Add, a1, a2)
+      case Length(str) =>
+        Call(ident("NumberLong"), List(select(hole(str), "length")))
+      case Substring(field, start, len) =>
+        If(BinOp(jscore.Lt, start, Literal(Js.Num(0, false))),
+          Literal(Js.Str("")),
+          If(BinOp(jscore.Lt, len, Literal(Js.Num(0, false))),
+            Call(select(field, "substr"), List(start, select(field, "length"))),
+            Call(select(field, "substr"), List(start, len))))
+      case Search(field, pattern, insen) =>
+          Call(
+            select(
+              New(Name("RegExp"), List(
+                pattern,
+                If(insen, Literal(Js.Str("im")), Literal(Js.Str("m"))))),
+              "test"),
+            List(field))
+      case Null(str) =>
+        If(
+          BinOp(jscore.Eq, str, Literal(Js.Str("null"))),
+          Literal(Js.Null),
+          ident("undefined"))
+      case Bool(str) =>
+        If(
+          BinOp(jscore.Eq, str, Literal(Js.Str("true"))),
+          Literal(Js.Bool(true)),
+          If(
+            BinOp(jscore.Eq, str, Literal(Js.Str("false"))),
+            Literal(Js.Bool(false)),
+            ident("undefined")))
+      case Integer(str) =>
+        If(Call(select(Call(ident("RegExp"), List(Literal(Js.Str("^" + string.intRegex + "$")))), "test"), List(str)),
+          Call(ident("NumberLong"), List(str)),
+          ident("undefined"))
+      case Decimal(str) =>
+          If(Call(select(Call(ident("RegExp"), List(Literal(Js.Str("^" + string.floatRegex + "$")))), "test"), List(str)),
+            Call(ident("parseFloat"), List(str)),
+            ident("undefined"))
+      case Date(str) =>
+        If(Call(select(Call(ident("RegExp"), List(Literal(Js.Str("^" + string.dateRegex + "$")))), "test"), List(str)),
+          Call(ident("ISODate"), List(str)),
+          ident("undefined"))
+      case Time(str) =>
+        If(Call(select(Call(ident("RegExp"), List(Literal(Js.Str("^" + string.timeRegex + "$")))), "test"), List(str)),
+          str,
+          ident("undefined"))
+      case Timestamp(str) =>
+        If(Call(select(Call(ident("RegExp"), List(Literal(Js.Str("^" + string.timestampRegex + "$")))), "test"), List(str)),
+          Call(ident("ISODate"), List(str)),
+          ident("undefined"))
+      case ToString(value) =>
+        If(isInt(value),
+          // NB: This is a terrible way to turn an int into a string, but the
+          //     only one that doesn’t involve converting to a decimal and
+          //     losing precision.
+          Call(select(Call(ident("String"), List(value)), "replace"), List(
+            Call(ident("RegExp"), List(
+              Literal(Js.Str("[^-0-9]+")),
+              Literal(Js.Str("g")))),
+            Literal(Js.Str("")))),
+          If(BinOp(jscore.Or, isTimestamp(value), isDate(value)),
+            Call(select(value, "toISOString"), Nil),
+            Call(ident("String"), List(value))))
+
+      case TimeOfDay(date) =>
+        def pad2(x: Free[JsCoreF, A]) =
+          Let(Name("x"), x,
+            If(
+              BinOp(jscore.Lt, ident("x"), Literal(Js.Num(10, false))),
+              BinOp(jscore.Add, Literal(Js.Str("0")), ident("x")),
+              ident("x")))
+        def pad3(x: Free[JsCoreF, A]) =
+          Let(Name("x"), x,
+            If(
+              BinOp(jscore.Lt, ident("x"), Literal(Js.Num(10, false))),
+              BinOp(jscore.Add, Literal(Js.Str("00")), ident("x")),
+              If(
+                BinOp(jscore.Lt, ident("x"), Literal(Js.Num(100, false))),
+                BinOp(jscore.Add, Literal(Js.Str("0")), ident("x")),
+                ident("x"))))
+        Let(Name("t"), date,
+          binop(jscore.Add,
+            pad2(Call(select(ident("t"), "getUTCHours"), Nil)),
+            Literal(Js.Str(":")),
+            pad2(Call(select(ident("t"), "getUTCMinutes"), Nil)),
+            Literal(Js.Str(":")),
+            pad2(Call(select(ident("t"), "getUTCSeconds"), Nil)),
+            Literal(Js.Str(".")),
+            pad3(Call(select(ident("t"), "getUTCMilliseconds"), Nil))))
+
+      case ProjectField(obj, field) => Access(obj, field)
+      case ProjectIndex(arr, index) => Access(arr, index)
+    }
+  }
+}

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/JsFuncHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/JsFuncHandler.scala
@@ -150,6 +150,64 @@ object JsFuncHandler {
             Literal(Js.Str(".")),
             pad3(Call(select(ident("t"), "getUTCMilliseconds"), Nil))))
 
+      case ExtractCentury(date) =>
+        BinOp(jscore.Div, Call(select(date, "getFullYear"), Nil), Literal(Js.Num(100, false)))
+      case ExtractDayOfMonth(date) => Call(select(date, "getDate"), Nil)
+      case ExtractDecade(date) =>
+        BinOp(jscore.Div, Call(select(date, "getFullYear"), Nil), Literal(Js.Num(10, false)))
+      case ExtractDayOfWeek(date) =>
+        // NB: MongoDB's Date's getDay (during filtering at least) seems to
+        // be monday=0 ... sunday=6, apparently in violation of the JavaScript
+        // convention.
+        If(
+          BinOp(jscore.Eq,
+            Call(select(date, "getDay"), Nil),
+            Literal(Js.Num(6, false))),
+          Literal(Js.Num(0, false)),
+          BinOp(jscore.Add,
+            Call(select(date, "getDay"), Nil),
+            Literal(Js.Num(1, false))))
+      // TODO: case ExtractDayOfYear(date) =>
+      case ExtractEpoch(date) =>
+        BinOp(jscore.Div, Call(select(date, "valueOf"), Nil), Literal(Js.Num(1000, false)))
+      case ExtractHour(date) => Call(select(date, "getHours"), Nil)
+      case ExtractIsoDayOfWeek(date) =>
+        BinOp(jscore.Add,
+          Call(select(date, "getDay"), Nil),
+          Literal(Js.Num(1, false)))
+      // TODO: case ExtractIsoYear(date) =>
+      case ExtractMicroseconds(date) =>
+        BinOp(jscore.Mult,
+          BinOp(jscore.Add,
+            Call(select(date, "getMilliseconds"), Nil),
+            BinOp(jscore.Mult, Call(select(date, "getSeconds"), Nil), Literal(Js.Num(1000, false)))),
+          Literal(Js.Num(1000, false)))
+      case ExtractMillenium(date) =>
+        BinOp(jscore.Div, Call(select(date, "getFullYear"), Nil), Literal(Js.Num(1000, false)))
+      case ExtractMilliseconds(date) =>
+        BinOp(jscore.Add,
+          Call(select(date, "getMilliseconds"), Nil),
+          BinOp(jscore.Mult, Call(select(date, "getSeconds"), Nil), Literal(Js.Num(1000, false))))
+      case ExtractMinute(date) =>
+        Call(select(date, "getMinutes"), Nil)
+      case ExtractMonth(date) =>
+        BinOp(jscore.Add,
+          Call(select(date, "getMonth"), Nil),
+          Literal(Js.Num(1, false)))
+      case ExtractQuarter(date) =>
+        BinOp(jscore.Add,
+          BinOp(jscore.BitOr,
+            BinOp(jscore.Div,
+              Call(select(date, "getMonth"), Nil),
+              Literal(Js.Num(3, false))),
+            Literal(Js.Num(0, false))),
+          Literal(Js.Num(1, false)))
+      case ExtractSecond(date) => Call(select(date, "getSeconds"), Nil)
+      // TODO: case ExtractWeek(date) =>
+      case ExtractYear(date) => Call(select(date, "getFullYear"), Nil)
+
+      case Now() => Call(select(ident("Date"), "now"), Nil)
+
       case ProjectField(obj, field) => Access(obj, field)
       case ProjectIndex(arr, index) => Access(arr, index)
     }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/JsFuncHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/JsFuncHandler.scala
@@ -108,6 +108,7 @@ object JsFuncHandler {
         If(Call(select(Call(ident("RegExp"), List(Literal(Js.Str("^" + string.timestampRegex + "$")))), "test"), List(str)),
           Call(ident("ISODate"), List(str)),
           ident("undefined"))
+      // TODO: case Interval(str) =>
       case ToString(value) =>
         If(isInt(value),
           // NB: This is a terrible way to turn an int into a string, but the
@@ -121,6 +122,7 @@ object JsFuncHandler {
           If(BinOp(jscore.Or, isTimestamp(value), isDate(value)),
             Call(select(value, "toISOString"), Nil),
             Call(ident("String"), List(value))))
+      // TODO: case ToTimestamp(str) =>
 
       case TimeOfDay(date) =>
         def pad2(x: Free[JsCoreF, A]) =

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/JsFuncHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/JsFuncHandler.scala
@@ -191,7 +191,7 @@ object JsFuncHandler {
               Call(select(date, "getUTCSeconds"), Nil),
               Literal(Js.Num(1000, false)))),
           Literal(Js.Num(1000, false)))
-      case ExtractMillenium(date) =>
+      case ExtractMillennium(date) =>
         Call(select(ident("Math"), "ceil"), List(
           BinOp(jscore.Div,
             Call(select(date, "getUTCFullYear"), Nil),

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/MongoDbPlanner.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/MongoDbPlanner.scala
@@ -304,10 +304,10 @@ object MongoDbPlanner {
           def pad3(x: JsCore) =
             Let(Name("x"), x,
               If(
-                BinOp(jscore.Lt, ident("x"), Literal(Js.Num(100, false))),
+                BinOp(jscore.Lt, ident("x"), Literal(Js.Num(10, false))),
                 BinOp(jscore.Add, Literal(Js.Str("00")), ident("x")),
                 If(
-                  BinOp(jscore.Lt, ident("x"), Literal(Js.Num(10, false))),
+                  BinOp(jscore.Lt, ident("x"), Literal(Js.Num(100, false))),
                   BinOp(jscore.Add, Literal(Js.Str("0")), ident("x")),
                   ident("x"))))
           Arity1(date =>

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/MongoDbPlanner.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/MongoDbPlanner.scala
@@ -27,7 +27,6 @@ import quasar.javascript._
 import quasar.jscore, jscore.{JsCore, JsFn}
 import quasar.namegen._
 import quasar.physical.mongodb._
-import quasar.physical.mongodb.javascript._
 import quasar.physical.mongodb.workflow._
 import quasar.qscript.{MapFunc, SortDir}
 import quasar.std.StdLib._
@@ -96,6 +95,9 @@ object MongoDbPlanner {
       And => _, Or => _, Not => _,
       _}
 
+    val mjs = quasar.physical.mongodb.javascript[Fix]
+    import mjs._
+
     val HasJs: Output => OutputM[PartialJs] =
       _ <+> \/-(({ case List(field) => field }, List(Here)))
 
@@ -151,88 +153,39 @@ object MongoDbPlanner {
       def makeSimpleUnop(op: UnaryOperator): Output =
         Arity1(UnOp(op, _))
 
-      func match {
-        case Constantly => Arity1(ι)
-        case Length =>
-          Arity1(expr => Call(ident("NumberLong"), List(Select(expr, "length"))))
-        case Add      => makeSimpleBinop(jscore.Add)
-        case Multiply => makeSimpleBinop(Mult)
-        case Subtract => makeSimpleBinop(Sub)
-        case Divide   => makeSimpleBinop(Div)
-        case Modulo   => makeSimpleBinop(Mod)
-        case Negate   => makeSimpleUnop(Neg)
+      ((func, args) match {
+        // NB: this one is missing from MapFunc.
+        case (ToId, _) => None
 
-        case Eq  => makeSimpleBinop(jscore.Eq)
-        case Neq => makeSimpleBinop(jscore.Neq)
-        case Lt  => makeSimpleBinop(jscore.Lt)
-        case Lte => makeSimpleBinop(jscore.Lte)
-        case Gt  => makeSimpleBinop(jscore.Gt)
-        case Gte => makeSimpleBinop(jscore.Gte)
-        case And => makeSimpleBinop(jscore.And)
-        case Or  => makeSimpleBinop(jscore.Or)
+        // NB: this would get mapped to the same MapFunc as string.Concat, which
+        // doesn't make sense here.
+        case (ArrayConcat, _) => None
+
+        case (func @ UnaryFunc(_, _, _, _, _, _, _, _), Sized(a1)) if func.effect ≟ Mapping =>
+          val mf = MapFunc.translateUnaryMapping[Fix, UnaryArg](func)(UnaryArg._1)
+          JsFuncHandler(mf).map(exp => Arity1(exp.eval))
+        case (func @ BinaryFunc(_, _, _, _, _, _, _, _), Sized(a1, a2)) if func.effect ≟ Mapping =>
+          val mf = MapFunc.translateBinaryMapping[Fix, BinaryArg](func)(BinaryArg._1, BinaryArg._2)
+          JsFuncHandler(mf).map(exp => Arity2(exp.eval))
+        case (func @ TernaryFunc(_, _, _, _, _, _, _, _), Sized(a1, a2, a3)) if func.effect ≟ Mapping =>
+          val mf = MapFunc.translateTernaryMapping[Fix, TernaryArg](func)(TernaryArg._1, TernaryArg._2, TernaryArg._3)
+          JsFuncHandler(mf).map(exp => Arity3(exp.eval))
+        case _ => None
+      }).getOrElse(func match {
+        case Constantly => Arity1(ι)  // FIXME: this cannot possibly be right
+
         case Squash      => Arity1(v => v)
         case IfUndefined => Arity2((value, fallback) =>
           // TODO: Only evaluate `value` once.
           If(BinOp(jscore.Eq, value, ident("undefined")), fallback, value))
-        case Not => makeSimpleUnop(jscore.Not)
-        case Concat => makeSimpleBinop(jscore.Add)
         case In | Within =>
           Arity2((value, array) =>
             BinOp(jscore.Neq,
               Literal(Js.Num(-1, false)),
               Call(Select(array, "indexOf"), List(value))))
-        case Substring =>
-          Arity3((field, start, len) =>
-            If(BinOp(jscore.Lt, start, Literal(Js.Num(0, false))),
-              Literal(Js.Str("")),
-              If(BinOp(jscore.Lt, len, Literal(Js.Num(0, false))),
-                Call(Select(field, "substr"), List(start, Select(field, "length"))),
-                Call(Select(field, "substr"), List(start, len)))))
-        case Search =>
-          Arity3((field, pattern, insen) =>
-            Call(
-              Select(
-                New(Name("RegExp"), List(
-                  pattern,
-                  If(insen, Literal(Js.Str("im")), Literal(Js.Str("m"))))),
-                "test"),
-              List(field)))
-        case Null => Arity1(str => If(BinOp(jscore.Eq, str, Literal(Js.Str("null"))), Literal(Js.Null), ident("undefined")))
-        case Boolean => Arity1(str => If(BinOp(jscore.Eq, str, Literal(Js.Str("true"))), Literal(Js.Bool(true)), If(BinOp(jscore.Eq, str, Literal(Js.Str("false"))), Literal(Js.Bool(false)), ident("undefined"))))
-        case Integer => Arity1(str =>
-          If(Call(Select(Call(ident("RegExp"), List(Literal(Js.Str("^" + intRegex + "$")))), "test"), List(str)),
-            Call(ident("NumberLong"), List(str)),
-            ident("undefined")))
-        case Decimal =>
-          Arity1(str =>
-            If(Call(Select(Call(ident("RegExp"), List(Literal(Js.Str("^" + floatRegex + "$")))), "test"), List(str)),
-              Call(ident("parseFloat"), List(str)),
-              ident("undefined")))
-        case Date => Arity1(str =>
-          If(Call(Select(Call(ident("RegExp"), List(Literal(Js.Str("^" + dateRegex + "$")))), "test"), List(str)),
-            Call(ident("ISODate"), List(str)),
-            ident("undefined")))
-        case Time => Arity1(str =>
-          If(Call(Select(Call(ident("RegExp"), List(Literal(Js.Str("^" + timeRegex + "$")))), "test"), List(str)),
-            str,
-            ident("undefined")))
-        case Timestamp => Arity1(str =>
-          If(Call(Select(Call(ident("RegExp"), List(Literal(Js.Str("^" + timestampRegex + "$")))), "test"), List(str)),
-            Call(ident("ISODate"), List(str)),
-            ident("undefined")))
-        case ToString => Arity1(value =>
-          If(isInt(value),
-            // NB: This is a terrible way to turn an int into a string, but the
-            //     only one that doesn’t involve converting to a decimal and
-            //     losing precision.
-            Call(Select(Call(ident("String"), List(value)), "replace"), List(
-              Call(ident("RegExp"), List(
-                Literal(Js.Str("[^-0-9]+")),
-                Literal(Js.Str("g")))),
-              Literal(Js.Str("")))),
-            If(binop(jscore.Or, isTimestamp(value), isDate(value)),
-              Call(Select(value, "toISOString"), Nil),
-              Call(ident("String"), List(value)))))
+
+        // TODO: when each of these is broken out as a separate Func, these will
+        // go to JsFuncHandler.
         case Extract =>
           args match {
             case Sized(a1, a2) => (HasStr(a1) |@| HasJs(a2)) {
@@ -294,45 +247,8 @@ object MongoDbPlanner {
             }.join
           }
 
-        case TimeOfDay    => {
-          def pad2(x: JsCore) =
-            Let(Name("x"), x,
-              If(
-                BinOp(jscore.Lt, ident("x"), Literal(Js.Num(10, false))),
-                BinOp(jscore.Add, Literal(Js.Str("0")), ident("x")),
-                ident("x")))
-          def pad3(x: JsCore) =
-            Let(Name("x"), x,
-              If(
-                BinOp(jscore.Lt, ident("x"), Literal(Js.Num(10, false))),
-                BinOp(jscore.Add, Literal(Js.Str("00")), ident("x")),
-                If(
-                  BinOp(jscore.Lt, ident("x"), Literal(Js.Num(100, false))),
-                  BinOp(jscore.Add, Literal(Js.Str("0")), ident("x")),
-                  ident("x"))))
-          Arity1(date =>
-            Let(Name("t"), date,
-              binop(jscore.Add,
-                pad2(Call(Select(ident("t"), "getUTCHours"), Nil)),
-                Literal(Js.Str(":")),
-                pad2(Call(Select(ident("t"), "getUTCMinutes"), Nil)),
-                Literal(Js.Str(":")),
-                pad2(Call(Select(ident("t"), "getUTCSeconds"), Nil)),
-                Literal(Js.Str(".")),
-                pad3(Call(Select(ident("t"), "getUTCMilliseconds"), Nil)))))
-        }
-
         case ToId => Arity1(id => Call(ident("ObjectId"), List(id)))
-        case Between =>
-          Arity3((value, min, max) =>
-            makeSimpleCall(
-              "&&",
-              List(
-                makeSimpleCall("<=", List(min, value)),
-                makeSimpleCall("<=", List(value, max))))
-          )
-        case ObjectProject => Arity2(Access(_, _))
-        case ArrayProject  => Arity2(Access(_, _))
+
         case MakeObject => args match {
           case Sized(a1, a2) => (HasStr(a1) |@| HasJs(a2)) {
             case (field, (sel, inputs)) =>
@@ -350,7 +266,7 @@ object MongoDbPlanner {
         }
         case MakeArray => Arity1(x => Arr(List(x)))
         case _ => -\/(UnsupportedFunction(func.name, "in JS planner".some))
-      }
+      })
     }
 
     {

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/MongoDbPlanner.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/MongoDbPlanner.scala
@@ -183,69 +183,6 @@ object MongoDbPlanner {
               Literal(Js.Num(-1, false)),
               Call(Select(array, "indexOf"), List(value))))
 
-        // // TODO: when each of these is broken out as a separate Func, these will
-        // // go to JsFuncHandler.
-        // case Extract =>
-        //   args match {
-        //     case Sized(a1, a2) => (HasStr(a1) |@| HasJs(a2)) {
-        //       case (field, (sel, inputs)) => ((field match {
-        //         case "century"      => \/-(x => BinOp(Div, Call(Select(x, "getFullYear"), Nil), Literal(Js.Num(100, false))))
-        //         case "day"          => \/-(x => Call(Select(x, "getDate"), Nil)) // (day of month)
-        //         case "decade"       => \/-(x => BinOp(Div, Call(Select(x, "getFullYear"), Nil), Literal(Js.Num(10, false))))
-        //         // Note: MongoDB's Date's getDay (during filtering at least) seems to be monday=0 ... sunday=6,
-        //         // apparently in violation of the JavaScript convention.
-        //         case "dow"          =>
-        //           \/-(x => If(BinOp(jscore.Eq,
-        //             Call(Select(x, "getDay"), Nil),
-        //             Literal(Js.Num(6, false))),
-        //             Literal(Js.Num(0, false)),
-        //             BinOp(jscore.Add,
-        //               Call(Select(x, "getDay"), Nil),
-        //               Literal(Js.Num(1, false)))))
-        //         // TODO: case "doy"          => \/- (???)
-        //         // TODO: epoch
-        //         case "hour"         => \/-(x => Call(Select(x, "getHours"), Nil))
-        //         case "isodow"       =>
-        //           \/-(x => BinOp(jscore.Add,
-        //             Call(Select(x, "getDay"), Nil),
-        //             Literal(Js.Num(1, false))))
-        //         // TODO: isoyear
-        //         case "microseconds" =>
-        //           \/-(x => BinOp(Mult,
-        //             BinOp(jscore.Add,
-        //               Call(Select(x, "getMilliseconds"), Nil),
-        //               BinOp(Mult, Call(Select(x, "getSeconds"), Nil), Literal(Js.Num(1000, false)))),
-        //             Literal(Js.Num(1000, false))))
-        //         case "millennium"   => \/-(x => BinOp(Div, Call(Select(x, "getFullYear"), Nil), Literal(Js.Num(1000, false))))
-        //         case "milliseconds" =>
-        //           \/-(x => BinOp(jscore.Add,
-        //             Call(Select(x, "getMilliseconds"), Nil),
-        //             BinOp(Mult, Call(Select(x, "getSeconds"), Nil), Literal(Js.Num(1000, false)))))
-        //         case "minute"       => \/-(x => Call(Select(x, "getMinutes"), Nil))
-        //         case "month"        =>
-        //           \/-(x => BinOp(jscore.Add,
-        //             Call(Select(x, "getMonth"), Nil),
-        //             Literal(Js.Num(1, false))))
-        //         case "quarter"      =>
-        //           \/-(x => BinOp(jscore.Add,
-        //             BinOp(BitOr,
-        //               BinOp(Div,
-        //                 Call(Select(x, "getMonth"), Nil),
-        //                 Literal(Js.Num(3, false))),
-        //               Literal(Js.Num(0, false))),
-        //             Literal(Js.Num(1, false))))
-        //         case "second"       => \/-(x => Call(Select(x, "getSeconds"), Nil))
-        //         // TODO: timezone, timezone_hour, timezone_minute
-        //         // case "week"         => \/- (???)
-        //         case "year"         => \/-(x => Call(Select(x, "getFullYear"), Nil))
-        //
-        //         case _ => -\/(FuncApply(func.name, "valid time period", field))
-        //       }): PlannerError \/ (JsCore => JsCore)).map(x =>
-        //         ({ case (list: List[JsFn]) => JsFn(JsFn.defaultName, x(sel(list)(Ident(JsFn.defaultName)))) },
-        //           inputs.map(There(1, _))): PartialJs)
-        //     }.join
-        //   }
-
         case ToId => Arity1(id => Call(ident("ObjectId"), List(id)))
 
         case MakeObject => args match {
@@ -264,6 +201,7 @@ object MongoDbPlanner {
           }
         }
         case MakeArray => Arity1(x => Arr(List(x)))
+
         case _ => -\/(UnsupportedFunction(func.name, "in JS planner".some))
       })
     }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/MongoDbPlanner.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/MongoDbPlanner.scala
@@ -183,7 +183,11 @@ object MongoDbPlanner {
               Call(Select(array, "indexOf"), List(value))))
         case Substring =>
           Arity3((field, start, len) =>
-            Call(Select(field, "substr"), List(start, len)))
+            If(BinOp(jscore.Lt, start, Literal(Js.Num(0, false))),
+              Literal(Js.Str("")),
+              If(BinOp(jscore.Lt, len, Literal(Js.Num(0, false))),
+                Call(Select(field, "substr"), List(start, Select(field, "length"))),
+                Call(Select(field, "substr"), List(start, len)))))
         case Search =>
           Arity3((field, pattern, insen) =>
             Call(

--- a/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -384,7 +384,11 @@ object MongoDbQScriptPlanner {
             "test"),
           List(a1)).right
       case Substring(a1, a2, a3) =>
-        Call(Select(a1, "substr"), List(a2, a3)).right
+        If(BinOp(jscore.Lt, a2, Literal(Js.Num(0, false))),
+          Literal(Js.Str("")),
+          If(BinOp(jscore.Lt, a3, Literal(Js.Num(0, false))),
+            Call(Select(a1, "substr"), List(a2, Select(a1, "length"))),
+            Call(Select(a1, "substr"), List(a2, a3)))).right
       // case ToId(a1) => Call(ident("ObjectId"), List(a1)).right
 
       case MakeArray(a1) => unimplemented

--- a/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -33,7 +33,6 @@ import quasar.physical.mongodb.planner.{FuncHandler, JoinHandler, JoinSource, In
 import quasar.physical.mongodb.workflow._
 import quasar.qscript.{Coalesce => _, _}
 import quasar.std.StdLib._ // TODO: remove this
-import javascript._
 
 import matryoshka.{Hole => _, _}, Recursive.ops._, TraverseT.ops._
 import matryoshka.patterns.CoEnv
@@ -201,6 +200,9 @@ object MongoDbQScriptPlanner {
       _}
 
     import MapFuncs._
+
+    val mjs = quasar.physical.mongodb.javascript[Fix]
+    import mjs._
 
     val unimplemented = InternalError("unimplemented").left
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -180,7 +180,6 @@ object MongoDbQScriptPlanner {
       case Constant(v1) => v1.cata(Data.fromEJson).toJs \/> NonRepresentableEJson(v1.shows)
       // FIXME: Not correct
       case Undefined() => ident("undefined").right
-      // TODO: case Now() => ???
 
       case IfUndefined(a1, a2) =>
         // TODO: Only evaluate `value` once.

--- a/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -236,10 +236,10 @@ object MongoDbQScriptPlanner {
         def pad3(x: JsCore) =
           Let(Name("x"), x,
             If(
-              BinOp(jscore.Lt, ident("x"), Literal(Js.Num(100, false))),
+              BinOp(jscore.Lt, ident("x"), Literal(Js.Num(10, false))),
               BinOp(jscore.Add, Literal(Js.Str("00")), ident("x")),
               If(
-                BinOp(jscore.Lt, ident("x"), Literal(Js.Num(10, false))),
+                BinOp(jscore.Lt, ident("x"), Literal(Js.Num(100, false))),
                 BinOp(jscore.Add, Literal(Js.Str("0")), ident("x")),
                 ident("x"))))
         Let(Name("t"), a1,

--- a/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -73,6 +73,8 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
   import fixExprOp._
   val expr3_0Fp: ExprOp3_0F.fixpoint[Fix, ExprOp] = ExprOp3_0F.fixpoint[Fix, ExprOp]
   import expr3_0Fp._
+  val expr3_2Fp: ExprOp3_2F.fixpoint[Fix, ExprOp] = ExprOp3_2F.fixpoint[Fix, ExprOp]
+  import expr3_2Fp._
 
   val basePath = rootDir[Sandboxed] </> dir("db")
 
@@ -355,9 +357,10 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
                  $and(
                    $lte($literal(Bson.Date(Instant.ofEpochMilli(0))), $field("baz")),
                    $lt($field("baz"), $literal(Bson.Regex("", "")))),
-                 $add(
-                   $divide($dayOfYear($field("baz")), $literal(Bson.Int32(92))),
-                   $literal(Bson.Int32(1))),
+                 $trunc(
+                   $add(
+                     $divide($dayOfYear($field("baz")), $literal(Bson.Int32(92))),
+                     $literal(Bson.Int32(1)))),
                  $literal(Bson.Undefined))),
            IgnoreId)))
     }
@@ -4053,7 +4056,7 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
     }.pendingUntilFixed("SD-1249")
 
     "include correct phases with planner error" in {
-      planLog("""select date_part("foo", bar) from zips""").map(_.map(_.name)) must
+      planLog("""select date_part("isoyear", bar) from zips""").map(_.map(_.name)) must
         beRightDisjunction(Vector(
           "SQL AST", "Variables Substituted", "Absolutized", "Annotated Tree",
           "Logical Plan", "Optimized", "Typechecked",

--- a/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -580,7 +580,8 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
     }
 
     "plan simple js filter" in {
-      import javascript._
+      val mjs: javascript[Fix] = javascript[Fix]
+      import mjs._
 
       plan("select * from zips where length(city) < 4") must
       beWorkflow(chain[Workflow](
@@ -606,7 +607,8 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
     }
 
     "plan filter with js and non-js" in {
-      import javascript._
+      val mjs: javascript[Fix] = javascript[Fix]
+      import mjs._
 
       plan("select * from zips where length(city) < 4 and pop < 20000") must
       beWorkflow(chain[Workflow](

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/CoreMap.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/CoreMap.scala
@@ -80,7 +80,7 @@ object CoreMap extends Serializable {
     case ExtractIsoDayOfWeek(f) => InternalError("not implemented").left // TODO
     case ExtractIsoYear(f) => InternalError("not implemented").left // TODO
     case ExtractMicroseconds(f) => InternalError("not implemented").left // TODO
-    case ExtractMillenium(f) => InternalError("not implemented").left // TODO
+    case ExtractMillennium(f) => InternalError("not implemented").left // TODO
     case ExtractMilliseconds(f) => InternalError("not implemented").left // TODO
     case ExtractMinute(f) => InternalError("not implemented").left // TODO
     case ExtractMonth(f) => InternalError("not implemented").left // TODO

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/CoreMap.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/CoreMap.scala
@@ -43,7 +43,7 @@ object CoreMap extends Serializable {
     case Length(f) => (f >>> {
       case Data.Str(v) => Data.Int(v.length)
       case Data.Arr(v) => Data.Int(v.size)
-      case _ => undefined 
+      case _ => undefined
     }).right
 
     case Date(f) => (f >>> {
@@ -70,7 +70,24 @@ object CoreMap extends Serializable {
       case Data.Int(epoch) => Data.Timestamp(Instant.ofEpochMilli(epoch.toLong))
       case _ => undefined
     }).right
-    case Extract(f1, f2) => InternalError("not implemented").left // TODO - waits for Moss changes
+    case ExtractCentury(f) => InternalError("not implemented").left // TODO
+    case ExtractDayOfMonth(f) => InternalError("not implemented").left // TODO
+    case ExtractDecade(f) => InternalError("not implemented").left // TODO
+    case ExtractDayOfWeek(f) => InternalError("not implemented").left // TODO
+    case ExtractDayOfYear(f) => InternalError("not implemented").left // TODO
+    case ExtractEpoch(f) => InternalError("not implemented").left // TODO
+    case ExtractHour(f) => InternalError("not implemented").left // TODO
+    case ExtractIsoDayOfWeek(f) => InternalError("not implemented").left // TODO
+    case ExtractIsoYear(f) => InternalError("not implemented").left // TODO
+    case ExtractMicroseconds(f) => InternalError("not implemented").left // TODO
+    case ExtractMillenium(f) => InternalError("not implemented").left // TODO
+    case ExtractMilliseconds(f) => InternalError("not implemented").left // TODO
+    case ExtractMinute(f) => InternalError("not implemented").left // TODO
+    case ExtractMonth(f) => InternalError("not implemented").left // TODO
+    case ExtractQuarter(f) => InternalError("not implemented").left // TODO
+    case ExtractSecond(f) => InternalError("not implemented").left // TODO
+    case ExtractWeek(f) => InternalError("not implemented").left // TODO
+    case ExtractYear(f) => InternalError("not implemented").left // TODO
     case Now() => ((x: Data) => Data.Timestamp(Instant.now())).right
 
     case Negate(f) => (f >>> {
@@ -118,7 +135,7 @@ object CoreMap extends Serializable {
       case Data.Bool(false) => fElse(x)
       case _ => undefined
     }).right
-      
+
     case Within(f1, f2) => ((x: Data) => (f1(x), f2(x)) match {
       case (d, Data.Arr(list)) => Data.Bool(list.contains(d))
       case _ => undefined

--- a/sql/src/main/scala/quasar/sql/compiler.scala
+++ b/sql/src/main/scala/quasar/sql/compiler.scala
@@ -500,7 +500,7 @@ trait Compiler[F[_]] {
               case "isodow"       => date.ExtractIsoDayOfWeek
               case "isoyear"      => date.ExtractIsoYear
               case "microseconds" => date.ExtractMicroseconds
-              case "millenium"    => date.ExtractMillenium
+              case "millennium"   => date.ExtractMillennium
               case "milliseconds" => date.ExtractMilliseconds
               case "minute"       => date.ExtractMinute
               case "month"        => date.ExtractMonth

--- a/sql/src/main/scala/quasar/sql/compiler.scala
+++ b/sql/src/main/scala/quasar/sql/compiler.scala
@@ -30,7 +30,7 @@ import quasar.sql.{SemanticAnalysis => SA}, SA._
 import matryoshka._, Recursive.ops._, FunctorT.ops._
 import pathy.Path._
 import scalaz.{Tree => _, _}, Scalaz._
-import shapeless.{Data => _, :: => _, _}
+import shapeless.{Annotations => _, Data => _, :: => _, _}
 
 trait Compiler[F[_]] {
   import identity._
@@ -485,6 +485,39 @@ trait Compiler[F[_]] {
             } yield
               if ((rName: String) ≟ name) table
               else Fix(ObjectProject(table, LogicalPlan.Constant(Data.Str(name)))))
+
+      case InvokeFunction(name, args) if name.toLowerCase ≟ "date_part" =>
+        args.traverse(compile0).flatMap {
+          case Fix(LogicalPlan.ConstantF(Data.Str(part))) :: expr :: Nil =>
+            (part.some collect {
+              case "century"      => date.ExtractCentury
+              case "day"          => date.ExtractDayOfMonth
+              case "decade"       => date.ExtractDecade
+              case "dow"          => date.ExtractDayOfWeek
+              case "doy"          => date.ExtractDayOfYear
+              case "epoch"        => date.ExtractEpoch
+              case "hour"         => date.ExtractHour
+              case "isodow"       => date.ExtractIsoDayOfWeek
+              case "isoyear"      => date.ExtractIsoYear
+              case "microseconds" => date.ExtractMicroseconds
+              case "millenium"    => date.ExtractMillenium
+              case "milliseconds" => date.ExtractMilliseconds
+              case "minute"       => date.ExtractMinute
+              case "month"        => date.ExtractMonth
+              case "quarter"      => date.ExtractQuarter
+              case "second"       => date.ExtractSecond
+              case "week"         => date.ExtractWeek
+              case "year"         => date.ExtractYear
+            }).cata(
+              f => emit(Fix(f(expr))),
+              fail(UnexpectedDatePart("\"" + part + "\"")))
+
+          case _ :: _ :: Nil =>
+            fail(UnexpectedDatePart(pprint[Cofree[?[_], Annotations]](args(0))))
+
+          case _ =>
+            fail(WrongArgumentCount("DATE_PART", 2, args.length))
+        }
 
       case InvokeFunction(name, List(a1)) =>
         findUnaryFunction(name).flatMap(compileFunction[nat._1](_, Func.Input1(a1)))


### PR DESCRIPTION
First part of #1311.

Adds fairly complete tests for `date`, `math`, and `relation` to `StdLibSpec`, and includes all of the fallout from seeing how broken things were.

Breaks out the `Extract` function into a distinct LP Func and QS MapFunc for each field.

Pulls out JavaScript compilation for both MongoDB planners into common code.

If there was a clean way to break this into 3 or so PRs, I would have, but it seemed sensible to start with the tests and so this is what I ended up with.