### PR TITLE
expand FreeQS nodes when rendering QScript trees

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- improve rendering of QScript nodes for debugging and "explain" (specifically, the sources of joins and unions)

--- a/connector/src/main/scala/quasar/qscript/EquiJoin.scala
+++ b/connector/src/main/scala/quasar/qscript/EquiJoin.scala
@@ -17,9 +17,8 @@
 package quasar.qscript
 
 import quasar.Predef._
-import quasar.{NonTerminal, RenderTree}, RenderTree.ops._
+import quasar.{NonTerminal, RenderTree, RenderTreeT}, RenderTree.ops._
 import quasar.contrib.matryoshka._
-import quasar.ejson.EJson
 import quasar.fp._
 
 import matryoshka._
@@ -74,9 +73,7 @@ object EquiJoin {
       }
     }
 
-  // TODO: implement Delay[RenderTree, EJson] and remove the oddball Show
-  implicit def renderTree[T[_[_]]: quasar.RenderTreeT](implicit ev: Show[T[EJson]])
-      : Delay[RenderTree, EquiJoin[T, ?]] =
+  implicit def renderTree[T[_[_]]: RenderTreeT: ShowT]: Delay[RenderTree, EquiJoin[T, ?]] =
     new Delay[RenderTree, EquiJoin[T, ?]] {
       val nt = List("EquiJoin")
       def apply[A](r: RenderTree[A]): RenderTree[EquiJoin[T, A]] = RenderTree.make {

--- a/connector/src/main/scala/quasar/qscript/MapFunc.scala
+++ b/connector/src/main/scala/quasar/qscript/MapFunc.scala
@@ -566,6 +566,7 @@ object MapFunc {
       }
     }
 
+  // TODO: implement Delay[RenderTree, EJson] and remove the oddball Show
   implicit def renderTree[T[_[_]]](implicit ev0: Show[T[EJson]], ev1: RenderTree[Type]): Delay[RenderTree, MapFunc[T, ?]] =
     new Delay[RenderTree, MapFunc[T, ?]] {
       val nt = "MapFunc" :: Nil

--- a/connector/src/main/scala/quasar/qscript/MapFunc.scala
+++ b/connector/src/main/scala/quasar/qscript/MapFunc.scala
@@ -567,7 +567,7 @@ object MapFunc {
     }
 
   // TODO: implement Delay[RenderTree, EJson] and remove the oddball Show
-  implicit def renderTree[T[_[_]]](implicit ev0: Show[T[EJson]], ev1: RenderTree[Type]): Delay[RenderTree, MapFunc[T, ?]] =
+  implicit def renderTree[T[_[_]]](implicit ev: Show[T[EJson]]): Delay[RenderTree, MapFunc[T, ?]] =
     new Delay[RenderTree, MapFunc[T, ?]] {
       val nt = "MapFunc" :: Nil
 

--- a/connector/src/main/scala/quasar/qscript/MapFunc.scala
+++ b/connector/src/main/scala/quasar/qscript/MapFunc.scala
@@ -566,8 +566,9 @@ object MapFunc {
       }
     }
 
-  // TODO: implement Delay[RenderTree, EJson] and remove the oddball Show
-  implicit def renderTree[T[_[_]]](implicit ev: Show[T[EJson]]): Delay[RenderTree, MapFunc[T, ?]] =
+  // TODO: replace this with some kind of pretty-printing based on a syntax for
+  // MapFunc + EJson.
+  implicit def renderTree[T[_[_]]: ShowT]: Delay[RenderTree, MapFunc[T, ?]] =
     new Delay[RenderTree, MapFunc[T, ?]] {
       val nt = "MapFunc" :: Nil
 
@@ -578,7 +579,7 @@ object MapFunc {
 
         RenderTree.make {
           // nullary
-          case Constant(a1) => Terminal("Constant" :: nt, a1.shows.some)  // TODO: use RenderTree[T[EJson]]?
+          case Constant(a1) => Terminal("Constant" :: nt, a1.shows.some)
           case Undefined() => Terminal("Undefined" :: nt, None)
           case Now() => Terminal("Now" :: nt, None)
 

--- a/connector/src/main/scala/quasar/qscript/ProjectBucket.scala
+++ b/connector/src/main/scala/quasar/qscript/ProjectBucket.scala
@@ -17,9 +17,8 @@
 package quasar.qscript
 
 import quasar.Predef._
-import quasar.{NonTerminal, RenderTree}, RenderTree.ops._
+import quasar.{NonTerminal, RenderTree, RenderTreeT}, RenderTree.ops._
 import quasar.contrib.matryoshka._
-import quasar.ejson.EJson
 import quasar.fp._
 
 import matryoshka._
@@ -90,9 +89,7 @@ object ProjectBucket {
         }
     }
 
-  // TODO: implement Delay[RenderTree, EJson] and remove the oddball Show
-  implicit def renderTree[T[_[_]]: quasar.RenderTreeT](implicit ev: Show[T[EJson]])
-      : Delay[RenderTree, ProjectBucket[T, ?]] =
+  implicit def renderTree[T[_[_]]: RenderTreeT: ShowT]: Delay[RenderTree, ProjectBucket[T, ?]] =
     new Delay[RenderTree, ProjectBucket[T, ?]] {
       def apply[A](RA: RenderTree[A]): RenderTree[ProjectBucket[T, A]] = RenderTree.make {
         case BucketField(src, value, name) =>

--- a/connector/src/main/scala/quasar/qscript/ProjectBucket.scala
+++ b/connector/src/main/scala/quasar/qscript/ProjectBucket.scala
@@ -19,6 +19,7 @@ package quasar.qscript
 import quasar.Predef._
 import quasar.{NonTerminal, RenderTree}, RenderTree.ops._
 import quasar.contrib.matryoshka._
+import quasar.ejson.EJson
 import quasar.fp._
 
 import matryoshka._
@@ -89,9 +90,9 @@ object ProjectBucket {
         }
     }
 
-  implicit def renderTree[T[_[_]]](implicit
-    FM: RenderTree[FreeMap[T]]
-  ): Delay[RenderTree, ProjectBucket[T, ?]] =
+  // TODO: implement Delay[RenderTree, EJson] and remove the oddball Show
+  implicit def renderTree[T[_[_]]: quasar.RenderTreeT](implicit ev: Show[T[EJson]])
+      : Delay[RenderTree, ProjectBucket[T, ?]] =
     new Delay[RenderTree, ProjectBucket[T, ?]] {
       def apply[A](RA: RenderTree[A]): RenderTree[ProjectBucket[T, A]] = RenderTree.make {
         case BucketField(src, value, name) =>

--- a/connector/src/main/scala/quasar/qscript/QScriptCore.scala
+++ b/connector/src/main/scala/quasar/qscript/QScriptCore.scala
@@ -19,7 +19,6 @@ package quasar.qscript
 import quasar.Predef._
 import quasar.{NonTerminal, Terminal, RenderTree, RenderTreeT}, RenderTree.ops._
 import quasar.contrib.matryoshka._
-import quasar.ejson.EJson
 import quasar.fp._
 
 import matryoshka._
@@ -209,8 +208,7 @@ object QScriptCore {
         }
     }
 
-  // TODO: implement Delay[RenderTree, EJson] and remove the oddball Show
-  implicit def renderTree[T[_[_]]: RenderTreeT](implicit ev: Show[T[EJson]])
+  implicit def renderTree[T[_[_]]: RenderTreeT: ShowT]
       : Delay[RenderTree, QScriptCore[T, ?]] =
     new Delay[RenderTree, QScriptCore[T, ?]] {
       def apply[A](RA: RenderTree[A]): RenderTree[QScriptCore[T, A]] =

--- a/connector/src/main/scala/quasar/qscript/ThetaJoin.scala
+++ b/connector/src/main/scala/quasar/qscript/ThetaJoin.scala
@@ -19,7 +19,6 @@ package quasar.qscript
 import quasar.Predef._
 import quasar.{RenderTree, NonTerminal, RenderTreeT}, RenderTree.ops._
 import quasar.contrib.matryoshka._
-import quasar.ejson.EJson
 import quasar.fp._
 
 import matryoshka._
@@ -77,9 +76,7 @@ object ThetaJoin {
       }
     }
 
-  // TODO: implement Delay[RenderTree, EJson] and remove the oddball Show
-  implicit def renderTree[T[_[_]]: RenderTreeT](implicit ev: Show[T[EJson]])
-      : Delay[RenderTree, ThetaJoin[T, ?]] =
+  implicit def renderTree[T[_[_]]: RenderTreeT: ShowT]: Delay[RenderTree, ThetaJoin[T, ?]] =
     new Delay[RenderTree, ThetaJoin[T, ?]] {
       val nt = List("ThetaJoin")
       def apply[A](r: RenderTree[A]): RenderTree[ThetaJoin[T, A]] = RenderTree.make {

--- a/foundation/src/main/scala/quasar/RenderTree.scala
+++ b/foundation/src/main/scala/quasar/RenderTree.scala
@@ -17,7 +17,7 @@
 package quasar
 
 import quasar.Predef._
-import quasar.fp._, ski._
+import quasar.fp._
 import quasar.contrib.matryoshka._
 
 import argonaut._, Argonaut._
@@ -199,13 +199,8 @@ object RenderTree extends RenderTreeInstances {
   implicit def naturalTransformation[F[_], A: RenderTree](implicit F: Delay[RenderTree, F]): RenderTree[F[A]] =
     F(RenderTree[A])
 
-  implicit def fix[F[_]](implicit RF: Delay[RenderTree, F]): RenderTree[Fix[F]] =
-    make(RF(fix[F]) render _.unFix)
-
   implicit def free[F[_]: Functor, A: RenderTree](implicit F: Delay[RenderTree, F]): RenderTree[Free[F, A]] =
-    make(t => freeCata(t)(interpret[F, A, RenderedTree](
-      a => a.render,
-      f => F(RenderTree.make[RenderedTree](ι)).render(f))))
+    RenderTreeT.free[A].renderTree[F](F)
 
   implicit def cofree[F[_], A: RenderTree](implicit RF: Delay[RenderTree, F]): RenderTree[Cofree[F, A]] =
     make(t => NonTerminal(List("Cofree"), None, List(t.head.render, RF(cofree[F, A]).render(t.tail))))

--- a/foundation/src/main/scala/quasar/RenderTreeT.scala
+++ b/foundation/src/main/scala/quasar/RenderTreeT.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar
+
+import quasar.Predef._
+import quasar.fp.ski._
+import quasar.contrib.matryoshka._
+
+import matryoshka.{Delay, Fix}
+import scalaz._
+import simulacrum.typeclass
+
+/** Analogous to `ShowT`; allows construction of `Delay[RenderTree, F]` for
+  * an `F` that refers to `T[... F ...]`. */
+@typeclass trait RenderTreeT[T[_[_]]] {
+  def render[F[_]: Functor](t: T[F])(implicit delay: Delay[RenderTree, F]): RenderedTree
+
+  def renderTree[F[_]: Functor](delay: Delay[RenderTree, F]): RenderTree[T[F]] =
+    RenderTree.make[T[F]](t => render(t)(Functor[F], delay))
+}
+object RenderTreeT {
+  implicit val fix: RenderTreeT[Fix] =
+    new RenderTreeT[Fix] {
+      def render[F[_]: Functor](t: Fix[F])(implicit delay: Delay[RenderTree, F]): RenderedTree =
+        delay(renderTree[F](delay)).render(t.unFix)
+    }
+
+  // NB: no point making it implicit because the separation of F and A defeats
+  // implicit search.
+  def free[A: RenderTree]: RenderTreeT[Free[?[_], A]] = new RenderTreeT[Free[?[_], A]] {
+    def render[F[_]: Functor](t: Free[F, A])(implicit delay: Delay[RenderTree, F]): RenderedTree =
+      freeCata(t)(interpret[F, A, RenderedTree](
+        a => RenderTree[A].render(a),
+        f => delay(RenderTree.make[RenderedTree](ι)).render(f)))
+  }
+}

--- a/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -812,7 +812,7 @@ object MongoDbQScriptPlanner {
 
   type GenT[X[_], A]  = StateT[X, NameGen, A]
 
-  def plan0[T[_[_]]: Recursive: Corecursive: EqualT: ShowT,
+  def plan0[T[_[_]]: Recursive: Corecursive: EqualT: ShowT: RenderTreeT,
             WF[_]: Functor: Coalesce: Crush: Crystallize,
             EX[_]: Traverse](
     joinHandler: JoinHandler[WF, WorkflowBuilder.M],
@@ -884,7 +884,7 @@ object MongoDbQScriptPlanner {
     * can be used, but the resulting plan uses the largest, common type so that
     * callers don't need to worry about it.
     */
-  def plan[T[_[_]]: Recursive: Corecursive: EqualT: ShowT](
+  def plan[T[_[_]]: Recursive: Corecursive: EqualT: ShowT: RenderTreeT](
     logical: T[LogicalPlan], queryContext: fs.QueryContext):
       EitherT[WriterT[MongoDbIO, PhaseResults, ?], FileSystemError, Crystallized[WorkflowF]] = {
     import MongoQueryModel._


### PR DESCRIPTION
This makes the sources of Join and Union nodes comprehensible (see upcoming comment).

Introduces `RenderTreeT`, which the join types use to get ahold of instances for types involving `QScriptTotal`. There is also still the oddball requirement of a `Show[T[EJson]]`, which could be eliminated by implementing `Delay[RenderTree, EJson]`, but that seems like a job for another day.

I'd like to collapse ProjectIndex and ProjectField nodes for readability (as we do in LogicalPlan), but it's going to be either tricky or a big hack, since it involves seeing through the rendering of both `T` and `EJson`.