### PR TITLE
implement `explain` in the REPL

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- add `explain` command in the REPL, which plans a query without attempting to run it

--- a/repl/src/main/scala/quasar/repl/Command.scala
+++ b/repl/src/main/scala/quasar/repl/Command.scala
@@ -29,6 +29,7 @@ object Command {
   private val HelpPattern         = "(?i)(?:help)|(?:commands)|\\?".r
   private val CdPattern           = "(?i)cd(?: +(.+))?".r
   private val NamedExprPattern    = "(?i)([^ :]+) *<- *(.+)".r
+  private val ExplainPattern      = "(?i)explain +(.+)".r
   private val LsPattern           = "(?i)ls(?: +(.+))?".r
   private val SavePattern         = "(?i)save +([\\S]+) (.+)".r
   private val AppendPattern       = "(?i)append +([\\S]+) (.+)".r
@@ -45,6 +46,7 @@ object Command {
   final case object ListVars extends Command
   final case class Cd(dir: XDir) extends Command
   final case class Select(name: Option[String], query: Query) extends Command
+  final case class Explain(query: Query) extends Command
   final case class Ls(dir: Option[XDir]) extends Command
   final case class Save(path: XFile, value: String) extends Command
   final case class Append(path: XFile, value: String) extends Command
@@ -62,6 +64,7 @@ object Command {
       case CdPattern(XDir(d))            => Cd(d)
       case CdPattern(_)                  => Cd(rootDir.right)
       case NamedExprPattern(name, query) => Select(Some(name), Query(query))
+      case ExplainPattern(query)         => Explain(Query(query))
       case LsPattern(XDir(d))            => Ls(d.some)
       case LsPattern(_)                  => Ls(none)
       case SavePattern(XFile(f), value)  => Save(f, value)


### PR DESCRIPTION
Keeping it pretty simple, this just uses `FileSystemQueries.explainQuery` and the same code used to print the phase log as is used when running queries in the REPL:

```
💪 $ explain select a from foo
Typechecked:
Invoke(SQUASH)
╰─ Invoke(MAKE_OBJECT)
   ├─ Str("a")
   ╰─ Let('__check0)
      ├─ Read(/foo)
      ╰─ Typecheck(Obj(Map(),Some(Top)))
         ├─ Free('__check0)
         ├─ ObjectProject('__check0["a"])
         ╰─ Constant(NA)

Quasar error: File not found: /foo
💪 $ explain select city from `local/quasar-test/zips`
MongoDB:
db.zips.find({ "city": true });

💪 $ explain select city from `localqs/quasar-test/zips`
Quasar error: ProjectField(Fix(Coproduct(\/-(Coproduct(\/-($varF(DocVar(Name(ROOT),None))))))),Fix(Coproduct(\/-(Coproduct(\/-($literalF(Text(city)))))))) (of class quasar.qscript.MapFuncs$ProjectField)

💪 $ debug=2
Set debug level: Verbose
💪 $ explain select * from `localqs/quasar-test/zips`
SQL AST:
Select
├─ Proj
│  ╰─ Splice
╰─ TableRelation(localqs/quasar-test/zips)

...

QScript:
List
├─ Read(Read(/quasar-test/zips))
╰─ LeftShift((),SrcHole,RightSide)
   ╰─ ExternallyManaged(Extern)

QScript (Mongo-specific):
Map((),SrcHole)
╰─ ShiftedRead(ShiftedRead(/quasar-test/zips, ExcludeId))

Workflow Builder:
CollectionBuilder(Root())
├─ $ReadF(quasar-test; zips)
╰─ Schema

Workflow (raw):
$ReadF(quasar-test; zips)

Workflow (crystallized):
$ReadF(quasar-test; zips)

MongoDB:
db.zips.find();

💪 $ 
```