### PR TITLE
Refactor Coalesce and Normalizable.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- refactor Coalesce and Normalizable

--- a/connector/src/main/scala/quasar/qscript/Coalesce.scala
+++ b/connector/src/main/scala/quasar/qscript/Coalesce.scala
@@ -57,274 +57,27 @@ trait Coalesce[IN[_]] {
       : IN[IT[F]] => Option[OUT[IT[F]]]
 }
 
-object Coalesce {
-  type Aux[T[_[_]], IN[_], F[_]] = Coalesce[IN] {
-    type IT[F[_]] = T[F]
-    type OUT[A] = F[A]
-  }
-
-  def apply[T[_[_]], IN[_], OUT[_]](implicit ev: Coalesce.Aux[T, IN, OUT]) = ev
-
-  private def CoalesceTotal[T[_[_]]: Recursive: Corecursive: EqualT] =
-    Coalesce[T, QScriptTotal[T, ?], QScriptTotal[T, ?]]
-
-  private def freeQC[T[_[_]]: Recursive: Corecursive: EqualT](branch: FreeQS[T])
-      : FreeQS[T] =
-    freeTransCata[T, QScriptTotal[T, ?], QScriptTotal[T, ?], Hole, Hole](branch)(co =>
-      co.run.fold(
-        κ(co),
-        in => CoEnv(repeatedly(CoalesceTotal.coalesceQC(coenvPrism[QScriptTotal[T, ?], Hole]))(in).right)))
-
-  private def freeSR[T[_[_]]: Recursive: Corecursive: EqualT](branch: FreeQS[T])
-      : FreeQS[T] =
-    freeTransCata[T, QScriptTotal[T, ?], QScriptTotal[T, ?], Hole, Hole](branch)(co =>
-      co.run.fold(
-        κ(co),
-        in => CoEnv(repeatedly(CoalesceTotal.coalesceSR(coenvPrism[QScriptTotal[T, ?], Hole]))(in).right)))
-
-  private def freeEJ[T[_[_]]: Recursive: Corecursive: EqualT](branch: FreeQS[T])
-      : FreeQS[T] =
-    freeTransCata[T, QScriptTotal[T, ?], QScriptTotal[T, ?], Hole, Hole](branch)(co =>
-      co.run.fold(
-        κ(co),
-        in => CoEnv(repeatedly(CoalesceTotal.coalesceEJ(coenvPrism[QScriptTotal[T, ?], Hole].get))(in).right)))
-
-  private def freeTJ[T[_[_]]: Recursive: Corecursive: EqualT](branch: FreeQS[T])
-      : FreeQS[T] =
-    freeTransCata[T, QScriptTotal[T, ?], QScriptTotal[T, ?], Hole, Hole](branch)(co =>
-      co.run.fold(
-        κ(co),
-        in => CoEnv(repeatedly(CoalesceTotal.coalesceTJ(coenvPrism[QScriptTotal[T, ?], Hole].get))(in).right)))
-
-  private def ifNeq[T[_[_]]: Recursive: Corecursive: EqualT]
-    (f: FreeQS[T] => FreeQS[T])
-      : FreeQS[T] => Option[FreeQS[T]] =
-    branch => {
-      val coalesced = f(branch)
-      (branch ≠ coalesced).option(coalesced)
-    }
-
-  private def makeBranched[A, B]
-    (lOrig: A, rOrig: A)
-    (op: A => Option[A])
-    (f: (A, A) => B)
-      : Option[B] =
-    (op(lOrig), op(rOrig)) match {
-      case (None, None) => None
-      case (l,    r)    => f(l.getOrElse(lOrig), r.getOrElse(rOrig)).some
-    }
-
-  def rewrite[T[_[_]]: Recursive: Corecursive: EqualT](elem0: FreeMap[T])
-      : Option[FreeMap[T]] = {
-    val elem: T[CoEnv[Hole, MapFunc[T, ?], ?]] = elem0.toCoEnv[T]
-
-    val hole: T[CoEnv[Hole, MapFunc[T, ?], ?]] = HoleF.toCoEnv[T]
-
-    val oneRef =
-      Free.roll[MapFunc[T, ?], Hole](ProjectIndex(HoleF, IntLit(1))).toCoEnv[T]
-    val rightCount: Int = elem.para(count(hole))
-
-    // all `RightSide` access is through `oneRef`
-    (elem.para(count(oneRef)) ≟ rightCount).option(
-      transApoT(elem)(substitute(oneRef, hole)).fromCoEnv)
-  }
+trait CoalesceInstances {
+  def coalesce[T[_[_]]: Recursive: Corecursive: EqualT] = new CoalesceT[T]
 
   implicit def qscriptCore[T[_[_]]: Recursive: Corecursive: EqualT, G[_]]
     (implicit QC: QScriptCore[T, ?] :<: G)
       : Coalesce.Aux[T, QScriptCore[T, ?], G] =
-    new Coalesce[QScriptCore[T, ?]] {
-      type IT[F[_]] = T[F]
-      type OUT[A] = G[A]
+    coalesce[T].qscriptCore[G]
 
-      // TODO: I feel like this must be some standard fold.
-      def sequenceReduce[T[_[_]]: EqualT](rf: ReduceFunc[(FreeMap[T], JoinFunc[T])])
-          : Option[(FreeMap[T], ReduceFunc[JoinFunc[T]])] =
-        rf match {
-          case ReduceFuncs.Count(a)           => (a._1, ReduceFuncs.Count(a._2)).some
-          case ReduceFuncs.Sum(a)             => (a._1, ReduceFuncs.Sum(a._2)).some
-          case ReduceFuncs.Min(a)             => (a._1, ReduceFuncs.Min(a._2)).some
-          case ReduceFuncs.Max(a)             => (a._1, ReduceFuncs.Max(a._2)).some
-          case ReduceFuncs.Avg(a)             => (a._1, ReduceFuncs.Avg(a._2)).some
-          case ReduceFuncs.Arbitrary(a)       => (a._1, ReduceFuncs.Arbitrary(a._2)).some
-          case ReduceFuncs.UnshiftArray(a)    => (a._1, ReduceFuncs.UnshiftArray(a._2)).some
-          case ReduceFuncs.UnshiftMap(a1, a2) =>
-            (a1._1 ≟ a2._1).option((a1._1, ReduceFuncs.UnshiftMap(a1._2, a2._2)))
-        }
-
-      def rightOnly(replacement: FreeMap[T])
-          : JoinFunc[T] => Option[FreeMap[T]] =
-        _.traverseM[Option, Hole] {
-          case LeftSide  => None
-          case RightSide => replacement.some
-        }
-
-      def coalesceQC[F[_]: Functor]
-        (FToOut: PrismNT[F, OUT])
-        (implicit QC: QScriptCore [IT, ?] :<: OUT) = {
-        case Map(Embed(src), mf) => FToOut.get(src) >>= QC.prj >>= (s =>
-          if (mf.length ≟ 0 && (s match { case Unreferenced() => false; case _ => true }))
-            Map(
-              FToOut.reverseGet(QC.inj(Unreferenced[T, T[F]]())).embed,
-              mf).some
-          else s match {
-            case Map(srcInner, mfInner) => Map(srcInner, mf >> mfInner).some
-            case LeftShift(srcInner, struct, repair) =>
-              LeftShift(srcInner, struct, mf >> repair).some
-            case Reduce(srcInner, bucket, funcs, repair) =>
-              Reduce(srcInner, bucket, funcs, mf >> repair).some
-            case Subset(innerSrc, lb, sel, rb) =>
-              Subset(innerSrc,
-                Free.roll(Inject[QScriptCore[T, ?], QScriptTotal[T, ?]].inj(Map(lb, mf))),
-                sel,
-                rb).some
-            case _ => None
-          })
-        case LeftShift(Embed(src), struct, shiftRepair) =>
-          FToOut.get(src) >>= QC.prj >>= {
-            case Map(innerSrc, mf) if !shiftRepair.element(LeftSide) =>
-              LeftShift(innerSrc, struct >> mf, shiftRepair).some
-            case Reduce(srcInner, _, List(ReduceFuncs.UnshiftArray(elem)), redRepair)
-                if freeTransCata(struct >> redRepair)(MapFunc.normalize) ≟ Free.point(ReduceIndex(0)) =>
-              rightOnly(elem)(shiftRepair) ∘ (Map(srcInner, _))
-            case Reduce(srcInner, _, List(ReduceFuncs.UnshiftMap(_, elem)), redRepair)
-                if freeTransCata(struct >> redRepair)(MapFunc.normalize) ≟ Free.point(ReduceIndex(0)) =>
-              rightOnly(elem)(shiftRepair) ∘ (Map(srcInner, _))
-            case Reduce(srcInner, _, List(ReduceFuncs.UnshiftMap(k, elem)), redRepair)
-                if freeTransCata(struct >> redRepair)(MapFunc.normalize) ≟ Free.roll(ZipMapKeys(Free.point(ReduceIndex(0)))) =>
-              rightOnly(
-                Free.roll(ConcatArrays[T, FreeMap[T]](Free.roll(MakeArray(k)), Free.roll(MakeArray(elem)))))(
-                shiftRepair) ∘
-                (Map(srcInner, _))
-            case _ => None
-          }
-        case Reduce(Embed(src), bucket, reducers, redRepair) =>
-          FToOut.get(src) >>= QC.prj >>= {
-            case LeftShift(innerSrc, struct, shiftRepair)
-                if shiftRepair =/= RightSideF =>
-              (rightOnly(HoleF)(freeTransCata(bucket >> shiftRepair)(MapFunc.normalize)) ⊛
-                reducers.traverse(_.traverse(mf => rightOnly(HoleF)(freeTransCata(mf >> shiftRepair)(MapFunc.normalize)))))((b, r) =>
-                Reduce(FToOut.reverseGet(QC.inj(LeftShift(innerSrc, struct, RightSideF))).embed, b, r, redRepair))
-            case LeftShift(innerSrc, struct, shiftRepair) =>
-              (rewriteShift(struct, freeTransCata(bucket >> shiftRepair)(MapFunc.normalize)) ⊛
-                reducers.traverse(_.traverse(mf => rewriteShift(struct, freeTransCata(mf >> shiftRepair)(MapFunc.normalize)))))((b, r) =>
-                r.foldRightM[Option, (FreeMap[T], (JoinFunc[T], List[ReduceFunc[JoinFunc[T]]]))]((b._1, (b._2, Nil)))((elem, acc) => {
-                  sequenceReduce(elem) >>= (e =>
-                    (e._1 ≟ acc._1).option(
-                      (acc._1, (acc._2._1, e._2 :: acc._2._2))))
-                })).join >>= {
-                case (st, (bucket, reducers)) =>
-                  if (st ≟ struct) None
-                  else
-                    (rightOnly(HoleF)(bucket) ⊛
-                      (reducers.traverse(_.traverse(rightOnly(HoleF)))))((sb, sr) =>
-                      Reduce(FToOut.reverseGet(QC.inj(LeftShift(innerSrc, st, RightSideF))).embed, sb, sr, redRepair))
-              }
-            case Map(innerSrc, mf) =>
-              Reduce(
-                innerSrc,
-                freeTransCata(bucket >> mf)(MapFunc.normalize),
-                reducers.map(_.map(red => freeTransCata(red >> mf)(MapFunc.normalize))),
-                redRepair).some
-            case _ => None
-          }
-        case Filter(Embed(src), cond) => FToOut.get(src) >>= QC.prj >>= {
-          case Filter(srcInner, condInner) =>
-            Filter(srcInner, Free.roll[MapFunc[T, ?], Hole](And(condInner, cond))).some
-          case _ => None
-        }
-        case Subset(src, from, sel, count) =>
-          makeBranched(from, count)(ifNeq(freeQC[T]))(Subset(src, _, sel, _))
-        case Union(src, from, count) =>
-          makeBranched(from, count)(ifNeq(freeQC[T]))(Union(src, _, _))
-        case _ => None
-      }
-
-      def coalesceSR[F[_]: Functor]
-        (FToOut: PrismNT[F, OUT])
-        (implicit SR: Const[ShiftedRead, ?] :<: OUT) = {
-        case Map(Embed(src), mf) =>
-          ((FToOut.get(src) >>= SR.prj) ⊛ rewrite(mf))((const, newMF) =>
-            Map(
-              FToOut.reverseGet(SR.inj(Const[ShiftedRead, T[F]](ShiftedRead(const.getConst.path, ExcludeId)))).embed,
-              newMF))
-        case Reduce(Embed(src), bucket, reducers, repair) =>
-          ((FToOut.get(src) >>= SR.prj) ⊛ rewrite(bucket) ⊛ reducers.traverse(_.traverse(rewrite[T])))(
-            (const, newBuck, newRed) =>
-            Reduce(
-              FToOut.reverseGet(SR.inj(Const[ShiftedRead, T[F]](ShiftedRead(const.getConst.path, ExcludeId)))).embed,
-              newBuck,
-              newRed,
-              repair))
-        case Subset(src, from, sel, count) =>
-          makeBranched(from, count)(ifNeq(freeSR[T]))(Subset(src, _, sel, _))
-        case Union(src, from, count) =>
-          makeBranched(from, count)(ifNeq(freeSR[T]))(Union(src, _, _))
-        case _ => None
-      }
-
-      def coalesceEJ[F[_]: Functor]
-        (FToOut: F ~> λ[α => Option[OUT[α]]])
-        (implicit EJ: EquiJoin[IT, ?] :<: OUT) = {
-        case Map(Embed(src), mf) =>
-          (FToOut(src) >>= EJ.prj).map(
-            ej => EJ.inj(EquiJoin.combine.modify(mf >> (_: JoinFunc[T]))(ej)))
-        case Subset(src, from, sel, count) =>
-          makeBranched(from, count)(ifNeq(freeEJ[T]))((l, r) => QC.inj(Subset(src, l, sel, r)))
-        case Union(src, from, count) =>
-          makeBranched(from, count)(ifNeq(freeEJ[T]))((l, r) => QC.inj(Union(src, l, r)))
-        case _ => None
-      }
-
-      def coalesceTJ[F[_]: Functor]
-        (FToOut: F ~> λ[α => Option[OUT[α]]])
-        (implicit TJ: ThetaJoin[IT, ?] :<: OUT) = {
-        case Map(Embed(src), mf) =>
-          (FToOut(src) >>= TJ.prj).map(
-            tj => TJ.inj(ThetaJoin.combine.modify(mf >> (_: JoinFunc[T]))(tj)))
-        case Subset(src, from, sel, count) =>
-          makeBranched(from, count)(ifNeq(freeTJ[T]))((l, r) => QC.inj(Subset(src, l, sel, r)))
-        case Union(src, from, count) =>
-          makeBranched(from, count)(ifNeq(freeTJ[T]))((l, r) => QC.inj(Union(src, l, r)))
-        case _ => None
-      }
-    }
-
-  implicit def projectBucket[T[_[_]]: Recursive, F[_]]
+  implicit def projectBucket[T[_[_]]: Recursive: Corecursive: EqualT, F[_]]
       : Coalesce.Aux[T, ProjectBucket[T, ?], F] =
-    new Coalesce[ProjectBucket[T, ?]] {
-      type IT[F[_]] = T[F]
-      type OUT[A] = F[A]
+    coalesce[T].projectBucket[F]
 
-      def coalesceQC[F[_]: Functor]
-        (FToOut: PrismNT[F, OUT])
-        (implicit QC: QScriptCore[IT, ?] :<: OUT) = {
-        case BucketField(Embed(src), value, field) => FToOut.get(src) >>= QC.prj >>= {
-          case Map(srcInner, mf) =>
-            BucketField(srcInner, value >> mf, field >> mf).some
-          case _ => None
-        }
-        case BucketIndex(Embed(src), value, index) => FToOut.get(src) >>= QC.prj >>= {
-          case Map(srcInner, mf) =>
-            BucketIndex(srcInner, value >> mf, index >> mf).some
-          case _ => None
-        }
-      }
+  implicit def thetaJoin[T[_[_]]: Recursive: Corecursive: EqualT, G[_]]
+    (implicit TJ: ThetaJoin[T, ?] :<: G)
+      : Coalesce.Aux[T, ThetaJoin[T, ?], G] =
+    coalesce[T].thetaJoin[G]
 
-      def coalesceSR[F[_]: Functor]
-        (FToOut: PrismNT[F, OUT])
-        (implicit SR: Const[ShiftedRead, ?] :<: OUT) =
-        κ(None)
-
-      def coalesceEJ[F[_]: Functor]
-        (FToOut: F ~> λ[α => Option[OUT[α]]])
-        (implicit EJ: EquiJoin[IT, ?] :<: OUT) =
-        κ(None)
-
-      def coalesceTJ[F[_]: Functor]
-        (FToOut: F ~> λ[α => Option[OUT[α]]])
-        (implicit TJ: ThetaJoin[IT, ?] :<: OUT) =
-        κ(None)
-    }
+  implicit def equiJoin[T[_[_]]: Recursive: Corecursive: EqualT, G[_]]
+    (implicit EJ: EquiJoin[T, ?] :<: G)
+      : Coalesce.Aux[T, EquiJoin[T, ?], G] =
+    coalesce[T].equiJoin
 
   implicit def coproduct[T[_[_]], F[_], G[_], H[_]]
     (implicit F: Coalesce.Aux[T, F, H], G: Coalesce.Aux[T, G, H])
@@ -361,7 +114,7 @@ object Coalesce {
 
       def coalesceQC[F[_]: Functor]
         (FToOut: PrismNT[F, OUT])
-        (implicit QC: QScriptCore [IT, ?] :<: OUT) =
+        (implicit QC: QScriptCore[IT, ?] :<: OUT) =
         κ(None)
 
       def coalesceSR[F[_]: Functor]
@@ -389,20 +142,269 @@ object Coalesce {
   implicit def shiftedRead[T[_[_]], OUT[_]]
       : Coalesce.Aux[T, Const[ShiftedRead, ?], OUT] =
     default
+}
 
-  implicit def thetaJoin[T[_[_]]: Recursive: Corecursive: EqualT, G[_]]
-    (implicit TJ: ThetaJoin[T, ?] :<: G)
-      : Coalesce.Aux[T, ThetaJoin[T, ?], G] =
-        new Coalesce[ThetaJoin[T, ?]] {
+class CoalesceT[T[_[_]]: Recursive: Corecursive: EqualT] extends TTypes[T] {
+  private def CoalesceTotal = Coalesce[T, QScriptTotal, QScriptTotal]
+
+  private def freeQC(branch: FreeQS): FreeQS =
+    freeTransCata[T, QScriptTotal, QScriptTotal, Hole, Hole](branch)(co =>
+      co.run.fold(
+        κ(co),
+        in => CoEnv(repeatedly(CoalesceTotal.coalesceQC(coenvPrism[QScriptTotal, Hole]))(in).right)))
+
+  private def freeSR(branch: FreeQS): FreeQS =
+    freeTransCata[T, QScriptTotal, QScriptTotal, Hole, Hole](branch)(co =>
+      co.run.fold(
+        κ(co),
+        in => CoEnv(repeatedly(CoalesceTotal.coalesceSR(coenvPrism[QScriptTotal, Hole]))(in).right)))
+
+  private def freeEJ(branch: FreeQS): FreeQS =
+    freeTransCata[T, QScriptTotal, QScriptTotal, Hole, Hole](branch)(co =>
+      co.run.fold(
+        κ(co),
+        in => CoEnv(repeatedly(CoalesceTotal.coalesceEJ(coenvPrism[QScriptTotal, Hole].get))(in).right)))
+
+  private def freeTJ(branch: FreeQS): FreeQS =
+    freeTransCata[T, QScriptTotal, QScriptTotal, Hole, Hole](branch)(co =>
+      co.run.fold(
+        κ(co),
+        in => CoEnv(repeatedly(CoalesceTotal.coalesceTJ(coenvPrism[QScriptTotal, Hole].get))(in).right)))
+
+  private def ifNeq(f: FreeQS => FreeQS): FreeQS => Option[FreeQS] =
+    branch => {
+      val coalesced = f(branch)
+      (branch ≠ coalesced).option(coalesced)
+    }
+
+  private def makeBranched[A, B]
+    (lOrig: A, rOrig: A)
+    (op: A => Option[A])
+    (f: (A, A) => B)
+      : Option[B] =
+    (op(lOrig), op(rOrig)) match {
+      case (None, None) => None
+      case (l,    r)    => f(l.getOrElse(lOrig), r.getOrElse(rOrig)).some
+    }
+
+  def rewrite(elem0: FreeMap): Option[FreeMap] = {
+    val elem: T[CoEnv[Hole, MapFunc, ?]] = elem0.toCoEnv[T]
+
+    val hole: T[CoEnv[Hole, MapFunc, ?]] = HoleF.toCoEnv[T]
+
+    val oneRef =
+      Free.roll[MapFunc, Hole](ProjectIndex(HoleF, IntLit(1))).toCoEnv[T]
+    val rightCount: Int = elem.para(count(hole))
+
+    // all `RightSide` access is through `oneRef`
+    (elem.para(count(oneRef)) ≟ rightCount).option(
+      transApoT(elem)(substitute(oneRef, hole)).fromCoEnv)
+  }
+
+  def qscriptCore[G[_]](implicit QC: QScriptCore :<: G): Coalesce.Aux[T, QScriptCore, G] =
+    new Coalesce[QScriptCore] {
+      type IT[F[_]] = T[F]
+      type OUT[A] = G[A]
+
+      // TODO: I feel like this must be some standard fold.
+      def sequenceReduce(rf: ReduceFunc[(FreeMap, JoinFunc)])
+          : Option[(FreeMap, ReduceFunc[JoinFunc])] =
+        rf match {
+          case ReduceFuncs.Count(a)           => (a._1, ReduceFuncs.Count(a._2)).some
+          case ReduceFuncs.Sum(a)             => (a._1, ReduceFuncs.Sum(a._2)).some
+          case ReduceFuncs.Min(a)             => (a._1, ReduceFuncs.Min(a._2)).some
+          case ReduceFuncs.Max(a)             => (a._1, ReduceFuncs.Max(a._2)).some
+          case ReduceFuncs.Avg(a)             => (a._1, ReduceFuncs.Avg(a._2)).some
+          case ReduceFuncs.Arbitrary(a)       => (a._1, ReduceFuncs.Arbitrary(a._2)).some
+          case ReduceFuncs.UnshiftArray(a)    => (a._1, ReduceFuncs.UnshiftArray(a._2)).some
+          case ReduceFuncs.UnshiftMap(a1, a2) =>
+            (a1._1 ≟ a2._1).option((a1._1, ReduceFuncs.UnshiftMap(a1._2, a2._2)))
+        }
+
+      def rightOnly(replacement: FreeMap): JoinFunc => Option[FreeMap] =
+        _.traverseM[Option, Hole] {
+          case LeftSide  => None
+          case RightSide => replacement.some
+        }
+
+      def coalesceQC[F[_]: Functor]
+        (FToOut: PrismNT[F, OUT])
+        (implicit QC: QScriptCore :<: OUT) = {
+        case Map(Embed(src), mf) => FToOut.get(src) >>= QC.prj >>= (s =>
+          if (mf.length ≟ 0 && (s match { case Unreferenced() => false; case _ => true }))
+            Map(
+              FToOut.reverseGet(QC.inj(Unreferenced[T, T[F]]())).embed,
+              mf).some
+          else s match {
+            case Map(srcInner, mfInner) => Map(srcInner, mf >> mfInner).some
+            case LeftShift(srcInner, struct, repair) =>
+              LeftShift(srcInner, struct, mf >> repair).some
+            case Reduce(srcInner, bucket, funcs, repair) =>
+              Reduce(srcInner, bucket, funcs, mf >> repair).some
+            case Subset(innerSrc, lb, sel, rb) =>
+              Subset(innerSrc,
+                Free.roll(Inject[QScriptCore, QScriptTotal].inj(Map(lb, mf))),
+                sel,
+                rb).some
+            case _ => None
+          })
+        case LeftShift(Embed(src), struct, shiftRepair) =>
+          FToOut.get(src) >>= QC.prj >>= {
+            case Map(innerSrc, mf) if !shiftRepair.element(LeftSide) =>
+              LeftShift(innerSrc, struct >> mf, shiftRepair).some
+            case Reduce(srcInner, _, List(ReduceFuncs.UnshiftArray(elem)), redRepair)
+                if freeTransCata(struct >> redRepair)(MapFunc.normalize) ≟ Free.point(ReduceIndex(0)) =>
+              rightOnly(elem)(shiftRepair) ∘ (Map(srcInner, _))
+            case Reduce(srcInner, _, List(ReduceFuncs.UnshiftMap(_, elem)), redRepair)
+                if freeTransCata(struct >> redRepair)(MapFunc.normalize) ≟ Free.point(ReduceIndex(0)) =>
+              rightOnly(elem)(shiftRepair) ∘ (Map(srcInner, _))
+            case Reduce(srcInner, _, List(ReduceFuncs.UnshiftMap(k, elem)), redRepair)
+                if freeTransCata(struct >> redRepair)(MapFunc.normalize) ≟ Free.roll(ZipMapKeys(Free.point(ReduceIndex(0)))) =>
+              rightOnly(
+                Free.roll(ConcatArrays[T, FreeMap](Free.roll(MakeArray(k)), Free.roll(MakeArray(elem)))))(
+                shiftRepair) ∘
+                (Map(srcInner, _))
+            case _ => None
+          }
+        case Reduce(Embed(src), bucket, reducers, redRepair) =>
+          FToOut.get(src) >>= QC.prj >>= {
+            case LeftShift(innerSrc, struct, shiftRepair)
+                if shiftRepair =/= RightSideF =>
+              (rightOnly(HoleF)(freeTransCata(bucket >> shiftRepair)(MapFunc.normalize)) ⊛
+                reducers.traverse(_.traverse(mf => rightOnly(HoleF)(freeTransCata(mf >> shiftRepair)(MapFunc.normalize)))))((b, r) =>
+                Reduce(FToOut.reverseGet(QC.inj(LeftShift(innerSrc, struct, RightSideF))).embed, b, r, redRepair))
+            case LeftShift(innerSrc, struct, shiftRepair) =>
+              (rewriteShift(struct, freeTransCata(bucket >> shiftRepair)(MapFunc.normalize)) ⊛
+                reducers.traverse(_.traverse(mf => rewriteShift(struct, freeTransCata(mf >> shiftRepair)(MapFunc.normalize)))))((b, r) =>
+                r.foldRightM[Option, (FreeMap, (JoinFunc, List[ReduceFunc[JoinFunc]]))]((b._1, (b._2, Nil)))((elem, acc) => {
+                  sequenceReduce(elem) >>= (e =>
+                    (e._1 ≟ acc._1).option(
+                      (acc._1, (acc._2._1, e._2 :: acc._2._2))))
+                })).join >>= {
+                case (st, (bucket, reducers)) =>
+                  if (st ≟ struct) None
+                  else
+                    (rightOnly(HoleF)(bucket) ⊛
+                      (reducers.traverse(_.traverse(rightOnly(HoleF)))))((sb, sr) =>
+                      Reduce(FToOut.reverseGet(QC.inj(LeftShift(innerSrc, st, RightSideF))).embed, sb, sr, redRepair))
+              }
+            case Map(innerSrc, mf) =>
+              Reduce(
+                innerSrc,
+                freeTransCata(bucket >> mf)(MapFunc.normalize),
+                reducers.map(_.map(red => freeTransCata(red >> mf)(MapFunc.normalize))),
+                redRepair).some
+            case _ => None
+          }
+        case Filter(Embed(src), cond) => FToOut.get(src) >>= QC.prj >>= {
+          case Filter(srcInner, condInner) =>
+            Filter(srcInner, Free.roll[MapFunc, Hole](And(condInner, cond))).some
+          case _ => None
+        }
+        case Subset(src, from, sel, count) =>
+          makeBranched(from, count)(ifNeq(freeQC))(Subset(src, _, sel, _))
+        case Union(src, from, count) =>
+          makeBranched(from, count)(ifNeq(freeQC))(Union(src, _, _))
+        case _ => None
+      }
+
+      def coalesceSR[F[_]: Functor]
+        (FToOut: PrismNT[F, OUT])
+        (implicit SR: Const[ShiftedRead, ?] :<: OUT) = {
+        case Map(Embed(src), mf) =>
+          ((FToOut.get(src) >>= SR.prj) ⊛ rewrite(mf))((const, newMF) =>
+            Map(
+              FToOut.reverseGet(SR.inj(Const[ShiftedRead, T[F]](ShiftedRead(const.getConst.path, ExcludeId)))).embed,
+              newMF))
+        case Reduce(Embed(src), bucket, reducers, repair) =>
+          ((FToOut.get(src) >>= SR.prj) ⊛ rewrite(bucket) ⊛ reducers.traverse(_.traverse(rewrite)))(
+            (const, newBuck, newRed) =>
+            Reduce(
+              FToOut.reverseGet(SR.inj(Const[ShiftedRead, T[F]](ShiftedRead(const.getConst.path, ExcludeId)))).embed,
+              newBuck,
+              newRed,
+              repair))
+        case Subset(src, from, sel, count) =>
+          makeBranched(from, count)(ifNeq(freeSR))(Subset(src, _, sel, _))
+        case Union(src, from, count) =>
+          makeBranched(from, count)(ifNeq(freeSR))(Union(src, _, _))
+        case _ => None
+      }
+
+      def coalesceEJ[F[_]: Functor]
+        (FToOut: F ~> λ[α => Option[OUT[α]]])
+        (implicit EJ: EquiJoin :<: OUT) = {
+        case Map(Embed(src), mf) =>
+          (FToOut(src) >>= EJ.prj).map(
+            ej => EJ.inj(EquiJoin.combine.modify(mf >> (_: JoinFunc))(ej)))
+        case Subset(src, from, sel, count) =>
+          makeBranched(from, count)(ifNeq(freeEJ))((l, r) => QC.inj(Subset(src, l, sel, r)))
+        case Union(src, from, count) =>
+          makeBranched(from, count)(ifNeq(freeEJ))((l, r) => QC.inj(Union(src, l, r)))
+        case _ => None
+      }
+
+      def coalesceTJ[F[_]: Functor]
+        (FToOut: F ~> λ[α => Option[OUT[α]]])
+        (implicit TJ: ThetaJoin :<: OUT) = {
+        case Map(Embed(src), mf) =>
+          (FToOut(src) >>= TJ.prj).map(
+            tj => TJ.inj(ThetaJoin.combine.modify(mf >> (_: JoinFunc))(tj)))
+        case Subset(src, from, sel, count) =>
+          makeBranched(from, count)(ifNeq(freeTJ))((l, r) => QC.inj(Subset(src, l, sel, r)))
+        case Union(src, from, count) =>
+          makeBranched(from, count)(ifNeq(freeTJ))((l, r) => QC.inj(Union(src, l, r)))
+        case _ => None
+      }
+    }
+
+  def projectBucket[F[_]]: Coalesce.Aux[T, ProjectBucket, F] =
+    new Coalesce[ProjectBucket] {
+      type IT[F[_]] = T[F]
+      type OUT[A] = F[A]
+
+      def coalesceQC[F[_]: Functor]
+        (FToOut: PrismNT[F, OUT])
+        (implicit QC: QScriptCore :<: OUT) = {
+        case BucketField(Embed(src), value, field) => FToOut.get(src) >>= QC.prj >>= {
+          case Map(srcInner, mf) =>
+            BucketField(srcInner, value >> mf, field >> mf).some
+          case _ => None
+        }
+        case BucketIndex(Embed(src), value, index) => FToOut.get(src) >>= QC.prj >>= {
+          case Map(srcInner, mf) =>
+            BucketIndex(srcInner, value >> mf, index >> mf).some
+          case _ => None
+        }
+      }
+
+      def coalesceSR[F[_]: Functor]
+        (FToOut: PrismNT[F, OUT])
+        (implicit SR: Const[ShiftedRead, ?] :<: OUT) =
+        κ(None)
+
+      def coalesceEJ[F[_]: Functor]
+        (FToOut: F ~> λ[α => Option[OUT[α]]])
+        (implicit EJ: EquiJoin :<: OUT) =
+        κ(None)
+
+      def coalesceTJ[F[_]: Functor]
+        (FToOut: F ~> λ[α => Option[OUT[α]]])
+        (implicit TJ: ThetaJoin :<: OUT) =
+        κ(None)
+    }
+
+  def thetaJoin[G[_]](implicit TJ: ThetaJoin :<: G): Coalesce.Aux[T, ThetaJoin, G] =
+    new Coalesce[ThetaJoin] {
       type IT[F[_]] = T[F]
       type OUT[A] = G[A]
 
       def coalesceQC[F[_]: Functor]
         (FToOut: PrismNT[F, OUT])
-        (implicit QC: QScriptCore [IT, ?] :<: OUT) =
+        (implicit QC: QScriptCore :<: OUT) =
         tj => makeBranched(
           tj.lBranch, tj.rBranch)(
-          ifNeq(freeQC[T]))(
+          ifNeq(freeQC))(
           ThetaJoin(tj.src, _, _, tj.on, tj.f, tj.combine))
 
       def coalesceSR[F[_]: Functor]
@@ -410,39 +412,37 @@ object Coalesce {
         (implicit SR: Const[ShiftedRead, ?] :<: OUT) =
         tj => makeBranched(
           tj.lBranch, tj.rBranch)(
-          ifNeq(freeSR[T]))(
+          ifNeq(freeSR))(
           ThetaJoin(tj.src, _, _, tj.on, tj.f, tj.combine))
 
       def coalesceEJ[F[_]: Functor]
         (FToOut: F ~> λ[α => Option[OUT[α]]])
-        (implicit EJ: EquiJoin[IT, ?] :<: OUT) =
+        (implicit EJ: EquiJoin :<: OUT) =
         tj => makeBranched(
           tj.lBranch, tj.rBranch)(
-          ifNeq(freeEJ[T]))((l, r) =>
+          ifNeq(freeEJ))((l, r) =>
           TJ.inj(ThetaJoin(tj.src, l, r, tj.on, tj.f, tj.combine)))
 
       def coalesceTJ[F[_]: Functor]
         (FToOut: F ~> λ[α => Option[OUT[α]]])
-        (implicit TJ: ThetaJoin[IT, ?] :<: OUT) =
+        (implicit TJ: ThetaJoin :<: OUT) =
         tj => makeBranched(
           tj.lBranch, tj.rBranch)(
-          ifNeq(freeTJ[T]))((l, r) =>
+          ifNeq(freeTJ))((l, r) =>
           TJ.inj(ThetaJoin(tj.src, l, r, tj.on, tj.f, tj.combine)))
     }
 
-  implicit def equiJoin[T[_[_]]: Recursive: Corecursive: EqualT, G[_]]
-    (implicit EJ: EquiJoin[T, ?] :<: G)
-      : Coalesce.Aux[T, EquiJoin[T, ?], G] =
-        new Coalesce[EquiJoin[T, ?]] {
+  def equiJoin[G[_]](implicit EJ: EquiJoin :<: G): Coalesce.Aux[T, EquiJoin, G] =
+    new Coalesce[EquiJoin] {
       type IT[F[_]] = T[F]
       type OUT[A] = G[A]
 
       def coalesceQC[F[_]: Functor]
         (FToOut: PrismNT[F, OUT])
-        (implicit QC: QScriptCore [IT, ?] :<: OUT) =
+        (implicit QC: QScriptCore :<: OUT) =
         ej => makeBranched(
           ej.lBranch, ej.rBranch)(
-          ifNeq(freeQC[T]))(
+          ifNeq(freeQC))(
           EquiJoin(ej.src, _, _, ej.lKey, ej.rKey, ej.f, ej.combine))
 
       def coalesceSR[F[_]: Functor]
@@ -450,23 +450,32 @@ object Coalesce {
         (implicit SR: Const[ShiftedRead, ?] :<: OUT) =
         ej => makeBranched(
           ej.lBranch, ej.rBranch)(
-          ifNeq(freeSR[T]))(
+          ifNeq(freeSR))(
           EquiJoin(ej.src, _, _, ej.lKey, ej.rKey, ej.f, ej.combine))
 
       def coalesceEJ[F[_]: Functor]
         (FToOut: F ~> λ[α => Option[OUT[α]]])
-        (implicit EJ: EquiJoin[IT, ?] :<: OUT) =
+        (implicit EJ: EquiJoin :<: OUT) =
         ej => makeBranched(
           ej.lBranch, ej.rBranch)(
-          ifNeq(freeEJ[T]))((l, r) =>
+          ifNeq(freeEJ))((l, r) =>
           EJ.inj(EquiJoin(ej.src, l, r, ej.lKey, ej.rKey, ej.f, ej.combine)))
 
       def coalesceTJ[F[_]: Functor]
         (FToOut: F ~> λ[α => Option[OUT[α]]])
-        (implicit TJ: ThetaJoin[IT, ?] :<: OUT) =
+        (implicit TJ: ThetaJoin :<: OUT) =
         ej => makeBranched(
           ej.lBranch, ej.rBranch)(
-          ifNeq(freeTJ[T]))((l, r) =>
+          ifNeq(freeTJ))((l, r) =>
           EJ.inj(EquiJoin(ej.src, l, r, ej.lKey, ej.rKey, ej.f, ej.combine)))
     }
+}
+
+object Coalesce extends CoalesceInstances {
+  type Aux[T[_[_]], IN[_], F[_]] = Coalesce[IN] {
+    type IT[F[_]] = T[F]
+    type OUT[A] = F[A]
+  }
+
+  def apply[T[_[_]], IN[_], OUT[_]](implicit ev: Coalesce.Aux[T, IN, OUT]) = ev
 }

--- a/connector/src/main/scala/quasar/qscript/EquiJoin.scala
+++ b/connector/src/main/scala/quasar/qscript/EquiJoin.scala
@@ -109,7 +109,4 @@ object EquiJoin {
             }
         }
     }
-
-  implicit def normalizable[T[_[_]]: Recursive: Corecursive: EqualT: ShowT]: Normalizable[EquiJoin[T, ?]] =
-    TTypes.normalizable[T].EquiJoin
 }

--- a/connector/src/main/scala/quasar/qscript/Normalizable.scala
+++ b/connector/src/main/scala/quasar/qscript/Normalizable.scala
@@ -17,7 +17,12 @@
 package quasar.qscript
 
 import quasar.Predef._
+import quasar.contrib.matryoshka._
+import quasar.ejson.EJson
 import quasar.fp._
+import quasar.fp.ski._
+
+import scala.Predef.$conforms
 
 import matryoshka._
 import scalaz._, Scalaz._
@@ -29,13 +34,170 @@ import simulacrum.typeclass
 
 // it would be nice to use the `NTComp` alias here, but it cannot compile
 trait NormalizableInstances {
+  def normalizable[T[_[_]] : Recursive : Corecursive : EqualT : ShowT] =
+    new NormalizableT[T]
+
   implicit def const[A] = new Normalizable[Const[A, ?]] {
     def normalizeF = λ[Const[A, ?] ~> (Option ∘ Const[A, ?])#λ](_ => None)
   }
-  implicit def coproduct[F[_]: Normalizable, G[_]: Normalizable] = new Normalizable[Coproduct[F, G, ?]] {
-    def normalizeF = λ[Coproduct[F, G, ?] ~> (Option ∘ Coproduct[F, G, ?])#λ](
-      _.run.bitraverse(Normalizable[F].normalizeF(_), Normalizable[G].normalizeF(_)).map(Coproduct(_)))
+
+  implicit def qscriptCore[T[_[_]]: Recursive: Corecursive: EqualT: ShowT]
+      : Normalizable[QScriptCore[T, ?]] =
+    normalizable[T].QScriptCore
+
+  implicit def projectBucket[T[_[_]]: Recursive: Corecursive: EqualT: ShowT]
+      : Normalizable[ProjectBucket[T, ?]] =
+    normalizable[T].ProjectBucket
+
+  implicit def thetaJoin[T[_[_]]: Recursive: Corecursive: EqualT: ShowT]
+      : Normalizable[ThetaJoin[T, ?]] =
+    normalizable[T].ThetaJoin
+
+  implicit def equiJoin[T[_[_]]: Recursive: Corecursive: EqualT: ShowT]
+      : Normalizable[EquiJoin[T, ?]] =
+    normalizable[T].EquiJoin
+
+  implicit def coproduct[F[_]: Normalizable, G[_]: Normalizable] =
+    new Normalizable[Coproduct[F, G, ?]] {
+      def normalizeF =
+        λ[Coproduct[F, G, ?] ~> (Option ∘ Coproduct[F, G, ?])#λ](
+          _.run.bitraverse(
+            Normalizable[F].normalizeF(_),
+            Normalizable[G].normalizeF(_)) ∘ (Coproduct(_)))
   }
+}
+
+// ShowT is needed for debugging
+class NormalizableT[T[_[_]] : Recursive : Corecursive : EqualT : ShowT]
+    extends TTypes[T] {
+  import Normalizable._
+  lazy val rewrite = new Rewrite[T]
+
+  def freeTC(free: FreeQS): FreeQS = {
+    freeTransCata[T, QScriptTotal, QScriptTotal, Hole, Hole](free)(
+      liftCo(rewrite.normalizeCoEnv[QScriptTotal])
+    )
+  }
+
+  def freeTCEq(free: FreeQS): Option[FreeQS] = {
+    val freeNormalized = freeTC(free)
+    (free ≠ freeNormalized).option(freeNormalized)
+  }
+
+  def freeMFEq[A: Equal](fm: Free[MapFunc, A]): Option[Free[MapFunc, A]] = {
+    val fmNormalized = freeMF[A](fm)
+    (fm ≠ fmNormalized).option(fmNormalized)
+  }
+
+  def freeMF[A](fm: Free[MapFunc, A]): Free[MapFunc, A] =
+    freeTransCata[T, MapFunc, MapFunc, A, A](fm)(MapFunc.normalize[T, A])
+
+  def makeNorm[A, B, C](
+    lOrig: A, rOrig: B)(
+    left: A => Option[A], right: B => Option[B])(
+    f: (A, B) => C):
+      Option[C] =
+    (left(lOrig), right(rOrig)) match {
+      case (None, None) => None
+      case (l, r)       => f(l.getOrElse(lOrig), r.getOrElse(rOrig)).some
+    }
+
+  def EquiJoin = make(
+    λ[EquiJoin ~> (Option ∘ EquiJoin)#λ](ej =>
+      (freeTCEq(ej.lBranch), freeTCEq(ej.rBranch), freeMFEq(ej.lKey), freeMFEq(ej.rKey), freeMFEq(ej.combine)) match {
+        case (None, None, None, None, None) => None
+        case (lBranchNorm, rBranchNorm, lKeyNorm, rKeyNorm, combineNorm) =>
+          quasar.qscript.EquiJoin(
+            ej.src,
+            lBranchNorm.getOrElse(ej.lBranch),
+            rBranchNorm.getOrElse(ej.rBranch),
+            lKeyNorm.getOrElse(ej.lKey),
+            rKeyNorm.getOrElse(ej.rKey),
+            ej.f,
+            combineNorm.getOrElse(ej.combine)).some
+      }))
+
+  def ThetaJoin = make(
+    λ[ThetaJoin ~> (Option ∘ ThetaJoin)#λ](tj =>
+      (freeTCEq(tj.lBranch), freeTCEq(tj.rBranch), freeMFEq(tj.on), freeMFEq(tj.combine)) match {
+        case (None, None, None, None) => None
+        case (lBranchNorm, rBranchNorm, onNorm, combineNorm) =>
+          quasar.qscript.ThetaJoin(
+            tj.src,
+            lBranchNorm.getOrElse(tj.lBranch),
+            rBranchNorm.getOrElse(tj.rBranch),
+            onNorm.getOrElse(tj.on),
+            tj.f,
+            combineNorm.getOrElse(tj.combine)).some
+      }))
+
+  def QScriptCore = {
+    // NB: all single-bucket reductions should reduce on `null`
+    def normalizeBucket(bucket: FreeMap): FreeMap = bucket.resume.fold({
+      case MapFuncs.Constant(_) => MapFuncs.NullLit[T, Hole]()
+      case _                    => bucket
+    }, κ(bucket))
+
+    make(λ[QScriptCore ~> (Option ∘ QScriptCore)#λ] {
+      case Reduce(src, bucket, reducers, repair) => {
+        val reducersOpt: List[Option[ReduceFunc[FreeMap]]] =
+          reducers.map(_.traverse(freeMFEq[Hole](_)))
+
+        val reducersNormOpt: Option[List[ReduceFunc[FreeMap]]] =
+          (!reducersOpt.map(_.toList).flatten.isEmpty).option(
+            Zip[List].zipWith(reducersOpt, reducers)(_.getOrElse(_)))
+
+        val bucketNormOpt: Option[FreeMap] = freeMFEq(bucket)
+
+        val bucketNormConst: Option[FreeMap] =
+          bucketNormOpt.getOrElse(bucket).resume.fold({
+            case MapFuncs.Constant(ej) =>
+              (!EJson.isNull(ej)).option(MapFuncs.NullLit[T, Hole]())
+            case _ => bucketNormOpt
+          }, κ(bucketNormOpt))
+
+        (bucketNormConst, reducersNormOpt, freeMFEq(repair)) match {
+          case (None, None, None) =>
+            None
+          case (bucketNorm, reducersNorm, repairNorm)  =>
+            Reduce(
+              src,
+              bucketNorm.getOrElse(bucket),
+              reducersNorm.getOrElse(reducers),
+              repairNorm.getOrElse(repair)).some
+        }
+      }
+
+      case Sort(src, bucket, order) => {
+        val orderOpt: List[Option[(FreeMap, SortDir)]] =
+          order.map {
+            _.leftMap(freeMFEq(_)) match {
+              case (Some(fm), dir) => Some((fm, dir))
+              case (_, _)          => None
+            }
+          }
+
+        val orderNormOpt: Option[List[(FreeMap, SortDir)]] =
+          (!orderOpt.map(_.toList).flatten.isEmpty).option(
+            Zip[List].zipWith(orderOpt, order)(_.getOrElse(_)))
+
+        makeNorm(bucket, order)(freeMFEq(_), _ => orderNormOpt)(Sort(src, _, _))
+      }
+      case Map(src, f)            => freeMFEq(f).map(Map(src, _))
+      case LeftShift(src, s, r)   => makeNorm(s, r)(freeMFEq(_), freeMFEq(_))(LeftShift(src, _, _))
+      case Union(src, l, r)       => makeNorm(l, r)(freeTCEq(_), freeTCEq(_))(Union(src, _, _))
+      case Filter(src, f)         => freeMFEq(f).map(Filter(src, _))
+      case Subset(src, from, sel, count) => makeNorm(from, count)(freeTCEq(_), freeTCEq(_))(Subset(src, _, sel, _))
+      case Unreferenced()         => None
+    })
+  }
+
+  def ProjectBucket = make(
+    λ[ProjectBucket ~> (Option ∘ ProjectBucket)#λ] {
+      case BucketField(a, v, f) => makeNorm(v, f)(freeMFEq(_), freeMFEq(_))(BucketField(a, _, _))
+      case BucketIndex(a, v, i) => makeNorm(v, i)(freeMFEq(_), freeMFEq(_))(BucketIndex(a, _, _))
+    }
+  )
 }
 
 object Normalizable extends NormalizableInstances {

--- a/connector/src/main/scala/quasar/qscript/ProjectBucket.scala
+++ b/connector/src/main/scala/quasar/qscript/ProjectBucket.scala
@@ -115,8 +115,4 @@ object ProjectBucket {
           case (_, _) => None
       }
     }
-
-  implicit def normalizable[T[_[_]]: Recursive: Corecursive : EqualT : ShowT]
-      : Normalizable[ProjectBucket[T, ?]] =
-    TTypes.normalizable[T].ProjectBucket
 }

--- a/connector/src/main/scala/quasar/qscript/QScriptCore.scala
+++ b/connector/src/main/scala/quasar/qscript/QScriptCore.scala
@@ -252,7 +252,7 @@ object QScriptCore {
             LeftShift(_, struct2, repair2)) =>
             val (repair, repL, repR) = concat(repair1, repair2)
 
-            val norm = TTypes.normalizable[T]
+            val norm = Normalizable.normalizable[T]
             val lFunc: FreeMap[IT] = norm.freeMF(struct1 >> left)
             val rFunc: FreeMap[IT] = norm.freeMF(struct2 >> right)
 
@@ -294,7 +294,4 @@ object QScriptCore {
           case (_, _) => None
         }
     }
-
-  implicit def normalizable[T[_[_]]: Recursive: Corecursive: EqualT: ShowT]: Normalizable[QScriptCore[T, ?]] =
-    TTypes.normalizable[T].QScriptCore
 }

--- a/connector/src/main/scala/quasar/qscript/TTypes.scala
+++ b/connector/src/main/scala/quasar/qscript/TTypes.scala
@@ -16,15 +16,9 @@
 
 package quasar.qscript
 
-import scala.Predef.$conforms
-import quasar.Predef._
-import quasar.contrib.matryoshka._
-import quasar.ejson.EJson
 import quasar.fp._
-import quasar.fp.ski._
 
-import matryoshka._
-import scalaz._, Scalaz._
+import scalaz._
 
 /** Centralizes the knowledge of T[_[_]] as well as certain
  *  type classes required for many operations. This is for
@@ -48,7 +42,6 @@ trait TTypes[T[_[_]]] {
 }
 
 object TTypes {
-  def normalizable[T[_[_]] : Recursive : Corecursive : EqualT : ShowT] = new NormalizableT[T]
   def simplifiableProjection[T[_[_]]]                                  = new SimplifiableProjectionT[T]
 }
 
@@ -100,137 +93,5 @@ class SimplifiableProjectionT[T[_[_]]] extends TTypes[T] {
         ej.combine
       )
     )
-  )
-}
-
-// ShowT is needed for debugging
-class NormalizableT[T[_[_]] : Recursive : Corecursive : EqualT : ShowT] extends TTypes[T] {
-  import Normalizable._
-  lazy val rewrite = new Rewrite[T]
-
-  def freeTC(free: FreeQS): FreeQS = {
-    freeTransCata[T, QScriptTotal, QScriptTotal, Hole, Hole](free)(
-      liftCo(rewrite.normalizeCoEnv[QScriptTotal])
-    )
-  }
-
-  def freeTCEq(free: FreeQS): Option[FreeQS] = {
-    val freeNormalized = freeTC(free)
-    (free ≠ freeNormalized).option(freeNormalized)
-  }
-
-  def freeMFEq[A: Equal](fm: Free[MapFunc, A]): Option[Free[MapFunc, A]] = {
-    val fmNormalized = freeMF[A](fm)
-    (fm ≠ fmNormalized).option(fmNormalized)
-  }
-
-  def freeMF[A](fm: Free[MapFunc, A]): Free[MapFunc, A] =
-    freeTransCata[T, MapFunc, MapFunc, A, A](fm)(MapFunc.normalize[T, A])
-
-  def makeNorm[A, B, C](
-    lOrig: A, rOrig: B)(
-    left: A => Option[A], right: B => Option[B])(
-    f: (A, B) => C):
-      Option[C] =
-    (left(lOrig), right(rOrig)) match {
-      case (None, None) => None
-      case (l, r)       => f(l.getOrElse(lOrig), r.getOrElse(rOrig)).some
-    }
-
-  def EquiJoin = make(
-    λ[EquiJoin ~> (Option ∘ EquiJoin)#λ](ej =>
-      (freeTCEq(ej.lBranch), freeTCEq(ej.rBranch), freeMFEq(ej.lKey), freeMFEq(ej.rKey), freeMFEq(ej.combine)) match {
-        case (None, None, None, None, None) => None
-        case (lBranchNorm, rBranchNorm, lKeyNorm, rKeyNorm, combineNorm) =>
-          quasar.qscript.EquiJoin(
-            ej.src,
-            lBranchNorm.getOrElse(ej.lBranch),
-            rBranchNorm.getOrElse(ej.rBranch),
-            lKeyNorm.getOrElse(ej.lKey),
-            rKeyNorm.getOrElse(ej.rKey),
-            ej.f,
-            combineNorm.getOrElse(ej.combine)).some
-      }))
-
-  def ThetaJoin = make(
-    λ[ThetaJoin ~> (Option ∘ ThetaJoin)#λ](tj =>
-      (freeTCEq(tj.lBranch), freeTCEq(tj.rBranch), freeMFEq(tj.on), freeMFEq(tj.combine)) match {
-        case (None, None, None, None) => None
-        case (lBranchNorm, rBranchNorm, onNorm, combineNorm) =>
-          quasar.qscript.ThetaJoin(
-            tj.src,
-            lBranchNorm.getOrElse(tj.lBranch),
-            rBranchNorm.getOrElse(tj.rBranch),
-            onNorm.getOrElse(tj.on),
-            tj.f,
-            combineNorm.getOrElse(tj.combine)).some
-      }))
-
-  def QScriptCore = {
-    // NB: all single-bucket reductions should reduce on `null`
-    def normalizeBucket(bucket: FreeMap): FreeMap = bucket.resume.fold({
-      case MapFuncs.Constant(_) => MapFuncs.NullLit[T, Hole]()
-      case _                    => bucket
-    }, κ(bucket))
-
-    make(λ[QScriptCore ~> (Option ∘ QScriptCore)#λ] {
-      case Reduce(src, bucket, reducers, repair) => {
-        val reducersOpt: List[Option[ReduceFunc[FreeMap]]] =
-          reducers.map(_.traverse(freeMFEq[Hole](_)))
-
-        val reducersNormOpt: Option[List[ReduceFunc[FreeMap]]] =
-          (!reducersOpt.map(_.toList).flatten.isEmpty).option(
-            Zip[List].zipWith(reducersOpt, reducers)(_.getOrElse(_)))
-
-        val bucketNormOpt: Option[FreeMap] = freeMFEq(bucket)
-
-        val bucketNormConst: Option[FreeMap] =
-          bucketNormOpt.getOrElse(bucket).resume.fold({
-            case MapFuncs.Constant(ej) =>
-              (!EJson.isNull(ej)).option(MapFuncs.NullLit[T, Hole]())
-            case _ => bucketNormOpt
-          }, κ(bucketNormOpt))
-
-        (bucketNormConst, reducersNormOpt, freeMFEq(repair)) match {
-          case (None, None, None) =>
-            None
-          case (bucketNorm, reducersNorm, repairNorm)  =>
-            Reduce(
-              src,
-              bucketNorm.getOrElse(bucket),
-              reducersNorm.getOrElse(reducers),
-              repairNorm.getOrElse(repair)).some
-        }
-      }
-
-      case Sort(src, bucket, order) => {
-        val orderOpt: List[Option[(FreeMap, SortDir)]] =
-          order.map {
-            _.leftMap(freeMFEq(_)) match {
-              case (Some(fm), dir) => Some((fm, dir))
-              case (_, _)          => None
-            }
-          }
-
-        val orderNormOpt: Option[List[(FreeMap, SortDir)]] =
-          (!orderOpt.map(_.toList).flatten.isEmpty).option(
-            Zip[List].zipWith(orderOpt, order)(_.getOrElse(_)))
-
-        makeNorm(bucket, order)(freeMFEq(_), _ => orderNormOpt)(Sort(src, _, _))
-      }
-      case Map(src, f)            => freeMFEq(f).map(Map(src, _))
-      case LeftShift(src, s, r)   => makeNorm(s, r)(freeMFEq(_), freeMFEq(_))(LeftShift(src, _, _))
-      case Union(src, l, r)       => makeNorm(l, r)(freeTCEq(_), freeTCEq(_))(Union(src, _, _))
-      case Filter(src, f)         => freeMFEq(f).map(Filter(src, _))
-      case Subset(src, from, sel, count) => makeNorm(from, count)(freeTCEq(_), freeTCEq(_))(Subset(src, _, sel, _))
-      case Unreferenced()         => None
-    })
-  }
-
-  def ProjectBucket = make(
-    λ[ProjectBucket ~> (Option ∘ ProjectBucket)#λ] {
-      case BucketField(a, v, f) => makeNorm(v, f)(freeMFEq(_), freeMFEq(_))(BucketField(a, _, _))
-      case BucketIndex(a, v, i) => makeNorm(v, i)(freeMFEq(_), freeMFEq(_))(BucketIndex(a, _, _))
-    }
   )
 }

--- a/connector/src/main/scala/quasar/qscript/ThetaJoin.scala
+++ b/connector/src/main/scala/quasar/qscript/ThetaJoin.scala
@@ -101,7 +101,4 @@ object ThetaJoin {
             }
         }
     }
-
-  implicit def normalizable[T[_[_]]: Recursive: Corecursive: EqualT: ShowT]: Normalizable[ThetaJoin[T, ?]] =
-    TTypes.normalizable[T].ThetaJoin
 }


### PR DESCRIPTION
This currently fails to compile with the following errors:
```
[error] /Users/greg/Documents/SlamData/quasar/connector/src/main/scala/quasar/qscript/Coalesce.scala:205: can't existentially abstract over parameterized type F
[error]     new Coalesce[QScriptCore] {
[error]     ^
[error] /Users/greg/Documents/SlamData/quasar/connector/src/main/scala/quasar/qscript/Coalesce.scala:362: can't existentially abstract over parameterized type F
[error]     new Coalesce[ProjectBucket] {
[error]     ^
[error] /Users/greg/Documents/SlamData/quasar/connector/src/main/scala/quasar/qscript/Coalesce.scala:398: can't existentially abstract over parameterized type F
[error]     new Coalesce[ThetaJoin] {
[error]     ^
[error] /Users/greg/Documents/SlamData/quasar/connector/src/main/scala/quasar/qscript/Coalesce.scala:436: can't existentially abstract over parameterized type F
[error]     new Coalesce[EquiJoin] {
[error]     ^
[error] four errors found
```
I found http://stackoverflow.com/questions/3122398/cant-existentially-abstract-over-parameterized-type, but ¯\\\_(ツ)_/¯