### PR TITLE
Improve reporting of MarkLogic mount errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ To connect to Couchbase use the following `connectionUri` format:
 
 `couchbase://<host>[:<port>]?username=<username>&password=<password>`
 
+To connect to MarkLogic, specify an [XCC URL](https://docs.marklogic.com/guide/xcc/concepts#id_55196) as the `connectionUri`:
+
+`xcc://<username>:<password>@<host>:<port>/<database>`
+
 #### View mounts
 
 If the mount's key is "view" then the mount represents a "virtual" file, defined by a SQL² query. When the file's contents are read or referred to, the query is executed to generate the current result on-demand. A view can be used to create dynamic data that combines analysis and formatting of existing files without creating temporary results that need to be manually regenerated when sources are updated.

--- a/connector/src/main/scala/quasar/fs/PhysicalError.scala
+++ b/connector/src/main/scala/quasar/fs/PhysicalError.scala
@@ -22,9 +22,17 @@ import monocle.macros.Lenses
 import monocle.Prism
 import scalaz._
 
+/** A runtime error encountered within a data source connector. A user isn't
+  * expected to usually be able to handle these as they likely arise from a defect
+  * or an "environmental" issue (memory, network, storage, etc).
+  *
+  * This should not be used to communicate configuration/validation errors at
+  * mount-time as `DefinitionError` is more appropriate in that case.
+  */
 sealed abstract class PhysicalError {
   val cause: Exception
 }
+
 @Lenses final case class UnhandledFSError(cause: Exception)
     extends PhysicalError
 

--- a/connector/src/main/scala/quasar/fs/PhysicalError.scala
+++ b/connector/src/main/scala/quasar/fs/PhysicalError.scala
@@ -36,7 +36,7 @@ sealed abstract class PhysicalError {
 @Lenses final case class UnhandledFSError(cause: Exception)
     extends PhysicalError
 
-object PhysicalError {
+object PhysicalError extends PhysicalErrorPrisms {
   implicit val show: Show[PhysicalError] = Show.shows(_.cause.getMessage)
 }
 

--- a/interface/src/main/scala/quasar/main/package.scala
+++ b/interface/src/main/scala/quasar/main/package.scala
@@ -25,6 +25,7 @@ import quasar.fs._
 import quasar.fs.mount._
 import quasar.fs.mount.hierarchical._
 
+import eu.timepit.refined.auto._
 import monocle.Lens
 import pathy.Path.posixCodec
 import scalaz.{Failure => _, Lens => _, _}, Scalaz._
@@ -47,7 +48,7 @@ package object main {
     quasar.physical.mongodb.fs.mongoDbFileSystemDef[PhysFsEff],
     quasar.physical.mongodb.fs.mongoDbQScriptFileSystemDef[PhysFsEff],
     quasar.physical.postgresql.fs.definition[PhysFsEff],
-    quasar.physical.marklogic.fs.definition[PhysFsEff],
+    quasar.physical.marklogic.fs.definition[PhysFsEff](10000L),
     quasar.physical.sparkcore.fs.local.definition[PhysFsEff],
     quasar.physical.sparkcore.fs.hdfs.definition[PhysFsEff],
     quasar.physical.couchbase.fs.definition[PhysFsEff]

--- a/it/src/test/scala/quasar/fs/FileSystemTest.scala
+++ b/it/src/test/scala/quasar/fs/FileSystemTest.scala
@@ -30,6 +30,7 @@ import quasar.regression.{interpretHfsIO, HfsIO}
 
 import scala.Either
 
+import eu.timepit.refined.auto._
 import monocle.Optional
 import monocle.function.Index
 import monocle.std.vector._
@@ -136,7 +137,7 @@ object FileSystemTest {
     fsTestConfig(postgresql.fs.FsType,      postgresql.fs.definition)        orElse
     fsTestConfig(sparkcore.fs.local.FsType, sparkcore.fs.local.definition)   orElse
     fsTestConfig(sparkcore.fs.hdfs.FsType, sparkcore.fs.hdfs.definition)     orElse
-    fsTestConfig(marklogic.fs.FsType,       marklogic.fs.definition)         orElse
+    fsTestConfig(marklogic.fs.FsType,       marklogic.fs.definition(10000L)) orElse
     fsTestConfig(couchbase.fs.FsType,       couchbase.fs.definition)
   }
 

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xcc/SessionIO.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xcc/SessionIO.scala
@@ -80,6 +80,9 @@ object SessionIO {
   def executeQuery_(query: XQuery): SessionIO[Executed] =
     executeQuery(query, new RequestOptions)
 
+  val currentServerPointInTime: SessionIO[BigInt] =
+    SessionIO(_.getCurrentServerPointInTime) map (BigInt(_))
+
   def insertContent[F[_]: Foldable](content: F[Content]): SessionIO[Executed] =
     SessionIO(_.insertContent(content.to[Array])).as(executed)
 


### PR DESCRIPTION
Adds more fine-grained reporting of MarkLogic mount errors along with some documentation.

Also adds a transformation that reifies all non-fatal errors from any connector as `PhysicalError`s, ensuring they are reported properly.

Fixes #1608.