### PR TITLE
Attribute new constructs with their EJSON type

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- [1575] Attribute new XML elements with their EJSON type

--- a/it/src/main/resources/tests/concatArrayWithLiteral.test
+++ b/it/src/main/resources/tests/concatArrayWithLiteral.test
@@ -3,20 +3,19 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "skip",
         "couchbase":         "skip"
     },
     "data": "largeZips.data",
-    "query": "select loc || [1, 2], city from largeZips",
+    "query": "select loc || [1, 2] as arr, city from largeZips",
     "predicate": "containsAtLeast",
-    "expected": [{ "0": [ -72.51565, 42.377017, 1.0, 2.0], "city": "CUSHMAN"          },
-                 { "0": [-72.576142, 42.176443, 1.0, 2.0], "city": "CHICOPEE"         },
-                 { "0": [-72.626193, 42.202007, 1.0, 2.0], "city": "HOLYOKE"          },
-                 { "0": [-72.654245, 42.324662, 1.0, 2.0], "city": "FLORENCE"         },
-                 { "0": [-72.754318, 42.129484, 1.0, 2.0], "city": "MONTGOMERY"       },
-                 { "0": [-72.641109, 42.115066, 1.0, 2.0], "city": "WEST SPRINGFIELD" },
-                 { "0": [-72.558432, 42.085314, 1.0, 2.0], "city": "SPRINGFIELD"      },
-                 { "0": [-72.554349, 42.114455, 1.0, 2.0], "city": "SPRINGFIELD"      },
-                 { "0": [-73.247088, 42.453086, 1.0, 2.0], "city": "PITTSFIELD"       },
-                 { "0": [-71.803133, 42.579563, 1.0, 2.0], "city": "FITCHBURG"        }]
+    "expected": [{ "arr": [ -72.51565, 42.377017, 1.0, 2.0], "city": "CUSHMAN"          },
+                 { "arr": [-72.576142, 42.176443, 1.0, 2.0], "city": "CHICOPEE"         },
+                 { "arr": [-72.626193, 42.202007, 1.0, 2.0], "city": "HOLYOKE"          },
+                 { "arr": [-72.654245, 42.324662, 1.0, 2.0], "city": "FLORENCE"         },
+                 { "arr": [-72.754318, 42.129484, 1.0, 2.0], "city": "MONTGOMERY"       },
+                 { "arr": [-72.641109, 42.115066, 1.0, 2.0], "city": "WEST SPRINGFIELD" },
+                 { "arr": [-72.558432, 42.085314, 1.0, 2.0], "city": "SPRINGFIELD"      },
+                 { "arr": [-72.554349, 42.114455, 1.0, 2.0], "city": "SPRINGFIELD"      },
+                 { "arr": [-73.247088, 42.453086, 1.0, 2.0], "city": "PITTSFIELD"       },
+                 { "arr": [-71.803133, 42.579563, 1.0, 2.0], "city": "FITCHBURG"        }]
 }

--- a/it/src/main/resources/tests/concatBetween.test
+++ b/it/src/main/resources/tests/concatBetween.test
@@ -2,20 +2,19 @@
     "name": "concat BETWEEN with other fields",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "skip",
         "couchbase":  "skip"
     },
     "data": "zips.data",
-    "query": "select city, pop, pop between 1000 and 10000 from zips",
+    "query": "select city, pop, pop between 1000 and 10000 as midsized from zips",
     "predicate": "containsAtLeast",
-    "expected": [{ "city": "AGAWAM",       "pop": 15338, "2": false },
-                 { "city": "CUSHMAN",      "pop": 36963, "2": false },
-                 { "city": "BARRE",        "pop": 4546,  "2": true  },
-                 { "city": "BELCHERTOWN",  "pop": 10579, "2": false },
-                 { "city": "BLANDFORD",    "pop": 1240,  "2": true  },
-                 { "city": "BRIMFIELD",    "pop": 3706,  "2": true  },
-                 { "city": "CHESTER",      "pop": 1688,  "2": true  },
-                 { "city": "CHESTERFIELD", "pop": 177,   "2": false },
-                 { "city": "CHICOPEE",     "pop": 23396, "2": false },
-                 { "city": "CHICOPEE",     "pop": 31495, "2": false }]
+    "expected": [{ "city": "AGAWAM",       "pop": 15338, "midsized": false },
+                 { "city": "CUSHMAN",      "pop": 36963, "midsized": false },
+                 { "city": "BARRE",        "pop": 4546,  "midsized": true  },
+                 { "city": "BELCHERTOWN",  "pop": 10579, "midsized": false },
+                 { "city": "BLANDFORD",    "pop": 1240,  "midsized": true  },
+                 { "city": "BRIMFIELD",    "pop": 3706,  "midsized": true  },
+                 { "city": "CHESTER",      "pop": 1688,  "midsized": true  },
+                 { "city": "CHESTERFIELD", "pop": 177,   "midsized": false },
+                 { "city": "CHICOPEE",     "pop": 23396, "midsized": false },
+                 { "city": "CHICOPEE",     "pop": 31495, "midsized": false }]
 }

--- a/it/src/main/resources/tests/concatFieldAndConstant.test
+++ b/it/src/main/resources/tests/concatFieldAndConstant.test
@@ -3,20 +3,19 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "skip",
         "couchbase":         "skip"
     },
     "data": "largeZips.data",
-    "query": "select array_concat(make_array(pop), array_concat(make_array(1), make_array(2))) from largeZips",
+    "query": "select array_concat(make_array(pop), array_concat(make_array(1), make_array(2))) as arr from largeZips",
     "predicate": "containsAtLeast",
-    "expected": [{ "0": [36963, 1.0, 2.0] },
-                 { "0": [31495, 1.0, 2.0] },
-                 { "0": [43704, 1.0, 2.0] },
-                 { "0": [27939, 1.0, 2.0] },
-                 { "0": [40117, 1.0, 2.0] },
-                 { "0": [27537, 1.0, 2.0] },
-                 { "0": [25519, 1.0, 2.0] },
-                 { "0": [32635, 1.0, 2.0] },
-                 { "0": [50655, 1.0, 2.0] },
-                 { "0": [41194, 1.0, 2.0] }]
+    "expected": [{ "arr": [36963, 1.0, 2.0] },
+                 { "arr": [31495, 1.0, 2.0] },
+                 { "arr": [43704, 1.0, 2.0] },
+                 { "arr": [27939, 1.0, 2.0] },
+                 { "arr": [40117, 1.0, 2.0] },
+                 { "arr": [27537, 1.0, 2.0] },
+                 { "arr": [25519, 1.0, 2.0] },
+                 { "arr": [32635, 1.0, 2.0] },
+                 { "arr": [50655, 1.0, 2.0] },
+                 { "arr": [41194, 1.0, 2.0] }]
 }

--- a/it/src/main/resources/tests/convertFromString.test
+++ b/it/src/main/resources/tests/convertFromString.test
@@ -3,21 +3,20 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "skip",
         "couchbase":         "skip"
     },
     "data": "zips.data",
-    "query": "select integer(_id), decimal(_id) from zips",
+    "query": "select integer(_id) as intId, decimal(_id) as decId from zips",
     "predicate": "containsAtLeast",
     "expected": [
-        { "0": 1001, "1": 1001.0 },
-        { "0": 1002, "1": 1002.0 },
-        { "0": 1005, "1": 1005.0 },
-        { "0": 1007, "1": 1007.0 },
-        { "0": 1008, "1": 1008.0 },
-        { "0": 1010, "1": 1010.0 },
-        { "0": 1011, "1": 1011.0 },
-        { "0": 1012, "1": 1012.0 },
-        { "0": 1013, "1": 1013.0 },
-        { "0": 1020, "1": 1020.0 }]
+        { "intId": 1001, "decId": 1001.0 },
+        { "intId": 1002, "decId": 1002.0 },
+        { "intId": 1005, "decId": 1005.0 },
+        { "intId": 1007, "decId": 1007.0 },
+        { "intId": 1008, "decId": 1008.0 },
+        { "intId": 1010, "decId": 1010.0 },
+        { "intId": 1011, "decId": 1011.0 },
+        { "intId": 1012, "decId": 1012.0 },
+        { "intId": 1013, "decId": 1013.0 },
+        { "intId": 1020, "decId": 1020.0 }]
 }

--- a/it/src/main/resources/tests/countDistinct.test
+++ b/it/src/main/resources/tests/countDistinct.test
@@ -3,17 +3,16 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "skip",
     "couchbase":  "skip"
   },
 
   "data": "olympics.data",
 
-  "query": "select count(distinct sport) from olympics",
+  "query": "select count(distinct sport) as cnt from olympics",
 
   "predicate": "equalsExactly",
 
   "expected": [
-    { "0": 7 }
+    { "cnt": 7 }
   ]
 }

--- a/it/src/main/resources/tests/singleFieldDistinct.test
+++ b/it/src/main/resources/tests/singleFieldDistinct.test
@@ -2,7 +2,6 @@
   "name": "distinct of one field",
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "skip",
     "couchbase":  "skip"
   },
   "data": "olympics.data",

--- a/it/src/main/resources/tests/temporal/dateFilter.test
+++ b/it/src/main/resources/tests/temporal/dateFilter.test
@@ -3,7 +3,6 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "skip",
     "couchbase":  "skip"
   },
 

--- a/it/src/main/resources/tests/temporal/datePartsConvertedSimple.test
+++ b/it/src/main/resources/tests/temporal/datePartsConvertedSimple.test
@@ -4,7 +4,6 @@
   "backends": {
     "mongodb_read_only": "pending",
     "postgresql":        "pending",
-    "marklogic":         "skip",
     "couchbase":         "skip"
   },
 

--- a/it/src/main/resources/tests/temporal/days.test
+++ b/it/src/main/resources/tests/temporal/days.test
@@ -3,7 +3,6 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "skip",
     "couchbase":  "skip"
   },
 

--- a/it/src/main/resources/tests/temporal/invalidDateFilter.test
+++ b/it/src/main/resources/tests/temporal/invalidDateFilter.test
@@ -3,7 +3,6 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "skip",
     "couchbase":  "skip"
   },
 

--- a/it/src/main/resources/tests/trivial.test
+++ b/it/src/main/resources/tests/trivial.test
@@ -2,8 +2,7 @@
   "name": "simple read",
 
   "backends": {
-    "postgresql": "pending",
-    "marklogic":  "skip"
+    "postgresql": "pending"
   },
 
   "data": "smallZips.data",

--- a/it/src/main/resources/tests/wildcardWithMultipleConstants.test
+++ b/it/src/main/resources/tests/wildcardWithMultipleConstants.test
@@ -2,22 +2,26 @@
     "name": "splice a wildcard with multiple constants",
 
     "backends": {
-      "postgresql": "pending",
-      "marklogic":  "skip",
-      "couchbase":  "skip"
+      "mongodb_2_6":       "pending",
+      "mongodb_3_0":       "pending",
+      "mongodb_read_only": "pending",
+      "mongodb_3_2":       "pending",
+      "postgresql":        "pending",
+      "couchbase":         "skip"
     },
 
     "data": "largeZips.data",
 
-    "query": "select *, '1', '2' from largeZips",
+    "query": "select *, '1' as one, '2' as two from largeZips",
 
     "predicate": "containsAtLeast",
+    "ignoreFieldOrder": true,
     "expected": [
-        { "value": { "_id": "01002", "1": "1", "2": "2", "city": "CUSHMAN",          "loc": [ -72.51565, 42.377017], "pop": 36963, "state": "MA" } },
-        { "value": { "_id": "01020", "1": "1", "2": "2", "city": "CHICOPEE",         "loc": [-72.576142, 42.176443], "pop": 31495, "state": "MA" } },
-        { "value": { "_id": "01040", "1": "1", "2": "2", "city": "HOLYOKE",          "loc": [-72.626193, 42.202007], "pop": 43704, "state": "MA" } },
-        { "value": { "_id": "01060", "1": "1", "2": "2", "city": "FLORENCE",         "loc": [-72.654245, 42.324662], "pop": 27939, "state": "MA" } },
-        { "value": { "_id": "01085", "1": "1", "2": "2", "city": "MONTGOMERY",       "loc": [-72.754318, 42.129484], "pop": 40117, "state": "MA" } },
-        { "value": { "_id": "01089", "1": "1", "2": "2", "city": "WEST SPRINGFIELD", "loc": [-72.641109, 42.115066], "pop": 27537, "state": "MA" } },
-        { "value": { "_id": "01108", "1": "1", "2": "2", "city": "SPRINGFIELD",      "loc": [-72.558432, 42.085314], "pop": 25519, "state": "MA" } }]
+        { "_id": "01002", "one": "1", "two": "2", "city": "CUSHMAN",          "loc": [ -72.51565, 42.377017], "pop": 36963, "state": "MA" },
+        { "_id": "01020", "one": "1", "two": "2", "city": "CHICOPEE",         "loc": [-72.576142, 42.176443], "pop": 31495, "state": "MA" },
+        { "_id": "01040", "one": "1", "two": "2", "city": "HOLYOKE",          "loc": [-72.626193, 42.202007], "pop": 43704, "state": "MA" },
+        { "_id": "01060", "one": "1", "two": "2", "city": "FLORENCE",         "loc": [-72.654245, 42.324662], "pop": 27939, "state": "MA" },
+        { "_id": "01085", "one": "1", "two": "2", "city": "MONTGOMERY",       "loc": [-72.754318, 42.129484], "pop": 40117, "state": "MA" },
+        { "_id": "01089", "one": "1", "two": "2", "city": "WEST SPRINGFIELD", "loc": [-72.641109, 42.115066], "pop": 27537, "state": "MA" },
+        { "_id": "01108", "one": "1", "two": "2", "city": "SPRINGFIELD",      "loc": [-72.558432, 42.085314], "pop": 25519, "state": "MA" }]
 }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/fs/xdmitem.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/fs/xdmitem.scala
@@ -114,7 +114,7 @@ object xdmitem {
     val el = SecureXML.loadString(xmlString).fold(_.toString.wrapNel.raiseError[F, Elem], _.point[F])
 
     el flatMap { e =>
-      if (xml.qualifiedName(e) === xml.namespaces.ejsonEjson.shows)
+      if (Option(e.prefix) exists (_ === xml.namespaces.ejsonNs.prefix.shows))
         data.decodeXml[F](e)
       else
         xml.toData(e).point[F]

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/expr.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/expr.scala
@@ -104,7 +104,7 @@ object expr {
 
       val orderClause = {
         val specs = orderSpecs map {
-          case (xqy, mod) => s"$xqy $mod"
+          case (xqy, sortDir) => s"$xqy ${sortDir.asOrderModifier}"
         } intercalate ", "
 
         val orderKeyword = orderIsStable.fold("stable order", "order")

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/package.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/package.scala
@@ -39,7 +39,7 @@ package object xquery {
   type PrologW[F[_]] = MonadTell[F, Prologs]
 
   sealed abstract class SortDirection {
-    override def toString = this match {
+    def asOrderModifier: String = this match {
       case SortDirection.Ascending  => "ascending"
       case SortDirection.Descending => "descending"
     }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/package.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/package.scala
@@ -38,7 +38,12 @@ package object xquery {
   type Prologs = ISet[Prolog]
   type PrologW[F[_]] = MonadTell[F, Prologs]
 
-  sealed abstract class SortDirection
+  sealed abstract class SortDirection {
+    override def toString = this match {
+      case SortDirection.Ascending  => "ascending"
+      case SortDirection.Descending => "descending"
+    }
+  }
 
   object SortDirection {
 

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/qscript.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/qscript.scala
@@ -144,7 +144,7 @@ object qscript {
       ).as(SequenceType("item()*")) { elt: XQuery =>
         isArr(elt) map { eltIsArray =>
           if_ (eltIsArray)
-          .then_ { elt `/` child(aelt) `/` child.node() }
+          .then_ { elt `/` child(aelt)  }
           .else_ { elt `/` child.node() }
         }
       }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -88,16 +88,17 @@ object Dependencies {
     .exclude("commons-logging", "commons-logging")
     .exclude("com.esotericsoftware.minlog", "minlog")
     .exclude("org.spark-project.spark", "unused")
+    .exclude("org.scalatest", "scalatest_2.11")
 
   val sparkDep =
     if(quasar4Spark == "yes")
       sparkDepCore % buildSparkScope
-    else 
+    else
       sparkDepCore
         .exclude("io.netty", "netty-all")
         .exclude("io.netty", "netty")
         .excludeAll(ExclusionRule(organization = "javax.servlet")) % buildSparkScope
-  
+
   def sparkcore = Seq(sparkDep)
 
   def marklogicValidation = Seq(


### PR DESCRIPTION
When constructing new `Array`s or `Map`s, adds the appropriate `ejson:type` attribute so that values are properly deserialized to types other than `String`.

Also a couple other fixes, making `Data` decoding a bit more accepting, fixing an issue with how sort direction was rendered and left shift for arrays.

Enables another set of regression tests that pass due to the aforementioned improvements with the same caveats of explicit field aliases. One test is also enabled for MarkLogic and marked as pending for Mongo due to the presence of the `value` field (as including the field is not the correct behavior, as I understand it). If this is contentious, I can a) revert it or b) add another test that is skipped by all but Mongo and includes the `value` field.

Fixes #1575. 