### PR TITLE
order by constant

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- Check for constant value ordering in OrderBy LP to QS conversion.

--- a/connector/src/test/scala/quasar/qscript/QScript.scala
+++ b/connector/src/test/scala/quasar/qscript/QScript.scala
@@ -108,6 +108,12 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
               Free.roll(Undefined())))))))).some)
     }
 
+    "convert a basic order by" in {
+      val lp = fullCompileExp("select * from zips order by city")
+      val qs = convert(listContents.some, lp)
+      qs must equal(chain(RootR).some) // TODO incorrect expectation
+    }.pendingUntilFixed
+
     "convert a basic reduction" in {
       val lp = fullCompileExp("select sum(pop) from bar")
       val qs = convert(listContents.some, lp)


### PR DESCRIPTION
This makes progress toward #1411 - we no longer get the "unsupported ordering function" error. But the QScript generated is still too complex. It doesn't contain any `ThetaJoin`s, but it does appear to still have the provenance information stored in the QScript.