### PR TITLE
Many improvements to QScript joins.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,8 @@
+- combine `Take`/`Drop` into `Subset` (and add `Sample` case)
+- complete implementation for Mergable[*Join] (avoids autojoins after a join)
+- fix a bug where we included the provenance in the join condition
+- fix join combine func to use the result pointers
+- fix handling of `ProjectField` in Mongo-QScript planner
+- handle `ShiftedRead`’s `IncludeId` in Mongo-QScript planner
+- fix `Reduce`’s repairFunc handling in Mongo-QScript planner
+- normalize Mongo-specific QScript

--- a/connector/src/main/scala/quasar/qscript/DiscoverPath.scala
+++ b/connector/src/main/scala/quasar/qscript/DiscoverPath.scala
@@ -224,12 +224,9 @@ abstract class DiscoverPathInstances {
         case Union(src, lb, rb) if !src.isThat =>
           convertBranchingOp(src, lb, rb, g)((s, l, r) =>
             QC.inj(Union(s, l, r)))
-        case Take(src, lb, rb) if !src.isThat =>
+        case Subset(src, lb, sel, rb) if !src.isThat =>
           convertBranchingOp(src, lb, rb, g)((s, l, r) =>
-            QC.inj(Take(s, l, r)))
-        case Drop(src, lb, rb) if !src.isThat =>
-          convertBranchingOp(src, lb, rb, g)((s, l, r) =>
-            QC.inj(Drop(s, l, r)))
+            QC.inj(Subset(s, l, sel, r)))
 
         case x => x.traverse(unionAll(g)) ∘ (in => \&/-(QC.inj(in).embed))
       }

--- a/connector/src/main/scala/quasar/qscript/QScriptCore.scala
+++ b/connector/src/main/scala/quasar/qscript/QScriptCore.scala
@@ -121,10 +121,9 @@ object ReduceIndex {
 @Lenses final case class Filter[T[_[_]], A](src: A, f: FreeMap[T])
     extends QScriptCore[T, A]
 
-@Lenses final case class Take[T[_[_]], A](src: A, from: FreeQS[T], count: FreeQS[T])
-    extends QScriptCore[T, A]
-
-@Lenses final case class Drop[T[_[_]], A](src: A, from: FreeQS[T], count: FreeQS[T])
+/** Chooses a subset of values from a dataset, given a count. */
+@Lenses final case class Subset[T[_[_]], A]
+  (src: A, from: FreeQS[T], op: SelectionOp, count: FreeQS[T])
     extends QScriptCore[T, A]
 
 /** A placeholder value that can appear in plans, but will never be referenced
@@ -150,8 +149,7 @@ object QScriptCore {
           case (Union(a1, l1, r1), Union(a2, l2, r2)) =>
             eq.equal(a1, a2) && l1 ≟ l2 && r1 ≟ r2
           case (Filter(a1, f1), Filter(a2, f2)) => f1 ≟ f2 && eq.equal(a1, a2)
-          case (Take(a1, f1, c1), Take(a2, f2, c2)) => eq.equal(a1, a2) && f1 ≟ f2 && c1 ≟ c2
-          case (Drop(a1, f1, c1), Drop(a2, f2, c2)) => eq.equal(a1, a2) && f1 ≟ f2 && c1 ≟ c2
+          case (Subset(a1, f1, s1, c1), Subset(a2, f2, s2, c2)) => eq.equal(a1, a2) && f1 ≟ f2 && s1 ≟ s2 && c1 ≟ c2
           case (Unreferenced(), Unreferenced()) => true
           case (_, _) => false
         }
@@ -169,8 +167,7 @@ object QScriptCore {
           case Sort(a, b, o)              => f(a) ∘ (Sort(_, b, o))
           case Union(a, l, r)             => f(a) ∘ (Union(_, l, r))
           case Filter(a, func)            => f(a) ∘ (Filter(_, func))
-          case Take(a, from, c)           => f(a) ∘ (Take(_, from, c))
-          case Drop(a, from, c)           => f(a) ∘ (Drop(_, from, c))
+          case Subset(a, from, sel, c)    => f(a) ∘ (Subset(_, from, sel, c))
           case Unreferenced()             => (Unreferenced[T, B](): QScriptCore[T, B]).point[G]
         }
     }
@@ -202,13 +199,10 @@ object QScriptCore {
           case Filter(a, func) => Cord("Filter(") ++
             s.show(a) ++ Cord(",") ++
             func.show ++ Cord(")")
-          case Take(a, f, c) => Cord("Take(") ++
+          case Subset(a, f, sel, c) => Cord("Subset(") ++
             s.show(a) ++ Cord(",") ++
             f.show ++ Cord(",") ++
-            c.show ++ Cord(")")
-          case Drop(a, f, c) => Cord("Drop(") ++
-            s.show(a) ++ Cord(",") ++
-            f.show ++ Cord(",") ++
+            sel.show ++ Cord(",") ++
             c.show ++ Cord(")")
           case Unreferenced() => Cord("Unreferenced")
         }

--- a/connector/src/main/scala/quasar/qscript/SelectionOp.scala
+++ b/connector/src/main/scala/quasar/qscript/SelectionOp.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript
+
+import scalaz._
+
+sealed abstract class SelectionOp
+
+/** Drops the first `count` elements from a dataset. */
+final case object Drop extends SelectionOp
+
+/** Drops all elements after the first `count` elements from a dataset. */
+final case object Take extends SelectionOp
+
+/** Similar to Take, but keeps a random sampling of elements. */
+final case object Sample extends SelectionOp
+
+object SelectionOp {
+  implicit val equal: Equal[SelectionOp] = Equal.equalRef
+  implicit val show: Show[SelectionOp] = Show.showFromToString
+}

--- a/connector/src/main/scala/quasar/qscript/ShiftRead.scala
+++ b/connector/src/main/scala/quasar/qscript/ShiftRead.scala
@@ -85,10 +85,8 @@ object ShiftRead {
         GtoH(QC.inj(qc match {
           case Union(src, lb, rb) =>
             Union(Free.point(src), applyToBranch(lb), applyToBranch(rb))
-          case Drop(src, lb, rb) =>
-            Drop(Free.point(src), applyToBranch(lb), applyToBranch(rb))
-          case Take(src, lb, rb) =>
-            Take(Free.point(src), applyToBranch(lb), applyToBranch(rb))
+          case Subset(src, lb, sel, rb) =>
+            Subset(Free.point(src), applyToBranch(lb), sel, applyToBranch(rb))
           case _ => qc.map(Free.point)
         }))
       )

--- a/connector/src/main/scala/quasar/qscript/SimplifyJoin.scala
+++ b/connector/src/main/scala/quasar/qscript/SimplifyJoin.scala
@@ -124,10 +124,8 @@ object SimplifyJoin {
           : QScriptCore[T, T[H]] => H[T[H]] = fa => GtoH(QC.inj(fa match {
             case Union(src, lb, rb) =>
               Union(src, applyToBranch(lb), applyToBranch(rb))
-            case Drop(src, lb, rb) =>
-              Drop(src, applyToBranch(lb), applyToBranch(rb))
-            case Take(src, lb, rb) =>
-              Take(src, applyToBranch(lb), applyToBranch(rb))
+            case Subset(src, lb, sel, rb) =>
+              Subset(src, applyToBranch(lb), sel, applyToBranch(rb))
             case _ => fa
           }))
     }

--- a/connector/src/main/scala/quasar/qscript/TTypes.scala
+++ b/connector/src/main/scala/quasar/qscript/TTypes.scala
@@ -65,10 +65,11 @@ class SimplifiableProjectionT[T[_[_]]] extends TTypes[T] {
   def QScriptCore[G[_]](implicit QC: QScriptCore :<: G) = make(
     λ[QScriptCore ~> G](fa =>
       QC inj (fa match {
-        case Union(src, lb, rb) => Union(src, applyToBranch(lb), applyToBranch(rb))
-        case Drop(src, lb, rb)  => Drop(src, applyToBranch(lb), applyToBranch(rb))
-        case Take(src, lb, rb)  => Take(src, applyToBranch(lb), applyToBranch(rb))
-        case _                  => fa
+        case Union(src, lb, rb) =>
+          Union(src, applyToBranch(lb), applyToBranch(rb))
+        case Subset(src, lb, sel, rb) =>
+          Subset(src, applyToBranch(lb), sel, applyToBranch(rb))
+        case _ => fa
       })
     )
   )
@@ -218,8 +219,7 @@ class NormalizableT[T[_[_]] : Recursive : Corecursive : EqualT : ShowT] extends 
       case LeftShift(src, s, r)   => makeNorm(s, r)(freeMFEq(_), freeMFEq(_))(LeftShift(src, _, _))
       case Union(src, l, r)       => makeNorm(l, r)(freeTCEq(_), freeTCEq(_))(Union(src, _, _))
       case Filter(src, f)         => freeMFEq(f).map(Filter(src, _))
-      case Take(src, from, count) => makeNorm(from, count)(freeTCEq(_), freeTCEq(_))(Take(src, _, _))
-      case Drop(src, from, count) => makeNorm(from, count)(freeTCEq(_), freeTCEq(_))(Drop(src, _, _))
+      case Subset(src, from, sel, count) => makeNorm(from, count)(freeTCEq(_), freeTCEq(_))(Subset(src, _, sel, _))
       case Unreferenced()         => None
     })
   }

--- a/connector/src/main/scala/quasar/qscript/ThetaJoin.scala
+++ b/connector/src/main/scala/quasar/qscript/ThetaJoin.scala
@@ -16,7 +16,6 @@
 
 package quasar.qscript
 
-import quasar.Predef._
 import quasar.RenderTree
 import quasar.contrib.matryoshka._
 import quasar.fp._
@@ -79,17 +78,28 @@ object ThetaJoin {
   implicit def renderTree[T[_[_]]: ShowT]: Delay[RenderTree, ThetaJoin[T, ?]] =
     RenderTree.delayFromShow
 
-  implicit def mergeable[T[_[_]]: EqualT]: Mergeable.Aux[T, ThetaJoin[T, ?]] =
+  implicit def mergeable[T[_[_]]: Recursive: Corecursive: EqualT: ShowT]
+      : Mergeable.Aux[T, ThetaJoin[T, ?]] =
     new Mergeable[ThetaJoin[T, ?]] {
       type IT[F[_]] = T[F]
 
-      // TODO: merge two joins with different combine funcs
       def mergeSrcs(
         left: FreeMap[IT],
         right: FreeMap[IT],
         p1: ThetaJoin[IT, ExternallyManaged],
         p2: ThetaJoin[IT, ExternallyManaged]) =
-        None
+        (p1, p2) match {
+          case (ThetaJoin(s1, l1, r1, o1, f1, c1), ThetaJoin(_, l2, r2, o2, f2, c2)) =>
+            val left1 = rebaseBranch(l1, left)
+            val right1 = rebaseBranch(r1, left)
+            val left2 = rebaseBranch(l2, right)
+            val right2 = rebaseBranch(r2, right)
+
+            (left1 ≟ left2 && right1 ≟ right2 && o1 ≟ o2 && f1 ≟ f2).option {
+              val (merged, left, right) = concat(c1, c2)
+              SrcMerge(ThetaJoin(s1, left1, right1, o1, f1, merged), left, right)
+            }
+        }
     }
 
   implicit def normalizable[T[_[_]]: Recursive: Corecursive: EqualT: ShowT]: Normalizable[ThetaJoin[T, ?]] =

--- a/connector/src/main/scala/quasar/qscript/Transform.scala
+++ b/connector/src/main/scala/quasar/qscript/Transform.scala
@@ -57,6 +57,8 @@ class Transform
     eq:         Delay[Equal, F],
     show:       Delay[Show, F]) {
 
+  val optimize = new Optimize[T]
+
   val prov = new Provenance[T]
 
   type Target = (Ann[T], T[F])
@@ -111,7 +113,6 @@ class Transform
       ZipperAcc(Nil, sides, tails).left
   }
 
-
   /** Contains a common src, the MapFuncs required to access the left and right
     * sides, and the FreeQS that were unmergeable on either side.
     */
@@ -128,21 +129,16 @@ class Transform
 
     val leftF =
       foldIso(CoEnv.freeIso[Hole, F])
-        .get(lTail.reverse.ana[T, CoEnv[Hole, F, ?]](delinearizeTargets[F, ExternallyManaged] >>> (CoEnv(_))))
+        .get(lTail.reverse.ana[T, CoEnv[Hole, F, ?]](delinearizeTargets[F, ExternallyManaged] >>> (CoEnv(_)))).mapSuspension(FI.inject)
 
     val rightF =
       foldIso(CoEnv.freeIso[Hole, F])
-        .get(rTail.reverse.ana[T, CoEnv[Hole, F, ?]](delinearizeTargets[F, ExternallyManaged] >>> (CoEnv(_))))
+        .get(rTail.reverse.ana[T, CoEnv[Hole, F, ?]](delinearizeTargets[F, ExternallyManaged] >>> (CoEnv(_)))).mapSuspension(FI.inject)
 
     (common.reverse.ana[T, F](delinearizeInner),
-      rebaseBranch(leftF, lMap).mapSuspension(FI.inject),
-      rebaseBranch(rightF, rMap).mapSuspension(FI.inject))
+      rebaseBranch(leftF, lMap),
+      rebaseBranch(rightF, rMap))
   }
-
-  def rebaseBranch(br: Free[F, Hole], fm: FreeMap[T]): Free[F, Hole] =
-    freeTransCata[T, F, F, Hole, Hole](
-      br >> Free.roll(QC.inj(Map(Free.point[F, Hole](SrcHole), fm))))(
-      liftCo((new Optimize[T]).applyToFreeQS[F]))
 
   /** This unifies a pair of sources into a single one, with additional
     * expressions to access the combined bucketing info, as well as the left and
@@ -157,7 +153,7 @@ class Transform
 
     val (src, lBranch, rBranch) = merge(left._2, right._2)
 
-    (new Optimize[T]).unifySimpleBranches[F, T[F]](src, lBranch, rBranch, combine).fold {
+    optimize.unifySimpleBranches[F, T[F]](src, lBranch, rBranch, combine).fold {
       // FIXME: Need a better prov representation, to know when the provs are
       //        the same even when the paths to the values differ.
       val commonProv =
@@ -409,15 +405,10 @@ class Transform
       : PlannerError \/ Target = {
     val condError: PlannerError \/ JoinFunc[T] = {
       // FIXME: This won’t work where we join a collection against itself
-      TJ.prj(values(2)._2.project).fold(
+      TJ.prj(QC.inj(reifyResult(values(2)._1, values(2)._2)).embed.transCata(optimize.applyAll).project).fold(
         (InternalError(s"non theta join condition found: ${values(2).shows}"): PlannerError).left[JoinFunc[T]])(
         _.combine.right[PlannerError])
     }
-
-    // NB: This is a magic structure. Improve LP to not imply this structure.
-    val combine: JoinFunc[T] = Free.roll(ConcatMaps(
-      Free.roll(MakeMap(StrLit[T, JoinSide]("left"), Free.point[MapFunc[T, ?], JoinSide](LeftSide))),
-      Free.roll(MakeMap(StrLit[T, JoinSide]("right"), Free.point[MapFunc[T, ?], JoinSide](RightSide)))))
 
     condError.map { cond =>
       val (commonSrc, lBranch, rBranch) = merge(values(0)._2, values(1)._2)
@@ -425,11 +416,12 @@ class Transform
       val Ann(leftBuckets, leftValue) = values(0)._1
       val Ann(rightBuckets, rightValue) = values(1)._1
 
-      // cond >>= {
-      //   case LeftSide => leftValue.map(κ(LeftSide))
-      //   case RightSide => rightValue.map(κ(RightSide))
-      // }
+      // NB: This is a magic structure. Improve LP to not imply this structure.
+      val combine: JoinFunc[T] = Free.roll(ConcatMaps(
+        Free.roll(MakeMap(StrLit[T, JoinSide]("left"), leftValue.as(LeftSide))),
+        Free.roll(MakeMap(StrLit[T, JoinSide]("right"), rightValue.as(RightSide)))))
 
+      // FIXME: The provenances are not correct here
       (Ann(prov.joinProvenances(leftBuckets, rightBuckets), HoleF),
         TJ.inj(ThetaJoin(
           commonSrc,
@@ -464,7 +456,7 @@ class Transform
 
   /** We carry around metadata with pointers to provenance and result value as
     * we build up QScript. At the point where a particular chain ends (E.g., the
-    * final result, or the `count` of a Take/Drop, we need to make sure we
+    * final result, or the `count` of a Subset, we need to make sure we
     * extract the result pointed to by the metadata.
     */
   def reifyResult[A](ann: Ann[T], src: A): QScriptCore[T, A] =
@@ -543,12 +535,12 @@ class Transform
     case LogicalPlan.InvokeFUnapply(set.Take, Sized(a1, a2)) =>
       val (src, lfree, rfree) = merge(a1._2, a2._2)
 
-      (a1._1, QC.inj(Take(src, lfree, Free.roll(FI.inject(QC.inj(reifyResult(a2._1, rfree)))))).embed).right
+      (a1._1, QC.inj(Subset(src, lfree, Take, Free.roll(FI.inject(QC.inj(reifyResult(a2._1, rfree)))))).embed).right
 
     case LogicalPlan.InvokeFUnapply(set.Drop, Sized(a1, a2)) =>
       val (src, lfree, rfree) = merge(a1._2, a2._2)
 
-      (a1._1, QC.inj(Drop(src, lfree, Free.roll(FI.inject(QC.inj(reifyResult(a2._1, rfree)))))).embed).right
+      (a1._1, QC.inj(Subset(src, lfree, Drop, Free.roll(FI.inject(QC.inj(reifyResult(a2._1, rfree)))))).embed).right
 
     case LogicalPlan.InvokeFUnapply(set.OrderBy, Sized(a1, a2, a3)) =>
       val (src, bucketsSrc, ordering, buckets, directions) = autojoin3(a1, a2, a3)

--- a/connector/src/main/scala/quasar/qscript/package.scala
+++ b/connector/src/main/scala/quasar/qscript/package.scala
@@ -143,6 +143,15 @@ package object qscript {
       Free.roll(ProjectIndex(HoleF[T], IntLit[T, Hole](1))),
       Free.roll(ProjectIndex(HoleF[T], IntLit[T, Hole](2))))
 
+  def rebaseBranch[T[_[_]]: Recursive: Corecursive: EqualT: ShowT]
+    (br: FreeQS[T], fm: FreeMap[T]): FreeQS[T] = {
+    val optimize = new Optimize[T]
+
+    freeTransCata(
+      br >> Free.roll(Inject[QScriptCore[T, ?], QScriptTotal[T, ?]].inj(Map(Free.point[QScriptTotal[T, ?], Hole](SrcHole), fm))))(
+      liftCo(optimize.applyToFreeQS))
+  }
+
   def rewriteShift[T[_[_]]: Recursive: Corecursive: EqualT]
     (struct: FreeMap[T], repair0: JoinFunc[T])
       : Option[(FreeMap[T], JoinFunc[T])] = {

--- a/connector/src/test/scala/quasar/qscript/QScript.scala
+++ b/connector/src/test/scala/quasar/qscript/QScript.scala
@@ -132,8 +132,9 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
       val lp = fullCompileExp("select * from bar limit 10")
       val qs = convert(listContents.some, lp)
       qs must equal(
-        QC.inj(Take(QC.inj(Unreferenced[Fix, Fix[QS]]()).embed,
+        QC.inj(Subset(QC.inj(Unreferenced[Fix, Fix[QS]]()).embed,
           Free.roll(QCT.inj(LeftShift(Free.roll(RT.inj(Const[Read, FreeQS[Fix]](Read(rootDir </> file("bar"))))), HoleF, RightSideF))),
+          Take,
           Free.roll(QCT.inj(Map(Free.roll(QCT.inj(Unreferenced())), IntLit(10)))))).embed.some)
     }
 
@@ -171,8 +172,9 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
         chain(
           ReadR(rootDir </> dir("foo") </> file("bar")),
           QC.inj(LeftShift((), HoleF, Free.point(RightSide))),
-          QC.inj(Take((),
+          QC.inj(Subset((),
             Free.point(SrcHole),
+            Take,
             Free.roll(QCT.inj(Map(
               Free.roll(QCT.inj(Unreferenced[Fix, FreeQS[Fix]]())),
               IntLit[Fix, Hole](10))))))).some)

--- a/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -891,7 +891,7 @@ object MongoDbQScriptPlanner {
       case RightSide => a2
     } ∘ (JsFn(JsFn.defaultName, _))
 
-  def meh[M[_]: Functor: Plus, A](a: A)(exf: A => M[Fix[ExprOp]], jsf: A => M[JsFn])
+  def exprOrJs[M[_]: Functor: Plus, A](a: A)(exf: A => M[Fix[ExprOp]], jsf: A => M[JsFn])
       : M[Expr] =
     exf(a).map(_.right[JsFn]) <+> jsf(a).map(_.left[Fix[ExprOp]])
 
@@ -899,13 +899,13 @@ object MongoDbQScriptPlanner {
     (funcHandler: FuncHandler[T, EX], fm: FreeMap[T])
     (implicit ev: EX :<: ExprOp)
       : OutputM[Expr] =
-    meh(fm)(getExpr(funcHandler)(_), getJsFn[T])
+    exprOrJs(fm)(getExpr(funcHandler)(_), getJsFn[T])
 
   def handleRedRepair[T[_[_]]: Recursive: ShowT, EX[_]: Traverse]
     (funcHandler: FuncHandler[T, EX], jr: FreeMapA[T, ReduceIndex])
     (implicit ev: EX :<: ExprOp)
       : OutputM[Expr] =
-    meh(jr)(getExprRed(funcHandler)(_), getJsRed[T])
+    exprOrJs(jr)(getExprRed(funcHandler)(_), getJsRed[T])
 
   def getExprRed[T[_[_]]: Recursive: ShowT, EX[_]: Traverse]
     (funcHandler: FuncHandler[T, EX])

--- a/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -26,12 +26,12 @@ import quasar.fs.{FileSystemError, QueryFile}
 import quasar.javascript._
 import quasar.jscore, jscore.{JsCore, JsFn}
 import quasar.namegen._
-import quasar.physical.mongodb.WorkflowBuilder._
+import quasar.physical.mongodb.WorkflowBuilder.{Subset => _, _}
 import quasar.physical.mongodb.accumulator._
 import quasar.physical.mongodb.expression._
 import quasar.physical.mongodb.fs.listContents
 import quasar.physical.mongodb.planner.{FuncHandler, JoinHandler, JoinSource, InputFinder, Here, There}
-import quasar.physical.mongodb.workflow._
+import quasar.physical.mongodb.workflow.{ExcludeId => _, IncludeId => _, _}
 import quasar.qscript.{Coalesce => _, _}
 import quasar.std.StdLib._ // TODO: remove this
 import javascript._
@@ -174,8 +174,9 @@ object MongoDbQScriptPlanner {
       case MakeArray(a1) => unimplemented("MakeArray expression")
       case MakeMap(a1, a2) => unimplemented("MakeMap expression")
       case ConcatMaps(a1, a2) => unimplemented("ConcatMap expression")
-      case ProjectField($var(DocField(base)), $literal(Bson.Text(field))) =>
-        $var(DocField(base \ BsonField.Name(field))).right
+      case ProjectField($var(dv), $literal(Bson.Text(field))) =>
+        $var(dv \ BsonField.Name(field)).right
+      case ProjectField(a1, a2) => unimplemented(s"ProjectField expression")
       case ProjectIndex(a1, a2)  => unimplemented("ProjectIndex expression")
       case DeleteField(a1, a2)  => unimplemented("DeleteField expression")
 
@@ -696,7 +697,20 @@ object MongoDbQScriptPlanner {
                    ev1: Show[WorkflowBuilder[WF]],
                    WB: WorkflowBuilder.Ops[WF],
                    ev3: EX :<: ExprOp) =
-          qs => Collection.fromFile(qs.getConst.path).bimap(PlanPathError(_): PlannerError, WB.read).liftM[GenT]
+          qs => Collection
+            .fromFile(qs.getConst.path)
+            .bimap(
+              PlanPathError(_): PlannerError,
+              coll => {
+                val dataset = WB.read(coll)
+                // TODO: exclude `_id` here?
+                qs.getConst.idStatus match {
+                  case IncludeId =>
+                    ArrayBuilder(dataset, List($field("_id").right, $$ROOT.right))
+                  case ExcludeId => dataset
+                }
+              })
+            .liftM[GenT]
       }
 
     implicit def qscriptCore[T[_[_]]: Recursive: ShowT]:
@@ -718,14 +732,14 @@ object MongoDbQScriptPlanner {
           case Reduce(src, bucket, reducers, repair) =>
             (getExprBuilder(funcHandler)(src, bucket) ⊛
               reducers.traverse(_.traverse(getExpr(funcHandler))) ⊛
-              getJsRed(repair))((b, red, rep) =>
+              handleRedRepair(funcHandler, repair))((b, red, rep) =>
               ExprBuilder(
                 GroupBuilder(src,
                   List(b),
                   Contents.Doc(red.zipWithIndex.map(ai =>
                     (BsonField.Name(ai._2.toString),
                       accumulator(ai._1).left[Fix[ExprOp]])).toListMap)),
-                rep.left)).liftM[GenT]
+                rep)).liftM[GenT]
           case Sort(src, bucket, order) =>
             val (keys, dirs) = ((bucket, SortDir.Ascending) :: order).unzip
             keys.traverse(getExprBuilder(funcHandler)(src, _))
@@ -739,14 +753,15 @@ object MongoDbQScriptPlanner {
             (rebaseWB(joinHandler, funcHandler, lBranch, src) ⊛
               rebaseWB(joinHandler, funcHandler, rBranch, src))(
               WB.unionAll).join
-          case Take(src, from, count) =>
+          case Subset(src, from, sel, count) =>
             (rebaseWB(joinHandler, funcHandler, from, src) ⊛
               (rebaseWB(joinHandler, funcHandler, count, src) >>= (HasInt(_).liftM[GenT])))(
-              WB.limit)
-          case Drop(src, from, count) =>
-            (rebaseWB(joinHandler, funcHandler, from, src) ⊛
-              (rebaseWB(joinHandler, funcHandler, count, src) >>= (HasInt(_).liftM[GenT])))(
-              WB.skip)
+              sel match {
+                case Drop => WB.skip
+                case Take => WB.limit
+                // TODO: Better sampling
+                case Sample => WB.limit
+              })
           case Unreferenced() => ValueBuilder(Bson.Null).point[M]
         }
       }
@@ -866,8 +881,8 @@ object MongoDbQScriptPlanner {
     src: WorkflowBuilder[WF], fm: FreeMap[T])(
     implicit ev: EX :<: ExprOp):
       OutputM[WorkflowBuilder[WF]] =
-    (getExpr(funcHandler)(fm).map(_.right[JsFn]) <+> getJsFn(fm).map(_.left[Fix[ExprOp]])) ∘
-      (ExprBuilder(src, _))
+    // TODO: identify cases for ArrayBuilder, DocBuilder, and SpliceBuilder.
+    handleFreeMap(funcHandler, fm) ∘ (ExprBuilder(src, _))
 
   def getJsMerge[T[_[_]]: Recursive: ShowT](jf: JoinFunc[T], a1: JsCore, a2: JsCore):
       OutputM[JsFn] =
@@ -876,9 +891,32 @@ object MongoDbQScriptPlanner {
       case RightSide => a2
     } ∘ (JsFn(JsFn.defaultName, _))
 
+  def meh[M[_]: Functor: Plus, A](a: A)(exf: A => M[Fix[ExprOp]], jsf: A => M[JsFn])
+      : M[Expr] =
+    exf(a).map(_.right[JsFn]) <+> jsf(a).map(_.left[Fix[ExprOp]])
+
+  def handleFreeMap[T[_[_]]: Recursive: ShowT, EX[_]: Traverse]
+    (funcHandler: FuncHandler[T, EX], fm: FreeMap[T])
+    (implicit ev: EX :<: ExprOp)
+      : OutputM[Expr] =
+    meh(fm)(getExpr(funcHandler)(_), getJsFn[T])
+
+  def handleRedRepair[T[_[_]]: Recursive: ShowT, EX[_]: Traverse]
+    (funcHandler: FuncHandler[T, EX], jr: FreeMapA[T, ReduceIndex])
+    (implicit ev: EX :<: ExprOp)
+      : OutputM[Expr] =
+    meh(jr)(getExprRed(funcHandler)(_), getJsRed[T])
+
+  def getExprRed[T[_[_]]: Recursive: ShowT, EX[_]: Traverse]
+    (funcHandler: FuncHandler[T, EX])
+    (jr: FreeMapA[T, ReduceIndex])
+    (implicit ev: EX :<: ExprOp)
+      : OutputM[Fix[ExprOp]] =
+    processMapFuncExpr(funcHandler)(jr)(ri => $field(ri.idx.toString).right)
+
   def getJsRed[T[_[_]]: Recursive: ShowT](jr: FreeMapA[T, ReduceIndex]):
       OutputM[JsFn] =
-    processMapFunc(jr)(ri => jscore.ident(ri.idx.toString)) ∘ (JsFn(JsFn.defaultName, _))
+    processMapFunc(jr)(ri => jscore.Access(jscore.Ident(JsFn.defaultName), jscore.ident(ri.idx.toString))) ∘ (JsFn(JsFn.defaultName, _))
 
   def rebaseWB[T[_[_]], WF[_]: Functor: Coalesce: Crush: Crystallize, EX[_]: Traverse](
     joinHandler: JoinHandler[WF, WorkflowBuilder.M],
@@ -969,9 +1007,6 @@ object MongoDbQScriptPlanner {
     type F[A]           = PlanT[W, A]
     type M[A]           = GenT[F, A]
 
-    type MongoQScriptInterim[A] =
-      (QScriptCore[T, ?] :\: EquiJoin[T, ?] :/: Const[Read, ?])#M[A]
-
     type MongoQScript[A] =
       (QScriptCore[T, ?] :\: EquiJoin[T, ?] :/: Const[ShiftedRead, ?])#M[A]
 
@@ -992,6 +1027,7 @@ object MongoDbQScriptPlanner {
       EitherT(ea.leftMap(FileSystemError.planningFailed(lp.convertTo[Fix], _)).point[W]).liftM[GenT]
 
     val P = scala.Predef.implicitly[Planner.Aux[T, MongoQScript]]
+    val C = quasar.qscript.Coalesce[T, MongoQScript, MongoQScript]
 
     val lc = listContents andThen (ss => EitherT(ss.run.liftM[PhaseResultT]))
 
@@ -1001,8 +1037,14 @@ object MongoDbQScriptPlanner {
       // NB: right now this only outputs one phase, but it’d be cool if we could
       //     interleave phase building in the composed recursion scheme
       opt <- log("QScript (Mongo-specific)")(
-        shiftRead(qs).transCata[MongoQScript](
-          SimplifyJoin[T, QScriptShiftRead[T, ?], MongoQScript].simplifyJoin(idPrism.reverseGet)).point[M])
+        shiftRead(qs)
+          .transCata[MongoQScript](SimplifyJoin[T, QScriptShiftRead[T, ?], MongoQScript].simplifyJoin(idPrism.reverseGet))
+          .transAna(
+            repeatedly(C.coalesceQC[MongoQScript](idPrism)) ⋙
+            repeatedly(C.coalesceEJ[MongoQScript](idPrism.get)) ⋙
+            repeatedly(C.coalesceSR[MongoQScript](idPrism)))
+          .transCata(optimize.optimize(idPrism.reverseGet))
+          .point[M])
       wb  <- log("Workflow Builder")(swizzle(opt.cataM[StateT[OutputM, NameGen, ?], WorkflowBuilder[WF]](P.plan(joinHandler, funcHandler) ∘ (_ ∘ (_ ∘ normalize)))))
       wf1 <- log("Workflow (raw)")         (swizzle(WorkflowBuilder.build(wb)))
       wf2 <- log("Workflow (crystallized)")(Crystallize[WF].crystallize(wf1).point[M])

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/Planner.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/Planner.scala
@@ -222,11 +222,14 @@ object Planner {
               })).point[Task]
             }
           )
-        case Take(src, from, count) =>
-          filterOut(fromFile, src, from, count, (i: Index, c: Count) => i < c)
-          
-        case Drop(src, from, count) =>
-          filterOut(fromFile, src, from, count, (i: Index, c: Count) => i >= c)
+        case Subset(src, from, sel, count) =>
+          filterOut(fromFile, src, from, count,
+            sel match {
+              case Drop => (i: Index, c: Count) => i >= c
+              case Take => (i: Index, c: Count) => i < c
+              // TODO: Better sampling
+              case Sample => (i: Index, c: Count) => i < c
+            })
 
         case LeftShift(src, struct, repair) =>
 


### PR DESCRIPTION
- complete implementation for Mergable\[*Join\] (avoids autojoins after a join)
- fix a bug where we included the provenance in the join condition
- fix join combine func to use the result pointers

Also,
- combine `Take`/`Drop` into `Subset` (and add `Sample` case)
- fix handling of `ProjectField` in Mongo-QScript planner
- handle `ShiftedRead`’s `IncludeId` in Mongo-QScript planner
- fix `Reduce`’s repairFunc handling in Mongo-QScript planner
- normalize Mongo-specific QScript