### PR TITLE
Enable integration tests for MarkLogic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ tmp
 .settings
 *.sw*
 tags
+scripts/marklogic/MarkLogic.rpm
+.ml-dev-cookies

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@ tmp
 .settings
 *.sw*
 tags
-scripts/marklogic/MarkLogic.rpm
+scripts/marklogic/docker/
 .ml-dev-cookies

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ cache:
   directories:
   - $HOME/.ivy2/cache
   - $HOME/.sbt
+  - scripts/marklogic/docker
 
 before_cache:
 - find "$HOME/.sbt/" -name '*.lock' -print0 | xargs -0 rm

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script:
   - export MONGO_AUTH="MONGO_${MONGO_RELEASE}_AUTH"
   - ./scripts/installMongo mongodb-linux-x86_64-${!MONGO_LINUX} mongo ${!MONGO_PORT} ${!MONGO_AUTH}
   - if [ $QUASAR_COUCHBASE ]; then ./scripts/startCouchbase; fi
+  - if [ $QUASAR_MARKLOGIC ]; then ./scripts/installMarkLogic; fi
   - psql -c 'CREATE DATABASE "quasar-test";' -U postgres
   - ./scripts/build $MONGO_RELEASE
 after_success: ./scripts/afterSuccess
@@ -41,6 +42,7 @@ env:
   - MONGO_RELEASE=3_0_RO
   - MONGO_RELEASE=3_2
   - QUASAR_POSTGRESQL='{"postgresql":{"connectionUri":"jdbc:postgresql://localhost/quasar-test?user=postgres&password=postgres"}}'
+  - QUASAR_MARKLOGIC='{"marklogic":{"connectionUri":"xcc://marklogic:marklogic@localhost:8000/Documents"}}'
 
   global:
   - LOCAL_MONGODB=true

--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- Enable integration tests for MarkLogic

--- a/it/src/main/resources/tests/LocationCount.test
+++ b/it/src/main/resources/tests/LocationCount.test
@@ -6,7 +6,7 @@
         "mongodb_read_only": "pending",
         "mongodb_3_2":       "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "jobs_jobinfo.data",

--- a/it/src/main/resources/tests/aliasedFieldSortedByOriginal.test
+++ b/it/src/main/resources/tests/aliasedFieldSortedByOriginal.test
@@ -2,7 +2,7 @@
     "name": "select aliased field sorted by original name",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/boulderLikePop.test
+++ b/it/src/main/resources/tests/boulderLikePop.test
@@ -3,7 +3,7 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
 

--- a/it/src/main/resources/tests/boulderPop.test
+++ b/it/src/main/resources/tests/boulderPop.test
@@ -2,7 +2,7 @@
     "name": "population of Boulder",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/caseVariations.test
+++ b/it/src/main/resources/tests/caseVariations.test
@@ -3,7 +3,7 @@
 
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
 

--- a/it/src/main/resources/tests/caseWithGroup.test
+++ b/it/src/main/resources/tests/caseWithGroup.test
@@ -3,7 +3,7 @@
 
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
 

--- a/it/src/main/resources/tests/citiesByLargestZip.test
+++ b/it/src/main/resources/tests/citiesByLargestZip.test
@@ -2,7 +2,7 @@
   "name": "cities with largest individual zip codes",
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
   "note": "This is tricky because the sort key does not appear in the result. The

--- a/it/src/main/resources/tests/citiesByTotalPopulation.test
+++ b/it/src/main/resources/tests/citiesByTotalPopulation.test
@@ -2,7 +2,7 @@
     "name": "top 5 cities by total population",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/complex-vars.test
+++ b/it/src/main/resources/tests/complex-vars.test
@@ -3,7 +3,7 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
 

--- a/it/src/main/resources/tests/concatArray.test
+++ b/it/src/main/resources/tests/concatArray.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/concatArrayWithLiteral.test
+++ b/it/src/main/resources/tests/concatArrayWithLiteral.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/concatArrayWithUnknown.test
+++ b/it/src/main/resources/tests/concatArrayWithUnknown.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/concatBetween.test
+++ b/it/src/main/resources/tests/concatBetween.test
@@ -2,7 +2,7 @@
     "name": "concat BETWEEN with other fields",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/constantAndGrouped.test
+++ b/it/src/main/resources/tests/constantAndGrouped.test
@@ -3,7 +3,7 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
 

--- a/it/src/main/resources/tests/convertFromString.test
+++ b/it/src/main/resources/tests/convertFromString.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/convertToFromString.test
+++ b/it/src/main/resources/tests/convertToFromString.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/countDistinct.test
+++ b/it/src/main/resources/tests/countDistinct.test
@@ -3,7 +3,7 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
 

--- a/it/src/main/resources/tests/countDistinctStar.test
+++ b/it/src/main/resources/tests/countDistinctStar.test
@@ -3,7 +3,7 @@
   "backends": {
     "mongodb_read_only": "pending",
     "postgresql":        "pending",
-    "marklogic":         "pending",
+    "marklogic":         "skip",
     "couchbase":         "pending"
   },
   "data": "olympics.data",

--- a/it/src/main/resources/tests/delete.test
+++ b/it/src/main/resources/tests/delete.test
@@ -2,7 +2,7 @@
     "name": "delete",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/different-flattens.test
+++ b/it/src/main/resources/tests/different-flattens.test
@@ -2,7 +2,7 @@
     "name": "merge differently-nested flattens",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "user_comments.data",

--- a/it/src/main/resources/tests/distinctStar.test
+++ b/it/src/main/resources/tests/distinctStar.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "cities.data",

--- a/it/src/main/resources/tests/doubleFlatten.test
+++ b/it/src/main/resources/tests/doubleFlatten.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "slamengine_commits.data",

--- a/it/src/main/resources/tests/doubleFlattenWithIntervening.test
+++ b/it/src/main/resources/tests/doubleFlattenWithIntervening.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "nested.data",

--- a/it/src/main/resources/tests/fakeObjectId.test
+++ b/it/src/main/resources/tests/fakeObjectId.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "objectids.data",

--- a/it/src/main/resources/tests/fieldOrder.test
+++ b/it/src/main/resources/tests/fieldOrder.test
@@ -7,7 +7,7 @@
         "mongodb_read_only": "pending",
         "mongodb_3_2":       "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
 

--- a/it/src/main/resources/tests/filter-vars.test
+++ b/it/src/main/resources/tests/filter-vars.test
@@ -3,7 +3,7 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
 

--- a/it/src/main/resources/tests/filter.test
+++ b/it/src/main/resources/tests/filter.test
@@ -4,7 +4,7 @@
   "backends": {
       "mongodb_read_only": "pending",
       "postgresql":        "pending",
-      "marklogic":         "pending",
+      "marklogic":         "skip",
       "couchbase":         "pending"
   },
 

--- a/it/src/main/resources/tests/filterByJsWithOnlyReducing.test
+++ b/it/src/main/resources/tests/filterByJsWithOnlyReducing.test
@@ -4,7 +4,7 @@
   "backends": {
       "mongodb_read_only": "pending",
       "postgresql":        "pending",
-      "marklogic":         "pending",
+      "marklogic":         "skip",
       "couchbase":         "pending"
   },
 

--- a/it/src/main/resources/tests/filterComplement.test
+++ b/it/src/main/resources/tests/filterComplement.test
@@ -2,7 +2,7 @@
     "name": "filter on list complement",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/filterMembership.test
+++ b/it/src/main/resources/tests/filterMembership.test
@@ -2,7 +2,7 @@
     "name": "filter on list membership",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/filterOnContains.test
+++ b/it/src/main/resources/tests/filterOnContains.test
@@ -2,7 +2,7 @@
     "name": "filter on contains",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/filterOnFieldComparison.test
+++ b/it/src/main/resources/tests/filterOnFieldComparison.test
@@ -3,7 +3,8 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "couchbase":         "pending"
+        "couchbase":         "pending",
+        "marklogic":         "skip"
     },
     "data": "zips.data",
     "query": "select * from zips where pop < loc[1] limit 10",

--- a/it/src/main/resources/tests/filterOnOid.test
+++ b/it/src/main/resources/tests/filterOnOid.test
@@ -2,7 +2,7 @@
     "name": "match on ObjectId",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "days.data",

--- a/it/src/main/resources/tests/filterSkipLimitCount.test
+++ b/it/src/main/resources/tests/filterSkipLimitCount.test
@@ -3,7 +3,7 @@
 
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
 

--- a/it/src/main/resources/tests/filterSortLimit.test
+++ b/it/src/main/resources/tests/filterSortLimit.test
@@ -3,7 +3,7 @@
 
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
 

--- a/it/src/main/resources/tests/filterWithComplexNot.test
+++ b/it/src/main/resources/tests/filterWithComplexNot.test
@@ -4,7 +4,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
 

--- a/it/src/main/resources/tests/filterWithNot.test
+++ b/it/src/main/resources/tests/filterWithNot.test
@@ -3,7 +3,7 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
 

--- a/it/src/main/resources/tests/filteredDistinct.test
+++ b/it/src/main/resources/tests/filteredDistinct.test
@@ -2,7 +2,7 @@
   "name": "filtered distinct of one field",
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
   "data": "olympics.data",

--- a/it/src/main/resources/tests/flattenArray.test
+++ b/it/src/main/resources/tests/flattenArray.test
@@ -2,7 +2,7 @@
     "name": "flatten array",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/flattenArrayProjection.test
+++ b/it/src/main/resources/tests/flattenArrayProjection.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "slamengine_commits.data",

--- a/it/src/main/resources/tests/flattenArrayWithUnflattened.test
+++ b/it/src/main/resources/tests/flattenArrayWithUnflattened.test
@@ -2,7 +2,7 @@
     "name": "flatten array with unflattened field",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/flattenGroupedObject.test
+++ b/it/src/main/resources/tests/flattenGroupedObject.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "slamengine_commits.data",

--- a/it/src/main/resources/tests/flattenNestedObject.test
+++ b/it/src/main/resources/tests/flattenNestedObject.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "slamengine_commits.data",

--- a/it/src/main/resources/tests/flattenObject.test
+++ b/it/src/main/resources/tests/flattenObject.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "usa_factbook.data",

--- a/it/src/main/resources/tests/groupAndFilterWithNoUnreduced.test
+++ b/it/src/main/resources/tests/groupAndFilterWithNoUnreduced.test
@@ -3,7 +3,7 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
 

--- a/it/src/main/resources/tests/groupAndWildcard.test
+++ b/it/src/main/resources/tests/groupAndWildcard.test
@@ -3,7 +3,7 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
 

--- a/it/src/main/resources/tests/groupByArray.test
+++ b/it/src/main/resources/tests/groupByArray.test
@@ -2,7 +2,7 @@
     "name": "group by array",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "slamengine_commits.data",

--- a/it/src/main/resources/tests/groupByExpression.test
+++ b/it/src/main/resources/tests/groupByExpression.test
@@ -3,7 +3,7 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
 

--- a/it/src/main/resources/tests/groupByFlatten.test
+++ b/it/src/main/resources/tests/groupByFlatten.test
@@ -2,7 +2,7 @@
     "name": "group by flattened field",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "slamengine_commits.data",

--- a/it/src/main/resources/tests/guardedExpression.test
+++ b/it/src/main/resources/tests/guardedExpression.test
@@ -3,7 +3,7 @@
   "backends": {
       "mongodb_read_only": "pending",
       "postgresql":        "pending",
-      "marklogic":         "pending",
+      "marklogic":         "skip",
       "couchbase":         "pending"
   },
   "data": "zips.data",

--- a/it/src/main/resources/tests/idAliased.test
+++ b/it/src/main/resources/tests/idAliased.test
@@ -3,7 +3,7 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
 

--- a/it/src/main/resources/tests/idNotAliased.test
+++ b/it/src/main/resources/tests/idNotAliased.test
@@ -6,7 +6,7 @@
         "mongodb_read_only": "pending",
         "mongodb_3_2":       "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/ifUndefined.test
+++ b/it/src/main/resources/tests/ifUndefined.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/implicitGroupWithFilter.test
+++ b/it/src/main/resources/tests/implicitGroupWithFilter.test
@@ -3,7 +3,7 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
 

--- a/it/src/main/resources/tests/inBareElement.test
+++ b/it/src/main/resources/tests/inBareElement.test
@@ -2,7 +2,7 @@
     "name": "filter field “in” a bare value",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/joins/3WayJoin.test
+++ b/it/src/main/resources/tests/joins/3WayJoin.test
@@ -3,7 +3,8 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "couchbase":         "pending"
+        "couchbase":         "pending",
+        "marklogic":         "skip"
     },
     "data": "../largeZips.data",
     "query": "select z1.city, z2.state

--- a/it/src/main/resources/tests/joins/constantOnLeft.test
+++ b/it/src/main/resources/tests/joins/constantOnLeft.test
@@ -4,7 +4,8 @@
   "backends": {
     "mongodb_read_only": "pending",
     "postgresql":        "pending",
-    "couchbase":         "pending"
+    "couchbase":         "pending",
+    "marklogic":         "skip"
   },
 
   "data": "../largeZips.data",

--- a/it/src/main/resources/tests/joins/crossJoin.test
+++ b/it/src/main/resources/tests/joins/crossJoin.test
@@ -4,7 +4,8 @@
   "backends": {
     "mongodb_read_only": "pending",
     "postgresql":        "pending",
-    "couchbase":         "pending"
+    "couchbase":         "pending",
+    "marklogic":         "skip"
   },
 
   "data": "../largeZips.data",

--- a/it/src/main/resources/tests/joins/crossJoinWithOneSidedConditions.test
+++ b/it/src/main/resources/tests/joins/crossJoinWithOneSidedConditions.test
@@ -4,7 +4,8 @@
   "backends": {
     "mongodb_read_only": "pending",
     "postgresql":        "pending",
-    "couchbase":         "pending"
+    "couchbase":         "pending",
+    "marklogic":         "skip"
   },
 
   "data": "../largeZips.data",

--- a/it/src/main/resources/tests/joins/groupedJoin.test
+++ b/it/src/main/resources/tests/joins/groupedJoin.test
@@ -3,7 +3,8 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "couchbase":         "pending"
+        "couchbase":         "pending",
+        "marklogic":         "skip"
     },
     "data": "../slamengine_commits.data",
     "query": "SELECT p.author.login, COUNT(*)

--- a/it/src/main/resources/tests/joins/innerEquiJoin.test
+++ b/it/src/main/resources/tests/joins/innerEquiJoin.test
@@ -3,7 +3,8 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "couchbase":         "pending"
+        "couchbase":         "pending",
+        "marklogic":         "skip"
     },
     "data": "../largeZips.data",
     "query": "select largeZips.city, z2.state from `../largeZips` join `../largeZips` as z2 on largeZips._id = z2._id",

--- a/it/src/main/resources/tests/joins/innerEquiJoinWithWildcard.test
+++ b/it/src/main/resources/tests/joins/innerEquiJoinWithWildcard.test
@@ -3,7 +3,8 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "couchbase":         "pending"
+        "couchbase":         "pending",
+        "marklogic":         "skip"
     },
     "data": "../largeZips.data",
     "query": "select * from `../largeZips` join `../largeZips` as z2 on largeZips._id = z2._id",

--- a/it/src/main/resources/tests/joins/joinSubSelects.test
+++ b/it/src/main/resources/tests/joins/joinSubSelects.test
@@ -4,7 +4,8 @@
   "backends": {
     "mongodb_read_only": "pending",
     "postgresql":        "pending",
-    "couchbase":         "pending"
+    "couchbase":         "pending",
+    "marklogic":         "skip"
   },
 
   "data": "../zips.data",

--- a/it/src/main/resources/tests/joins/joinWithComplexCondition.test
+++ b/it/src/main/resources/tests/joins/joinWithComplexCondition.test
@@ -3,7 +3,8 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "couchbase":         "pending"
+        "couchbase":         "pending",
+        "marklogic":         "skip"
     },
     "data": "../slamengine_commits.data",
     "query": "select l.sha as child, l.author.login as c_auth, r.sha as parent, r.author.login as p_auth

--- a/it/src/main/resources/tests/joins/joinWithMultipleConditions.test
+++ b/it/src/main/resources/tests/joins/joinWithMultipleConditions.test
@@ -3,7 +3,8 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "couchbase":         "pending"
+        "couchbase":         "pending",
+        "marklogic":         "skip"
     },
     "data": "../slamengine_commits.data",
     "query": "select l.sha as child, l.author.login as c_auth, r.sha as parent, r.author.login as p_auth

--- a/it/src/main/resources/tests/joins/joinWithReversedCondition.test
+++ b/it/src/main/resources/tests/joins/joinWithReversedCondition.test
@@ -3,7 +3,8 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "couchbase":         "pending"
+        "couchbase":         "pending",
+        "marklogic":         "skip"
     },
     "data": "../slamengine_commits.data",
     "query": "select l.sha as child, l.author.login as c_auth, r.sha as parent, r.author.login as p_auth

--- a/it/src/main/resources/tests/joins/orderJoinByAlias.test
+++ b/it/src/main/resources/tests/joins/orderJoinByAlias.test
@@ -3,7 +3,8 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "couchbase":         "pending"
+        "couchbase":         "pending",
+        "marklogic":         "skip"
     },
     "data": "../largeZips.data",
     "query": "select z1._id as zip, z2.pop / 1000 as popK from `../largeZips` as z1 inner join `../largeZips` as z2 on z1._id = z2._id order by popK desc",

--- a/it/src/main/resources/tests/jsWithNonJsFilter.test
+++ b/it/src/main/resources/tests/jsWithNonJsFilter.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/largestCities.test
+++ b/it/src/main/resources/tests/largestCities.test
@@ -2,7 +2,7 @@
     "name": "largest cities",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/largestZips.test
+++ b/it/src/main/resources/tests/largestZips.test
@@ -2,7 +2,7 @@
     "name": "largest zips",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/letBinding.test
+++ b/it/src/main/resources/tests/letBinding.test
@@ -3,7 +3,7 @@
 
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
 

--- a/it/src/main/resources/tests/letBindingSelect.test
+++ b/it/src/main/resources/tests/letBindingSelect.test
@@ -3,7 +3,7 @@
 
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
 

--- a/it/src/main/resources/tests/letInSelectProjection.test
+++ b/it/src/main/resources/tests/letInSelectProjection.test
@@ -3,7 +3,7 @@
 
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
 

--- a/it/src/main/resources/tests/likeWithConstantFoldablePattern.test
+++ b/it/src/main/resources/tests/likeWithConstantFoldablePattern.test
@@ -2,7 +2,7 @@
     "name": "LIKE with constant-foldable pattern",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/literalReductionWithNegative.test
+++ b/it/src/main/resources/tests/literalReductionWithNegative.test
@@ -1,7 +1,8 @@
 {
     "name": "reduce a literal set with negatives",
-    "data": "zips.data",
-    "query": "select max((0, 1, -2, 5)) from zips",
+    "backends": { "marklogic": "skip" },
+    "data": "cars.data",
+    "query": "select max((0, 1, -2, 5)) from cars",
     "predicate": "equalsExactly",
     "expected": [{ "0": 5 }]
 }

--- a/it/src/main/resources/tests/longCitiesWithLength.test
+++ b/it/src/main/resources/tests/longCitiesWithLength.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/manySimpleProjections.test
+++ b/it/src/main/resources/tests/manySimpleProjections.test
@@ -3,7 +3,7 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
 

--- a/it/src/main/resources/tests/matchCaseInsensitiveRegex.test
+++ b/it/src/main/resources/tests/matchCaseInsensitiveRegex.test
@@ -2,7 +2,7 @@
     "name": "match on case-insensitive string",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/matchLikeComplement.test
+++ b/it/src/main/resources/tests/matchLikeComplement.test
@@ -2,7 +2,7 @@
     "name": "match like complement",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/matchLikePattern.test
+++ b/it/src/main/resources/tests/matchLikePattern.test
@@ -2,7 +2,7 @@
     "name": "match like pattern",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/matchRegexPattern.test
+++ b/it/src/main/resources/tests/matchRegexPattern.test
@@ -2,7 +2,7 @@
     "name": "match regex pattern",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/matchRegexPatternWithExpressions.test
+++ b/it/src/main/resources/tests/matchRegexPatternWithExpressions.test
@@ -4,7 +4,7 @@
   "backends": {
     "mongodb_read_only": "pending",
     "postgresql":        "pending",
-    "marklogic":         "pending",
+    "marklogic":         "skip",
     "couchbase":         "pending"
   },
 

--- a/it/src/main/resources/tests/multilineLike.test
+++ b/it/src/main/resources/tests/multilineLike.test
@@ -2,7 +2,7 @@
     "name": "match LIKE with multiple lines",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "slamengine_commits.data",

--- a/it/src/main/resources/tests/multistageFlatten.test
+++ b/it/src/main/resources/tests/multistageFlatten.test
@@ -2,7 +2,7 @@
     "name": "multi-flatten with fields at various depths",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "nested_foo.data",

--- a/it/src/main/resources/tests/multitypeFlatten.test
+++ b/it/src/main/resources/tests/multitypeFlatten.test
@@ -4,7 +4,7 @@
         "mongodb_read_only": "pending",
         "mongodb_3_2":       "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "nested_foo.data",

--- a/it/src/main/resources/tests/negatedRegex.test
+++ b/it/src/main/resources/tests/negatedRegex.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/nonJsJoinCondition.test
+++ b/it/src/main/resources/tests/nonJsJoinCondition.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/null/notNullFilter.test
+++ b/it/src/main/resources/tests/null/notNullFilter.test
@@ -2,7 +2,7 @@
     "name": "filter on is not null",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "description": "expression with `is not null` should be true whenever the same filter is satisfied",

--- a/it/src/main/resources/tests/null/nullComparison.test
+++ b/it/src/main/resources/tests/null/nullComparison.test
@@ -2,7 +2,7 @@
     "name": "filter on `!= null`",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "nulls.data",

--- a/it/src/main/resources/tests/null/nullFilter.test
+++ b/it/src/main/resources/tests/null/nullFilter.test
@@ -3,7 +3,7 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
 

--- a/it/src/main/resources/tests/null/nullTestExprs.test
+++ b/it/src/main/resources/tests/null/nullTestExprs.test
@@ -2,7 +2,7 @@
     "name": "expressions with `= null` and `is null`",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "nulls.data",

--- a/it/src/main/resources/tests/null/nullTestExprsWithMissing.test
+++ b/it/src/main/resources/tests/null/nullTestExprsWithMissing.test
@@ -6,7 +6,8 @@
         "mongodb_read_only": "pending",
         "mongodb_3_2":       "pending",
         "postgresql":        "pending",
-        "couchbase":         "pending"
+        "couchbase":         "pending",
+        "marklogic":         "skip"
     },
     "data": "nullsWithMissing.data",
     "query": "select name,

--- a/it/src/main/resources/tests/null/toFromString.test
+++ b/it/src/main/resources/tests/null/toFromString.test
@@ -3,7 +3,8 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "couchbase":         "pending"
+        "couchbase":         "pending",
+        "marklogic":         "skip"
     },
     "data": "nulls.data",
     "query": "select null(name), to_string(val) from nulls where name = \"null\"",

--- a/it/src/main/resources/tests/orderedWildcardWithProjection.test
+++ b/it/src/main/resources/tests/orderedWildcardWithProjection.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/projectCaseInsensitiveRegex.test
+++ b/it/src/main/resources/tests/projectCaseInsensitiveRegex.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/projectFieldWithFlatten.test
+++ b/it/src/main/resources/tests/projectFieldWithFlatten.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "usa_factbook.data",

--- a/it/src/main/resources/tests/projectFromConcattedArray.test
+++ b/it/src/main/resources/tests/projectFromConcattedArray.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/projectIndexFromGroup.test
+++ b/it/src/main/resources/tests/projectIndexFromGroup.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "slamengine_commits.data",

--- a/it/src/main/resources/tests/projectIndexFromGroupWithFilter.test
+++ b/it/src/main/resources/tests/projectIndexFromGroupWithFilter.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "slamengine_commits.data",

--- a/it/src/main/resources/tests/projectIndexWithObjectFlatten.test
+++ b/it/src/main/resources/tests/projectIndexWithObjectFlatten.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "slamengine_commits.data",

--- a/it/src/main/resources/tests/sameFieldName.test
+++ b/it/src/main/resources/tests/sameFieldName.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": ["owners.data", "cars.data"],

--- a/it/src/main/resources/tests/selectArrayElement.test
+++ b/it/src/main/resources/tests/selectArrayElement.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/selectWildcardAndField.test
+++ b/it/src/main/resources/tests/selectWildcardAndField.test
@@ -2,7 +2,7 @@
     "name": "select wildcard and field",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/servlet.test
+++ b/it/src/main/resources/tests/servlet.test
@@ -6,7 +6,7 @@
         "mongodb_read_only": "pending",
         "mongodb_3_2":       "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "webapp.data",

--- a/it/src/main/resources/tests/shortCities.test
+++ b/it/src/main/resources/tests/shortCities.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/simpleDistinct.test
+++ b/it/src/main/resources/tests/simpleDistinct.test
@@ -3,7 +3,7 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
 

--- a/it/src/main/resources/tests/simpleJsFilter.test
+++ b/it/src/main/resources/tests/simpleJsFilter.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/simpleProjectWithOneRenamed.test
+++ b/it/src/main/resources/tests/simpleProjectWithOneRenamed.test
@@ -7,7 +7,7 @@
     "mongodb_read_only": "pending",
     "mongodb_3_2":       "pending",
     "postgresql":        "pending",
-    "marklogic":         "pending",
+    "marklogic":         "skip",
     "couchbase":         "pending"
   },
 

--- a/it/src/main/resources/tests/singleElementSet.test
+++ b/it/src/main/resources/tests/singleElementSet.test
@@ -2,7 +2,7 @@
     "name": "filter field in single-element set",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/singleFieldDistinct.test
+++ b/it/src/main/resources/tests/singleFieldDistinct.test
@@ -2,7 +2,7 @@
   "name": "distinct of one field",
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
   "data": "olympics.data",

--- a/it/src/main/resources/tests/skipCount.test
+++ b/it/src/main/resources/tests/skipCount.test
@@ -3,7 +3,7 @@
 
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
 

--- a/it/src/main/resources/tests/sortByJS.test
+++ b/it/src/main/resources/tests/sortByJS.test
@@ -4,7 +4,7 @@
   "backends": {
     "mongodb_read_only": "pending",
     "postgresql":        "pending",
-    "marklogic":         "pending",
+    "marklogic":         "skip",
     "couchbase":         "pending"
   },
 

--- a/it/src/main/resources/tests/sortProjectLimit.test
+++ b/it/src/main/resources/tests/sortProjectLimit.test
@@ -3,7 +3,7 @@
 
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
 

--- a/it/src/main/resources/tests/sortWildcardOnExpression.test
+++ b/it/src/main/resources/tests/sortWildcardOnExpression.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/statesByShortestFirstCity.test
+++ b/it/src/main/resources/tests/statesByShortestFirstCity.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "description": "combines an aggregate function (min) with a function implemented in JS (length)",

--- a/it/src/main/resources/tests/symmetricNonJsJoinCondition.test
+++ b/it/src/main/resources/tests/symmetricNonJsJoinCondition.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/temporal/convertTimestamp.test
+++ b/it/src/main/resources/tests/temporal/convertTimestamp.test
@@ -3,7 +3,7 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
 

--- a/it/src/main/resources/tests/temporal/dateFilter.test
+++ b/it/src/main/resources/tests/temporal/dateFilter.test
@@ -3,7 +3,7 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
 

--- a/it/src/main/resources/tests/temporal/datePartsConverted.test
+++ b/it/src/main/resources/tests/temporal/datePartsConverted.test
@@ -7,7 +7,7 @@
       "mongodb_read_only": "pending",
       "mongodb_3_2":       "pending",
       "postgresql":        "pending",
-      "marklogic":         "pending"
+      "marklogic":         "skip"
   },
 
   "data": "../slamengine_commits.data",

--- a/it/src/main/resources/tests/temporal/datePartsConvertedSimple.test
+++ b/it/src/main/resources/tests/temporal/datePartsConvertedSimple.test
@@ -1,7 +1,7 @@
 {
   "name": "date_part, after conversion to JS (see #1238)",
 
-  "backends": { "mongodb_read_only": "pending", "postgresql": "pending", "marklogic": "pending" },
+  "backends": { "mongodb_read_only": "pending", "postgresql": "pending", "marklogic": "skip" },
 
   "data": "../slamengine_commits.data",
 

--- a/it/src/main/resources/tests/temporal/days.test
+++ b/it/src/main/resources/tests/temporal/days.test
@@ -3,7 +3,7 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
 

--- a/it/src/main/resources/tests/temporal/filterOnDate.test
+++ b/it/src/main/resources/tests/temporal/filterOnDate.test
@@ -2,7 +2,7 @@
     "name": "filter with date literals",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "../days.data",

--- a/it/src/main/resources/tests/temporal/invalidDateFilter.test
+++ b/it/src/main/resources/tests/temporal/invalidDateFilter.test
@@ -3,7 +3,7 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
 

--- a/it/src/main/resources/tests/temporal/time.test
+++ b/it/src/main/resources/tests/temporal/time.test
@@ -3,7 +3,8 @@
 
   "backends": {
     "postgresql":        "pending",
-    "couchbase":         "pending"
+    "couchbase":         "pending",
+    "marklogic":         "skip"
   },
 
   "data": "../days.data",

--- a/it/src/main/resources/tests/temporal/timestampsAndIntervals.test
+++ b/it/src/main/resources/tests/temporal/timestampsAndIntervals.test
@@ -3,7 +3,7 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
 

--- a/it/src/main/resources/tests/temporal/toFromString.test
+++ b/it/src/main/resources/tests/temporal/toFromString.test
@@ -3,7 +3,8 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "couchbase":         "pending"
+        "couchbase":         "pending",
+        "marklogic":         "skip"
     },
     "data": "../days.data",
     "query": "select date(substring(str, 0, 10)), time(substring(str, 11, 20)), timestamp(str), to_string(ts) from `../days`",

--- a/it/src/main/resources/tests/tripleFlatten.test
+++ b/it/src/main/resources/tests/tripleFlatten.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "nested.data",

--- a/it/src/main/resources/tests/trivial.test
+++ b/it/src/main/resources/tests/trivial.test
@@ -3,7 +3,7 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
 

--- a/it/src/main/resources/tests/trivialGroup.test
+++ b/it/src/main/resources/tests/trivialGroup.test
@@ -2,7 +2,7 @@
     "name": "trivial group by",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "description": "Should project the result at the root (not under 'value').",

--- a/it/src/main/resources/tests/undefinedJsInExpr.test
+++ b/it/src/main/resources/tests/undefinedJsInExpr.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/unifyFlattenedFields.test
+++ b/it/src/main/resources/tests/unifyFlattenedFields.test
@@ -2,7 +2,7 @@
     "name": "unify flattened fields",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/unifyFlattenedFieldsWithMultipleUses.test
+++ b/it/src/main/resources/tests/unifyFlattenedFieldsWithMultipleUses.test
@@ -2,7 +2,7 @@
     "name": "unify flattened fields with multiple shape-preserving ops.",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/unifyFlattenedFieldsWithUnflattened.test
+++ b/it/src/main/resources/tests/unifyFlattenedFieldsWithUnflattened.test
@@ -2,7 +2,7 @@
     "name": "unify flattened fields with unflattened field",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/union.test
+++ b/it/src/main/resources/tests/union.test
@@ -1,7 +1,7 @@
 {
     "name": "union",
     "backends": {
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/unshiftAggregation.test
+++ b/it/src/main/resources/tests/unshiftAggregation.test
@@ -1,7 +1,7 @@
 {
     "name": "unshift aggregation",
     "backends": {
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "postgresql": "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/var-relation.test
+++ b/it/src/main/resources/tests/var-relation.test
@@ -3,7 +3,7 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "pending",
+    "marklogic":  "skip",
     "couchbase":  "pending"
   },
 

--- a/it/src/main/resources/tests/wildcardWithExtraProjections.test
+++ b/it/src/main/resources/tests/wildcardWithExtraProjections.test
@@ -3,7 +3,7 @@
   "backends": {
     "mongodb_read_only": "pending",
     "postgresql":        "pending",
-    "marklogic":         "pending",
+    "marklogic":         "skip",
     "couchbase":         "pending"
   },
   "data": "zips.data",

--- a/it/src/main/resources/tests/wildcardWithMultipleConstants.test
+++ b/it/src/main/resources/tests/wildcardWithMultipleConstants.test
@@ -3,7 +3,7 @@
 
     "backends": {
       "postgresql": "pending",
-      "marklogic":  "pending",
+      "marklogic":  "skip",
       "couchbase":  "pending"
     },
 

--- a/it/src/main/resources/tests/wildcardWithSort.test
+++ b/it/src/main/resources/tests/wildcardWithSort.test
@@ -2,7 +2,7 @@
     "name": "wildcard with sort",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "pending",
+        "marklogic":  "skip",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/zipsByCityLength.test
+++ b/it/src/main/resources/tests/zipsByCityLength.test
@@ -3,7 +3,7 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "pending",
+        "marklogic":         "skip",
         "couchbase":         "pending"
     },
     "data": "largeZips.data",

--- a/marklogic/src/main/scala/quasar/physical/marklogic/ejson/EncodeXQuery.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/ejson/EncodeXQuery.scala
@@ -71,7 +71,7 @@ object EncodeXQuery {
           val objEntries = entries.traverse[ValM, XQuery] {
             case (XQuery.StringLit(s), value) =>
               refineV[IsNCName](s).validation map { ncname =>
-                ejsxqy.mkObjectEntry[M] apply (xs.QName(ncname.get.xs), value)
+                ejsxqy.renameOrWrap[M] apply (xs.QName(ncname.get.xs), value)
               } leftAs s"'$s' is not a valid XML QName.".wrapNel
 
             case (xqy, _) =>

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/QScriptCorePlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/QScriptCorePlanner.scala
@@ -143,9 +143,7 @@ private[qscript] final class QScriptCorePlanner[F[_]: NameGenerator: PrologW: Mo
   }
 
   def reduceFuncCombine(rf: ReduceFunc[FreeMap[T]]): F[XQuery] = rf match {
-    case Avg(fm)              =>
-      combiner(fm)((st, x) => mapFuncXQuery[T, F](fm, x) >>= (qscript.incAvg[F].apply(st, _)))
-
+    case Avg(fm)              => combiner(fm)(qscript.incAvg[F].apply(_, _))
     case Count(fm)            => combiner(fm)((c, _) => (c + 1.xqy).point[F])
     case Max(fm)              => combiner(fm)((x, y) => fn.max(mkSeq_(x, y)).point[F])
     case Min(fm)              => combiner(fm)((x, y) => fn.min(mkSeq_(x, y)).point[F])

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/QScriptCorePlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/QScriptCorePlanner.scala
@@ -46,7 +46,7 @@ private[qscript] final class QScriptCorePlanner[F[_]: NameGenerator: PrologW: Mo
         rs      <- freshVar[F]
         r       <- freshVar[F]
         extract <- mapFuncXQuery(struct, l.xqy)
-        lshift  <- qscript.nodeLeftShift[F] apply (v.xqy)
+        lshift  <- qscript.elementLeftShift[F] apply (v.xqy)
         merge   <- mergeXQuery(repair, l.xqy, r.xqy)
       } yield for_ (l -> src) let_ (v -> extract, rs -> lshift) return_ fn.map(func(r)(merge), rs.xqy)
 
@@ -131,7 +131,7 @@ private[qscript] final class QScriptCorePlanner[F[_]: NameGenerator: PrologW: Mo
     case Min(fm)              => fx(mapFuncXQuery[T, F](fm, _))
     case Sum(fm)              => fx(mapFuncXQuery[T, F](fm, _))
     case Arbitrary(fm)        => fx(mapFuncXQuery[T, F](fm, _))
-    case UnshiftArray(fm)     => fx(x => mapFuncXQuery[T, F](fm, x) flatMap (ejson.singletonArray[F].apply(_)))
+    case UnshiftArray(fm)     => fx(x => mapFuncXQuery[T, F](fm, x) flatMap (ejson.seqToArray_[F](_)))
     case UnshiftMap(kfm, vfm) => fx(x => mapFuncXQuery[T, F](kfm, x).tuple(mapFuncXQuery[T, F](vfm, x)).flatMap {
                                    case (k, v) => ejson.singletonObject[F].apply(k, v)
                                  })

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/ejson.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/ejson.scala
@@ -45,7 +45,7 @@ object ejson {
         $("arr")  as SequenceType("element()"),
         $("item") as SequenceType.Top
       ).as(SequenceType("element()")) { (arr: XQuery, item: XQuery) =>
-        mkArrayElt[F].apply(item) flatMap (mem.nodeInsertChild(arr, _))
+        mkArrayElt[F](item) flatMap (mem.nodeInsertChild(arr, _))
       }
     }
 
@@ -95,9 +95,9 @@ object ejson {
         val (i, elts, zelts) = ("$i", "$elts", "$zelts")
 
         for {
-          ixelt <- mkArrayElt[F] apply i.xqy
+          ixelt <- mkArrayElt[F](i.xqy)
           pair  <- mkArray_[F](mkSeq_(ixelt, elts.xqy(i.xqy)))
-          zpair <- mkArrayElt[F] apply pair
+          zpair <- mkArrayElt[F](pair)
           zarr  <- mkArray[F] apply (fn.nodeName(arr), zelts.xqy)
         } yield {
           let_(elts -> (arr `/` child(aelt))) return_ {
@@ -157,15 +157,8 @@ object ejson {
   def mkArray_[F[_]: PrologW](elements: XQuery): F[XQuery] =
     ejsonN.qn[F] flatMap (ename => mkArray[F].apply(ename.xqy, elements))
 
-  // ejson:make-array-element($value as item()*) as element(ejson:array-element)
-  def mkArrayElt[F[_]: PrologW]: F[FunctionDecl1] =
-    (ejs.name("make-array-element").qn[F] |@| arrayEltN.qn |@| arrayEltN.xs) { (fname, aelt, aeltxs) =>
-      declare(fname)(
-        $("value") as SequenceType.Top
-      ).as(SequenceType(s"element($aelt)")) { value =>
-        element { aeltxs } { value }
-      }
-    }
+  def mkArrayElt[F[_]: PrologW](value: XQuery): F[XQuery] =
+    arrayEltN.qn[F] flatMap (name => renameOrWrap[F].apply(name.xqy, value))
 
   // ejson:make-object($entries as element()*) as element(ejson:ejson)
   def mkObject[F[_]: PrologW]: F[FunctionDecl1] =
@@ -176,20 +169,6 @@ object ejson {
         $("entries") as SequenceType(s"element()*")
       ).as(SequenceType(s"element($ename)")) { entries =>
         element { ejsxs } { mkSeq_(attribute { tpexs } { "object".xs }, entries) }
-      }
-    }
-
-  // ejson:make-object-entry($key as xs:string*, $value as item()*) as element()
-  def mkObjectEntry[F[_]: PrologW]: F[FunctionDecl2] =
-    ejs.name("make-object-entry").qn[F] map { fname =>
-      declare(fname)(
-        $("key") as SequenceType("xs:QName"),
-        $("value") as SequenceType.Top
-      ).as(SequenceType(s"element()")) { (key, value) =>
-        typeswitch(value)(
-          $("e") as SequenceType("element()") return_ (e =>
-            element { key } { mkSeq_(e `/` axes.attribute.node(), e `/` child.node()) })
-        ) default (element { key } { value })
       }
     }
 
@@ -226,7 +205,21 @@ object ejson {
         $("key")   as SequenceType("xs:QName"),
         $("value") as SequenceType.Top
       ).as(SequenceType("element()")) { (obj: XQuery, key: XQuery, value: XQuery) =>
-        mkObjectEntry[F].apply(key, value) flatMap (mem.nodeInsertChild(obj, _))
+        renameOrWrap[F].apply(key, value) flatMap (mem.nodeInsertChild(obj, _))
+      }
+    }
+
+  // ejson:rename-or-wrap($name as xs:QName, $value as item()*) as element()
+  def renameOrWrap[F[_]: PrologW]: F[FunctionDecl2] =
+    ejs.name("rename-or-wrap").qn[F] map { fname =>
+      declare(fname)(
+        $("name")  as SequenceType("xs:QName"),
+        $("value") as SequenceType.Top
+      ).as(SequenceType(s"element()")) { (name, value) =>
+        typeswitch(value)(
+          $("e") as SequenceType("element()") return_ (e =>
+            element { name } { mkSeq_(e `/` axes.attribute.node(), e `/` child.node()) })
+        ) default (element { name } { value })
       }
     }
 
@@ -239,7 +232,7 @@ object ejson {
       ).as(SequenceType(s"element()")) { (name: XQuery, items: XQuery) =>
         val x = "$x"
         for {
-          arrElt <- mkArrayElt[F] apply x.xqy
+          arrElt <- mkArrayElt[F](x.xqy)
           arr    <- mkArray[F] apply (name, fn.map(func(x) { arrElt }, items))
         } yield arr
       }
@@ -255,7 +248,7 @@ object ejson {
         $("key") as SequenceType("xs:QName"),
         $("value") as SequenceType.Top
       ).as(SequenceType(s"element($ename)")) { (key: XQuery, value: XQuery) =>
-        mkObjectEntry[F].apply(key, value) flatMap (xqy => mkObject[F].apply(xqy))
+        renameOrWrap[F].apply(key, value) flatMap (xqy => mkObject[F].apply(xqy))
       }
     }.join
 
@@ -273,7 +266,7 @@ object ejson {
       ).as(SequenceType(s"element($ename)")) { (keyf: XQuery, valf: XQuery, seq: XQuery) =>
         val x = "$x"
         for {
-          entry <- mkObjectEntry[F].apply(keyf.fnapply(x.xqy), valf.fnapply(x.xqy))
+          entry <- renameOrWrap[F].apply(keyf.fnapply(x.xqy), valf.fnapply(x.xqy))
           obj   <- mkObject[F].apply(fn.map(func(x)(entry), seq))
         } yield obj
       }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/qscript.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/qscript.scala
@@ -323,10 +323,10 @@ object qscript {
         val n = "$name"
 
         for {
-          kelt    <- ejson.mkArrayElt[F] apply n.xqy
-          velt    <- ejson.mkArrayElt[F] apply c.xqy
+          kelt    <- ejson.mkArrayElt[F](n.xqy)
+          velt    <- ejson.mkArrayElt[F](c.xqy)
           kvArr   <- ejson.mkArray_[F](mkSeq_(kelt, velt))
-          kvEnt   <- ejson.mkObjectEntry[F] apply (n.xqy, kvArr)
+          kvEnt   <- ejson.renameOrWrap[F] apply (n.xqy, kvArr)
           entries =  for_ (c -> elt `/` child.element())
                      .let_(n -> fn.nodeName(c.xqy))
                      .return_(kvEnt)

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/qscript.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/qscript.scala
@@ -158,7 +158,7 @@ object qscript {
       }
     }
 
-  // qscript:inc-avg-state($cntavg as map:map, $x as item()*) as map:map
+  // qscript:inc-avg-state($cnt as xs:integer, $avg as xs:double) as map:map
   def incAvgState[F[_]: PrologW]: F[FunctionDecl2] =
     qs.name("inc-avg-state").qn[F] map { fname =>
       declare(fname)(

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/qscript.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/qscript.scala
@@ -136,8 +136,8 @@ object qscript {
         val (c, a, y) = ("$c", "$a", "$y")
         incAvgState[F].apply(c.xqy, y.xqy) map { nextSt =>
           let_(
-            c -> (map.get(st, "cnt".xqy) + 1.xqy),
-            a -> map.get(st, "avg".xqy),
+            c -> (map.get(st, "cnt".xs) + 1.xqy),
+            a -> map.get(st, "avg".xs),
             y -> (a.xqy + mkSeq_(mkSeq_(x - a.xqy) div c.xqy)))
           .return_(nextSt)
         }
@@ -149,7 +149,7 @@ object qscript {
     qs.name("inc-avg-state").qn[F] map { fname =>
       declare(fname)(
         $("cnt") as SequenceType("xs:integer"),
-        $("avg") as SequenceType("xs:decimal")
+        $("avg") as SequenceType("xs:double")
       ).as(SequenceType("map:map")) { (cnt, avg) =>
         map.new_(IList(
           map.entry("cnt".xs, cnt),
@@ -236,12 +236,12 @@ object qscript {
       }
     }.join
 
-  // qscript:seconds-since-epoch($dt as xs:dateTime) as xs:decimal
+  // qscript:seconds-since-epoch($dt as xs:dateTime) as xs:double
   def secondsSinceEpoch[F[_]: PrologW]: F[FunctionDecl1] =
     qs.name("seconds-since-epoch").qn[F] map { fname =>
       declare(fname)(
         $("dt") as SequenceType("xs:dateTime")
-      ).as(SequenceType("xs:decimal")) { dt =>
+      ).as(SequenceType("xs:double")) { dt =>
         mkSeq_(dt - epoch) div xs.dayTimeDuration("PT1S".xs)
       }
     }
@@ -283,7 +283,7 @@ object qscript {
       }
     }
 
-  // qscript:timezone-offset-seconds($dt as xs:dateTime) as xs:decimal
+  // qscript:timezone-offset-seconds($dt as xs:dateTime) as xs:integer
   def timezoneOffsetSeconds[F[_]: PrologW]: F[FunctionDecl1] =
     qs.name("timezone-offset-seconds").qn[F] map { fname =>
       declare(fname)(

--- a/scripts/installMarkLogic
+++ b/scripts/installMarkLogic
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail # STRICT MODE
+IFS=$'\n\t'       # http://redsymbol.net/articles/unofficial-bash-strict-mode/
+
+ML_IMG_NAME="quasarml/marklogic:8.0-5.8"
+ML_CNT_NAME="ml8"
+ML_ADMIN_PREFIX="http://localhost:8001/admin/v1"
+ML_USERNAME="marklogic"
+ML_PASSWORD="marklogic"
+
+if [[ -z "${ML_DOCKERHUB_USERNAME-}" || -z "${ML_DOCKERHUB_PASSWORD-}" ]]; then
+  echo "ERROR: ML_DOCKERHUB_USERNAME and ML_DOCKERHUB_PASSWORD must be set."
+  exit 1
+fi
+
+# Login to dockerhub
+docker login -u "$ML_DOCKERHUB_USERNAME" -p "$ML_DOCKERHUB_PASSWORD"
+
+# Start the MarkLogic container
+docker run -d --name $ML_CNT_NAME -p 8000-8002:8000-8002 $ML_IMG_NAME
+
+# Allow the server to start
+sleep 20
+
+# Initialize the server with the license info
+curl --anyauth -i -X POST -d "" ${ML_ADMIN_PREFIX}/init
+
+# Allow the server to restart
+sleep 20
+
+# Add the admin user
+curl -i -X POST --data "admin-username=${ML_USERNAME}&admin-password=${ML_PASSWORD}" ${ML_ADMIN_PREFIX}/instance-admin
+
+# TODO: Add indexes as needed to speedup tests

--- a/scripts/installMarkLogic
+++ b/scripts/installMarkLogic
@@ -2,19 +2,35 @@
 set -euo pipefail # STRICT MODE
 IFS=$'\n\t'       # http://redsymbol.net/articles/unofficial-bash-strict-mode/
 
-ML_IMG_NAME="quasarml/marklogic:8.0-5.8"
+ML_VERSION="8.0-5.8"
+ML_DEV_URL="https://developer.marklogic.com"
+ML_DEV_LOGIN="${ML_DEV_URL}/login"
+ML_DEV_GET_TOKEN="${ML_DEV_URL}/get-download-url"
+ML_DEV_COOKIES=".ml-dev-cookies"
+
+ML_ASSET_PATH="/download/binaries/8.0/MarkLogic-RHEL6-${ML_VERSION}.x86_64.rpm"
+ML_DOWNLOAD_EMAIL="quasarci@slamdata.com"
+ML_DOWNLOAD_PASSWORD="quasarci"
+
+ML_DOCKER_DIR="scripts/marklogic"
+ML_IMG_NAME="marklogic:${ML_VERSION}"
 ML_CNT_NAME="ml8"
+
 ML_ADMIN_PREFIX="http://localhost:8001/admin/v1"
 ML_USERNAME="marklogic"
 ML_PASSWORD="marklogic"
 
-if [[ -z "${ML_DOCKERHUB_USERNAME-}" || -z "${ML_DOCKERHUB_PASSWORD-}" ]]; then
-  echo "ERROR: ML_DOCKERHUB_USERNAME and ML_DOCKERHUB_PASSWORD must be set."
-  exit 1
-fi
+# Login to developer.marklogic.com
+curl -X POST --data "email=${ML_DOWNLOAD_EMAIL}&password=${ML_DOWNLOAD_PASSWORD}" -c $ML_DEV_COOKIES $ML_DEV_LOGIN
 
-# Login to dockerhub
-docker login -u "$ML_DOCKERHUB_USERNAME" -p "$ML_DOCKERHUB_PASSWORD"
+# Obtain a download URL
+ML_DOWNLOAD_PATH="$(curl -X POST --data "download=$ML_ASSET_PATH" -b $ML_DEV_COOKIES $ML_DEV_GET_TOKEN | jq -r '.path')"
+
+# Fetch the MarkLogic binary
+curl -o $ML_DOCKER_DIR/MarkLogic.rpm "${ML_DEV_URL}${ML_DOWNLOAD_PATH}"
+
+# Build the docker image
+docker build --rm=true --tag $ML_IMG_NAME $ML_DOCKER_DIR
 
 # Start the MarkLogic container
 docker run -d --name $ML_CNT_NAME -p 8000-8002:8000-8002 $ML_IMG_NAME

--- a/scripts/installMarkLogic
+++ b/scripts/installMarkLogic
@@ -12,7 +12,11 @@ ML_ASSET_PATH="/download/binaries/8.0/MarkLogic-RHEL6-${ML_VERSION}.x86_64.rpm"
 ML_DOWNLOAD_EMAIL="quasarci@slamdata.com"
 ML_DOWNLOAD_PASSWORD="quasarci"
 
-ML_DOCKER_DIR="scripts/marklogic"
+ML_DIR="scripts/marklogic"
+ML_DOCKERFILE="$ML_DIR/Dockerfile"
+ML_DOCKER_DIR="$ML_DIR/docker"
+ML_RPM_SHA1="$ML_DIR/MarkLogic.rpm.sha1"
+ML_RPM_PATH="$ML_DOCKER_DIR/MarkLogic.rpm"
 ML_IMG_NAME="marklogic:${ML_VERSION}"
 ML_CNT_NAME="ml8"
 
@@ -20,14 +24,33 @@ ML_ADMIN_PREFIX="http://localhost:8001/admin/v1"
 ML_USERNAME="marklogic"
 ML_PASSWORD="marklogic"
 
-# Login to developer.marklogic.com
-curl -X POST --data "email=${ML_DOWNLOAD_EMAIL}&password=${ML_DOWNLOAD_PASSWORD}" -c $ML_DEV_COOKIES $ML_DEV_LOGIN
+verify_asset () {
+  sha1sum --status -c $ML_RPM_SHA1
+  echo "$?"
+}
 
-# Obtain a download URL
-ML_DOWNLOAD_PATH="$(curl -X POST --data "download=$ML_ASSET_PATH" -b $ML_DEV_COOKIES $ML_DEV_GET_TOKEN | jq -r '.path')"
+# Create the docker build dir
+mkdir -p $ML_DOCKER_DIR
 
-# Fetch the MarkLogic binary
-curl -o $ML_DOCKER_DIR/MarkLogic.rpm "${ML_DEV_URL}${ML_DOWNLOAD_PATH}"
+# Copy the dockerfile into it
+cp $ML_DOCKERFILE $ML_DOCKER_DIR
+
+if [[ ! -f $ML_RPM_PATH || $(verify_asset) != "0" ]]; then
+  # Login to developer.marklogic.com
+  curl -X POST --data "email=${ML_DOWNLOAD_EMAIL}&password=${ML_DOWNLOAD_PASSWORD}" -c $ML_DEV_COOKIES $ML_DEV_LOGIN
+
+  # Obtain a download URL
+  ML_DOWNLOAD_PATH="$(curl -X POST --data "download=$ML_ASSET_PATH" -b $ML_DEV_COOKIES $ML_DEV_GET_TOKEN | jq -r '.path')"
+
+  # Fetch the MarkLogic binary
+  curl -o $ML_RPM_PATH "${ML_DEV_URL}${ML_DOWNLOAD_PATH}"
+
+  # Ensure checksum matches
+  if [[ $(verify_asset) != "0" ]]; then
+    echo "ERROR: Invalid checksum for $ML_RPM_PATH"
+    exit 1
+  fi
+fi
 
 # Build the docker image
 docker build --rm=true --tag $ML_IMG_NAME $ML_DOCKER_DIR

--- a/scripts/marklogic/Dockerfile
+++ b/scripts/marklogic/Dockerfile
@@ -1,0 +1,16 @@
+FROM patrickmcelwee/marklogic-dependencies:8-latest
+
+RUN yum -y install vim
+
+# Install MarkLogic
+WORKDIR /tmp
+ADD MarkLogic.rpm /tmp/MarkLogic.rpm
+
+RUN yum -y install /tmp/MarkLogic.rpm
+
+# Expose MarkLogic Server ports - plus 8040, 8041, 8042 for your REST, etc
+# endpoints - feel free to add more
+EXPOSE 7997 7998 7999 8000 8001 8002 8040 8041 8042
+
+# Define default command (which avoids immediate shutdown)
+CMD /opt/MarkLogic/bin/MarkLogic && tail -f /dev/null

--- a/scripts/marklogic/MarkLogic.rpm.sha1
+++ b/scripts/marklogic/MarkLogic.rpm.sha1
@@ -1,0 +1,1 @@
+48cfbd30d003547feb6b60e120abd4542e8b83f9  scripts/marklogic/docker/MarkLogic.rpm


### PR DESCRIPTION
Adds an installer script for MarkLogic and adds it to the travis build matrix. Only the filesystem integration tests are enabled atm, all regression tests are skipped.

Also fixes a couple issues discovered thanks to the improved `QScript` generation.