### PR TITLE
Simplify runtime Provenance representation.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,5 @@
+- simplify runtime provenance representation
+- improve QScript PhaseResult output (improves #1550)
+- handle constant join conditions (fixes #1559)
+- fixes autojoin condition
+- improve typechecker error message

--- a/connector/src/main/scala/quasar/fs/QueryFile.scala
+++ b/connector/src/main/scala/quasar/fs/QueryFile.scala
@@ -123,9 +123,7 @@ object QueryFile {
         simplifyAndNormalize[T, QScriptInternal[T, ?], QS]
 
     EitherT(Writer(
-      qs.fold(
-        κ(Vector()),
-        a => Vector(PhaseResult.tree("QScript", a.cata(transform.linearize).reverse))),
+      qs.fold(κ(Vector()), a => Vector(PhaseResult.tree("QScript", a))),
       qs))
   }
 
@@ -167,9 +165,7 @@ object QueryFile {
         simplifyAndNormalize[T, InterimQS, QS])
 
     merr.bind(qs) { qs =>
-      mtell.writer(
-        Vector(PhaseResult.tree("QScript", qs.cata(transform.linearize).reverse)),
-        qs)
+      mtell.writer(Vector(PhaseResult.tree("QScript", qs)), qs)
     }
   }
 

--- a/connector/src/main/scala/quasar/qscript/Provenance.scala
+++ b/connector/src/main/scala/quasar/qscript/Provenance.scala
@@ -14,80 +14,172 @@
  * limitations under the License.
  */
 
-package quasar.qscript
+package quasar.qscript.provenance
 
 import quasar.Predef._
 import quasar.contrib.matryoshka._
+import quasar.ejson.EJson
+import quasar.fp._
+import quasar.qscript._
 import quasar.qscript.MapFuncs._
 
+import scala.Predef.$conforms
+
 import matryoshka._
+import monocle.macros.Lenses
 import scalaz._, Scalaz._
 
-// NB: Should we use char lits instead?
-class Provenance[T[_[_]]: Corecursive: EqualT] {
-  private def tagIdentity[A](tag: String, mf: Free[MapFunc[T, ?], A]): FreeMapA[T, A] =
-    Free.roll(MakeMap[T, FreeMapA[T, A]](StrLit(tag), mf))
+// TODO: Convert to fixed-point
+sealed abstract class Provenance[T[_[_]]]
+@Lenses final case class Nada[T[_[_]]]() extends Provenance[T]
+@Lenses final case class Value[T[_[_]]](expr: FreeMap[T]) extends Provenance[T]
+@Lenses final case class Proj[T[_[_]]](field: T[EJson]) extends Provenance[T]
+@Lenses final case class Both[T[_[_]]](l: Provenance[T], r: Provenance[T])
+    extends Provenance[T]
+@Lenses final case class OneOf[T[_[_]]](l: Provenance[T], r: Provenance[T])
+    extends Provenance[T]
+@Lenses final case class Then[T[_[_]]](l: Provenance[T], r: Provenance[T])
+    extends Provenance[T]
 
-  // provenances:
-  // projectfield: f
-  // projectindex: i
-  // join:         j [] // should be commutative, but currently isn’t
-  // union:        u [] // should be commutative, but currently isn’t
-  // nest:         n []
-  // shiftmap:     m
-  // shiftarray:   a
-  def projectField[A](mf: FreeMapA[T, A]) = tagIdentity("f", mf)
-  def projectIndex[A](mf: FreeMapA[T, A]) = tagIdentity("i", mf)
-  def shiftMap[A](mf: FreeMapA[T, A]) = tagIdentity("m", mf)
-  def shiftArray[A](mf: FreeMapA[T, A]) = tagIdentity("a", mf)
-
-  def join[A](left: FreeMapA[T, A], right: FreeMapA[T, A]) =
-    tagIdentity("j",
-      Free.roll(ConcatArrays(
-        Free.roll(MakeArray[T, FreeMapA[T, A]](left)),
-        Free.roll(MakeArray[T, FreeMapA[T, A]](right)))))
-
-  def union[A](left: FreeMapA[T, A], right: FreeMapA[T, A]) =
-    tagIdentity("u",
-      Free.roll(ConcatArrays(
-        Free.roll(MakeArray[T, FreeMapA[T, A]](left)),
-        Free.roll(MakeArray[T, FreeMapA[T, A]](right)))))
-
-  def nest[A](car: FreeMapA[T, A], cadr: FreeMapA[T, A]) =
-    tagIdentity("n",
-      Free.roll(ConcatArrays(
-        Free.roll(MakeArray[T, FreeMapA[T, A]](car)),
-        Free.roll(MakeArray[T, FreeMapA[T, A]](cadr)))))
-
-  def joinProvenances(leftBuckets: List[FreeMap[T]], rightBuckets: List[FreeMap[T]]):
-      List[FreeMap[T]] =
-    leftBuckets.alignWith(rightBuckets) {
-      case \&/.Both(l, r) => if (l ≟ r) l else join(l, r)
-      case \&/.This(l)    => join(l, NullLit())
-      case \&/.That(r)    => join(NullLit(), r)
+object Provenance {
+  // TODO: This might not be the proper notion of equality – this just tells us
+  //       which things align properly for autojoins.
+  implicit def equal[T[_[_]]: EqualT]: Equal[Provenance[T]] =
+    Equal.equal {
+      case (Nada(),        Nada())        => true
+      case (Value(_),      Value(_))      => true
+      case (Value(_),      Proj(_))       => true
+      case (Proj(_),       Value(_))      => true
+      case (Proj(d1),      Proj(d2))      => d1 ≟ d2
+      case (Both(l1, r1),  Both(l2, r2))  => l1 ≟ l2 && r1 ≟ r2
+      case (OneOf(l1, r1), OneOf(l2, r2)) =>
+        l1 ≟ l2 && r1 ≟ r2 || l1 ≟ r2 && r1 ≟ l2
+      case (Then(l1, r1),  Then(l2, r2))  => l1 ≟ l2 && r1 ≟ r2
+      case (_,             _)             => false
     }
 
-  def unionProvenances(leftBuckets: List[FreeMap[T]], rightBuckets: List[FreeMap[T]]):
-      List[FreeMap[T]] =
-    leftBuckets.alignWith(rightBuckets) {
-      case \&/.Both(l, r) => union(l, r)
-      case \&/.This(l)    => union(l, NullLit[T, Hole]())
-      case \&/.That(r)    => union(NullLit[T, Hole](), r)
+  implicit def show[T[_[_]]: ShowT]: Show[Provenance[T]] = Show.show {
+    case Nada() => Cord("Nada")
+    case Value(expr) => Cord("Value(") ++ expr.show ++ Cord(")")
+    case Proj(field) => Cord("Proj(") ++ field.show ++ Cord(")")
+    case Both(l, r) => Cord("Both(") ++ l.show ++ Cord(", ") ++ r.show ++ Cord(")")
+    case OneOf(l, r) => Cord("OneOf(") ++ l.show ++ Cord(", ") ++ r.show ++ Cord(")")
+    case Then(l, r) => Cord("Then(") ++ l.show ++ Cord(", ") ++ r.show ++ Cord(")")
+  }
+}
+
+class ProvenanceT[T[_[_]]: Corecursive: EqualT] extends TTypes[T] {
+  type Provenance = quasar.qscript.provenance.Provenance[T]
+
+  def genComparisons(lps: List[Provenance], rps: List[Provenance]): JoinFunc =
+    lps.reverse.zip(rps.reverse).takeWhile { case (l, r) => l ≟ r }.reverse.map((genComparison(_, _)).tupled(_).toList).join match {
+      case Nil    => BoolLit(true)
+      case h :: t => t.foldLeft(h)((a, e) => Free.roll(And(a, e)))
     }
 
-  def nestProvenances(buckets: List[FreeMap[T]]): List[FreeMap[T]] =
+  def genComparison(lp: Provenance, rp: Provenance): Option[JoinFunc] =
+    (lp, rp) match {
+      case (Value(v1), Value(v2)) => Free.roll(MapFuncs.Eq[T, JoinFunc](v1.as(LeftSide), v2.as(RightSide))).some
+      case (Value(v1), Proj(d2)) => Free.roll(MapFuncs.Eq[T, JoinFunc](v1.as(LeftSide), Free.roll(Constant(d2)))).some
+      case (Proj(d1), Value(v2)) => Free.roll(MapFuncs.Eq[T, JoinFunc](Free.roll(Constant(d1)), v2.as(RightSide))).some
+      case (Both(l1, r1),  Both(l2, r2)) =>
+        genComparison(l1, l2).fold(
+          genComparison(r1, r2))(
+          lc => genComparison(r1, r2).fold(lc)(rc => Free.roll(And[T, JoinFunc](lc, rc))).some)
+      case (OneOf(l1, r1),  OneOf(l2, r2)) =>
+        genComparison(l1, l2).fold(
+          genComparison(r1, r2))(
+          lc => genComparison(r1, r2).fold(lc)(rc => Free.roll(And[T, JoinFunc](lc, rc))).some)
+      case (Then(l1, r1),  Then(l2, r2)) =>
+        genComparison(l1, l2).fold(
+          genComparison(r1, r2))(
+          lc => genComparison(r1, r2).fold(lc)(rc => Free.roll(And[T, JoinFunc](lc, rc))).some)
+      case (_, _) => None
+    }
+
+  def rebase0(newBase: FreeMap): Provenance => Option[Provenance] = {
+    case Value(expr) => Value(expr >> newBase).some
+    case Both(l, r)  => (rebase0(newBase)(l), rebase0(newBase)(r)) match {
+      case (None,     None)     => None
+      case (None,     Some(r0)) => Both(l, r0).some
+      case (Some(l0), None)     => Both(l0, r).some
+      case (Some(l0), Some(r0)) => Both(l0, r0).some
+    }
+    case OneOf(l, r) => (rebase0(newBase)(l), rebase0(newBase)(r)) match {
+      case (None,     None)     => None
+      case (None,     Some(r0)) => OneOf(l, r0).some
+      case (Some(l0), None)     => OneOf(l0, r).some
+      case (Some(l0), Some(r0)) => OneOf(l0, r0).some
+    }
+    case Then(l, r)  => (rebase0(newBase)(l), rebase0(newBase)(r)) match {
+      case (None,     None)     => None
+      case (None,     Some(r0)) => Then(l, r0).some
+      case (Some(l0), None)     => Then(l0, r).some
+      case (Some(l0), Some(r0)) => Then(l0, r0).some
+    }
+    case _           => None
+  }
+
+  def rebase(newBase: FreeMap, ps: List[Provenance]): List[Provenance] =
+    ps.map(orOriginal(rebase0(newBase)))
+
+  /** Reifies the part of the provenance that must exist in the plan.
+    */
+  def genBuckets(ps: List[Provenance]): Option[(List[Provenance], FreeMap)] =
+    ps.traverse(genBucket).eval(0).unzip.traverse(_.join match {
+      case Nil      => None
+      case h :: Nil => h.some
+      case h :: t   =>
+        t.foldLeft(
+          Free.roll(MakeArray[T, FreeMap](h)))(
+          (a, e) => Free.roll(ConcatArrays(a, Free.roll(MakeArray(e))))).some
+    })
+
+  val genBucket: Provenance => State[Int, (Provenance, List[FreeMap])] = {
+    case Nada()      => (Nada[T](): Provenance, Nil: List[FreeMap]).point[State[Int, ?]]
+    case Value(expr) =>
+      State(i => (i + 1, (Value(Free.roll(ProjectIndex(HoleF, IntLit(i)))), List(expr))))
+    case Proj(d)     => (Proj(d): Provenance, Nil: List[FreeMap]).point[State[Int, ?]]
+    case Both(l, r)  => (genBucket(l) ⊛ genBucket(r)) {
+      case ((lp, lf), (rp, rf)) => (Both(lp, rp), lf ++ rf)
+    }
+    case OneOf(l, r)  => (genBucket(l) ⊛ genBucket(r)) {
+      case ((lp, lf), (rp, rf)) => (OneOf(lp, rp), lf ++ rf)
+    }
+    case Then(l, r)  => (genBucket(l) ⊛ genBucket(r)) {
+      case ((lp, lf), (rp, rf)) => (Then(lp, rp), lf ++ rf)
+    }
+  }
+
+  def joinProvenances(leftBuckets: List[Provenance], rightBuckets: List[Provenance]):
+      List[Provenance] =
+    leftBuckets.reverse.alignWith(rightBuckets.reverse) {
+      case \&/.Both(l, r) => if (l ≟ r) l else Both(l, r)
+      case \&/.This(l)    => Both(l, Nada())
+      case \&/.That(r)    => Both(Nada(), r)
+    }.reverse
+
+  def unionProvenances(leftBuckets: List[Provenance], rightBuckets: List[Provenance]):
+      List[Provenance] =
+    leftBuckets.reverse.alignWith(rightBuckets.reverse) {
+      case \&/.Both(l, r) => OneOf(l, r)
+      case \&/.This(l)    => OneOf(l, Nada())
+      case \&/.That(r)    => OneOf(Nada(), r)
+    }.reverse
+
+  def nestProvenances(buckets: List[Provenance]): List[Provenance] =
     buckets match {
-      case a :: b :: tail => nest(a, b) :: tail
+      case a :: b :: tail => Then(a, b) :: tail
       case _              => buckets
     }
 
-  def squashProvenances(buckets: List[FreeMap[T]]): List[FreeMap[T]] =
+  def squashProvenances(buckets: List[Provenance]): List[Provenance] =
     buckets match {
-      case a :: b :: tail => squashProvenances(nest(a, b) :: tail)
+      case a :: b :: tail => squashProvenances(Then(a, b) :: tail)
       case _              => buckets
     }
 
-  def swapProvenances(buckets: List[FreeMap[T]]): List[FreeMap[T]] =
+  def swapProvenances(buckets: List[Provenance]): List[Provenance] =
     buckets match {
       case a :: b :: tail => b :: a :: tail
       case _              => buckets

--- a/connector/src/main/scala/quasar/qscript/Transform.scala
+++ b/connector/src/main/scala/quasar/qscript/Transform.scala
@@ -56,7 +56,7 @@ class Transform
     eq:         Delay[Equal, F],
     show:       Delay[Show, F]) extends TTypes[T] {
 
-  private val prov = new Provenance[T]
+  private val prov = new provenance.ProvenanceT[T]
   private val rewrite = new Rewrite[T]
 
   private type LinearF = List[F[ExternallyManaged]]
@@ -137,7 +137,7 @@ class Transform
       rebaseBranch(rightF, rMap))
   }
 
-  private case class AutoJoinBase(src: T[F], buckets: List[FreeMap])
+  private case class AutoJoinBase(src: T[F], buckets: List[prov.Provenance])
   private case class AutoJoinResult(base: AutoJoinBase, lval: FreeMap, rval: FreeMap)
   private case class AutoJoin3Result(base: AutoJoinBase, lval: FreeMap, cval: FreeMap, rval: FreeMap)
 
@@ -145,69 +145,40 @@ class Transform
     * expressions to access the combined bucketing info, as well as the left and
     * right values.
     */
-  private def autojoin(left: Target[F], right: Target[F])
-      : AutoJoinResult = {
+  private def autojoin(left: Target[F], right: Target[F]): AutoJoinResult = {
     val lann = left.ann
     val rann = right.ann
+    val lval = lann.values.as[JoinSide](LeftSide)
+    val rval = rann.values.as[JoinSide](RightSide)
     val MergeResult(src, lBranch, rBranch) = merge(left.value, right.value)
 
-    val lprovs = concatBuckets(lann.provenance) ∘ (_.leftMap(_.as[JoinSide](LeftSide)))
-    val rprovs = concatBuckets(rann.provenance) ∘ (_.leftMap(_.as[JoinSide](RightSide)))
-    val (combine, newProvs, lacc, racc) =
+    val lprovs = prov.genBuckets(lann.provenance) ∘ (_ ∘ (_.as[JoinSide](LeftSide)))
+    val rprovs = prov.genBuckets(rann.provenance) ∘ (_ ∘ (_.as[JoinSide](RightSide)))
+
+    val (combine, newLprov, newRprov, lacc, racc) =
       (lprovs, rprovs) match {
         case (None, None) =>
-          val (combine, lacc, racc) =
-            concat(
-              lann.values.as[JoinSide](LeftSide),
-              rann.values.as[JoinSide](RightSide))
-          (combine, Nil, lacc, racc)
-        case (None, Some((rBuck, rProvs))) =>
-          val (combine, bacc, lacc, racc) =
-            concat3(
-              rBuck,
-              lann.values.as[JoinSide](LeftSide),
-              rann.values.as[JoinSide](RightSide))
-          (combine, prov.joinProvenances(Nil, rProvs.map(_ >> bacc).toList), lacc, racc)
-        case (Some((lBuck, lProvs)), None) =>
-          val (combine, bacc, lacc, racc) =
-            concat3(
-              lBuck,
-              lann.values.as[JoinSide](LeftSide),
-              rann.values.as[JoinSide](RightSide))
-          (combine, prov.joinProvenances(lProvs.map(_ >> bacc).toList, Nil), lacc, racc)
-        case (Some((lBuck, lProvs)), Some((rBuck, rProvs))) =>
+          val (combine, lacc, racc) = concat(lval, rval)
+          (combine, lann.provenance, rann.provenance, lacc, racc)
+        case (None, Some((rProvs, rBuck))) =>
+          val (combine, bacc, lacc, racc) = concat3(rBuck, lval, rval)
+          (combine, lann.provenance, prov.rebase(bacc, rProvs), lacc, racc)
+        case (Some((lProvs, lBuck)), None) =>
+          val (combine, bacc, lacc, racc) = concat3(lBuck, lval, rval)
+          (combine, prov.rebase(bacc, lProvs), rann.provenance, lacc, racc)
+        case (Some((lProvs, lBuck)), Some((rProvs, rBuck))) =>
           val (combine, lbacc, rbacc, lacc, racc) =
-            concat4(
-              lBuck,
-              rBuck,
-              lann.values.as[JoinSide](LeftSide),
-              rann.values.as[JoinSide](RightSide))
-          (combine, prov.joinProvenances(lProvs.map(_ >> lbacc).toList, rProvs.map(_ >> rbacc).toList), lacc, racc)
+            concat4(lBuck, rBuck, lval, rval)
+          (combine, prov.rebase(lbacc, lProvs), prov.rebase(rbacc, rProvs), lacc, racc)
       }
 
-    AutoJoinResult(
-      AutoJoinBase(
-        rewrite.unifySimpleBranches[F, T[F]](src, lBranch, rBranch, combine)(rewrite.rebaseT).getOrElse {
-          // FIXME: Need a better prov representation, to know when the provs are
-          //        the same even when the paths to the values differ.
-          val commonProv =
-            lann.provenance.reverse.zip(rann.provenance.reverse).reverse.foldRightM[List[FreeMap] \/ ?, List[FreeMap]](Nil) {
-              case ((l, r), acc) => if (l ≟ r) (l :: acc).right else acc.left
-            }.merge
-
-          val commonBuck = concatBuckets(commonProv)
-
-          val condition: JoinFunc = commonBuck.fold(
-            BoolLit[T, JoinSide](true))( // when both sides are empty, perform a full cross
-            c => Free.roll[MapFunc, JoinSide](Eq(
-              c._1.as(LeftSide),
-              c._1.as(RightSide))))
-
-          TJ.inj(ThetaJoin(src, lBranch, rBranch, condition, Inner, combine))
-        }.embed,
-        newProvs),
-      lacc,
-      racc)
+      AutoJoinResult(
+        AutoJoinBase(
+          rewrite.unifySimpleBranches[F, T[F]](src, lBranch, rBranch, combine)(rewrite.rebaseT).getOrElse(
+            TJ.inj(ThetaJoin(src, lBranch, rBranch, prov.genComparisons(newLprov, newRprov), Inner, combine))).embed,
+          prov.joinProvenances(newLprov, newRprov)),
+        lacc,
+        racc)
   }
 
   /** A convenience for a pair of autojoins, does the same thing, but returns
@@ -215,14 +186,12 @@ class Transform
     */
   private def autojoin3(left: Target[F], center: Target[F], right: Target[F]):
       AutoJoin3Result = {
-    val AutoJoinResult(AutoJoinBase(lsrc, lbuckets), lval, cval) =
+    val AutoJoinResult(AutoJoinBase(lsrc, lprov), lval, cval) =
       autojoin(left, center)
-    val AutoJoinResult(base, bval, rval) =
-      autojoin(Target(Ann(lbuckets, HoleF), lsrc), right)
 
-    // the holes in `bval` reference `fullSrc`
-    // so we replace the holes in `lval` with `bval` because the holes in `lval >> bval` must reference `fullSrc`
-    // and `bval` applied to `fullSrc` gives us access to `lsrc`, so we apply `lval` after `bval`
+    val AutoJoinResult(base, bval, rval) =
+      autojoin(Target(Ann(lprov, HoleF), lsrc), right)
+
     AutoJoin3Result(base, lval >> bval, cval >> bval, rval)
   }
 
@@ -244,7 +213,7 @@ class Transform
         Free.point[MapFunc, JoinSide](RightSide))
 
     Target(Ann(
-      prov.shiftMap(Free.roll[MapFunc, Hole](ProjectIndex(rightAccess, IntLit(0)))) :: provs.map(_ >> leftAccess),
+      provenance.Value(Free.roll[MapFunc, Hole](ProjectIndex(rightAccess, IntLit(0)))) :: prov.rebase(leftAccess, provs),
       Free.roll(ProjectIndex(rightAccess, IntLit(1)))),
       QC.inj(LeftShift(input.value, Free.roll(f(value)), sides)).embed)
   }
@@ -258,14 +227,14 @@ class Transform
         Free.point[MapFunc, JoinSide](RightSide))
 
     Target(Ann(
-      prov.shiftMap(rightAccess) :: provs.map(_ >> leftAccess),
+      provenance.Value(rightAccess) :: prov.rebase(leftAccess, provs),
       rightAccess),
       QC.inj(LeftShift(input.value, Free.roll(f(value)), sides)).embed)
   }
 
   private def flatten(input: Target[F]): Target[F] = {
-    val Target(Ann(buckets, value), fa) = input
-    Target(Ann(prov.nestProvenances(buckets), value), fa)
+    val Target(Ann(provs, value), fa) = input
+    Target(Ann(prov.nestProvenances(provs), value), fa)
   }
 
   // NB: More complicated LeftShifts are generated as an optimization:
@@ -331,9 +300,8 @@ class Transform
             Free.point[MapFunc, JoinSide](LeftSide),
             Free.point[MapFunc, JoinSide](RightSide))
 
-        Target(Ann(
-          NullLit[T, Hole]() :: join.base.buckets.map(_ >> leftAccess),
-          rightAccess),
+        Target(
+          Ann(provenance.Nada[T]() :: prov.rebase(leftAccess, join.base.buckets), rightAccess),
           QC.inj(LeftShift(
             join.base.src,
             Free.roll(Range(join.lval, join.rval)),
@@ -348,22 +316,23 @@ class Transform
     // NB: If there’s no provenance, then there’s nothing to reduce. We’re
     //     already holding a single value.
     provs.tailOption.fold(values(0)) { tail =>
-      concatBuckets(tail) match {
-        case Some((newProvs, provAccess)) =>
+      prov.genBuckets(tail) match {
+        case Some((newProvs, buckets)) =>
           Target(Ann(
-            provAccess.list.toList.map(_ >> Free.roll(ProjectIndex(HoleF[T], IntLit[T, Hole](0)))),
+            prov.rebase(Free.roll(ProjectIndex(HoleF[T], IntLit[T, Hole](0))), newProvs),
             Free.roll(ProjectIndex(HoleF[T], IntLit[T, Hole](1)))),
             QC.inj(Reduce[T, T[F]](
               values(0).value,
-              newProvs,
+              buckets,
               List(
-                ReduceFuncs.Arbitrary(newProvs),
+                ReduceFuncs.Arbitrary(buckets),
                 ReduceFunc.translateUnaryReduction[FreeMap](func)(reduce)),
               Free.roll(ConcatArrays(
                 Free.roll(MakeArray(Free.point(ReduceIndex(0)))),
                 Free.roll(MakeArray(Free.point(ReduceIndex(1)))))))).embed)
         case None =>
-          Target(EmptyAnn[T],
+          Target(
+            Ann(provs, HoleF),
             QC.inj(Reduce[T, T[F]](
               values(0).value,
               NullLit(),
@@ -380,22 +349,23 @@ class Transform
     // NB: If there’s no provenance, then there’s nothing to reduce. We’re
     //     already holding a single value.
     join.base.buckets.tailOption.fold(Target(EmptyAnn[T], join.base.src)) { tail =>
-      concatBuckets(tail) match {
-        case Some((newProvs, provAccess)) =>
+      prov.genBuckets(tail) match {
+        case Some((newProvs, buckets)) =>
           Target(Ann(
-            provAccess.list.toList.map(_ >> Free.roll(ProjectIndex(HoleF[T], IntLit[T, Hole](0)))),
+            prov.rebase(Free.roll(ProjectIndex(HoleF[T], IntLit[T, Hole](0))), newProvs),
             Free.roll(ProjectIndex(HoleF[T], IntLit[T, Hole](1)))),
             QC.inj(Reduce[T, T[F]](
               values(0).value,
-              newProvs,
+              buckets,
               List(
-                ReduceFuncs.Arbitrary(newProvs),
+                ReduceFuncs.Arbitrary(buckets),
                 ReduceFunc.translateBinaryReduction[FreeMap](func)(join.lval, join.rval)),
               Free.roll(ConcatArrays(
                 Free.roll(MakeArray(Free.point(ReduceIndex(0)))),
                 Free.roll(MakeArray(Free.point(ReduceIndex(1)))))))).embed)
         case None =>
-          Target(EmptyAnn[T],
+          Target(
+            Ann(join.base.buckets, HoleF),
             QC.inj(Reduce[T, T[F]](
               values(0).value,
               NullLit(),
@@ -408,9 +378,14 @@ class Transform
   private def invokeThetaJoin(values: Func.Input[Target[F], nat._3], tpe: JoinType)
       : PlannerError \/ Target[F] = {
     val condError: PlannerError \/ JoinFunc = {
+      val combiner =
+        QC.inj(reifyResult(values(2).ann, values(2).value)).embed.transCata(rewrite.normalize).project
       // FIXME: This won’t work where we join a collection against itself
-      TJ.prj(QC.inj(reifyResult(values(2).ann, values(2).value)).embed.transCata(rewrite.normalize).project).fold(
-        (InternalError(s"non theta join condition found: ${values(2).value.shows} with provenance: ${values(2).ann.shows}"): PlannerError).left[JoinFunc])(
+      TJ.prj(combiner).fold(
+        QC.prj(combiner) match {
+          case Some(Map(_, mf)) if mf.count ≟ 0 => mf.as[JoinSide](LeftSide).right[PlannerError]
+          case _ => (InternalError(s"non theta join condition found: ${values(2).value.shows} with provenance: ${values(2).ann.shows}"): PlannerError).left[JoinFunc]
+        })(
         _.combine.right[PlannerError])
     }
 
@@ -437,17 +412,17 @@ class Transform
     }
   }
 
-  private def ProjectTarget(prefix: Target[F], field: FreeMap): Target[F] = {
-    val Ann(provenance, values) = prefix.ann
-    Target(Ann(prov.projectField(field) :: provenance, values),
-      PB.inj(BucketField(prefix.value, HoleF[T], field)).embed)
+  private def ProjectTarget(prefix: Target[F], field: T[EJson]): Target[F] = {
+    val Ann(provs, values) = prefix.ann
+    Target(Ann(provenance.Proj(field) :: provs, HoleF),
+      PB.inj(BucketField(prefix.value, values, Free.roll(Constant[T, FreeMap](field)))).embed)
   }
 
   private def pathToProj(path: pathy.Path[_, _, _]): Target[F] =
     pathy.Path.peel(path).fold[Target[F]](
       Target(EmptyAnn[T], DE.inj(Const[DeadEnd, T[F]](Root)).embed)) {
       case (p, n) =>
-        ProjectTarget(pathToProj(p), StrLit(n.fold(_.value, _.value)))
+        ProjectTarget(pathToProj(p), ejson.CommonEJson(ejson.Str[T[EJson]](n.fold(_.value, _.value))).embed)
     }
 
   private def fromData[T[_[_]]: Corecursive](data: Data): Data \/ T[EJson] = {
@@ -547,7 +522,7 @@ class Transform
         Func.Input1(
           Target(
             Ann(
-              prov.swapProvenances(a1.ann.values :: a1.ann.provenance),
+              prov.swapProvenances(provenance.Value(a1.ann.values) :: a1.ann.provenance),
               a1.ann.values),
             a1.value))).right
 
@@ -591,15 +566,12 @@ class Transform
       }
 
       directionsList.map(dirs =>
-        concatBuckets(base.buckets).fold(
-          Target(
-            Ann[T](Nil, dataset),
-            QC.inj(Sort(base.src, NullLit(), keysList.zip(dirs))).embed)) {
-          case (newProvs, provAccess) =>
-            Target(
-              Ann[T](provAccess.list.toList, dataset),
-              QC.inj(Sort(base.src, newProvs, keysList.zip(dirs))).embed)
-        })
+        Target(
+          Ann[T](base.buckets, dataset),
+          QC.inj(Sort(
+            base.src,
+            prov.genBuckets(base.buckets).fold(NullLit[T, Hole]())(_._2),
+            keysList.zip(dirs))).embed))
 
     case LogicalPlan.InvokeFUnapply(set.Filter, Sized(a1, a2)) =>
       val AutoJoinResult(base, lval, rval) = autojoin(a1, a2)
@@ -622,7 +594,7 @@ class Transform
 
     case LogicalPlan.InvokeFUnapply(set.GroupBy, Sized(a1, a2)) =>
       val join: AutoJoinResult = autojoin(a1, a2)
-      Target(Ann(prov.swapProvenances(join.rval :: join.base.buckets), join.lval), join.base.src).right
+      Target(Ann(prov.swapProvenances(provenance.Value(join.rval) :: join.base.buckets), join.lval), join.base.src).right
 
     case LogicalPlan.InvokeFUnapply(set.Union, Sized(a1, a2)) =>
       val MergeResult(src, lfree, rfree) = merge(a1.value, a2.value)
@@ -631,29 +603,31 @@ class Transform
 
       // TODO: Need to align provenances, so each component is at the same
       //       location on both sides
-      (concatBuckets(a1.ann.provenance), concatBuckets(a2.ann.provenance)) match {
+      (prov.genBuckets(a1.ann.provenance), prov.genBuckets(a2.ann.provenance)) match {
         case (None, None) =>
-          Target(Ann[T](Nil, HoleF), QC.inj(Union(src, lbranch, rbranch)).embed).right
-        case (None, Some((rBuck, rProvs))) =>
+          Target(
+            Ann[T](prov.unionProvenances(a1.ann.provenance, a2.ann.provenance), HoleF),
+            QC.inj(Union(src, lbranch, rbranch)).embed).right
+        case (None, Some((rProvs, rBuck))) =>
           val (merged, rbacc, vacc) = concat(rBuck, HoleF[T])
           Target(
-            Ann(rProvs.map(_ >> rbacc).toList, vacc),
+            Ann(prov.unionProvenances(a1.ann.provenance, prov.rebase(rbacc, rProvs)), vacc),
             QC.inj(Union(src,
               Free.roll(FI.inject(QC.inj(Map(lbranch, merged)))),
               Free.roll(FI.inject(QC.inj(Map(rbranch, merged)))))).embed).right
-        case (Some((lBuck, lProvs)), None) =>
+        case (Some((lProvs, lBuck)), None) =>
           val (merged, lbacc, vacc) = concat(lBuck, HoleF[T])
           Target(
-            Ann(lProvs.map(_ >> lbacc).toList, vacc),
+            Ann(prov.unionProvenances(prov.rebase(lbacc, lProvs), a2.ann.provenance), vacc),
             QC.inj(Union(src,
               Free.roll(FI.inject(QC.inj(Map(lbranch, merged)))),
               Free.roll(FI.inject(QC.inj(Map(rbranch, merged)))))).embed).right
-        case (Some((lBuck, lProvs)), Some((rBuck, rProvs))) =>
+        case (Some((lProvs, lBuck)), Some((rProvs, rBuck))) =>
           val (merged, lbacc, lvacc) = concat(lBuck, HoleF[T])
           val (_, rbacc, rvacc) = concat(rBuck, HoleF[T])
           (lbacc ≟ rbacc && lvacc ≟ rvacc).fold(
             Target(
-              Ann(lProvs.map(_ >> lbacc).toList, lvacc),
+              Ann(prov.unionProvenances(prov.rebase(lbacc, lProvs), prov.rebase(rbacc, rProvs)), lvacc),
               QC.inj(Union(src,
                 Free.roll(FI.inject(QC.inj(Map(lbranch, merged)))),
                 Free.roll(FI.inject(QC.inj(Map(rbranch, merged)))))).embed).right,

--- a/connector/src/main/scala/quasar/qscript/package.scala
+++ b/connector/src/main/scala/quasar/qscript/package.scala
@@ -19,6 +19,7 @@ package quasar
 import quasar.Predef._
 import quasar.contrib.matryoshka._
 import quasar.fp._
+import quasar.qscript.{provenance => prov}
 
 import matryoshka._, FunctorT.ops._, Recursive.ops._
 import matryoshka.patterns._
@@ -228,7 +229,7 @@ package object qscript {
 package qscript {
   final case class SrcMerge[A, B](src: A, left: B, right: B)
 
-  @Lenses final case class Ann[T[_[_]]](provenance: List[FreeMap[T]], values: FreeMap[T])
+  @Lenses final case class Ann[T[_[_]]](provenance: List[prov.Provenance[T]], values: FreeMap[T])
 
   object Ann {
     implicit def equal[T[_[_]]: EqualT]: Equal[Ann[T]] =
@@ -241,10 +242,15 @@ package qscript {
   @Lenses final case class Target[T[_[_]], F[_]](ann: Ann[T], value: T[F])
 
   object Target {
-    implicit def equal[T[_[_]]: EqualT, F[_]: EqualF]: Equal[Target[T, F]] =
+    implicit def equal[T[_[_]]: EqualT, F[_]](implicit F: Delay[Equal, F])
+        : Equal[Target[T, F]] =
       Equal.equal((a, b) => a.ann ≟ b.ann && a.value ≟ b.value)
 
-    implicit def show[T[_[_]]: ShowT, F[_]: ShowF]: Show[Target[T, F]] =
-      Show.show(target => Cord("Target(") ++ target.ann.show ++ Cord(", ") ++ target.value.show ++ Cord(")"))
+    implicit def show[T[_[_]]: ShowT, F[_]](implicit F: Delay[Show, F])
+        : Show[Target[T, F]] =
+      Show.show(target =>
+        Cord("Target(") ++
+          target.ann.shows ++ Cord(", ") ++
+          target.value.shows ++ Cord(")"))
   }
 }

--- a/connector/src/test/scala/quasar/qscript/QScript.scala
+++ b/connector/src/test/scala/quasar/qscript/QScript.scala
@@ -55,9 +55,7 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
       convert(listContents.some, lpRead("/foo/bar")) must
       equal(chain(
         ReadR(rootDir </> dir("foo") </> file("bar")),
-        QC.inj(LeftShift((),
-          HoleF,
-          Free.point(RightSide)))).some)
+        QC.inj(LeftShift((), HoleF, RightSideF))).some)
     }
 
     // FIXME: This can be simplified to a Union of the Reads - the LeftShift
@@ -75,10 +73,7 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
               Free.roll(QCT.inj(Union(Free.roll(QCT.inj(Unreferenced[Fix, FreeQS]())),
                 Free.roll(QCT.inj(Map(Free.roll(RT.inj(Const[Read, FreeQS](Read(rootDir </> dir("foo") </> file("person"))))), Free.roll(MakeMap(StrLit("person"), HoleF))))),
                 Free.roll(QCT.inj(Map(Free.roll(RT.inj(Const[Read, FreeQS](Read(rootDir </> dir("foo") </> file("zips"))))), Free.roll(MakeMap(StrLit("zips"), HoleF)))))))))))))))),
-
-        QC.inj(LeftShift((),
-          HoleF,
-          Free.point(RightSide)))).some)
+        QC.inj(LeftShift((), HoleF, RightSideF))).some)
     }
 
     "convert a squashed read" in {
@@ -86,9 +81,7 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
       convert(listContents.some, identity.Squash(lpRead("/foo/bar")).embed) must
       equal(chain(
         ReadR(rootDir </> dir("foo") </> file("bar")),
-        QC.inj(LeftShift((),
-          HoleF,
-          Free.point(RightSide)))).some)
+        QC.inj(LeftShift((), HoleF, RightSideF))).some)
     }
 
     "convert a basic select with type checking" in {
@@ -108,8 +101,6 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
     }
 
     // TODO: This would benefit from better normalization around Sort (#1545)
-    // TODO: The provenance here is complicated (#1550), so the results are not
-    //       completely verifiable by hand.
     "convert a basic order by" in {
       val lp = fullCompileExp("select * from zips order by city")
       val qs = convert(listContents.some, lp)
@@ -119,118 +110,39 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           Free.roll(ZipMapKeys(HoleF)),
           Free.roll(ConcatArrays(
             Free.roll(ConcatArrays(
-              // {{{ provenance
+              // FIXME: Why so many projections – there should only be one
               Free.roll(ConcatArrays(
                 Free.roll(MakeArray(
-                  Free.roll(MakeArray(
-                    Free.roll(MakeMap(
-                      StrLit("n"),
-                      Free.roll(ConcatArrays(
-                        Free.roll(MakeArray(
-                          Free.roll(MakeMap(
-                            StrLit("j"),
-                            Free.roll(ConcatArrays(
-                              Free.roll(MakeArray(
-                                prov.join(
-                                  prov.shiftMap(Free.roll(ProjectIndex(RightSideF, IntLit(0)))),
-                                  prov.shiftMap(Free.roll(ProjectIndex(RightSideF, IntLit(0))))))),
-                              Free.roll(Constant(ejsonNullArr)))))))),
-                        Free.roll(Constant(ejsonArr(
-                          ejsonJoin(
-                            ejsonJoin(
-                              ejsonProjectField(ejsonStr("zips")),
-                              ejsonProjectField(ejsonStr("zips"))),
-                            ejsonNull)))))))))))),
+                  ProjectIndexR(
+                    ProjectIndexR(ProjectIndexR(RightSideF, IntLit(0)), IntLit(0)),
+                    IntLit(0)))),
                 Free.roll(MakeArray(
-                  Free.roll(ConcatArrays(
-                    Free.roll(MakeArray(
-                      Free.roll(MakeMap(
-                        StrLit("j"),
-                        Free.roll(ConcatArrays(
-                          Free.roll(MakeArray(
-                            Free.roll(MakeMap(
-                              StrLit("n"),
-                              Free.roll(ConcatArrays(
-                                Free.roll(MakeArray(
-                                  Free.roll(MakeMap(
-                                    StrLit("j"),
-                                    Free.roll(ConcatArrays(
-                                      Free.roll(MakeArray(
-                                        prov.join(
-                                          prov.shiftMap(Free.roll(ProjectIndex(RightSideF, IntLit(0)))),
-                                          prov.shiftMap(Free.roll(ProjectIndex(RightSideF, IntLit(0))))))),
-                                      Free.roll(Constant(ejsonNullArr)))))))),
-                                Free.roll(Constant(ejsonArr(
-                                  ejsonJoin(
-                                    ejsonJoin(
-                                      ejsonProjectField(ejsonStr("zips")),
-                                      ejsonProjectField(ejsonStr("zips"))),
-                                    ejsonNull)))))))))),
-                          Free.roll(Constant(ejsonNullArr)))))))),
-                    Free.roll(MakeArray(
-                      Free.roll(MakeMap(
-                        StrLit("j"),
-                        Free.roll(ConcatArrays(
-                          Free.roll(MakeArray(
-                            Free.roll(ProjectIndex(
-                              Free.roll(MakeArray(
-                                Free.roll(MakeMap(
-                                  StrLit("n"),
-                                  Free.roll(ConcatArrays(
-                                    Free.roll(MakeArray(
-                                      Free.roll(MakeMap(
-                                        StrLit("j"),
-                                        Free.roll(ConcatArrays(
-                                          Free.roll(MakeArray(
-                                            prov.join(
-                                              prov.shiftMap(Free.roll(ProjectIndex(RightSideF, IntLit(0)))),
-                                              prov.shiftMap(Free.roll(ProjectIndex(RightSideF, IntLit(0))))))),
-                                          Free.roll(Constant(ejsonNullArr)))))))),
-                                    Free.roll(Constant(ejsonArr(
-                                      ejsonJoin(
-                                        ejsonJoin(
-                                          ejsonProjectField(ejsonStr("zips")),
-                                          ejsonProjectField(ejsonStr("zips"))),
-                                      ejsonNull)))))))))),
-                              IntLit(1))))),
-                          Free.roll(Constant(ejsonNullArr)))))))))))))),
-              // }}}
+                  ProjectIndexR(
+                    ProjectIndexR(
+                      ProjectIndexR(ProjectIndexR(RightSideF, IntLit(0)), IntLit(0)),
+                      IntLit(0)),
+                    IntLit(0)))))),
               Free.roll(MakeArray(
                 Free.roll(Guard(
-                  Free.roll(ProjectIndex(RightSideF, IntLit(1))),
+                  ProjectIndexR(RightSideF, IntLit(1)),
                   Type.Obj(scala.Predef.Map(), Type.Top.some),
-                  Free.roll(ProjectIndex(RightSideF, IntLit(1))),
+                  ProjectIndexR(RightSideF, IntLit(1)),
                   Free.roll(Undefined()))))))),
             Free.roll(MakeArray(
               Free.roll(MakeArray(
                 ProjectFieldR(
                   Free.roll(Guard(
-                    Free.roll(ProjectIndex(RightSideF, IntLit(1))),
+                    ProjectIndexR(RightSideF, IntLit(1)),
                     Type.Obj(scala.Predef.Map(), Type.Top.some),
-                    Free.roll(ProjectIndex(RightSideF, IntLit(1))),
+                    ProjectIndexR(RightSideF, IntLit(1)),
                     Free.roll(Undefined()))),
                   StrLit("city")))))))))),
         QC.inj(Sort((),
           Free.roll(ConcatArrays(
-            Free.roll(MakeArray(
-              prov.join(
-                Free.roll(ProjectIndex(
-                  Free.roll(ProjectIndex(HoleF, IntLit(0))),
-                  IntLit(0))),
-                Free.roll(ProjectIndex(
-                  Free.roll(ProjectIndex(HoleF, IntLit(1))),
-                  IntLit(0)))))),
-            Free.roll(MakeArray(
-              prov.join(
-                Free.roll(ProjectIndex(
-                  Free.roll(ProjectIndex(HoleF, IntLit(0))),
-                  IntLit(1))),
-                Free.roll(ProjectIndex(
-                  Free.roll(ProjectIndex(HoleF, IntLit(1))),
-                  IntLit(1)))))))),
-          List((Free.roll(ProjectIndex(HoleF, IntLit(3))), SortDir.Ascending)))),
-        QC.inj(Map((),
-          Free.roll(ProjectIndex(HoleF, IntLit(2)))))).some)
+            Free.roll(MakeArray(ProjectIndexR(ProjectIndexR(HoleF, IntLit(0)), IntLit(0)))),
+            Free.roll(MakeArray(ProjectIndexR(ProjectIndexR(HoleF, IntLit(1)), IntLit(0)))))),
+          List((ProjectIndexR(HoleF, IntLit(3)), SortDir.Ascending)))),
+        QC.inj(Map((), ProjectIndexR(HoleF, IntLit(2))))).some)
     }
 
     "convert a basic reduction" in {
@@ -307,7 +219,7 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
         ReadR(rootDir </> dir("some") </> file("bar")),
         QC.inj(LeftShift((),
           ProjectFieldR(HoleF, StrLit("car")),
-          Free.point(RightSide)))).some)
+          RightSideF))).some)
     }
 
     "convert a basic invoke" in {
@@ -321,25 +233,21 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
             QCT.inj(LeftShift((),
               Free.roll(ZipMapKeys(HoleF)),
               Free.roll(ConcatArrays(
-                Free.roll(MakeArray(Free.point(LeftSide))),
-                Free.roll(MakeArray(Free.point(RightSide)))))))),
+                Free.roll(MakeArray(LeftSideF)),
+                Free.roll(MakeArray(RightSideF))))))),
           chain[Free[?[_], Hole], QScriptTotal](
             QCT.inj(Map(Free.point(SrcHole),
               ProjectFieldR(HoleF, StrLit("bar")))),
             QCT.inj(LeftShift((),
               Free.roll(ZipMapKeys(HoleF)),
               Free.roll(ConcatArrays(
-                Free.roll(MakeArray(Free.point(LeftSide))),
-                Free.roll(MakeArray(Free.point(RightSide)))))))),
+                Free.roll(MakeArray(LeftSideF)),
+                Free.roll(MakeArray(RightSideF))))))),
           BoolLit(true),
           Inner,
           Free.roll(Add(
-            Free.roll(ProjectIndex(
-              Free.roll(ProjectIndex(Free.point(LeftSide), IntLit(1))),
-              IntLit(1))),
-            Free.roll(ProjectIndex(
-              Free.roll(ProjectIndex(Free.point(RightSide), IntLit(1))),
-              IntLit(1)))))))).some)
+            ProjectIndexR(ProjectIndexR(LeftSideF, IntLit(1)), IntLit(1)),
+            ProjectIndexR(ProjectIndexR(RightSideF, IntLit(1)), IntLit(1))))))).some)
     }
 
     "convert project object and make object" in {
@@ -356,9 +264,7 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           ProjectFieldR(HoleF, StrLit("city")),
           Free.roll(MakeMap[Fix, JoinFunc](
             StrLit[Fix, JoinSide]("name"),
-            ProjectFieldR(
-              Free.point[MapFunc, JoinSide](RightSide),
-              StrLit[Fix, JoinSide]("name"))))))).some)
+            ProjectFieldR(RightSideF, StrLit("name"))))))).some)
     }
 
     "convert a basic reduction" in {
@@ -421,10 +327,9 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
             structural.MakeArrayN[Fix](LP.Constant(Data.Int(7))).embed).embed).embed) must
       equal(chain(
         UnreferencedR,
-        QC.inj(LeftShift(
-          (),
+        QC.inj(LeftShift((),
           Free.roll(Constant(ejsonArr(ejsonInt(7)))),
-          Free.point(RightSide)))).some)
+          RightSideF))).some)
     }
 
     "convert a constant shift array of size two" in {
@@ -442,7 +347,7 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
         QC.inj(LeftShift(
           (),
           Free.roll(Constant(ejsonArr(ejsonInt(7), ejsonInt(8)))),
-          Free.point(RightSide)))).some)
+          RightSideF))).some)
     }
 
     "convert a constant shift array of size three" in {
@@ -459,10 +364,9 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
               structural.MakeArrayN[Fix](LP.Constant(Data.Int(9))).embed).embed).embed).embed) must
       equal(chain(
         QC.inj(Unreferenced[Fix, Fix[QS]]()),
-        QC.inj(LeftShift(
-          (),
+        QC.inj(LeftShift((),
           Free.roll(Constant(ejsonArr(ejsonInt(7), ejsonInt(8), ejsonInt(9)))),
-          Free.point(RightSide)))).some)
+          RightSideF))).some)
     }
 
     "convert a read shift array" in {
@@ -491,7 +395,7 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
     "convert a shift/unshift array" in {
       // "select [loc[_:] * 10 ...] from zips",
       convert(
-        None,
+        listContents.some,
         makeObj(
           "0" ->
             structural.UnshiftArray(
@@ -500,24 +404,42 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
                   structural.ObjectProject(lpRead("/zips"), LP.Constant(Data.Str("loc"))).embed).embed,
                 LP.Constant(Data.Int(10))).embed))) must
       equal(chain(
-        RootR,
+        ReadR(rootDir </> file("zips")),
         QC.inj(LeftShift((),
-          ProjectFieldR(HoleF, StrLit("zips")),
-          Free.point[MapFunc, JoinSide](RightSide))),
+          Free.roll(ZipMapKeys(HoleF)),
+          Free.roll(ConcatArrays(
+            Free.roll(ConcatArrays(
+              Free.roll(MakeArray(ProjectIndexR(RightSideF, IntLit(0)))),
+              Free.roll(MakeArray(ProjectIndexR(RightSideF, IntLit(1)))))),
+            Free.roll(Constant(ejsonArr(ejsonStr("loc")))))))),
         QC.inj(LeftShift((),
           Free.roll(DupArrayIndices(
-            ProjectFieldR(HoleF, StrLit("loc")))),
-          Free.roll(Multiply(Free.point(RightSide), IntLit(10))))),
+            ProjectFieldR(
+              ProjectIndexR(HoleF, IntLit(1)),
+              ProjectIndexR(HoleF, IntLit(2))))),
+          Free.roll(ConcatArrays(
+            Free.roll(ConcatArrays(
+              Free.roll(MakeArray(
+                Free.roll(ConcatArrays(
+                  Free.roll(MakeArray(RightSideF)),
+                  Free.roll(MakeArray(
+                    ProjectIndexR(
+                      ProjectIndexR(LeftSideF, IntLit(0)),
+                      IntLit(0)))))))),
+              Free.roll(MakeArray(RightSideF)))),
+            Free.roll(Constant(ejsonArr(ejsonInt(10)))))))),
         QC.inj(Reduce((),
-          HoleF, // FIXME provenance needs to be here
-          List(ReduceFuncs.UnshiftArray(HoleF[Fix])),
+          ProjectIndexR(ProjectIndexR(HoleF, IntLit(0)), IntLit(1)),
+          List(
+            ReduceFuncs.UnshiftArray(
+              Free.roll(Multiply(
+                ProjectIndexR(HoleF, IntLit(1)),
+                ProjectIndexR(HoleF, IntLit(2)))))),
           Free.roll(MakeMap[Fix, FreeMapA[ReduceIndex]](
             StrLit[Fix, ReduceIndex]("0"),
-            Free.point(ReduceIndex(0))))))).some)
-    }.pendingUntilFixed("verify includes proper provenance")
+            ReduceIndexF(0)))))).some)
+    }
 
-    // TODO: The provenance here is complicated (#1550), so the results are not
-    //       completely verifiable by hand.
     "convert a filter" in {
       // "select * from foo where bar between 1 and 10"
       convert(
@@ -534,67 +456,54 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           Free.roll(ZipMapKeys(HoleF)),
           Free.roll(ConcatArrays(
             Free.roll(ConcatArrays(
-              // {{{ provenance
               Free.roll(ConcatArrays(
-                Free.roll(MakeArray(
-                  Free.roll(ConcatArrays(
-                    Free.roll(MakeArray(
-                      prov.shiftMap(Free.roll(ProjectIndex(RightSideF, IntLit(0)))))),
-                    Free.roll(Constant(ejsonArr(
-                      ejsonProjectField(ejsonStr("bar"))))))))),
-                Free.roll(MakeArray(
-                  Free.roll(ConcatArrays(
-                    Free.roll(MakeArray(
-                      Free.roll(MakeMap(
-                        StrLit("j"),
-                        Free.roll(ConcatArrays(
-                          Free.roll(MakeArray(
-                            Free.roll(MakeMap(
-                              StrLit("j"),
-                              Free.roll(ConcatArrays(
-                                Free.roll(MakeArray(
-                                  Free.roll(MakeMap(
-                                    StrLit("j"),
-                                    Free.roll(ConcatArrays(
-                                      Free.roll(MakeArray(
-                                        prov.shiftMap(Free.roll(ProjectIndex(RightSideF, IntLit(0)))))),
-                                      Free.roll(Constant(ejsonNullArr)))))))),
-                                Free.roll(Constant(ejsonNullArr)))))))),
-                          Free.roll(Constant(ejsonNullArr)))))))),
-                    Free.roll(Constant(ejsonArr(
-                      ejsonJoin(
-                        ejsonJoin(
-                          ejsonJoin(
-                            ejsonProjectField(ejsonStr("bar")),
-                            ejsonNull),
-                          ejsonNull),
-                        ejsonNull)))))))))),
-              // }}}
-              Free.roll(MakeArray(Free.roll(ProjectIndex(RightSideF, IntLit(1))))))),
+                Free.roll(MakeArray(ProjectIndexR(RightSideF, IntLit(0)))),
+                // FIXME: This line is wrong.
+                Free.roll(MakeArray(ProjectIndexR(ProjectIndexR(ProjectIndexR(ProjectIndexR(RightSideF, IntLit(0)), IntLit(0)), IntLit(0)), IntLit(0)))))),
+              Free.roll(MakeArray(ProjectIndexR(RightSideF, IntLit(1)))))),
             Free.roll(MakeArray(
               Free.roll(Between(
                 ProjectFieldR(
-                  Free.roll(ProjectIndex(RightSideF, IntLit(1))),
+                  ProjectIndexR(RightSideF, IntLit(1)),
                   StrLit("baz")),
                 IntLit(1),
                 IntLit(10))))))))),
-        QC.inj(Filter((), Free.roll(ProjectIndex(HoleF, IntLit(3))))),
-        QC.inj(Map((), Free.roll(ProjectIndex(HoleF, IntLit(2)))))).some)
+        QC.inj(Filter((), ProjectIndexR(HoleF, IntLit(3)))),
+        QC.inj(Map((), ProjectIndexR(HoleF, IntLit(2))))).some)
     }
 
     // an example of how logical plan expects magical "left" and "right" fields to exist
     "convert magical query" in {
       // "select * from person, car",
       convert(
-        None,
+        listContents.some,
         LP.Let('__tmp0,
           StdLib.set.InnerJoin(lpRead("/person"), lpRead("/car"), LP.Constant(Data.Bool(true))).embed,
           identity.Squash(
             structural.ObjectConcat(
               structural.ObjectProject(LP.Free('__tmp0), LP.Constant(Data.Str("left"))).embed,
               structural.ObjectProject(LP.Free('__tmp0), LP.Constant(Data.Str("right"))).embed).embed).embed)) must
-      equal(chain(RootR).some) // TODO incorrect expectation
-    }.pendingUntilFixed
+      equal(chain(
+        QC.inj(Unreferenced[Fix, Fix[QS]]()),
+        TJ.inj(ThetaJoin((),
+          Free.roll(QCT.inj(LeftShift(
+            Free.roll(RT.inj(Const(Read(rootDir </> file("person"))))),
+            Free.roll(ZipMapKeys(HoleF)),
+            Free.roll(ConcatArrays(
+              Free.roll(MakeArray(LeftSideF)),
+              Free.roll(MakeArray(RightSideF))))))),
+          Free.roll(QCT.inj(LeftShift(
+            Free.roll(RT.inj(Const(Read(rootDir </> file("car"))))),
+            Free.roll(ZipMapKeys(HoleF)),
+            Free.roll(ConcatArrays(
+              Free.roll(MakeArray(LeftSideF)),
+              Free.roll(MakeArray(RightSideF))))))),
+          BoolLit(true),
+          Inner,
+          Free.roll(ConcatMaps(
+            ProjectIndexR(ProjectIndexR(LeftSideF, IntLit(1)), IntLit(1)),
+            ProjectIndexR(ProjectIndexR(RightSideF, IntLit(1)), IntLit(1))))))).some)
+    }
 
     "convert basic join with explicit join condition" in {
       //"select foo.name, bar.address from foo join bar on foo.id = bar.foo_id",
@@ -632,43 +541,19 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           Free.roll(RT.inj(Const(Read(rootDir </> file("city"))))),
           HoleF,
           Free.roll(ConcatArrays(
-            // {{{ provenance
             Free.roll(MakeArray(
-              Free.roll(MakeArray(
-                Free.roll(MakeMap(
-                  StrLit("n"),
-                  Free.roll(ConcatArrays(
-                    Free.roll(MakeArray(
-                      prov.shiftMap(
-                        Free.roll(ProjectIndex(
-                          Free.roll(ProjectIndex(RightSideF, IntLit(1))),
-                          IntLit(0)))))),
-                    Free.roll(Constant(ejsonArr(ejsonProjectField(ejsonStr("city"))))))))))))),
-            // }}}
+              ProjectIndexR(ProjectIndexR(RightSideF, IntLit(1)), IntLit(0)))),
             Free.roll(MakeArray(RightSideF))))))),
         Free.roll(QCT.inj(LeftShift(
           Free.roll(RT.inj(Const(Read(rootDir </> file("person"))))),
           HoleF,
           Free.roll(ConcatArrays(
-            // {{{ provenance
             Free.roll(MakeArray(
-              Free.roll(MakeArray(
-                Free.roll(MakeMap(
-                  StrLit("n"),
-                  Free.roll(ConcatArrays(
-                    Free.roll(MakeArray(
-                      prov.shiftMap(
-                        Free.roll(ProjectIndex(
-                          Free.roll(ProjectIndex(RightSideF, IntLit(1))),
-                          IntLit(0)))))),
-                    Free.roll(Constant(ejsonArr(ejsonProjectField(ejsonStr("city"))))))))))))),
-            // }}}
+              ProjectIndexR(ProjectIndexR(RightSideF, IntLit(1)), IntLit(0)))),
             Free.roll(MakeArray(RightSideF))))))))),
       QC.inj(Reduce((),
-        Free.roll(ConcatArrays(
-          Free.roll(MakeArray(Free.roll(ProjectIndex(HoleF, IntLit(1))))),
-          Free.roll(MakeArray(Free.roll(ProjectIndex(Free.roll(ProjectIndex(HoleF, IntLit(0))), IntLit(1))))))),
-        List(ReduceFuncs.Arbitrary[FreeMap](Free.roll(ProjectIndex(HoleF, IntLit(1))))),
+        ProjectIndexR(HoleF, IntLit(1)),
+        List(ReduceFuncs.Arbitrary[FreeMap](ProjectIndexR(HoleF, IntLit(1)))),
         ReduceIndexF(0)))).some)
   }
 }

--- a/connector/src/test/scala/quasar/qscript/QScriptHelpers.scala
+++ b/connector/src/test/scala/quasar/qscript/QScriptHelpers.scala
@@ -66,10 +66,14 @@ trait QScriptHelpers extends TTypes[Fix] {
       FreeMapA[A] =
     Free.roll(ProjectField(src, field))
 
+  def ProjectIndexR[A](src: FreeMapA[A], field: FreeMapA[A]):
+      FreeMapA[A] =
+    Free.roll(ProjectIndex(src, field))
+
   def lpRead(path: String): Fix[LP] =
     LP.Read(sandboxAbs(posixCodec.parseAbsFile(path).get))
 
-  val prov = new Provenance[Fix]
+  val prov = new provenance.ProvenanceT[Fix]
 
   /** A helper when writing examples that allows them to be written in order of
     * execution.

--- a/frontend/src/main/scala/quasar/logicalplan.scala
+++ b/frontend/src/main/scala/quasar/logicalplan.scala
@@ -115,6 +115,7 @@ object LogicalPlan {
           }
         }
     }
+
   implicit val EqualFLogicalPlan: EqualF[LogicalPlan] =
     new EqualF[LogicalPlan] {
       def equal[A: Equal](v1: LogicalPlan[A], v2: LogicalPlan[A]): Boolean =
@@ -350,7 +351,7 @@ object LogicalPlan {
       emitName(freshName("check").map(name =>
         ConstrainedPlan(inf, List(NamedConstraint(name, inf, term)), Free(name))))
     }
-    else lift((SemanticError.genericError(s"couldn’t unify inferred (${inf}) and possible (${poss}) types in $term")).wrapNel.left)
+    else lift((SemanticError.genericError(s"You provided a ${poss.shows} where we expected a ${inf.shows} in $term")).wrapNel.left)
   }
 
   private def appConst(constraints: ConstrainedPlan, fallback: Fix[LogicalPlan]) =

--- a/frontend/src/main/scala/quasar/types.scala
+++ b/frontend/src/main/scala/quasar/types.scala
@@ -207,7 +207,30 @@ trait TypeInstances {
     def append(f1: Type, f2: => Type) = Type.lub(f1, f2)
   }
 
-  implicit val show: Show[Type] = Show.showFromToString
+  implicit val show: Show[Type] = Show.show {
+    case Top => "Top"
+    case Bottom => "Bottom"
+    case Const(d) => s"constant value ${d.shows}"
+    case Null => "Null"
+    case Str => "Str"
+    case Int => "Int"
+    case Dec => "Dec"
+    case Bool => "Bool"
+    case Binary => "Binary"
+    case Timestamp => "Timestamp"
+    case Date => "Date"
+    case Time => "Time"
+    case Interval => "Interval"
+    case Id => "Id"
+    case Arr(types) => "Arr(" + types.shows + ")"
+    case FlexArr(min, max, mbrs) =>
+      "FlexArr(" + min.shows + ", " + max.shows + ", "  + mbrs.shows + ")"
+    case Obj(assocs, unkns) =>
+      "Obj(" + assocs.shows + ", " + unkns.shows + ")"
+    case cp @ Coproduct(_, _) =>
+      val cos = cp.flatten.map(_.shows)
+      cos.init.mkString(", ") + ", or " + cos.last
+  }
 
   implicit val TypeRenderTree: RenderTree[Type] =
     RenderTree.fromShow[Type]("Type")

--- a/frontend/src/main/scala/quasar/types.scala
+++ b/frontend/src/main/scala/quasar/types.scala
@@ -207,21 +207,9 @@ trait TypeInstances {
     def append(f1: Type, f2: => Type) = Type.lub(f1, f2)
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   implicit val show: Show[Type] = Show.show {
-    case Top => "Top"
-    case Bottom => "Bottom"
     case Const(d) => s"constant value ${d.shows}"
-    case Null => "Null"
-    case Str => "Str"
-    case Int => "Int"
-    case Dec => "Dec"
-    case Bool => "Bool"
-    case Binary => "Binary"
-    case Timestamp => "Timestamp"
-    case Date => "Date"
-    case Time => "Time"
-    case Interval => "Interval"
-    case Id => "Id"
     case Arr(types) => "Arr(" + types.shows + ")"
     case FlexArr(min, max, mbrs) =>
       "FlexArr(" + min.shows + ", " + max.shows + ", "  + mbrs.shows + ")"
@@ -230,6 +218,7 @@ trait TypeInstances {
     case cp @ Coproduct(_, _) =>
       val cos = cp.flatten.map(_.shows)
       cos.init.mkString(", ") + ", or " + cos.last
+    case x => x.toString
   }
 
   implicit val TypeRenderTree: RenderTree[Type] =


### PR DESCRIPTION
Previously we reified _all_ of provenance into QScript, however much of
it is static and is only required during compilation. So we now only
reify the dynamic portion required for bucketing, autojoin, etc. Which
simplifies queries greatly.

This also fixes #1558 and #1559 (tests that were pending). And also
improves both typechecker error messages and QScript phase results.