### PR TITLE
Couchbase: Increase query timeout

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- Couchbase: Increase query timeout

--- a/couchbase/src/main/scala/quasar/physical/couchbase/fs/package.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/fs/package.scala
@@ -64,7 +64,7 @@ package object fs {
     // TODO: retrieve from connectionUri params
     val env = DefaultCouchbaseEnvironment
       .builder()
-      .queryTimeout(SECONDS.toMillis(150))
+      .queryTimeout(SECONDS.toMillis(250))
       .build()
 
     val cbCtx: DefErrT[Task, Context] =


### PR DESCRIPTION
It's tough to say whether or not this will decrease the number of timeouts we are seeing since we don't know what state Couchbase server is getting into on Travis builds at this point. Despite that I think it's worth a try.