### PR TITLE
A collection of QScript fixes.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,4 @@
+- handle the `Ann#values` pointer more consistently
+- implement Distinct => QScript
+- fix union conversion
+- in Mongo-QScript, identify arrays and maps with statically-known indices/keys to take advantage of ArrayBuilder and DocBuilder

--- a/connector/src/main/scala/quasar/fs/QueryFile.scala
+++ b/connector/src/main/scala/quasar/fs/QueryFile.scala
@@ -64,7 +64,7 @@ object QueryFile {
     //       so we don’t duplicate work.
     lp.transCata[LogicalPlan](orOriginal(Optimizer.elideLets[T]))
       .cataM[PlannerError \/ ?, (Ann[T], T[QS])](newLP => transform.lpToQScript(newLP.map(_ ∘ (_.transCata(eval)))))
-      .map(qs => QC.inj((transform.reifyResult(qs._1, qs._2))).embed.transCata(eval))
+      .map(qs => QC.inj((transform.reifyResult(qs._1, qs._2))).embed.transAna(eval))
   }
 
   def simplifyAndNormalize
@@ -85,8 +85,8 @@ object QueryFile {
     _.transAna(SP.simplifyProjection)
       // TODO: Rather than explicitly applying multiple times, we should apply
       //       repeatedly until unchanged.
-      .transCata(rewrite.normalize)
-      .transCata(rewrite.normalize)
+      .transAna(rewrite.normalize)
+      .transAna(rewrite.normalize)
   }
 
   /** The shape of QScript that’s used during conversion from LP. */

--- a/connector/src/main/scala/quasar/qscript/Coalesce.scala
+++ b/connector/src/main/scala/quasar/qscript/Coalesce.scala
@@ -181,6 +181,12 @@ object Coalesce {
           })
         case LeftShift(Embed(src), struct, shiftRepair) =>
           FToOut.get(src) >>= QC.prj >>= {
+            case LeftShift(innerSrc, innerStruct, innerRepair)
+                if !shiftRepair.element(LeftSide) && struct != HoleF =>
+              LeftShift(
+                FToOut.reverseGet(QC.inj(LeftShift(innerSrc, innerStruct, struct >> innerRepair))).embed,
+                HoleF,
+                shiftRepair).some
             case Map(innerSrc, mf) if !shiftRepair.element(LeftSide) =>
               LeftShift(innerSrc, struct >> mf, shiftRepair).some
             case Reduce(srcInner, _, List(ReduceFuncs.UnshiftArray(elem)), redRepair)

--- a/connector/src/main/scala/quasar/qscript/QScriptCore.scala
+++ b/connector/src/main/scala/quasar/qscript/QScriptCore.scala
@@ -221,8 +221,15 @@ object QScriptCore {
         left: FreeMap[T],
         right: FreeMap[T],
         p1: QScriptCore[IT, ExternallyManaged],
-        p2: QScriptCore[IT, ExternallyManaged]) =
+        p2: QScriptCore[IT, ExternallyManaged]) = {
+        val norm = TTypes.normalizable[T]
+
         (p1, p2) match {
+          case (Unreferenced(), Unreferenced()) =>
+            SrcMerge[QScriptCore[IT, ExternallyManaged], FreeMap[IT]](
+              Unreferenced(),
+              HoleF,
+              HoleF).some
           case (Map(_, m1), Map(_, m2)) =>
             // TODO: optimize cases where one side is a subset of the other
             val (mf, lv, rv) = concat(m1 >> left, m2 >> right)
@@ -252,7 +259,6 @@ object QScriptCore {
             LeftShift(_, struct2, repair2)) =>
             val (repair, repL, repR) = concat(repair1, repair2)
 
-            val norm = TTypes.normalizable[T]
             val lFunc: FreeMap[IT] = norm.freeMF(struct1 >> left)
             val rFunc: FreeMap[IT] = norm.freeMF(struct2 >> right)
 
@@ -291,8 +297,38 @@ object QScriptCore {
                   case (_, _) => None
                 }
             }
+          case (Filter(s1, c1), Filter(_, c2)) =>
+            val lCond = norm.freeMF(c1 >> left)
+            val rCond = norm.freeMF(c2 >> right)
+            (lCond ≟ rCond).option(SrcMerge(Filter(s1, lCond), left, right))
+
+          case (Sort(s1, b1, o1), Sort(_, b2, o2)) =>
+            val lBucket = norm.freeMF(b1 >> left)
+            val rBucket = norm.freeMF(b2 >> right)
+            val lOrder = o1.map(_.leftMap(o => norm.freeMF(o >> left)))
+            val rOrder = o2.map(_.leftMap(o => norm.freeMF(o >> right)))
+            (lBucket ≟ rBucket && lOrder ≟ rOrder).option(
+                SrcMerge(Sort(s1, lBucket, lOrder), left, right))
+
+          case (Subset(s1, f1, o1, c1), Subset(_, f2, o2, c2)) =>
+            val from1 = rebaseBranch(f1, left)
+            val from2 = rebaseBranch(f2, right)
+            val count1 = rebaseBranch(c1, left)
+            val count2 = rebaseBranch(c2, right)
+            (from1 ≟ from2 && o1 ≟ o2 && count1 ≟ count2).option(
+              SrcMerge(Subset(s1, from1, o1, count1), HoleF, HoleF))
+
+          case (Union(s1, l1, r1), Union(_, l2, r2)) =>
+            val left1 = rebaseBranch(l1, left)
+            val left2 = rebaseBranch(l2, right)
+            val right1 = rebaseBranch(r1, left)
+            val right2 = rebaseBranch(r2, right)
+            (left1 ≟ left2 && right1 ≟ right2).option(
+              SrcMerge(Union(s1, left1, right1), HoleF, HoleF))
+
           case (_, _) => None
         }
+      }
     }
 
   implicit def normalizable[T[_[_]]: Recursive: Corecursive: EqualT: ShowT]: Normalizable[QScriptCore[T, ?]] =

--- a/connector/src/main/scala/quasar/qscript/package.scala
+++ b/connector/src/main/scala/quasar/qscript/package.scala
@@ -143,6 +143,15 @@ package object qscript {
       Free.roll(ProjectIndex(HoleF[T], IntLit[T, Hole](1))),
       Free.roll(ProjectIndex(HoleF[T], IntLit[T, Hole](2))))
 
+  def concat4[T[_[_]]: Corecursive, A](
+    l: FreeMapA[T, A], c: FreeMapA[T, A], r: FreeMapA[T, A], r2: FreeMapA[T, A]):
+      (FreeMapA[T, A], FreeMap[T], FreeMap[T], FreeMap[T], FreeMap[T]) =
+    (Free.roll(ConcatArrays(Free.roll(ConcatArrays(Free.roll(ConcatArrays(Free.roll(MakeArray(l)), Free.roll(MakeArray(c)))), Free.roll(MakeArray(r)))), Free.roll(MakeArray(r2)))),
+      Free.roll(ProjectIndex(HoleF[T], IntLit[T, Hole](0))),
+      Free.roll(ProjectIndex(HoleF[T], IntLit[T, Hole](1))),
+      Free.roll(ProjectIndex(HoleF[T], IntLit[T, Hole](2))),
+      Free.roll(ProjectIndex(HoleF[T], IntLit[T, Hole](3))))
+
   def rebaseBranch[T[_[_]]: Recursive: Corecursive: EqualT: ShowT]
     (br: FreeQS[T], fm: FreeMap[T]): FreeQS[T] = {
     val rewrite = new Rewrite[T]

--- a/connector/src/test/scala/quasar/qscript/QScript.scala
+++ b/connector/src/test/scala/quasar/qscript/QScript.scala
@@ -315,7 +315,7 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
               structural.MakeArrayN[Fix](LP.Constant(Data.Int(7))).embed,
               structural.MakeArrayN[Fix](LP.Constant(Data.Int(8))).embed).embed).embed).embed) must
       equal(chain(
-        RootR,
+        QC.inj(Unreferenced[Fix, Fix[QS]]()),
         QC.inj(LeftShift(
           (),
           Free.roll(Constant(
@@ -338,7 +338,7 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
                 structural.MakeArrayN[Fix](LP.Constant(Data.Int(8))).embed).embed,
               structural.MakeArrayN[Fix](LP.Constant(Data.Int(9))).embed).embed).embed).embed) must
       equal(chain(
-        RootR,
+        QC.inj(Unreferenced[Fix, Fix[QS]]()),
         QC.inj(LeftShift(
           (),
           Free.roll(Constant(

--- a/connector/src/test/scala/quasar/qscript/QScript.scala
+++ b/connector/src/test/scala/quasar/qscript/QScript.scala
@@ -360,8 +360,17 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
                 structural.ObjectProject(LP.Free('x), LP.Constant(Data.Str("baz"))).embed,
                 structural.ObjectProject(LP.Free('x), LP.Constant(Data.Str("quux"))).embed).embed,
               structural.ObjectProject(LP.Free('x), LP.Constant(Data.Str("ducks"))).embed).embed).embed)) must
-      equal(chain(RootR).some) // TODO incorrect expectation
-    }.pendingUntilFixed
+      equal(chain(
+        RootR,
+        QC.inj(LeftShift((),
+          ProjectFieldR(ProjectFieldR(HoleF, StrLit("foo")), StrLit("bar")),
+          Free.roll(ConcatArrays[Fix, JoinFunc](
+            Free.roll(ConcatArrays[Fix, JoinFunc](
+              ProjectFieldR(RightSideF, StrLit("baz")),
+              ProjectFieldR(RightSideF, StrLit("quux")))),
+            ProjectFieldR(RightSideF, StrLit("ducks")))))),
+        QC.inj(LeftShift((), HoleF, RightSideF))).some)
+    }
 
     "convert a shift/unshift array" in {
       // "select [loc[_:] * 10 ...] from zips",
@@ -389,9 +398,9 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           Free.roll(MakeMap[Fix, FreeMapA[ReduceIndex]](
             StrLit[Fix, ReduceIndex]("0"),
             Free.point(ReduceIndex(0))))))).some)
-    }.pendingUntilFixed
+    }.pendingUntilFixed("verify includes proper provenance")
 
-    "convert a filter" in { // takes 1 min 17 sec to run
+    "convert a filter" in {
       // "select * from foo where bar between 1 and 10"
       convert(
         listContents.some,
@@ -411,7 +420,7 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
             ProjectFieldR(HoleF, StrLit("baz")),
             IntLit(1),
             IntLit(10)))))).some)
-    }.pendingUntilFixed
+    }.pendingUntilFixed("need to normalize around filter")
 
     // an example of how logical plan expects magical "left" and "right" fields to exist
     "convert magical query" in {
@@ -451,5 +460,65 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
         RootR,
         QC.inj(Map((), ProjectFieldR(HoleF, StrLit("foo"))))).some)
     }.pendingUntilFixed
+  }
+
+  "convert union" in {
+    val lp = fullCompileExp("select * from city union select * from person")
+    val qs = convert(listContents.some, lp)
+    qs must equal(chain(
+      QC.inj(Unreferenced[Fix, Fix[QS]]()),
+      QC.inj(Union((),
+        Free.roll(QCT.inj(LeftShift(
+          Free.roll(RT.inj(Const(Read(rootDir </> file("city"))))),
+          HoleF,
+          Free.roll(ConcatArrays(
+            // begin provenance
+            Free.roll(MakeArray(
+              Free.roll(MakeArray(
+                Free.roll(MakeMap(
+                  StrLit("n"),
+                  Free.roll(ConcatArrays(
+                    Free.roll(MakeArray(
+                      Free.roll(MakeMap(
+                        StrLit("m"),
+                        Free.roll(ProjectIndex(
+                          Free.roll(ProjectIndex(RightSideF, IntLit(1))),
+                          IntLit(0))))))),
+                    Free.roll(Constant(
+                      ejson.CommonEJson(ejson.Arr(List(
+                        ejson.ExtEJson(ejson.Map(List((
+                          ejson.CommonEJson(ejson.Str[Fix[EJson]]("f")).embed,
+                          ejson.CommonEJson(ejson.Str[Fix[EJson]]("city")).embed)))).embed))).embed)))))))))),
+            // end provenance
+            Free.roll(MakeArray(RightSideF))))))),
+        Free.roll(QCT.inj(LeftShift(
+          Free.roll(RT.inj(Const(Read(rootDir </> file("person"))))),
+          HoleF,
+          Free.roll(ConcatArrays(
+            // begin provenance
+            Free.roll(MakeArray(
+              Free.roll(MakeArray(
+                Free.roll(MakeMap(
+                  StrLit("n"),
+                  Free.roll(ConcatArrays(
+                    Free.roll(MakeArray(
+                      Free.roll(MakeMap(
+                        StrLit("m"),
+                        Free.roll(ProjectIndex(
+                          Free.roll(ProjectIndex(RightSideF, IntLit(1))),
+                          IntLit(0))))))),
+                    Free.roll(Constant(
+                      ejson.CommonEJson(ejson.Arr(List(
+                        ejson.ExtEJson(ejson.Map(List((
+                          ejson.CommonEJson(ejson.Str[Fix[EJson]]("f")).embed,
+                          ejson.CommonEJson(ejson.Str[Fix[EJson]]("city")).embed)))).embed))).embed)))))))))),
+            // end provenance
+            Free.roll(MakeArray(RightSideF))))))))),
+      QC.inj(Reduce((),
+        Free.roll(ConcatArrays(
+          Free.roll(MakeArray(Free.roll(ProjectIndex(HoleF, IntLit(1))))),
+          Free.roll(MakeArray(Free.roll(ProjectIndex(Free.roll(ProjectIndex(HoleF, IntLit(0))), IntLit(1))))))),
+        List(ReduceFuncs.Arbitrary[FreeMap](Free.roll(ProjectIndex(HoleF, IntLit(1))))),
+        ReduceIndexF(0)))).some)
   }
 }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -72,20 +72,20 @@ object MongoDbQScriptPlanner {
 
   def processMapFuncExpr[T[_[_]]: Recursive: ShowT, EX[_]: Traverse, A](
     funcHandler: FuncHandler[T, EX])(
-    fm: FreeMapA[T,  A])(
+    fm: T[CoEnv[A, MapFunc[T, ?], ?]])(
     recovery: A => OutputM[Fix[ExprOp]])(
     implicit inj: EX :<: ExprOp):
       OutputM[Fix[ExprOp]] =
-    freeCataM(fm)(
+    fm.cataM(
       interpretM[OutputM, MapFunc[T, ?], A, Fix[ExprOp]](
         recovery,
         expression(funcHandler)))
 
   def processMapFunc[T[_[_]]: Recursive: ShowT, A](
-    fm: FreeMapA[T,  A])(
+    fm: T[CoEnv[A, MapFunc[T, ?], ?]])(
     recovery: A => JsCore):
       OutputM[JsCore] =
-    freeCataM(fm)(interpretM[OutputM, MapFunc[T, ?], A, JsCore](recovery(_).right, javascript))
+    fm.cataM(interpretM[OutputM, MapFunc[T, ?], A, JsCore](recovery(_).right, javascript))
 
   def unimplemented(name: String) = InternalError(s"unimplemented $name").left
 
@@ -526,7 +526,7 @@ object MongoDbQScriptPlanner {
             .liftM[GenT]
       }
 
-    implicit def qscriptCore[T[_[_]]: Recursive: ShowT]:
+    implicit def qscriptCore[T[_[_]]: Recursive: Corecursive: ShowT]:
         Planner.Aux[T, QScriptCore[T, ?]] =
       new Planner[QScriptCore[T, ?]] {
         type IT[G[_]] = T[G]
@@ -544,7 +544,7 @@ object MongoDbQScriptPlanner {
           //   (expr, jm) => WB.jsExpr(List(src, WB.flattenMap(expr)), jm))
           case Reduce(src, bucket, reducers, repair) =>
             (getExprBuilder(funcHandler)(src, bucket) ⊛
-              reducers.traverse(_.traverse(getExpr(funcHandler))) ⊛
+              reducers.traverse(_.traverse(fm => getExpr(funcHandler)(fm.toCoEnv[T]))) ⊛
               handleRedRepair(funcHandler, repair))((b, red, rep) =>
               ExprBuilder(
                 GroupBuilder(src,
@@ -579,7 +579,7 @@ object MongoDbQScriptPlanner {
         }
       }
 
-    implicit def equiJoin[T[_[_]]: Recursive: ShowT]:
+    implicit def equiJoin[T[_[_]]: Recursive: Corecursive: ShowT]:
         Planner.Aux[T, EquiJoin[T, ?]] =
       new Planner[EquiJoin[T, ?]] {
         type IT[G[_]] = T[G]
@@ -604,8 +604,8 @@ object MongoDbQScriptPlanner {
               case LeftOuter => set.LeftOuterJoin
               case RightOuter => set.RightOuterJoin
             },
-            JoinSource(lb, List(lk), getJsFn(qs.lKey).toOption.map(List(_))),
-            JoinSource(rb, List(rk), getJsFn(qs.rKey).toOption.map(List(_))))).join
+            JoinSource(lb, List(lk), getJsFn(qs.lKey.toCoEnv[T]).toOption.map(List(_))),
+            JoinSource(rb, List(rk), getJsFn(qs.rKey.toCoEnv[T]).toOption.map(List(_))))).join
       }
 
     implicit def coproduct[T[_[_]], F[_], G[_]](
@@ -682,24 +682,36 @@ object MongoDbQScriptPlanner {
 
   def getExpr[T[_[_]]: Recursive: ShowT, EX[_]: Traverse](
     funcHandler: FuncHandler[T, EX])(
-    fm: FreeMap[T])(
+    fm: T[CoEnv[Hole, MapFunc[T, ?], ?]])(
     implicit ev: EX :<: ExprOp): OutputM[Fix[ExprOp]] =
     processMapFuncExpr(funcHandler)(fm)(κ($$ROOT.right))
 
-  def getJsFn[T[_[_]]: Recursive: ShowT](fm: FreeMap[T]): OutputM[JsFn] =
+  def getJsFn[T[_[_]]: Recursive: ShowT](fm: T[CoEnv[Hole, MapFunc[T, ?], ?]])
+      : OutputM[JsFn] =
     processMapFunc(fm)(κ(jscore.Ident(JsFn.defaultName))) ∘ (JsFn(JsFn.defaultName, _))
 
-  def getExprBuilder[T[_[_]]: Recursive: ShowT, WF[_], EX[_]: Traverse](
+  def getExprBuilder[T[_[_]]: Recursive: Corecursive: ShowT, WF[_], EX[_]: Traverse](
     funcHandler: FuncHandler[T, EX])(
     src: WorkflowBuilder[WF], fm: FreeMap[T])(
     implicit ev: EX :<: ExprOp):
       OutputM[WorkflowBuilder[WF]] =
-    // TODO: identify cases for ArrayBuilder, DocBuilder, and SpliceBuilder.
-    handleFreeMap(funcHandler, fm) ∘ (ExprBuilder(src, _))
+    fm.toCoEnv[T].project match {
+      // TODO: identify cases for SpliceBuilder.
+      case MapFunc.StaticArray(elems) =>
+        elems.traverse(handleFreeMap(funcHandler, _)) ∘ (ArrayBuilder(src, _))
+      case MapFunc.StaticMap(elems) =>
+        elems.traverse(_.bitraverse({
+          case Embed(ejson.Common(ejson.Str(key))) => BsonField.Name(key).right
+          case key => InternalError(s"Unsupported object key: ${key.shows}").left
+        },
+          handleFreeMap(funcHandler, _))) ∘
+        (es => DocBuilder(src, es.toListMap))
+      case co => handleFreeMap(funcHandler, co.embed) ∘ (ExprBuilder(src, _))
+    }
 
-  def getJsMerge[T[_[_]]: Recursive: ShowT](jf: JoinFunc[T], a1: JsCore, a2: JsCore):
+  def getJsMerge[T[_[_]]: Recursive: Corecursive: ShowT](jf: JoinFunc[T], a1: JsCore, a2: JsCore):
       OutputM[JsFn] =
-    processMapFunc(jf) {
+    processMapFunc(jf.toCoEnv[T]) {
       case LeftSide => a1
       case RightSide => a2
     } ∘ (JsFn(JsFn.defaultName, _))
@@ -709,25 +721,25 @@ object MongoDbQScriptPlanner {
     exf(a).map(_.right[JsFn]) <+> jsf(a).map(_.left[Fix[ExprOp]])
 
   def handleFreeMap[T[_[_]]: Recursive: ShowT, EX[_]: Traverse]
-    (funcHandler: FuncHandler[T, EX], fm: FreeMap[T])
+    (funcHandler: FuncHandler[T, EX], fm: T[CoEnv[Hole, MapFunc[T, ?], ?]])
     (implicit ev: EX :<: ExprOp)
       : OutputM[Expr] =
     exprOrJs(fm)(getExpr(funcHandler)(_), getJsFn[T])
 
-  def handleRedRepair[T[_[_]]: Recursive: ShowT, EX[_]: Traverse]
+  def handleRedRepair[T[_[_]]: Recursive: Corecursive: ShowT, EX[_]: Traverse]
     (funcHandler: FuncHandler[T, EX], jr: FreeMapA[T, ReduceIndex])
     (implicit ev: EX :<: ExprOp)
       : OutputM[Expr] =
-    exprOrJs(jr)(getExprRed(funcHandler)(_), getJsRed[T])
+    exprOrJs(jr.toCoEnv[T])(getExprRed(funcHandler)(_), getJsRed[T])
 
   def getExprRed[T[_[_]]: Recursive: ShowT, EX[_]: Traverse]
     (funcHandler: FuncHandler[T, EX])
-    (jr: FreeMapA[T, ReduceIndex])
+    (jr: T[CoEnv[ReduceIndex, MapFunc[T, ?], ?]])
     (implicit ev: EX :<: ExprOp)
       : OutputM[Fix[ExprOp]] =
     processMapFuncExpr(funcHandler)(jr)(ri => $field(ri.idx.toString).right)
 
-  def getJsRed[T[_[_]]: Recursive: ShowT](jr: FreeMapA[T, ReduceIndex]):
+  def getJsRed[T[_[_]]: Recursive: ShowT](jr: T[CoEnv[ReduceIndex, MapFunc[T, ?], ?]]):
       OutputM[JsFn] =
     processMapFunc(jr)(ri => jscore.Access(jscore.Ident(JsFn.defaultName), jscore.ident(ri.idx.toString))) ∘ (JsFn(JsFn.defaultName, _))
 


### PR DESCRIPTION
This is a bunch of small fixes to QScript motivated by one of two things
1. the included changes to the Mongo-QScript connector or
2. a simplification in the way we handle Constants in qscript.Transform.

The latter exposed a number of places we weren’t properly dealing with
the value pointer in the annotation. Basically, that change broke a
number of tests (when it should have been semantically equivalent), and
the subsequent fixes were needed to make them pass again. In general, I
also took advantage of the value pointer more often, to simplify some
Transform cases and avoid creating intermediate Map nodes.

In the Mongo-QScript connector, we now identify arrays and maps with
statically-known indices/keys to take advantage of ArrayBuilder and
DocBuilder.