### PR TITLE
Report errors from the workflow phase

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,2 @@
+- [#1526] improve error reporting for cases that aren't handled in the MongoDB planner (those requiring and auto-self-join).
+- Fix some date_part cases, mostly when evaluated in MongoDB's map-reduce.

--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,2 +1,2 @@
-- [#1526] improve error reporting for cases that aren't handled in the MongoDB planner (those requiring and auto-self-join).
+- [#1526] improve error reporting for cases that aren't handled in the MongoDB planner (those requiring an autojoin).
 - Fix some date_part cases, mostly when evaluated in MongoDB's map-reduce.

--- a/it/src/main/resources/tests/temporal/datePartsConverted.test
+++ b/it/src/main/resources/tests/temporal/datePartsConverted.test
@@ -10,13 +10,13 @@
 
   "data": "../slamengine_commits.data",
 
-  "nb": "`doy`, `week`, and `quarter` are missing because we currently have
-         no JS implementation.",
+  "nb": "`doy` and `week` are missing because we currently have no JS implementation.",
   "query": "select
               date_part(\"millennium\", timestamp(commit.committer.date)) as millennium,
               date_part(\"century\", timestamp(commit.committer.date)) as century,
               date_part(\"decade\", timestamp(commit.committer.date)) as decade,
               date_part(\"year\", timestamp(commit.committer.date)) as year,
+              date_part(\"quarter\", timestamp(commit.committer.date)) as quarter,
               date_part(\"month\", timestamp(commit.committer.date)) as month,
               date_part(\"day\", timestamp(commit.committer.date)) as dayOfMonth,
               date_part(\"dow\", timestamp(commit.committer.date)) as dayOfWeek,
@@ -34,7 +34,7 @@
   "expected": [
     {
     "millennium": 3.0, "century": 21.0, "decade": 201.0, "year": 2015.0,
-    "month": 1.0, "dayOfMonth": 29.0, "dayOfWeek": 4.0, "dayOfWeek (ISO)": 4.0,
+    "quarter": 1.0, "month": 1.0, "dayOfMonth": 29.0, "dayOfWeek": 4.0, "dayOfWeek (ISO)": 4.0,
     "hour": 15.0, "minute": 52.0, "second": 37.0, "millis": 37000.0, "micros": 3.7e7,
     "id": "33031"
     }

--- a/it/src/main/resources/tests/temporal/datePartsConverted.test
+++ b/it/src/main/resources/tests/temporal/datePartsConverted.test
@@ -1,11 +1,8 @@
 {
-  "name": "date_part with all selectors, after conversion to JS (see #1238)",
+  "name": "date_part with (virtually) all selectors, after conversion to JS (see #1238)",
 
   "backends": {
-      "mongodb_2_6":       "pending",
-      "mongodb_3_0":       "pending",
       "mongodb_read_only": "pending",
-      "mongodb_3_2":       "pending",
       "postgresql":        "pending",
       "marklogic":         "skip",
       "couchbase":         "skip"
@@ -13,14 +10,13 @@
 
   "data": "../slamengine_commits.data",
 
-  "nb": "Currently pending for Mongo because the shape is somehow not handled for JS.
-         Also `doy` and `week` are missing because we currently have no JS implementation.",
+  "nb": "`doy`, `week`, and `quarter` are missing because we currently have
+         no JS implementation.",
   "query": "select
-              date_part(\"millennium\", timestamp(commit.committer.date)) as millenium,
+              date_part(\"millennium\", timestamp(commit.committer.date)) as millennium,
               date_part(\"century\", timestamp(commit.committer.date)) as century,
               date_part(\"decade\", timestamp(commit.committer.date)) as decade,
               date_part(\"year\", timestamp(commit.committer.date)) as year,
-              date_part(\"quarter\", timestamp(commit.committer.date)) as quarter,
               date_part(\"month\", timestamp(commit.committer.date)) as month,
               date_part(\"day\", timestamp(commit.committer.date)) as dayOfMonth,
               date_part(\"dow\", timestamp(commit.committer.date)) as dayOfWeek,
@@ -28,8 +24,8 @@
               date_part(\"hour\", timestamp(commit.committer.date)) as hour,
               date_part(\"minute\", timestamp(commit.committer.date)) as minute,
               date_part(\"second\", timestamp(commit.committer.date)) as second,
-              date_part(\"millisecond\", timestamp(commit.committer.date)) as millis,
-              date_part(\"microsecond\", timestamp(commit.committer.date)) as micros,
+              date_part(\"milliseconds\", timestamp(commit.committer.date)) as millis,
+              date_part(\"microseconds\", timestamp(commit.committer.date)) as micros,
               to_string(author.id) as id
               from `../slamengine_commits`",
 
@@ -37,9 +33,10 @@
 
   "expected": [
     {
-      "id": "33031",
-      "millennium": 2, "century": 20, "decade": 201, "year": 2015,
-      "doy": 1
+    "millennium": 3.0, "century": 21.0, "decade": 201.0, "year": 2015.0,
+    "month": 1.0, "dayOfMonth": 29.0, "dayOfWeek": 4.0, "dayOfWeek (ISO)": 4.0,
+    "hour": 15.0, "minute": 52.0, "second": 37.0, "millis": 37000.0, "micros": 3.7e7,
+    "id": "33031"
     }
   ]
 }

--- a/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
@@ -47,7 +47,6 @@ class MongoDbExprStdLibSpec extends MongoDbStdLibSpec {
     case (string.ToString, _) => notHandled.left
 
     case (date.ExtractIsoYear, _) => notHandled.left
-    case (date.ExtractQuarter, _) => Skipped("TODO").left
 
     case (date.TimeOfDay, _) if is2_6(backend) => Skipped("not implemented in aggregation on MongoDB 2.6").left
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/expression/ExprOpCore.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/expression/ExprOpCore.scala
@@ -348,6 +348,7 @@ object ExprOpCoreF {
         case $lteF(l, r)             => binop(jscore.Lte, l, r)
         case expr @ $metaF()          => -\/(NonRepresentableInJS(expr.toString))
         case $multiplyF(l, r)        => binop(jscore.Mult, l, r)
+        case $modF(l, r)             => binop(jscore.Mod, l, r)
         case $neqF(l, r)             => binop(jscore.Neq, l, r)
         case $notF(a)                => unop(jscore.Not, a)
         case $orF(f, s, o @ _*)      =>
@@ -368,7 +369,10 @@ object ExprOpCoreF {
 
         case $yearF(a)               => invoke(a, "getUTCFullYear")
         // case $dayOfYear(a)           => // TODO: no JS equivalent
-        case $monthF(a)              => invoke(a, "getUTCMonth")
+        case $monthF(a)              => expr1(a)(x =>
+          jscore.BinOp(jscore.Add,
+            jscore.Call(jscore.Select(x, "getUTCMonth"), Nil),
+            jscore.Literal(Js.Num(1, false))))
         case $dayOfMonthF(a)         => invoke(a, "getUTCDate")
         // case $week(a)                => // TODO: no JS equivalent
         case $dayOfWeekF(a)          => expr1(a)(x =>

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/FuncHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/FuncHandler.scala
@@ -117,10 +117,12 @@ object FuncHandler {
           case ExtractMinute(a1) => $minute(a1)
           case ExtractMonth(a1) => $month(a1)
           case ExtractQuarter(a1) =>
-            // FIXME
-            trunc($add(
-              $divide($dayOfYear(a1), $literal(Bson.Int32(92))),
-              $literal(Bson.Int32(1))))
+            trunc(
+              $add(
+                $divide(
+                  $subtract($month(a1), $literal(Bson.Int32(1))),
+                  $literal(Bson.Int32(3))),
+                $literal(Bson.Int32(1))))
           case ExtractSecond(a1) =>
             $add($second(a1), $divide($millisecond(a1), $literal(Bson.Int32(1000))))
           case ExtractWeek(a1) => $week(a1)

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/JoinHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/JoinHandler.scala
@@ -17,6 +17,7 @@
 package quasar.physical.mongodb.planner
 
 import quasar.Predef._
+import quasar.RenderTree
 import quasar.fp._
 import quasar.fp.ski._
 import quasar.javascript._
@@ -66,7 +67,7 @@ object JoinHandler {
       C: Classify[WF],
       ev0: WorkflowOpCoreF :<: WF,
       ev1: WorkflowOp3_2F :<: WF,
-      ev2: Show[WorkflowBuilder[WF]],
+      ev2: RenderTree[WorkflowBuilder[WF]],
       ev3: ExprOpOps.Uni[ExprOp])
     : JoinHandler[WF, OptionT[WorkflowBuilder.M, ?]] = JoinHandler({ (tpe, left, right) =>
 
@@ -202,7 +203,7 @@ object JoinHandler {
 
   /** Plan an arbitrary join using only "core" operators, which always means a map-reduce. */
   def mapReduce[WF[_]: Functor: Coalesce: Crush: Crystallize]
-    (implicit ev0: WorkflowOpCoreF :<: WF, ev1: Show[WorkflowBuilder[WF]], ev2: ExprOpOps.Uni[ExprOp])
+    (implicit ev0: WorkflowOpCoreF :<: WF, ev1: RenderTree[WorkflowBuilder[WF]], ev2: ExprOpOps.Uni[ExprOp])
     : JoinHandler[WF, WorkflowBuilder.M] = JoinHandler({ (tpe, left0, right0) =>
 
     val ops = Ops[WF]
@@ -341,7 +342,7 @@ object JoinHandler {
   //      `Workflow.crush`, when we actually have a task (whether aggregation or
   //       mapReduce) in hand, we would know for sure.
   private def preferMapReduce[WF[_]: Coalesce: Crush: Crystallize: Functor](wb: WorkflowBuilder[WF])
-    (implicit ev0: WorkflowOpCoreF :<: WF, ev1: Show[WorkflowBuilder[WF]], ev2: ExprOpOps.Uni[ExprOp])
+    (implicit ev0: WorkflowOpCoreF :<: WF, ev1: RenderTree[WorkflowBuilder[WF]], ev2: ExprOpOps.Uni[ExprOp])
     : Boolean = {
     // TODO: Get rid of this when we functorize WorkflowTask
     def checkTask(wt: workflowtask.WorkflowTask): Boolean = wt match {

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/MongoDbPlanner.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/MongoDbPlanner.scala
@@ -478,7 +478,7 @@ object MongoDbPlanner {
     (joinHandler: JoinHandler[F, WorkflowBuilder.M], funcHandler: FuncHandler[Fix, EX])
     (implicit
       ev0: WorkflowOpCoreF :<: F,
-      ev1: Show[WorkflowBuilder[F]],
+      ev1: RenderTree[WorkflowBuilder[F]],
       ev2: ExprOpCoreF :<: EX,
       inj: EX :<: ExprOp,
       WB: WorkflowBuilder.Ops[F])
@@ -541,7 +541,7 @@ object MongoDbPlanner {
       val HasLiteral: Ann => OutputM[Bson] = ann => HasWorkflow(ann).flatMap { p =>
         asLiteral(p) match {
           case Some(value) => \/-(value)
-          case _           => -\/(FuncApply(func.name, "literal", p.shows))
+          case _           => -\/(FuncApply(func.name, "literal", p.render.shows))
         }
       }
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -482,7 +482,7 @@ object MongoDbQScriptPlanner {
       joinHandler: JoinHandler[WF, WorkflowBuilder.M],
       funcHandler: FuncHandler[IT, EX])(
           implicit ev0: WorkflowOpCoreF :<: WF,
-                   ev1: Show[WorkflowBuilder[WF]],
+                   ev1: RenderTree[WorkflowBuilder[WF]],
                    ev2: WorkflowBuilder.Ops[WF],
                    ev3: EX :<: ExprOp):
         AlgebraM[StateT[OutputM, NameGen, ?], F, WorkflowBuilder[WF]]
@@ -507,7 +507,7 @@ object MongoDbQScriptPlanner {
           joinHandler: JoinHandler[WF, WorkflowBuilder.M],
           funcHandler: FuncHandler[T, EX])(
           implicit ev0: WorkflowOpCoreF :<: WF,
-                   ev1: Show[WorkflowBuilder[WF]],
+                   ev1: RenderTree[WorkflowBuilder[WF]],
                    WB: WorkflowBuilder.Ops[WF],
                    ev3: EX :<: ExprOp) =
           qs => Collection
@@ -534,7 +534,7 @@ object MongoDbQScriptPlanner {
           joinHandler: JoinHandler[WF, WorkflowBuilder.M],
           funcHandler: FuncHandler[T, EX])(
           implicit ev0: WorkflowOpCoreF :<: WF,
-                   ev1: Show[WorkflowBuilder[WF]],
+                   ev1: RenderTree[WorkflowBuilder[WF]],
                    WB: WorkflowBuilder.Ops[WF],
                    ev3: EX :<: ExprOp) = {
           case qscript.Map(src, f) =>
@@ -587,7 +587,7 @@ object MongoDbQScriptPlanner {
           joinHandler: JoinHandler[WF, WorkflowBuilder.M],
           funcHandler: FuncHandler[T, EX])(
           implicit ev0: WorkflowOpCoreF :<: WF,
-                   ev1: Show[WorkflowBuilder[WF]],
+                   ev1: RenderTree[WorkflowBuilder[WF]],
                    ev2: WorkflowBuilder.Ops[WF],
                    ev3: EX :<: ExprOp) =
           qs =>
@@ -617,7 +617,7 @@ object MongoDbQScriptPlanner {
           joinHandler: JoinHandler[WF, WorkflowBuilder.M],
           funcHandler: FuncHandler[T, EX])(
           implicit ev0: WorkflowOpCoreF :<: WF,
-                   ev1: Show[WorkflowBuilder[WF]],
+                   ev1: RenderTree[WorkflowBuilder[WF]],
                    ev2: WorkflowBuilder.Ops[WF],
                    ev3: EX :<: ExprOp) =
           _.run.fold(F.plan(joinHandler, funcHandler), G.plan(joinHandler, funcHandler))
@@ -634,7 +634,7 @@ object MongoDbQScriptPlanner {
           joinHandler: JoinHandler[WF, WorkflowBuilder.M],
           funcHandler: FuncHandler[T, EX])(
           implicit ev0: WorkflowOpCoreF :<: WF,
-                   ev1: Show[WorkflowBuilder[WF]],
+                   ev1: RenderTree[WorkflowBuilder[WF]],
                    ev2: WorkflowBuilder.Ops[WF],
                    ev3: EX :<: ExprOp) =
           κ(shouldNotBeReached)
@@ -647,7 +647,7 @@ object MongoDbQScriptPlanner {
           joinHandler: JoinHandler[WF, WorkflowBuilder.M],
           funcHandler: FuncHandler[T, EX])(
           implicit ev0: WorkflowOpCoreF :<: WF,
-                   ev1: Show[WorkflowBuilder[WF]],
+                   ev1: RenderTree[WorkflowBuilder[WF]],
                    ev2: WorkflowBuilder.Ops[WF],
                    ev3: EX :<: ExprOp) =
           κ(shouldNotBeReached)
@@ -660,7 +660,7 @@ object MongoDbQScriptPlanner {
           joinHandler: JoinHandler[WF, WorkflowBuilder.M],
           funcHandler: FuncHandler[T, EX])(
           implicit ev0: WorkflowOpCoreF :<: WF,
-                   ev1: Show[WorkflowBuilder[WF]],
+                   ev1: RenderTree[WorkflowBuilder[WF]],
                    ev2: WorkflowBuilder.Ops[WF],
                    ev3: EX :<: ExprOp) =
           κ(shouldNotBeReached)
@@ -673,7 +673,7 @@ object MongoDbQScriptPlanner {
           joinHandler: JoinHandler[WF, WorkflowBuilder.M],
           funcHandler: FuncHandler[T, EX])(
           implicit ev0: WorkflowOpCoreF :<: WF,
-                   ev1: Show[WorkflowBuilder[WF]],
+                   ev1: RenderTree[WorkflowBuilder[WF]],
                    ev2: WorkflowBuilder.Ops[WF],
                    ev3: EX :<: ExprOp) =
           κ(shouldNotBeReached)
@@ -750,7 +750,7 @@ object MongoDbQScriptPlanner {
     src: WorkflowBuilder[WF])(
     implicit F: Planner.Aux[T, QScriptTotal[T, ?]],
              ev0: WorkflowOpCoreF :<: WF,
-             ev1: Show[WorkflowBuilder[WF]],
+             ev1: RenderTree[WorkflowBuilder[WF]],
              ev2: WorkflowBuilder.Ops[WF],
              ev3: EX :<: ExprOp):
       StateT[OutputM, NameGen, WorkflowBuilder[WF]] =

--- a/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -359,7 +359,9 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
                    $lt($field("baz"), $literal(Bson.Regex("", "")))),
                  $trunc(
                    $add(
-                     $divide($dayOfYear($field("baz")), $literal(Bson.Int32(92))),
+                     $divide(
+                       $subtract($month($field("baz")), $literal(Bson.Int32(1))),
+                       $literal(Bson.Int32(3))),
                      $literal(Bson.Int32(1)))),
                  $literal(Bson.Undefined))),
            IgnoreId)))


### PR DESCRIPTION
This produces a much more comprehensible error than the one the refers to JS phase.

With that in hand, it was possible to debug and enable a more comprehensive `date_part` regression test that had been pending.