### PR TITLE
Run StdLib tests on sparkcore's MapFunc implementation

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- implement StdLibSpec for sparkcore

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/CoreMap.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/CoreMap.scala
@@ -178,6 +178,7 @@ object CoreMap extends Serializable {
     }).right
     case ConcatArrays(f1, f2) => ((x: Data) => (f1(x), f2(x)) match {
       case (Data.Arr(l1), Data.Arr(l2)) => Data.Arr(l1 ++ l2)
+      case (Data.Str(s1), Data.Str(s2)) => Data.Str(s1 ++ s2)
       case _ => undefined
     }).right
     case ConcatMaps(f1, f2) => ((x: Data) => (f1(x), f2(x)) match {
@@ -264,7 +265,7 @@ object CoreMap extends Serializable {
     case (Data.Dec(a), Data.Dec(b)) => Data.Dec(a / b)
     case (Data.Int(a), Data.Dec(b)) => Data.Dec(BigDecimal(a) / b)
     case (Data.Dec(a), Data.Int(b)) => Data.Dec(a / BigDecimal(b))
-    case (Data.Int(a), Data.Int(b)) => Data.Int(a / b)
+    case (Data.Int(a), Data.Int(b)) => Data.Dec(BigDecimal(a) / BigDecimal(b))
     case (Data.Interval(a), Data.Dec(b)) => Data.Interval(a.multipliedBy(b.toLong))
     case (Data.Interval(a), Data.Int(b)) => Data.Interval(a.multipliedBy(b.toLong))
     case _ => undefined
@@ -352,19 +353,19 @@ object CoreMap extends Serializable {
 
   private def between(d1: Data, d2: Data, d3: Data): Data = (d1, d2, d3) match {
     case (Data.Int(a), Data.Int(b), Data.Int(c)) =>
-      Data.Bool(a <= b && b <= c)
+      Data.Bool(b <= a && a <= c)
     case (Data.Dec(a), Data.Dec(b), Data.Dec(c)) =>
-      Data.Bool(a <= b && b <= c)
+      Data.Bool(b <= a && a <= c)
     case (Data.Interval(a), Data.Interval(b), Data.Interval(c)) =>
-      Data.Bool(a.compareTo(b) <= 0 && b.compareTo(c) <= 0)
+      Data.Bool(b.compareTo(a) <= 0 && a.compareTo(c) <= 0)
     case (Data.Str(a), Data.Str(b), Data.Str(c)) =>
-      Data.Bool(a.compareTo(b) <= 0 && b.compareTo(c) <= 0)
+      Data.Bool(b.compareTo(a) <= 0 && a.compareTo(c) <= 0)
     case (Data.Timestamp(a), Data.Timestamp(b), Data.Timestamp(c)) =>
-      Data.Bool(a.compareTo(b) <= 0 && b.compareTo(c) <= 0)
+      Data.Bool(b.compareTo(a) <= 0 && a.compareTo(c) <= 0)
     case (Data.Date(a), Data.Date(b), Data.Date(c)) =>
-      Data.Bool(a.compareTo(b) <= 0 && b.compareTo(c) <= 0)
+      Data.Bool(b.compareTo(a) <= 0 && a.compareTo(c) <= 0)
     case (Data.Time(a), Data.Time(b), Data.Time(c)) =>
-      Data.Bool(a.compareTo(b) <= 0 && b.compareTo(c) <= 0)
+      Data.Bool(b.compareTo(a) <= 0 && a.compareTo(c) <= 0)
     case (Data.Bool(a), Data.Bool(b), Data.Bool(c)) => (a,b,c) match {
       case (false, false, true) => Data.Bool(true)
       case (false, true, true) => Data.Bool(true)
@@ -400,7 +401,7 @@ object CoreMap extends Serializable {
   private def substring(dStr: Data, dFrom: Data, dCount: Data): Data =
     (dStr, dFrom, dCount) match {
       case (Data.Str(str), Data.Int(from), Data.Int(count)) =>
-        \/.fromTryCatchNonFatal(Data.Str(str.substring(from.toInt, count.toInt))).fold(κ(Data.NA), ι)
+        \/.fromTryCatchNonFatal(Data.Str(StringLib.safeSubstring(str, from.toInt, count.toInt))).fold(κ(Data.NA), ι)
       case _ => undefined
     }
 

--- a/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/CoreMapStdLibSpec.scala
+++ b/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/CoreMapStdLibSpec.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.sparkcore.fs
+
+import quasar.Predef._
+import quasar._
+import quasar.Planner.PlannerError
+import quasar.fp.ski._
+import quasar.fp.tree._
+import quasar.std._
+import quasar.qscript.MapFunc
+import quasar.contrib.matryoshka._
+
+import matryoshka._, Recursive.ops._
+import org.scalacheck.Arbitrary.arbitrary
+import org.specs2.execute._
+import scalaz._, Scalaz._
+import shapeless.Sized
+
+// TODO: pull out MapFunc translation as MapFuncStdLibSpec
+class CoreMapStdLibSpec extends StdLibSpec {
+
+  /** Translate to MapFunc (common to all QScript backends). */
+  def translate[A](prg: Fix[LogicalPlan], args: Symbol => A): Free[MapFunc[Fix, ?], A] =
+    prg.cata[Free[MapFunc[Fix, ?], A]] {
+      case LogicalPlan.InvokeFUnapply(func @ UnaryFunc(_, _, _, _, _, _, _, _), Sized(a1))
+          if func.effect ≟ Mapping =>
+        Free.roll(MapFunc.translateUnaryMapping(func)(a1))
+
+      case LogicalPlan.InvokeFUnapply(func @ BinaryFunc(_, _, _, _, _, _, _, _), Sized(a1, a2))
+          if func.effect ≟ Mapping =>
+        Free.roll(MapFunc.translateBinaryMapping(func)(a1, a2))
+
+      case LogicalPlan.InvokeFUnapply(func @ TernaryFunc(_, _, _, _, _, _, _, _), Sized(a1, a2, a3))
+          if func.effect ≟ Mapping =>
+        Free.roll(MapFunc.translateTernaryMapping(func)(a1, a2, a3))
+
+      case LogicalPlan.FreeF(sym) => Free.pure(args(sym))
+    }
+
+  /** Compile/execute on this backend, and compare with the expected value. */
+  // TODO: this signature might not work for other implementations.
+  def run[A](fm: Free[MapFunc[Fix, ?], A], args: A => Data, expected: Data): Result = {
+    val run = freeCataM(fm)(interpretM[PlannerError \/ ?, MapFunc[Fix, ?], A, Data => Data](
+      a => κ(args(a)).right, CoreMap.change))
+    (run.map(_(Data.NA)) must beRightDisjunction.like { case d => d must closeTo(expected) }).toResult
+  }
+
+  val runner = new StdLibTestRunner {
+    def nullary(prg: Fix[LogicalPlan], expected: Data) =
+      failure
+
+    def unary(prg: Fix[LogicalPlan] => Fix[LogicalPlan], arg: Data, expected: Data) = {
+      val mf = translate(prg(LogicalPlan.Free('arg)), κ(UnaryArg._1))
+
+      run(mf, κ(arg), expected)
+    }
+
+    def binary(prg: (Fix[LogicalPlan], Fix[LogicalPlan]) => Fix[LogicalPlan], arg1: Data, arg2: Data, expected: Data) = {
+      val mf = translate[BinaryArg](prg(LogicalPlan.Free('arg1), LogicalPlan.Free('arg2)), {
+        case 'arg1 => BinaryArg._1
+        case 'arg2 => BinaryArg._2
+      })
+
+      run[BinaryArg](mf, _.fold(arg1, arg2), expected)
+    }
+
+    def ternary(prg: (Fix[LogicalPlan], Fix[LogicalPlan], Fix[LogicalPlan]) => Fix[LogicalPlan], arg1: Data, arg2: Data, arg3: Data, expected: Data) = {
+      val mf = translate[TernaryArg](prg(LogicalPlan.Free('arg1), LogicalPlan.Free('arg2), LogicalPlan.Free('arg3)), {
+        case 'arg1 => TernaryArg._1
+        case 'arg2 => TernaryArg._2
+        case 'arg3 => TernaryArg._3
+      })
+
+      run[TernaryArg](mf, _.fold(arg1, arg2, arg3), expected)
+    }
+
+    def intDomain = arbitrary[BigInt]
+
+    // NB: BigDecimal parsing cannot handle values that are too close to the
+    // edges of its range.
+    def decDomain = arbitrary[BigDecimal].filter(i => i.scale > Int.MinValue && i.scale < Int.MaxValue)
+
+    def stringDomain = arbitrary[String]
+  }
+
+  tests(runner)
+}


### PR DESCRIPTION
This runs all the tests, skipping the Extract functions and the tests for `Power` since the implementation is limited to small values. 

Other than that, it found only a few small problems which are fixed here.

I tried to factor out the parts that should be common to QScript/MapFunc implementations, and included a few TODO comments about how that might work.