### PR TITLE
Containment of "left" and "right" sides in LogicalPlan.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- Containment of "left" and "right" hardcoded join sides in logical plan.

--- a/connector/src/main/scala/quasar/qscript/Transform.scala
+++ b/connector/src/main/scala/quasar/qscript/Transform.scala
@@ -24,6 +24,7 @@ import quasar.qscript.MapFunc._
 import quasar.qscript.MapFuncs._
 import quasar.Planner._
 import quasar.Predef.{ Eq => _, _ }
+import quasar.sql.JoinDir
 import quasar.std.StdLib._
 
 import matryoshka._, Recursive.ops._, FunctorT.ops._, TraverseT.nonInheritedOps._
@@ -397,8 +398,8 @@ class Transform
 
       // NB: This is a magic structure. Improve LP to not imply this structure.
       val combine: JoinFunc = Free.roll(ConcatMaps(
-        Free.roll(MakeMap(StrLit[T, JoinSide]("left"), leftValue.as(LeftSide))),
-        Free.roll(MakeMap(StrLit[T, JoinSide]("right"), rightValue.as(RightSide)))))
+        Free.roll(MakeMap(StrLit[T, JoinSide](JoinDir.Left.name), leftValue.as(LeftSide))),
+        Free.roll(MakeMap(StrLit[T, JoinSide](JoinDir.Right.name), rightValue.as(RightSide)))))
 
       // FIXME: The provenances are not correct here
       Target(Ann(prov.joinProvenances(leftBuckets, rightBuckets), HoleF),

--- a/connector/src/test/scala/quasar/qscript/QScript.scala
+++ b/connector/src/test/scala/quasar/qscript/QScript.scala
@@ -20,7 +20,7 @@ import quasar.Predef._
 import quasar.{Data, LogicalPlan => LP, Type}
 import quasar.fp._
 import quasar.qscript.MapFuncs._
-import quasar.sql.CompilerHelpers
+import quasar.sql.{CompilerHelpers, JoinDir}
 import quasar.std.StdLib, StdLib._
 
 import scala.collection.immutable.{Map => ScalaMap}
@@ -481,8 +481,8 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           StdLib.set.InnerJoin(lpRead("/person"), lpRead("/car"), LP.Constant(Data.Bool(true))).embed,
           identity.Squash(
             structural.ObjectConcat(
-              structural.ObjectProject(LP.Free('__tmp0), LP.Constant(Data.Str("left"))).embed,
-              structural.ObjectProject(LP.Free('__tmp0), LP.Constant(Data.Str("right"))).embed).embed).embed)) must
+              JoinDir.Left.projectFrom(LP.Free('__tmp0)),
+              JoinDir.Right.projectFrom(LP.Free('__tmp0))).embed).embed)) must
       equal(chain(
         QC.inj(Unreferenced[Fix, Fix[QS]]()),
         TJ.inj(ThetaJoin((),
@@ -518,11 +518,11 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
             makeObj(
               "name" ->
                 structural.ObjectProject(
-                  structural.ObjectProject(LP.Free('__tmp2), LP.Constant(Data.Str("left"))).embed,
+                  JoinDir.Left.projectFrom(LP.Free('__tmp2)),
                   LP.Constant(Data.Str("name"))),
               "address" ->
                 structural.ObjectProject(
-                  structural.ObjectProject(LP.Free('__tmp2), LP.Constant(Data.Str("right"))).embed,
+                  JoinDir.Right.projectFrom(LP.Free('__tmp2)),
                   LP.Constant(Data.Str("address")))))))
       convert(None, lp) must
       equal(chain(

--- a/core/src/test/scala/quasar/sql/compiler.scala
+++ b/core/src/test/scala/quasar/sql/compiler.scala
@@ -127,11 +127,11 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
           InnerJoin(read("foo"), read("bar"), Constant(Data.Bool(true))),
           Squash[FLP](
             ObjectConcat[FLP](
-              ObjectProject(Free('__tmp0), Constant(Data.Str("left"))),
+              ObjectProject(Free('__tmp0), JoinDir.Left.const),
               makeObj(
                 "address" ->
                   ObjectProject[FLP](
-                    ObjectProject(Free('__tmp0), Constant(Data.Str("right"))),
+                    ObjectProject(Free('__tmp0), JoinDir.Right.const),
                     Constant(Data.Str("address"))))))))
     }
 
@@ -144,13 +144,13 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
             ObjectConcat[FLP](
               ObjectProject[FLP](
                 ObjectProject[FLP](
-                  ObjectProject(Free('__tmp0), Constant(Data.Str("left"))),
+                  ObjectProject(Free('__tmp0), JoinDir.Left.const),
                   Constant(Data.Str("bar"))),
                 Constant(Data.Str("baz"))),
               makeObj(
                 "address" ->
                   ObjectProject[FLP](
-                    ObjectProject(Free('__tmp0), Constant(Data.Str("right"))),
+                    ObjectProject(Free('__tmp0), JoinDir.Right.const),
                     Constant(Data.Str("address"))))))))
     }
 
@@ -569,8 +569,8 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
           InnerJoin(read("person"), read("car"), Constant(Data.Bool(true))),
           Squash[FLP](
             ObjectConcat[FLP](
-              ObjectProject(Free('__tmp0), Constant(Data.Str("left"))),
-              ObjectProject(Free('__tmp0), Constant(Data.Str("right")))))))
+              ObjectProject(Free('__tmp0), JoinDir.Left.const),
+              ObjectProject(Free('__tmp0), JoinDir.Right.const)))))
     }
 
     "compile two term multiplication from two tables" in {
@@ -583,10 +583,10 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
               "0" ->
                 Multiply[FLP](
                   ObjectProject[FLP](
-                    ObjectProject(Free('__tmp0), Constant(Data.Str("left"))),
+                    ObjectProject(Free('__tmp0), JoinDir.Left.const),
                     Constant(Data.Str("age"))),
                   ObjectProject[FLP](
-                    ObjectProject(Free('__tmp0), Constant(Data.Str("right"))),
+                    ObjectProject(Free('__tmp0), JoinDir.Right.const),
                     Constant(Data.Str("modelYear"))))))))
     }
 
@@ -1111,11 +1111,11 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
                 makeObj(
                   "name" ->
                     ObjectProject[FLP](
-                      ObjectProject(Free('__tmp2), Constant(Data.Str("left"))),
+                      ObjectProject(Free('__tmp2), JoinDir.Left.const),
                       Constant(Data.Str("name"))),
                   "address" ->
                     ObjectProject[FLP](
-                      ObjectProject(Free('__tmp2), Constant(Data.Str("right"))),
+                      ObjectProject(Free('__tmp2), JoinDir.Right.const),
                       Constant(Data.Str("address")))))))))
     }
 
@@ -1176,10 +1176,10 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
                     Fix(Squash(
                        makeObj(
                          "name" -> ObjectProject[FLP](
-                           ObjectProject(Free('__tmp4), Constant(Data.Str("left"))),
+                           ObjectProject(Free('__tmp4), JoinDir.Left.const),
                            Constant(Data.Str("name"))),
                          "address" -> ObjectProject[FLP](
-                           ObjectProject(Free('__tmp4), Constant(Data.Str("right"))),
+                           ObjectProject(Free('__tmp4), JoinDir.Right.const),
                            Constant(Data.Str("address"))))))))))))
     }
 
@@ -1213,10 +1213,10 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
                   Fix(Squash(
                     makeObj(
                       "name" -> ObjectProject[FLP](
-                        ObjectProject(Free('__tmp4), Constant(Data.Str("left"))),
+                        ObjectProject(Free('__tmp4), JoinDir.Left.const),
                         Constant(Data.Str("name"))),
                       "address" -> ObjectProject[FLP](
-                        ObjectProject(Free('__tmp4), Constant(Data.Str("right"))),
+                        ObjectProject(Free('__tmp4), JoinDir.Right.const),
                         Constant(Data.Str("address"))))))))))))
     }
 
@@ -1235,11 +1235,11 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
                 makeObj(
                   "name" ->
                     ObjectProject[FLP](
-                      ObjectProject(Free('__tmp2), Constant(Data.Str("left"))),
+                      ObjectProject(Free('__tmp2), JoinDir.Left.const),
                       Constant(Data.Str("name"))),
                   "address" ->
                     ObjectProject[FLP](
-                      ObjectProject(Free('__tmp2), Constant(Data.Str("right"))),
+                      ObjectProject(Free('__tmp2), JoinDir.Right.const),
                       Constant(Data.Str("address")))))))))
     }
 
@@ -1267,21 +1267,21 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
                         Constant(Data.Str("bar_id"))),
                       ObjectProject[FLP](
                         ObjectProject(Free('__tmp2),
-                          Constant(Data.Str("right"))),
+                          JoinDir.Right.const),
                         Constant(Data.Str("id"))))),
                   Squash(
                     makeObj(
                       "name" ->
                         ObjectProject[FLP](
                           ObjectProject[FLP](
-                            ObjectProject(Free('__tmp4), Constant(Data.Str("left"))),
-                            Constant(Data.Str("left"))),
+                            ObjectProject(Free('__tmp4), JoinDir.Left.const),
+                            JoinDir.Left.const),
                           Constant(Data.Str("name"))),
                       "address" ->
                         ObjectProject[FLP](
                           ObjectProject[FLP](
-                            ObjectProject(Free('__tmp4), Constant(Data.Str("left"))),
-                            Constant(Data.Str("right"))),
+                            ObjectProject(Free('__tmp4), JoinDir.Left.const),
+                            JoinDir.Right.const),
                           Constant(Data.Str("address")))))))))))
     }
 

--- a/frontend/src/main/scala/quasar/optimizer.scala
+++ b/frontend/src/main/scala/quasar/optimizer.scala
@@ -108,7 +108,7 @@ object Optimizer {
     case InvokeFUnapply(Drop, Sized(src, _)) => src._2
     case InvokeFUnapply(Filter, Sized(src, _)) => src._2
     case InvokeFUnapply(InnerJoin | LeftOuterJoin | RightOuterJoin | FullOuterJoin, _) =>
-      Some(List(Constant(Data.Str("left")), Constant(Data.Str("right"))))
+      Some(List(JoinDir.Left.const, JoinDir.Right.const))
     case InvokeFUnapply(GroupBy, Sized(src, _)) => src._2
     case InvokeFUnapply(Distinct, Sized(src, _)) => src._2
     case InvokeFUnapply(DistinctBy, Sized(src, _)) => src._2

--- a/frontend/src/main/scala/quasar/sql/JoinDir.scala
+++ b/frontend/src/main/scala/quasar/sql/JoinDir.scala
@@ -22,22 +22,15 @@ import quasar.std.StdLib._
 
 import matryoshka.Fix
 
-sealed trait JoinDir {
+sealed abstract class JoinDir(val name: String) {
   import structural.ObjectProject
 
-  val name: String
-
-  lazy val data: Data = Data.Str(name)
-  lazy val const: Fix[LP] = LP.Constant(data)
+  val data: Data = Data.Str(name)
+  val const: Fix[LP] = LP.Constant(data)
   def projectFrom(lp: Fix[LP]): Fix[LP] = Fix(ObjectProject(lp, const))
 }
 
 object JoinDir {
-  final case object Left extends JoinDir {
-    val name: String = "left"
-  }
-
-  final case object Right extends JoinDir {
-    val name: String = "right"
-  }
+  final case object Left extends JoinDir("left")
+  final case object Right extends JoinDir("right")
 }

--- a/frontend/src/main/scala/quasar/sql/JoinDir.scala
+++ b/frontend/src/main/scala/quasar/sql/JoinDir.scala
@@ -16,25 +16,28 @@
 
 package quasar.sql
 
-import quasar.{Data, LogicalPlan}
+import quasar.{Data, LogicalPlan => LP}
+import quasar.Predef.String
 import quasar.std.StdLib._
 
 import matryoshka.Fix
 
 sealed trait JoinDir {
-  def projectFrom(t: Fix[LogicalPlan]): Fix[LogicalPlan]
+  import structural.ObjectProject
+
+  val name: String
+
+  lazy val data: Data = Data.Str(name)
+  lazy val const: Fix[LP] = LP.Constant(data)
+  def projectFrom(lp: Fix[LP]): Fix[LP] = Fix(ObjectProject(lp, const))
 }
 
 object JoinDir {
-  import structural._
-
   final case object Left extends JoinDir {
-    def projectFrom(t: Fix[LogicalPlan]) =
-      Fix(ObjectProject(t, LogicalPlan.Constant(Data.Str("left"))))
+    val name: String = "left"
   }
 
   final case object Right extends JoinDir {
-    def projectFrom(t: Fix[LogicalPlan]) =
-      Fix(ObjectProject(t, LogicalPlan.Constant(Data.Str("right"))))
+    val name: String = "right"
   }
 }

--- a/frontend/src/main/scala/quasar/std/set.scala
+++ b/frontend/src/main/scala/quasar/std/set.scala
@@ -19,6 +19,7 @@ package quasar.std
 import quasar.Predef._
 import quasar.fp._
 import quasar.fp.ski._
+import quasar.sql.JoinDir
 import quasar._, LogicalPlan._
 
 import scala.collection.immutable.NumericRange
@@ -144,10 +145,10 @@ trait SetLib extends Library {
       case Sized(_, _, Type.Const(Data.Bool(false))) => Type.Const(Data.Set(Nil))
       case Sized(Type.Const(Data.Set(Nil)), _, _) => Type.Const(Data.Set(Nil))
       case Sized(_, Type.Const(Data.Set(Nil)), _) => Type.Const(Data.Set(Nil))
-      case Sized(s1, s2, _) => Type.Obj(Map("left" -> s1, "right" -> s2), None)
+      case Sized(s1, s2, _) => Type.Obj(Map(JoinDir.Left.name -> s1, JoinDir.Right.name -> s2), None)
     },
     untyper[nat._3](t =>
-      (t.objectField(Type.Const(Data.Str("left"))) |@| t.objectField(Type.Const(Data.Str("right"))))((l, r) =>
+      (t.objectField(Type.Const(JoinDir.Left.data)) |@| t.objectField(Type.Const(JoinDir.Right.data)))((l, r) =>
         Func.Input3(l, r, Type.Bool))))
 
   val LeftOuterJoin = TernaryFunc(
@@ -159,13 +160,13 @@ trait SetLib extends Library {
     noSimplification,
     partialTyper[nat._3] {
       case Sized(s1, _, Type.Const(Data.Bool(false))) =>
-        Type.Obj(Map("left" -> s1, "right" -> Type.Null), None)
+        Type.Obj(Map(JoinDir.Left.name -> s1, JoinDir.Right.name -> Type.Null), None)
       case Sized(Type.Const(Data.Set(Nil)), _, _) => Type.Const(Data.Set(Nil))
       case Sized(s1, s2, _) =>
-        Type.Obj(Map("left" -> s1, "right" -> (s2 ⨿ Type.Null)), None)
+        Type.Obj(Map(JoinDir.Left.name -> s1, JoinDir.Right.name -> (s2 ⨿ Type.Null)), None)
     },
     untyper[nat._3](t =>
-      (t.objectField(Type.Const(Data.Str("left"))) |@| t.objectField(Type.Const(Data.Str("right"))))((l, r) =>
+      (t.objectField(Type.Const(JoinDir.Left.data)) |@| t.objectField(Type.Const(JoinDir.Right.data)))((l, r) =>
         Func.Input3(l, r, Type.Bool))))
 
   val RightOuterJoin = TernaryFunc(
@@ -177,12 +178,12 @@ trait SetLib extends Library {
     noSimplification,
     partialTyper[nat._3] {
       case Sized(_, s2, Type.Const(Data.Bool(false))) =>
-        Type.Obj(Map("left" -> Type.Null, "right" -> s2), None)
+        Type.Obj(Map(JoinDir.Left.name -> Type.Null, JoinDir.Right.name -> s2), None)
       case Sized(_, Type.Const(Data.Set(Nil)), _) => Type.Const(Data.Set(Nil))
-      case Sized(s1, s2, _) => Type.Obj(Map("left" -> (s1 ⨿ Type.Null), "right" -> s2), None)
+      case Sized(s1, s2, _) => Type.Obj(Map(JoinDir.Left.name -> (s1 ⨿ Type.Null), JoinDir.Right.name -> s2), None)
     },
     untyper[nat._3](t =>
-      (t.objectField(Type.Const(Data.Str("left"))) |@| t.objectField(Type.Const(Data.Str("right"))))((l, r) =>
+      (t.objectField(Type.Const(JoinDir.Left.data)) |@| t.objectField(Type.Const(JoinDir.Right.data)))((l, r) =>
         Func.Input3(l, r, Type.Bool))))
 
   val FullOuterJoin = TernaryFunc(
@@ -196,10 +197,10 @@ trait SetLib extends Library {
       case Sized(Type.Const(Data.Set(Nil)), Type.Const(Data.Set(Nil)), _) =>
         Type.Const(Data.Set(Nil))
       case Sized(s1, s2, _) =>
-        Type.Obj(Map("left" -> (s1 ⨿ Type.Null), "right" -> (s2 ⨿ Type.Null)), None)
+        Type.Obj(Map(JoinDir.Left.name -> (s1 ⨿ Type.Null), JoinDir.Right.name -> (s2 ⨿ Type.Null)), None)
     },
     untyper[nat._3](t =>
-      (t.objectField(Type.Const(Data.Str("left"))) |@| t.objectField(Type.Const(Data.Str("right"))))((l, r) =>
+      (t.objectField(Type.Const(JoinDir.Left.data)) |@| t.objectField(Type.Const(JoinDir.Right.data)))((l, r) =>
         Func.Input3(l, r, Type.Bool))))
 
   val GroupBy = BinaryFunc(

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/JoinHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/JoinHandler.scala
@@ -27,6 +27,7 @@ import quasar.physical.mongodb.accumulator._
 import quasar.physical.mongodb.expression._
 import quasar.physical.mongodb.workflow._
 import WorkflowBuilder._
+import quasar.sql.JoinDir
 
 import matryoshka._, Recursive.ops._
 import scalaz._, Scalaz._
@@ -44,8 +45,8 @@ object JoinHandler {
   // FIXME: these have to match the names used in the logical plan. Should
   //        change this to ensure left0/right0 are `Free` and pull the names
   //        from those.
-  val LeftName: BsonField.Name = BsonField.Name("left")
-  val RightName: BsonField.Name = BsonField.Name("right")
+  val LeftName: BsonField.Name = BsonField.Name(JoinDir.Left.name)
+  val RightName: BsonField.Name = BsonField.Name(JoinDir.Right.name)
 
   // NB: it's only safe to emit "core" expr ops here, but we always use the
   // largest type in WorkflowOp, so they're immediately injected into ExprOp.

--- a/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -26,7 +26,7 @@ import quasar.physical.mongodb.expression._
 import quasar.physical.mongodb.planner._
 import quasar.physical.mongodb.workflow._
 import quasar.qscript.SortDir
-import quasar.sql.{fixpoint => sql, JoinDir, _}
+import quasar.sql.{fixpoint => sql, _}
 import quasar.std._
 
 import scala.Either

--- a/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -26,7 +26,7 @@ import quasar.physical.mongodb.expression._
 import quasar.physical.mongodb.planner._
 import quasar.physical.mongodb.workflow._
 import quasar.qscript.SortDir
-import quasar.sql.{fixpoint => sql, _}
+import quasar.sql.{fixpoint => sql, JoinDir, _}
 import quasar.std._
 
 import scala.Either
@@ -2665,7 +2665,7 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
       swapped: Boolean) = {
 
       val (leftLabel, rightLabel) =
-        if (swapped) ("right", "left") else ("left", "right")
+        if (swapped) (JoinDir.Right.name, JoinDir.Left.name) else (JoinDir.Left.name, JoinDir.Right.name)
       def initialPipeOps(
         src: Workflow, name: String, base: Fix[ExprOp], key: Reshape.Shape[ExprOp], mainLabel: String, otherLabel: String):
           Workflow =
@@ -2732,17 +2732,17 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
             Obj(ListMap(Name("0") -> Select(ident("value"), "_id"))).right,
             chain[Workflow](_,
               $match(Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
-                BsonField.Name("left") -> Selector.NotExpr(Selector.Size(0)),
-                BsonField.Name("right") -> Selector.NotExpr(Selector.Size(0))))),
-              $unwind(DocField(BsonField.Name("left"))),
-              $unwind(DocField(BsonField.Name("right"))),
+                JoinHandler.LeftName -> Selector.NotExpr(Selector.Size(0)),
+                JoinHandler.RightName -> Selector.NotExpr(Selector.Size(0))))),
+              $unwind(DocField(JoinHandler.LeftName)),
+              $unwind(DocField(JoinHandler.RightName)),
               $project(
                 reshape("city" ->
                   $cond(
                     $and(
-                      $lte($literal(Bson.Doc()), $field("right")),
-                      $lt($field("right"), $literal(Bson.Arr()))),
-                    $field("right", "city"),
+                      $lte($literal(Bson.Doc()), $field(JoinDir.Right.name)),
+                      $lt($field(JoinDir.Right.name), $literal(Bson.Arr()))),
+                    $field(JoinDir.Right.name, "city"),
                     $literal(Bson.Undefined))),
                 IgnoreId)),
             false).op)
@@ -2754,20 +2754,20 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
           $read(collection("db", "zips")),
           $match(Selector.Doc(
             BsonField.Name("_id") -> Selector.Exists(true))),
-          $project(reshape("left" -> $$ROOT)),
+          $project(reshape(JoinDir.Left.name -> $$ROOT)),
           $lookup(
             CollectionName("zips2"),
-            BsonField.Name("left") \ BsonField.Name("_id"),
+            JoinHandler.LeftName \ BsonField.Name("_id"),
             BsonField.Name("_id"),
-            BsonField.Name("right")),
-          $unwind(DocField(BsonField.Name("right"))),
+            JoinHandler.RightName),
+          $unwind(DocField(JoinHandler.RightName)),
           $project(
             reshape("city" ->
               $cond(
                 $and(
-                  $lte($literal(Bson.Doc()), $field("right")),
-                  $lt($field("right"), $literal(Bson.Arr()))),
-                $field("right", "city"),
+                  $lte($literal(Bson.Doc()), $field(JoinDir.Right.name)),
+                  $lt($field(JoinDir.Right.name), $literal(Bson.Arr()))),
+                $field(JoinDir.Right.name, "city"),
                 $literal(Bson.Undefined))),
             IgnoreId)))
     }
@@ -2805,18 +2805,18 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
           jscore.Literal(Js.Null).right,
           chain[Workflow](_,
             $match(Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
-              BsonField.Name("left") -> Selector.NotExpr(Selector.Size(0)),
-              BsonField.Name("right") -> Selector.NotExpr(Selector.Size(0))))),
-            $unwind(DocField(BsonField.Name("left"))),
-            $unwind(DocField(BsonField.Name("right"))),
+              JoinHandler.LeftName -> Selector.NotExpr(Selector.Size(0)),
+              JoinHandler.RightName -> Selector.NotExpr(Selector.Size(0))))),
+            $unwind(DocField(JoinHandler.LeftName)),
+            $unwind(DocField(JoinHandler.RightName)),
             $project(
               reshape(
                 "__tmp11"   ->
                   $cond(
                     $and(
-                      $lte($literal(Bson.Doc()), $field("right")),
-                      $lt($field("right"), $literal(Bson.Arr()))),
-                    $field("right"),
+                      $lte($literal(Bson.Doc()), $field(JoinDir.Right.name)),
+                      $lt($field(JoinDir.Right.name), $literal(Bson.Arr()))),
+                    $field(JoinDir.Right.name),
                     $literal(Bson.Undefined)),
                 "__tmp12" -> $$ROOT),
               IgnoreId),
@@ -2826,29 +2826,29 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
                 "__tmp13" ->
                   $cond(
                     $and(
-                      $lte($literal(Bson.Doc()), $field("__tmp12", "right")),
-                      $lt($field("__tmp12", "right"), $literal(Bson.Arr(List())))),
+                      $lte($literal(Bson.Doc()), $field("__tmp12", JoinDir.Right.name)),
+                      $lt($field("__tmp12", JoinDir.Right.name), $literal(Bson.Arr(List())))),
                     $cond(
                       $or(
                         $and(
-                          $lt($literal(Bson.Null), $field("__tmp12", "right", "_id")),
-                          $lt($field("__tmp12", "right", "_id"), $literal(Bson.Doc()))),
+                          $lt($literal(Bson.Null), $field("__tmp12", JoinDir.Right.name, "_id")),
+                          $lt($field("__tmp12", JoinDir.Right.name, "_id"), $literal(Bson.Doc()))),
                         $and(
-                          $lte($literal(Bson.Bool(false)), $field("__tmp12", "right", "_id")),
-                          $lt($field("__tmp12", "right", "_id"), $literal(Bson.Regex("", ""))))),
+                          $lte($literal(Bson.Bool(false)), $field("__tmp12", JoinDir.Right.name, "_id")),
+                          $lt($field("__tmp12", JoinDir.Right.name, "_id"), $literal(Bson.Regex("", ""))))),
                       $cond(
                         $and(
-                          $lte($literal(Bson.Doc()), $field("__tmp12", "left")),
-                          $lt($field("__tmp12", "left"), $literal(Bson.Arr(List())))),
+                          $lte($literal(Bson.Doc()), $field("__tmp12", JoinDir.Left.name)),
+                          $lt($field("__tmp12", JoinDir.Left.name), $literal(Bson.Arr(List())))),
                         $cond(
                           $or(
                             $and(
-                              $lt($literal(Bson.Null), $field("__tmp12", "left", "_id")),
-                              $lt($field("__tmp12", "left", "_id"), $literal(Bson.Doc()))),
+                              $lt($literal(Bson.Null), $field("__tmp12", JoinDir.Left.name, "_id")),
+                              $lt($field("__tmp12", JoinDir.Left.name, "_id"), $literal(Bson.Doc()))),
                             $and(
-                              $lte($literal(Bson.Bool(false)), $field("__tmp12", "left", "_id")),
-                              $lt($field("__tmp12", "left", "_id"), $literal(Bson.Regex("", ""))))),
-                          $lt($field("__tmp12", "left", "_id"), $field("__tmp12", "right", "_id")),
+                              $lte($literal(Bson.Bool(false)), $field("__tmp12", JoinDir.Left.name, "_id")),
+                              $lt($field("__tmp12", JoinDir.Left.name, "_id"), $literal(Bson.Regex("", ""))))),
+                          $lt($field("__tmp12", JoinDir.Left.name, "_id"), $field("__tmp12", JoinDir.Right.name, "_id")),
                           $literal(Bson.Undefined)),
                         $literal(Bson.Undefined)),
                       $literal(Bson.Undefined)),
@@ -2874,25 +2874,25 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
           Obj(ListMap(Name("0") -> Select(ident("value"), "foo_id"))).right,
           chain[Workflow](_,
             $match(Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
-              BsonField.Name("left") -> Selector.NotExpr(Selector.Size(0)),
-              BsonField.Name("right") -> Selector.NotExpr(Selector.Size(0))))),
-            $unwind(DocField(BsonField.Name("left"))),
-            $unwind(DocField(BsonField.Name("right"))),
+              JoinHandler.LeftName -> Selector.NotExpr(Selector.Size(0)),
+              JoinHandler.RightName -> Selector.NotExpr(Selector.Size(0))))),
+            $unwind(DocField(JoinHandler.LeftName)),
+            $unwind(DocField(JoinHandler.RightName)),
             $project(
               reshape(
                 "name"    ->
                   $cond(
                     $and(
-                      $lte($literal(Bson.Doc()), $field("left")),
-                      $lt($field("left"), $literal(Bson.Arr()))),
-                    $field("left", "name"),
+                      $lte($literal(Bson.Doc()), $field(JoinDir.Left.name)),
+                      $lt($field(JoinDir.Left.name), $literal(Bson.Arr()))),
+                    $field(JoinDir.Left.name, "name"),
                     $literal(Bson.Undefined)),
                 "address" ->
                   $cond(
                     $and(
-                      $lte($literal(Bson.Doc()), $field("right")),
-                      $lt($field("right"), $literal(Bson.Arr()))),
-                    $field("right", "address"),
+                      $lte($literal(Bson.Doc()), $field(JoinDir.Right.name)),
+                      $lt($field(JoinDir.Right.name), $literal(Bson.Arr()))),
+                    $field(JoinDir.Right.name, "address"),
                     $literal(Bson.Undefined))),
               IgnoreId)),
           false).op)
@@ -2907,27 +2907,27 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
         $read(collection("db", "foo")),
         $match(Selector.Doc(
           BsonField.Name("id") -> Selector.Exists(true))),
-        $project(reshape("left" -> $$ROOT)),
+        $project(reshape(JoinDir.Left.name -> $$ROOT)),
         $lookup(
           CollectionName("bar"),
-          BsonField.Name("left") \ BsonField.Name("id"),
+          JoinHandler.LeftName \ BsonField.Name("id"),
           BsonField.Name("foo_id"),
-          BsonField.Name("right")),
-        $unwind(DocField(BsonField.Name("right"))),
+          JoinHandler.RightName),
+        $unwind(DocField(JoinHandler.RightName)),
         $project(reshape(
           "name" ->
             $cond(
               $and(
-                $lte($literal(Bson.Doc()), $field("left")),
-                $lt($field("left"), $literal(Bson.Arr(Nil)))),
-              $field("left", "name"),
+                $lte($literal(Bson.Doc()), $field(JoinDir.Left.name)),
+                $lt($field(JoinDir.Left.name), $literal(Bson.Arr(Nil)))),
+              $field(JoinDir.Left.name, "name"),
               $literal(Bson.Undefined)),
           "address" ->
             $cond(
               $and(
-                $lte($literal(Bson.Doc()), $field("right")),
-                $lt($field("right"), $literal(Bson.Arr(Nil)))),
-              $field("right", "address"),
+                $lte($literal(Bson.Doc()), $field(JoinDir.Right.name)),
+                $lt($field(JoinDir.Right.name), $literal(Bson.Arr(Nil)))),
+              $field(JoinDir.Right.name, "address"),
               $literal(Bson.Undefined))),
           IgnoreId)))
     }
@@ -2940,32 +2940,32 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
       beWorkflow(chain[Workflow](
         $read(collection("db", "foo")),
         $project(reshape(
-          "left" -> $$ROOT,
+          JoinDir.Left.name -> $$ROOT,
           "__tmp0" -> $toLower($field("id"))),
           IgnoreId),
         $lookup(
           CollectionName("bar"),
           BsonField.Name("__tmp0"),
           BsonField.Name("foo_id"),
-          BsonField.Name("right")),
+          JoinHandler.RightName),
         $project(reshape(
-          "left" -> $field("left"),
-          "right" -> $field("right"))),
-        $unwind(DocField(BsonField.Name("right"))),
+          JoinDir.Left.name -> $field(JoinDir.Left.name),
+          JoinDir.Right.name -> $field(JoinDir.Right.name))),
+        $unwind(DocField(JoinHandler.RightName)),
         $project(reshape(
           "name" ->
             $cond(
               $and(
-                $lte($literal(Bson.Doc()), $field("left")),
-                $lt($field("left"), $literal(Bson.Arr()))),
-              $field("left", "name"),
+                $lte($literal(Bson.Doc()), $field(JoinDir.Left.name)),
+                $lt($field(JoinDir.Left.name), $literal(Bson.Arr()))),
+              $field(JoinDir.Left.name, "name"),
               $literal(Bson.Undefined)),
           "address" ->
             $cond(
               $and(
-                $lte($literal(Bson.Doc()), $field("right")),
-                $lt($field("right"), $literal(Bson.Arr()))),
-              $field("right", "address"),
+                $lte($literal(Bson.Doc()), $field(JoinDir.Right.name)),
+                $lt($field(JoinDir.Right.name), $literal(Bson.Arr()))),
+              $field(JoinDir.Right.name, "address"),
               $literal(Bson.Undefined))),
           IgnoreId)))
     }
@@ -2983,32 +2983,32 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
             Selector.Doc(
               BsonField.Name("rating") -> Selector.Gte(Bson.Int32(4))))),
         $project(reshape(
-          "right" -> $$ROOT,
+          JoinDir.Right.name -> $$ROOT,
           "__tmp2" -> $field("foo_id")),
           ExcludeId),
         $lookup(
           CollectionName("foo"),
           BsonField.Name("__tmp2"),
           BsonField.Name("id"),
-          BsonField.Name("left")),
+          JoinHandler.LeftName),
         $project(reshape(
-          "right" -> $field("right"),
-          "left" -> $field("left"))),
-        $unwind(DocField(BsonField.Name("left"))),
+          JoinDir.Right.name -> $field(JoinDir.Right.name),
+          JoinDir.Left.name -> $field(JoinDir.Left.name))),
+        $unwind(DocField(JoinHandler.LeftName)),
         $project(reshape(
           "name" ->
             $cond(
               $and(
-                $lte($literal(Bson.Doc()), $field("left")),
-                $lt($field("left"), $literal(Bson.Arr()))),
-              $field("left", "name"),
+                $lte($literal(Bson.Doc()), $field(JoinDir.Left.name)),
+                $lt($field(JoinDir.Left.name), $literal(Bson.Arr()))),
+              $field(JoinDir.Left.name, "name"),
               $literal(Bson.Undefined)),
           "address" ->
             $cond(
               $and(
-                $lte($literal(Bson.Doc()), $field("right")),
-                $lt($field("right"), $literal(Bson.Arr()))),
-              $field("right", "address"),
+                $lte($literal(Bson.Doc()), $field(JoinDir.Right.name)),
+                $lt($field(JoinDir.Right.name), $literal(Bson.Arr()))),
+              $field(JoinDir.Right.name, "address"),
               $literal(Bson.Undefined))),
           IgnoreId)))
     }
@@ -3024,17 +3024,17 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
           chain[Workflow](_,
             $project(
               reshape(
-                "left" ->
-                  $cond($eq($size($field("left")), $literal(Bson.Int32(0))),
+                JoinDir.Left.name ->
+                  $cond($eq($size($field(JoinDir.Left.name)), $literal(Bson.Int32(0))),
                     $literal(Bson.Arr(List(Bson.Doc()))),
-                    $field("left")),
-                "right" ->
-                  $cond($eq($size($field("right")), $literal(Bson.Int32(0))),
+                    $field(JoinDir.Left.name)),
+                JoinDir.Right.name ->
+                  $cond($eq($size($field(JoinDir.Right.name)), $literal(Bson.Int32(0))),
                     $literal(Bson.Arr(List(Bson.Doc()))),
-                    $field("right"))),
+                    $field(JoinDir.Right.name))),
               IgnoreId),
-            $unwind(DocField(BsonField.Name("left"))),
-            $unwind(DocField(BsonField.Name("right"))),
+            $unwind(DocField(JoinHandler.LeftName)),
+            $unwind(DocField(JoinHandler.RightName)),
             $simpleMap(
               NonEmptyList(
                 MapExpr(JsFn(Name("x"),
@@ -3042,17 +3042,17 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
                     Name("__tmp7") ->
                       If(
                         BinOp(jscore.And,
-                          Call(ident("isObject"), List(Select(ident("x"), "right"))),
+                          Call(ident("isObject"), List(Select(ident("x"), JoinDir.Right.name))),
                           UnOp(jscore.Not,
-                            Call(Select(ident("Array"), "isArray"), List(Select(ident("x"), "right"))))),
+                            Call(Select(ident("Array"), "isArray"), List(Select(ident("x"), JoinDir.Right.name))))),
                         If(
                           BinOp(jscore.And,
-                            Call(ident("isObject"), List(Select(ident("x"), "left"))),
+                            Call(ident("isObject"), List(Select(ident("x"), JoinDir.Left.name))),
                             UnOp(jscore.Not,
-                              Call(Select(ident("Array"), "isArray"), List(Select(ident("x"), "left"))))),
+                              Call(Select(ident("Array"), "isArray"), List(Select(ident("x"), JoinDir.Left.name))))),
                           SpliceObjects(List(
-                            Select(ident("x"), "left"),
-                            Select(ident("x"), "right"))),
+                            Select(ident("x"), JoinDir.Left.name),
+                            Select(ident("x"), JoinDir.Right.name))),
                           ident("undefined")),
                         ident("undefined"))))))),
               ListMap()),
@@ -3074,32 +3074,32 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
           Obj(ListMap(Name("0") -> Select(ident("value"), "foo_id"))).right,
           chain[Workflow](_,
             $match(Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
-              BsonField.Name("left") -> Selector.NotExpr(Selector.Size(0))))),
+              JoinHandler.LeftName -> Selector.NotExpr(Selector.Size(0))))),
             $project(
               reshape(
-                "left"  -> $field("left"),
-                "right" ->
-                  $cond($eq($size($field("right")), $literal(Bson.Int32(0))),
+                JoinDir.Left.name  -> $field(JoinDir.Left.name),
+                JoinDir.Right.name ->
+                  $cond($eq($size($field(JoinDir.Right.name)), $literal(Bson.Int32(0))),
                     $literal(Bson.Arr(List(Bson.Doc()))),
-                    $field("right"))),
+                    $field(JoinDir.Right.name))),
               IgnoreId),
-            $unwind(DocField(BsonField.Name("left"))),
-            $unwind(DocField(BsonField.Name("right"))),
+            $unwind(DocField(JoinHandler.LeftName)),
+            $unwind(DocField(JoinHandler.RightName)),
             $project(
               reshape(
                 "name"    ->
                   $cond(
                     $and(
-                      $lte($literal(Bson.Doc()), $field("left")),
-                      $lt($field("left"), $literal(Bson.Arr()))),
-                    $field("left", "name"),
+                      $lte($literal(Bson.Doc()), $field(JoinDir.Left.name)),
+                      $lt($field(JoinDir.Left.name), $literal(Bson.Arr()))),
+                    $field(JoinDir.Left.name, "name"),
                     $literal(Bson.Undefined)),
                 "address" ->
                   $cond(
                     $and(
-                      $lte($literal(Bson.Doc()), $field("right")),
-                      $lt($field("right"), $literal(Bson.Arr()))),
-                    $field("right", "address"),
+                      $lte($literal(Bson.Doc()), $field(JoinDir.Right.name)),
+                      $lt($field(JoinDir.Right.name), $literal(Bson.Arr()))),
+                    $field(JoinDir.Right.name, "address"),
                     $literal(Bson.Undefined))),
               IgnoreId)),
           false).op)
@@ -3113,27 +3113,27 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
         indexes(collection("db", "bar") -> BsonField.Name("foo_id"))) must
       beWorkflow(chain[Workflow](
         $read(collection("db", "foo")),
-        $project(reshape("left" -> $$ROOT)),
+        $project(reshape(JoinDir.Left.name -> $$ROOT)),
         $lookup(
           CollectionName("bar"),
-          BsonField.Name("left") \ BsonField.Name("id"),
+          JoinHandler.LeftName \ BsonField.Name("id"),
           BsonField.Name("foo_id"),
-          BsonField.Name("right")),
-        $unwind(DocField(BsonField.Name("right"))),  // FIXME: need to preserve docs with no match
+          JoinHandler.RightName),
+        $unwind(DocField(JoinHandler.RightName)),  // FIXME: need to preserve docs with no match
         $project(reshape(
           "name" ->
             $cond(
               $and(
-                $lte($literal(Bson.Doc()), $field("left")),
-                $lt($field("left"), $literal(Bson.Arr()))),
-              $field("left", "name"),
+                $lte($literal(Bson.Doc()), $field(JoinDir.Left.name)),
+                $lt($field(JoinDir.Left.name), $literal(Bson.Arr()))),
+              $field(JoinDir.Left.name, "name"),
               $literal(Bson.Undefined)),
           "address" ->
             $cond(
               $and(
-                $lte($literal(Bson.Doc()), $field("right")),
-                $lt($field("right"), $literal(Bson.Arr()))),
-              $field("right", "address"),
+                $lte($literal(Bson.Doc()), $field(JoinDir.Right.name)),
+                $lt($field(JoinDir.Right.name), $literal(Bson.Arr()))),
+              $field(JoinDir.Right.name, "address"),
               $literal(Bson.Undefined))),
           IgnoreId)))
     }.pendingUntilFixed("TODO: left/right joins in $lookup")
@@ -3146,27 +3146,27 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
         indexes(collection("db", "bar") -> BsonField.Name("foo_id"))) must
       beWorkflow(chain[Workflow](
         $read(collection("db", "bar")),
-        $project(reshape("right" -> $$ROOT)),
+        $project(reshape(JoinDir.Right.name -> $$ROOT)),
         $lookup(
           CollectionName("foo"),
-          BsonField.Name("right") \ BsonField.Name("foo_id"),
+          JoinHandler.RightName \ BsonField.Name("foo_id"),
           BsonField.Name("id"),
-          BsonField.Name("left")),
-        $unwind(DocField(BsonField.Name("left"))),  // FIXME: need to preserve docs with no match
+          JoinHandler.LeftName),
+        $unwind(DocField(JoinHandler.LeftName)),  // FIXME: need to preserve docs with no match
         $project(reshape(
           "name" ->
             $cond(
               $and(
-                $lte($literal(Bson.Doc()), $field("left")),
-                $lt($field("left"), $literal(Bson.Arr()))),
-              $field("left", "name"),
+                $lte($literal(Bson.Doc()), $field(JoinDir.Left.name)),
+                $lt($field(JoinDir.Left.name), $literal(Bson.Arr()))),
+              $field(JoinDir.Left.name, "name"),
               $literal(Bson.Undefined)),
           "address" ->
             $cond(
               $and(
-                $lte($literal(Bson.Doc()), $field("right")),
-                $lt($field("right"), $literal(Bson.Arr()))),
-              $field("right", "address"),
+                $lte($literal(Bson.Doc()), $field(JoinDir.Right.name)),
+                $lt($field(JoinDir.Right.name), $literal(Bson.Arr()))),
+              $field(JoinDir.Right.name, "address"),
               $literal(Bson.Undefined))),
           IgnoreId)))
     }.pendingUntilFixed("TODO: left/right joins in $lookup")
@@ -3186,58 +3186,58 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
             Obj(ListMap(Name("0") -> Select(ident("value"), "foo_id"))).right,
             chain[Workflow](_,
               $match(Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
-                BsonField.Name("left") -> Selector.NotExpr(Selector.Size(0)),
-                BsonField.Name("right") -> Selector.NotExpr(Selector.Size(0))))),
-              $unwind(DocField(BsonField.Name("left"))),
-              $unwind(DocField(BsonField.Name("right")))),
+                JoinHandler.LeftName -> Selector.NotExpr(Selector.Size(0)),
+                JoinHandler.RightName -> Selector.NotExpr(Selector.Size(0))))),
+              $unwind(DocField(JoinHandler.LeftName)),
+              $unwind(DocField(JoinHandler.RightName))),
             false),
           reshape("0" -> $field("bar_id")),
-          Obj(ListMap(Name("0") -> Select(Select(ident("value"), "right"), "id"))).right,
+          Obj(ListMap(Name("0") -> Select(Select(ident("value"), JoinDir.Right.name), "id"))).right,
           chain[Workflow](_,
             $match(Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
-              BsonField.Name("left") -> Selector.NotExpr(Selector.Size(0))))),
+              JoinHandler.LeftName -> Selector.NotExpr(Selector.Size(0))))),
             $project(
               reshape(
-                "right" ->
-                  $cond($eq($size($field("right")), $literal(Bson.Int32(0))),
+                JoinDir.Right.name ->
+                  $cond($eq($size($field(JoinDir.Right.name)), $literal(Bson.Int32(0))),
                     $literal(Bson.Arr(List(Bson.Doc()))),
-                    $field("right")),
-                "left" -> $field("left")),
+                    $field(JoinDir.Right.name)),
+                JoinDir.Left.name -> $field(JoinDir.Left.name)),
               IgnoreId),
-            $unwind(DocField(BsonField.Name("right"))),
-            $unwind(DocField(BsonField.Name("left"))),
+            $unwind(DocField(JoinHandler.RightName)),
+            $unwind(DocField(JoinHandler.LeftName)),
             $project(
               reshape(
                 "name"    ->
                   $cond(
                     $and(
-                      $lte($literal(Bson.Doc()), $field("left")),
-                      $lt($field("left"), $literal(Bson.Arr()))),
+                      $lte($literal(Bson.Doc()), $field(JoinDir.Left.name)),
+                      $lt($field(JoinDir.Left.name), $literal(Bson.Arr()))),
                     $cond(
                       $and(
-                        $lte($literal(Bson.Doc()), $field("left", "left")),
-                        $lt($field("left", "left"), $literal(Bson.Arr()))),
-                      $field("left", "left", "name"),
+                        $lte($literal(Bson.Doc()), $field(JoinDir.Left.name, JoinDir.Left.name)),
+                        $lt($field(JoinDir.Left.name, JoinDir.Left.name), $literal(Bson.Arr()))),
+                      $field(JoinDir.Left.name, JoinDir.Left.name, "name"),
                       $literal(Bson.Undefined)),
                     $literal(Bson.Undefined)),
                 "address" ->
                   $cond(
                     $and(
-                      $lte($literal(Bson.Doc()), $field("left")),
-                      $lt($field("left"), $literal(Bson.Arr()))),
+                      $lte($literal(Bson.Doc()), $field(JoinDir.Left.name)),
+                      $lt($field(JoinDir.Left.name), $literal(Bson.Arr()))),
                     $cond(
                       $and(
-                        $lte($literal(Bson.Doc()), $field("left", "right")),
-                        $lt($field("left", "right"), $literal(Bson.Arr()))),
-                      $field("left", "right", "address"),
+                        $lte($literal(Bson.Doc()), $field(JoinDir.Left.name, JoinDir.Right.name)),
+                        $lt($field(JoinDir.Left.name, JoinDir.Right.name), $literal(Bson.Arr()))),
+                      $field(JoinDir.Left.name, JoinDir.Right.name, "address"),
                       $literal(Bson.Undefined)),
                     $literal(Bson.Undefined)),
                 "zip"     ->
                   $cond(
                     $and(
-                      $lte($literal(Bson.Doc()), $field("right")),
-                      $lt($field("right"), $literal(Bson.Arr()))),
-                    $field("right", "zip"),
+                      $lte($literal(Bson.Doc()), $field(JoinDir.Right.name)),
+                      $lt($field(JoinDir.Right.name), $literal(Bson.Arr()))),
+                    $field(JoinDir.Right.name, "zip"),
                     $literal(Bson.Undefined))),
               IgnoreId)),
           true).op)
@@ -3256,53 +3256,53 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
           $read(collection("db", "foo")),
           $match(Selector.Doc(
             BsonField.Name("id") -> Selector.Exists(true))),
-          $project(reshape("left" -> $$ROOT)),
+          $project(reshape(JoinDir.Left.name -> $$ROOT)),
           $lookup(
             CollectionName("bar"),
-            BsonField.Name("left") \ BsonField.Name("id"),
+            JoinHandler.LeftName \ BsonField.Name("id"),
             BsonField.Name("foo_id"),
-            BsonField.Name("right")),
-          $unwind(DocField(BsonField.Name("right"))),
+            JoinHandler.RightName),
+          $unwind(DocField(JoinHandler.RightName)),
           $match(Selector.Doc(
-            BsonField.Name("right") \ BsonField.Name("id") -> Selector.Exists(true))),
-          $project(reshape("left" -> $$ROOT)),
+            JoinHandler.RightName \ BsonField.Name("id") -> Selector.Exists(true))),
+          $project(reshape(JoinDir.Left.name -> $$ROOT)),
           $lookup(
             CollectionName("baz"),
-            BsonField.Name("left") \ BsonField.Name("right") \ BsonField.Name("id"),
+            JoinHandler.LeftName \ JoinHandler.RightName \ BsonField.Name("id"),
             BsonField.Name("bar_id"),
-            BsonField.Name("right")),
-          $unwind(DocField(BsonField.Name("right"))),
+            JoinHandler.RightName),
+          $unwind(DocField(JoinHandler.RightName)),
           $project(reshape(
             "name" ->
               $cond(
                 $and(
-                  $lte($literal(Bson.Doc()), $field("left")),
-                  $lt($field("left"), $literal(Bson.Arr()))),
+                  $lte($literal(Bson.Doc()), $field(JoinDir.Left.name)),
+                  $lt($field(JoinDir.Left.name), $literal(Bson.Arr()))),
                 $cond(
                   $and(
-                    $lte($literal(Bson.Doc()), $field("left", "left")),
-                    $lt($field("left", "left"), $literal(Bson.Arr()))),
-                  $field("left", "left", "name"),
+                    $lte($literal(Bson.Doc()), $field(JoinDir.Left.name, JoinDir.Left.name)),
+                    $lt($field(JoinDir.Left.name, JoinDir.Left.name), $literal(Bson.Arr()))),
+                  $field(JoinDir.Left.name, JoinDir.Left.name, "name"),
                   $literal(Bson.Undefined)),
                 $literal(Bson.Undefined)),
             "address" ->
               $cond(
                 $and(
-                  $lte($literal(Bson.Doc()), $field("left")),
-                  $lt($field("left"), $literal(Bson.Arr()))),
+                  $lte($literal(Bson.Doc()), $field(JoinDir.Left.name)),
+                  $lt($field(JoinDir.Left.name), $literal(Bson.Arr()))),
                 $cond(
                   $and(
-                    $lte($literal(Bson.Doc()), $field("left", "right")),
-                    $lt($field("left", "right"), $literal(Bson.Arr()))),
-                  $field("left", "right", "address"),
+                    $lte($literal(Bson.Doc()), $field(JoinDir.Left.name, JoinDir.Right.name)),
+                    $lt($field(JoinDir.Left.name, JoinDir.Right.name), $literal(Bson.Arr()))),
+                  $field(JoinDir.Left.name, JoinDir.Right.name, "address"),
                   $literal(Bson.Undefined)),
                 $literal(Bson.Undefined)),
             "zip" ->
               $cond(
                 $and(
-                  $lte($literal(Bson.Doc()), $field("right")),
-                  $lt($field("right"), $literal(Bson.Arr()))),
-                $field("right", "zip"),
+                  $lte($literal(Bson.Doc()), $field(JoinDir.Right.name)),
+                  $lt($field(JoinDir.Right.name), $literal(Bson.Arr()))),
+                $field(JoinDir.Right.name, "zip"),
                 $literal(Bson.Undefined))),
             IgnoreId)))
     }
@@ -3329,48 +3329,48 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
             "1" -> Select(Select(ident("value"), "author"), "login")).right,
           chain[Workflow](_,
             $match(Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
-              BsonField.Name("left") -> Selector.NotExpr(Selector.Size(0)),
-              BsonField.Name("right") -> Selector.NotExpr(Selector.Size(0))))),
-            $unwind(DocField(BsonField.Name("left"))),
-            $unwind(DocField(BsonField.Name("right"))),
+              JoinHandler.LeftName -> Selector.NotExpr(Selector.Size(0)),
+              JoinHandler.RightName -> Selector.NotExpr(Selector.Size(0))))),
+            $unwind(DocField(JoinHandler.LeftName)),
+            $unwind(DocField(JoinHandler.RightName)),
             $project(
               reshape(
                 "child"  ->
                   $cond(
                     $and(
-                      $lte($literal(Bson.Doc()), $field("left")),
-                      $lt($field("left"), $literal(Bson.Arr()))),
-                    $field("left", "sha"),
+                      $lte($literal(Bson.Doc()), $field(JoinDir.Left.name)),
+                      $lt($field(JoinDir.Left.name), $literal(Bson.Arr()))),
+                    $field(JoinDir.Left.name, "sha"),
                     $literal(Bson.Undefined)),
                 "c_auth" ->
                   $cond(
                     $and(
-                      $lte($literal(Bson.Doc()), $field("left")),
-                      $lt($field("left"), $literal(Bson.Arr()))),
+                      $lte($literal(Bson.Doc()), $field(JoinDir.Left.name)),
+                      $lt($field(JoinDir.Left.name), $literal(Bson.Arr()))),
                     $cond(
                       $and(
-                        $lte($literal(Bson.Doc()), $field("left", "author")),
-                        $lt($field("left", "author"), $literal(Bson.Arr()))),
-                      $field("left", "author", "login"),
+                        $lte($literal(Bson.Doc()), $field(JoinDir.Left.name, "author")),
+                        $lt($field(JoinDir.Left.name, "author"), $literal(Bson.Arr()))),
+                      $field(JoinDir.Left.name, "author", "login"),
                       $literal(Bson.Undefined)),
                     $literal(Bson.Undefined)),
                 "parent" ->
                   $cond(
                     $and(
-                      $lte($literal(Bson.Doc()), $field("right")),
-                      $lt($field("right"), $literal(Bson.Arr()))),
-                    $field("right", "sha"),
+                      $lte($literal(Bson.Doc()), $field(JoinDir.Right.name)),
+                      $lt($field(JoinDir.Right.name), $literal(Bson.Arr()))),
+                    $field(JoinDir.Right.name, "sha"),
                     $literal(Bson.Undefined)),
                 "p_auth" ->
                   $cond(
                     $and(
-                      $lte($literal(Bson.Doc()), $field("right")),
-                      $lt($field("right"), $literal(Bson.Arr()))),
+                      $lte($literal(Bson.Doc()), $field(JoinDir.Right.name)),
+                      $lt($field(JoinDir.Right.name), $literal(Bson.Arr()))),
                     $cond(
                       $and(
-                        $lte($literal(Bson.Doc()), $field("right", "author")),
-                        $lt($field("right", "author"), $literal(Bson.Arr()))),
-                      $field("right", "author", "login"),
+                        $lte($literal(Bson.Doc()), $field(JoinDir.Right.name, "author")),
+                        $lt($field(JoinDir.Right.name, "author"), $literal(Bson.Arr()))),
+                      $field(JoinDir.Right.name, "author", "login"),
                       $literal(Bson.Undefined)),
                     $literal(Bson.Undefined))),
               IgnoreId)),
@@ -3403,39 +3403,39 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
             "0" -> $field("__tmp3")).left).left,
           chain[Workflow](_,
             $match(Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
-              BsonField.Name("left") -> Selector.NotExpr(Selector.Size(0)),
-              BsonField.Name("right") -> Selector.NotExpr(Selector.Size(0))))),
-            $unwind(DocField(BsonField.Name("left"))),
-            $unwind(DocField(BsonField.Name("right"))),
+              JoinHandler.LeftName -> Selector.NotExpr(Selector.Size(0)),
+              JoinHandler.RightName -> Selector.NotExpr(Selector.Size(0))))),
+            $unwind(DocField(JoinHandler.LeftName)),
+            $unwind(DocField(JoinHandler.RightName)),
             $project(
               reshape(
                 "city1" ->
                   $cond(
                     $and(
-                      $lte($literal(Bson.Doc()), $field("left")),
-                      $lt($field("left"), $literal(Bson.Arr()))),
-                    $field("left", "city"),
+                      $lte($literal(Bson.Doc()), $field(JoinDir.Left.name)),
+                      $lt($field(JoinDir.Left.name), $literal(Bson.Arr()))),
+                    $field(JoinDir.Left.name, "city"),
                     $literal(Bson.Undefined)),
                 "loc" ->
                   $cond(
                     $and(
-                      $lte($literal(Bson.Doc()), $field("left")),
-                      $lt($field("left"), $literal(Bson.Arr()))),
-                    $field("left", "loc"),
+                      $lte($literal(Bson.Doc()), $field(JoinDir.Left.name)),
+                      $lt($field(JoinDir.Left.name), $literal(Bson.Arr()))),
+                    $field(JoinDir.Left.name, "loc"),
                     $literal(Bson.Undefined)),
                 "city2" ->
                   $cond(
                     $and(
-                      $lte($literal(Bson.Doc()), $field("right")),
-                      $lt($field("right"), $literal(Bson.Arr()))),
-                    $field("right", "city"),
+                      $lte($literal(Bson.Doc()), $field(JoinDir.Right.name)),
+                      $lt($field(JoinDir.Right.name), $literal(Bson.Arr()))),
+                    $field(JoinDir.Right.name, "city"),
                     $literal(Bson.Undefined)),
                 "pop" ->
                   $cond(
                     $and(
-                      $lte($literal(Bson.Doc()), $field("right")),
-                      $lt($field("right"), $literal(Bson.Arr()))),
-                    $field("right", "pop"),
+                      $lte($literal(Bson.Doc()), $field(JoinDir.Right.name)),
+                      $lt($field(JoinDir.Right.name), $literal(Bson.Arr()))),
+                    $field(JoinDir.Right.name, "pop"),
                     $literal(Bson.Undefined))),
               IgnoreId)),
           false).op)
@@ -3451,18 +3451,18 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
           jscore.Literal(Js.Null).right,
           chain[Workflow](_,
             $match(Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
-              BsonField.Name("left") -> Selector.NotExpr(Selector.Size(0)),
-              BsonField.Name("right") -> Selector.NotExpr(Selector.Size(0))))),
-            $unwind(DocField(BsonField.Name("left"))),
-            $unwind(DocField(BsonField.Name("right"))),
+              JoinHandler.LeftName -> Selector.NotExpr(Selector.Size(0)),
+              JoinHandler.RightName -> Selector.NotExpr(Selector.Size(0))))),
+            $unwind(DocField(JoinHandler.LeftName)),
+            $unwind(DocField(JoinHandler.RightName)),
             $project(
               reshape(
                 "__tmp11"   ->
                   $cond(
                     $and(
-                      $lte($literal(Bson.Doc()), $field("right")),
-                      $lt($field("right"), $literal(Bson.Arr()))),
-                    $field("right"),
+                      $lte($literal(Bson.Doc()), $field(JoinDir.Right.name)),
+                      $lt($field(JoinDir.Right.name), $literal(Bson.Arr()))),
+                    $field(JoinDir.Right.name),
                     $literal(Bson.Undefined)),
                 "__tmp12" -> $$ROOT),
               IgnoreId),
@@ -3472,29 +3472,29 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
                 "__tmp13" ->
                   $cond(
                     $and(
-                      $lte($literal(Bson.Doc()), $field("__tmp12", "right")),
-                      $lt($field("__tmp12", "right"), $literal(Bson.Arr(List())))),
+                      $lte($literal(Bson.Doc()), $field("__tmp12", JoinDir.Right.name)),
+                      $lt($field("__tmp12", JoinDir.Right.name), $literal(Bson.Arr(List())))),
                     $cond(
                       $or(
                         $and(
-                          $lt($literal(Bson.Null), $field("__tmp12", "right", "pop")),
-                          $lt($field("__tmp12", "right", "pop"), $literal(Bson.Doc()))),
+                          $lt($literal(Bson.Null), $field("__tmp12", JoinDir.Right.name, "pop")),
+                          $lt($field("__tmp12", JoinDir.Right.name, "pop"), $literal(Bson.Doc()))),
                         $and(
-                          $lte($literal(Bson.Bool(false)), $field("__tmp12", "right", "pop")),
-                          $lt($field("__tmp12", "right", "pop"), $literal(Bson.Regex("", ""))))),
+                          $lte($literal(Bson.Bool(false)), $field("__tmp12", JoinDir.Right.name, "pop")),
+                          $lt($field("__tmp12", JoinDir.Right.name, "pop"), $literal(Bson.Regex("", ""))))),
                       $cond(
                         $and(
-                          $lte($literal(Bson.Doc()), $field("__tmp12", "left")),
-                          $lt($field("__tmp12", "left"), $literal(Bson.Arr(List())))),
+                          $lte($literal(Bson.Doc()), $field("__tmp12", JoinDir.Left.name)),
+                          $lt($field("__tmp12", JoinDir.Left.name), $literal(Bson.Arr(List())))),
                         $cond(
                           $or(
                             $and(
-                              $lt($literal(Bson.Null), $field("__tmp12", "left", "pop")),
-                              $lt($field("__tmp12", "left", "pop"), $literal(Bson.Doc()))),
+                              $lt($literal(Bson.Null), $field("__tmp12", JoinDir.Left.name, "pop")),
+                              $lt($field("__tmp12", JoinDir.Left.name, "pop"), $literal(Bson.Doc()))),
                             $and(
-                              $lte($literal(Bson.Bool(false)), $field("__tmp12", "left", "pop")),
-                              $lt($field("__tmp12", "left", "pop"), $literal(Bson.Regex("", ""))))),
-                          $lt($field("__tmp12", "left", "pop"), $field("__tmp12", "right", "pop")),
+                              $lte($literal(Bson.Bool(false)), $field("__tmp12", JoinDir.Left.name, "pop")),
+                              $lt($field("__tmp12", JoinDir.Left.name, "pop"), $literal(Bson.Regex("", ""))))),
+                          $lt($field("__tmp12", JoinDir.Left.name, "pop"), $field("__tmp12", JoinDir.Right.name, "pop")),
                           $literal(Bson.Undefined)),
                         $literal(Bson.Undefined)),
                       $literal(Bson.Undefined)),

--- a/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/PlannerSpec.scala
+++ b/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/PlannerSpec.scala
@@ -26,6 +26,7 @@ import quasar.contrib.pathy._
 import quasar.Data
 import quasar.DataCodec
 import quasar.qscript._
+import quasar.sql.JoinDir
 
 import org.apache.spark._
 import org.apache.spark.rdd._
@@ -297,8 +298,8 @@ class PlannerSpec extends quasar.Qspec with QScriptHelpers with DisjunctionMatch
         def right: FreeQS = Free.roll(QCT.inj(Filter(HoleQS, func("US"))))
         def key: FreeMap = ProjectFieldR(HoleF, StrLit("age"))
         def combine: JoinFunc = Free.roll(ConcatMaps(
-          Free.roll(MakeMap(StrLit("left"), LeftSideF)),
-          Free.roll(MakeMap(StrLit("right"), RightSideF))
+          Free.roll(MakeMap(StrLit(JoinDir.Left.name), LeftSideF)),
+          Free.roll(MakeMap(StrLit(JoinDir.Right.name), RightSideF))
         ))
 
         val equiJoin = quasar.qscript.EquiJoin(src, left, right, key, key, Inner, combine)
@@ -308,8 +309,8 @@ class PlannerSpec extends quasar.Qspec with QScriptHelpers with DisjunctionMatch
           case rdd =>
             rdd.collect.toList must_== List(
               Data.Obj(ListMap(
-                "left" -> Data.Obj(ListMap(("age" -> Data.Int(24)), ("country" -> Data.Str("Poland")))),
-                "right" -> Data.Obj(ListMap(("age" -> Data.Int(24)), ("country" -> Data.Str("US"))))
+                JoinDir.Left.name -> Data.Obj(ListMap(("age" -> Data.Int(24)), ("country" -> Data.Str("Poland")))),
+                JoinDir.Right.name -> Data.Obj(ListMap(("age" -> Data.Int(24)), ("country" -> Data.Str("US"))))
               )
             ))
         }
@@ -337,8 +338,8 @@ class PlannerSpec extends quasar.Qspec with QScriptHelpers with DisjunctionMatch
         def right: FreeQS = Free.roll(QCT.inj(Filter(HoleQS, func("US"))))
         def key: FreeMap = ProjectFieldR(HoleF, StrLit("age"))
         def combine: JoinFunc = Free.roll(ConcatMaps(
-          Free.roll(MakeMap(StrLit("left"), LeftSideF)),
-          Free.roll(MakeMap(StrLit("right"), RightSideF))
+          Free.roll(MakeMap(StrLit(JoinDir.Left.name), LeftSideF)),
+          Free.roll(MakeMap(StrLit(JoinDir.Right.name), RightSideF))
         ))
 
         val equiJoin = quasar.qscript.EquiJoin(src, left, right, key, key, LeftOuter, combine)
@@ -348,12 +349,12 @@ class PlannerSpec extends quasar.Qspec with QScriptHelpers with DisjunctionMatch
           case rdd =>
             rdd.collect.toList must_== List(
               Data.Obj(ListMap(
-                "left" -> Data.Obj(ListMap(("age" -> Data.Int(32)), ("country" -> Data.Str("Poland")))),
-                "right" -> Data.Null
+                JoinDir.Left.name -> Data.Obj(ListMap(("age" -> Data.Int(32)), ("country" -> Data.Str("Poland")))),
+                JoinDir.Right.name -> Data.Null
               )),
               Data.Obj(ListMap(
-                "left" -> Data.Obj(ListMap(("age" -> Data.Int(24)), ("country" -> Data.Str("Poland")))),
-                "right" -> Data.Obj(ListMap(("age" -> Data.Int(24)), ("country" -> Data.Str("US"))))
+                JoinDir.Left.name -> Data.Obj(ListMap(("age" -> Data.Int(24)), ("country" -> Data.Str("Poland")))),
+                JoinDir.Right.name -> Data.Obj(ListMap(("age" -> Data.Int(24)), ("country" -> Data.Str("US"))))
               ))
               )
         }
@@ -381,8 +382,8 @@ class PlannerSpec extends quasar.Qspec with QScriptHelpers with DisjunctionMatch
         def right: FreeQS = Free.roll(QCT.inj(Filter(HoleQS, func("US"))))
         def key: FreeMap = ProjectFieldR(HoleF, StrLit("age"))
         def combine: JoinFunc = Free.roll(ConcatMaps(
-          Free.roll(MakeMap(StrLit("left"), LeftSideF)),
-          Free.roll(MakeMap(StrLit("right"), RightSideF))
+          Free.roll(MakeMap(StrLit(JoinDir.Left.name), LeftSideF)),
+          Free.roll(MakeMap(StrLit(JoinDir.Right.name), RightSideF))
         ))
 
         val equiJoin = quasar.qscript.EquiJoin(src, left, right, key, key, RightOuter, combine)
@@ -392,12 +393,12 @@ class PlannerSpec extends quasar.Qspec with QScriptHelpers with DisjunctionMatch
           case rdd =>
             rdd.collect.toList must_== List(
               Data.Obj(ListMap(
-                "left" ->  Data.Null,
-                "right" -> Data.Obj(ListMap(("age" -> Data.Int(32)), ("country" -> Data.Str("US"))))
+                JoinDir.Left.name ->  Data.Null,
+                JoinDir.Right.name -> Data.Obj(ListMap(("age" -> Data.Int(32)), ("country" -> Data.Str("US"))))
               )),
               Data.Obj(ListMap(
-                "left" -> Data.Obj(ListMap(("age" -> Data.Int(24)), ("country" -> Data.Str("Poland")))),
-                "right" -> Data.Obj(ListMap(("age" -> Data.Int(24)), ("country" -> Data.Str("US"))))
+                JoinDir.Left.name -> Data.Obj(ListMap(("age" -> Data.Int(24)), ("country" -> Data.Str("Poland")))),
+                JoinDir.Right.name -> Data.Obj(ListMap(("age" -> Data.Int(24)), ("country" -> Data.Str("US"))))
               ))
               )
         }
@@ -426,8 +427,8 @@ class PlannerSpec extends quasar.Qspec with QScriptHelpers with DisjunctionMatch
         def right: FreeQS = Free.roll(QCT.inj(Filter(HoleQS, func("US"))))
         def key: FreeMap = ProjectFieldR(HoleF, StrLit("age"))
         def combine: JoinFunc = Free.roll(ConcatMaps(
-          Free.roll(MakeMap(StrLit("left"), LeftSideF)),
-          Free.roll(MakeMap(StrLit("right"), RightSideF))
+          Free.roll(MakeMap(StrLit(JoinDir.Left.name), LeftSideF)),
+          Free.roll(MakeMap(StrLit(JoinDir.Right.name), RightSideF))
         ))
 
         val equiJoin = quasar.qscript.EquiJoin(src, left, right, key, key, FullOuter, combine)
@@ -437,16 +438,16 @@ class PlannerSpec extends quasar.Qspec with QScriptHelpers with DisjunctionMatch
           case rdd =>
             rdd.collect.toList must_== List(
               Data.Obj(ListMap(
-                "left" ->  Data.Null,
-                "right" -> Data.Obj(ListMap(("age" -> Data.Int(32)), ("country" -> Data.Str("US"))))
+                JoinDir.Left.name ->  Data.Null,
+                JoinDir.Right.name -> Data.Obj(ListMap(("age" -> Data.Int(32)), ("country" -> Data.Str("US"))))
               )),
               Data.Obj(ListMap(
-                "left" ->  Data.Obj(ListMap(("age" -> Data.Int(27)), ("country" -> Data.Str("Poland")))),
-                "right" -> Data.Null
+                JoinDir.Left.name ->  Data.Obj(ListMap(("age" -> Data.Int(27)), ("country" -> Data.Str("Poland")))),
+                JoinDir.Right.name -> Data.Null
               )),
               Data.Obj(ListMap(
-                "left" -> Data.Obj(ListMap(("age" -> Data.Int(24)), ("country" -> Data.Str("Poland")))),
-                "right" -> Data.Obj(ListMap(("age" -> Data.Int(24)), ("country" -> Data.Str("US"))))
+                JoinDir.Left.name -> Data.Obj(ListMap(("age" -> Data.Int(24)), ("country" -> Data.Str("Poland")))),
+                JoinDir.Right.name -> Data.Obj(ListMap(("age" -> Data.Int(24)), ("country" -> Data.Str("US"))))
               ))
               )
         }


### PR DESCRIPTION
The first step toward #1556, which eliminates the hard-coded "left" and "right" fields in join access.

In order to complete that ticket, it will be useful to easily see all the places "left" and "right" are actually used.