### PR TITLE
Use Equal for LogicalPlan in as many places as possible.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- Use Equal for LogicalPlan in as many places as possible.

--- a/connector/src/main/scala/quasar/fs/InMemory.scala
+++ b/connector/src/main/scala/quasar/fs/InMemory.scala
@@ -224,7 +224,11 @@ object InMemory {
           case InvokeUnapply(Squash, Sized((_,src))) => src
           case Constant(data) => Vector(data).right
           case other =>
-            queryResponsesL.get(mem).mapKeys(optimizer.optimize).get(Fix(other.map(_._1))).toRightDisjunction(unsupported(optLp))
+            queryResponsesL
+              .get(mem)
+              .mapKeys(optimizer.optimize)
+              .get(Fix(other.map(_._1)))
+              .toRightDisjunction(unsupported(optLp))
         }
       })
     }

--- a/core/src/test/scala/quasar/fs/mount/ViewFileSystemSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/ViewFileSystemSpec.scala
@@ -571,7 +571,7 @@ class ViewFileSystemSpec extends quasar.Qspec with TreeMatchers {
 
     "no match" >> {
       resolvedRefs(Map(), lpf.read(rootDir </> file("zips"))) must
-        beRightDisjunction.like { case r => r must beTree(lpf.read(rootDir </> file("zips"))) }
+        beRightDisjunction.like { case r => r must beTreeEqual(lpf.read(rootDir </> file("zips"))) }
     }
 
     "trivial read" >> {
@@ -579,7 +579,7 @@ class ViewFileSystemSpec extends quasar.Qspec with TreeMatchers {
       val vs = Map[AFile, Fix[Sql]](p -> unsafeParse("select * from `/zips`"))
 
       resolvedRefs(vs, lpf.read(p)) must beRightDisjunction.like {
-        case r => r must beTree(
+        case r => r must beTreeEqual(
           Fix(Squash(lpf.read(rootDir </> file("zips"))))
         )
       }
@@ -590,7 +590,7 @@ class ViewFileSystemSpec extends quasar.Qspec with TreeMatchers {
       val vs = Map[AFile, Fix[Sql]](p -> unsafeParse("select * from zips"))
 
       resolvedRefs(vs, lpf.read(p)) must beRightDisjunction.like {
-        case r => r must beTree(
+        case r => r must beTreeEqual(
           Fix(Squash(lpf.read(rootDir </> dir("foo") </> file("zips"))))
         )
       }
@@ -620,7 +620,7 @@ class ViewFileSystemSpec extends quasar.Qspec with TreeMatchers {
           lpf.constant(Data.Int(10))).embed).run.value.toOption.get
 
       resolvedRefs(vs, outer) must beRightDisjunction.like {
-        case r => r must beTree(exp)
+        case r => r must beTreeEqual(exp)
       }
     }
 
@@ -632,7 +632,7 @@ class ViewFileSystemSpec extends quasar.Qspec with TreeMatchers {
           unsafeParse("select * from view1"))
 
       resolvedRefs(vs, lpf.read(rootDir </> dir("view") </> file("view2"))) must
-        beRightDisjunction.like { case r => r must beTree(
+        beRightDisjunction.like { case r => r must beTreeEqual(
           Squash(Squash(lpf.read(rootDir </> file("zips"))).embed).embed)
         }
     }
@@ -660,7 +660,7 @@ class ViewFileSystemSpec extends quasar.Qspec with TreeMatchers {
         Squash(lpf.read(zp)).embed,
         lpf.constant(Data.Bool(true))).embed
 
-      resolvedRefs(vs, q) must beRightDisjunction.like { case r => r must beTree(exp) }
+      resolvedRefs(vs, q) must beRightDisjunction.like { case r => r must beTreeEqual(exp) }
     }
 
     "self reference" >> {
@@ -678,7 +678,7 @@ class ViewFileSystemSpec extends quasar.Qspec with TreeMatchers {
 
       val vs = Map[AFile, Fix[Sql]](p -> q)
 
-      resolvedRefs(vs, lpf.read(p)) must beRightDisjunction.like { case r => r must beTree(qlp) }
+      resolvedRefs(vs, lpf.read(p)) must beRightDisjunction.like { case r => r must beTreeEqual(qlp) }
     }
 
     "circular reference" >> {
@@ -697,7 +697,7 @@ class ViewFileSystemSpec extends quasar.Qspec with TreeMatchers {
         v2p -> unsafeParse(s"select * from `${posixCodec.printPath(v1p)}` limit 10"))
 
       resolvedRefs(vs, lpf.read(v2p)) must beRightDisjunction.like {
-        case r => r must beTree(
+        case r => r must beTreeEqual(
           Take(
             Squash(Drop(
               Squash(lpf.read(v2p)).embed,

--- a/core/src/test/scala/quasar/optimizer.scala
+++ b/core/src/test/scala/quasar/optimizer.scala
@@ -35,7 +35,7 @@ class OptimizerSpec extends quasar.Qspec with CompilerHelpers with TreeMatchers 
 
     "inline trivial binding" in {
       optimizer.simplify(lpf.let('tmp0, read("foo"), lpf.free('tmp0))) must
-        beTree(read("foo"))
+        beTreeEqual(read("foo"))
     }
 
     "not inline binding that's used twice" in {
@@ -43,7 +43,7 @@ class OptimizerSpec extends quasar.Qspec with CompilerHelpers with TreeMatchers 
         makeObj(
           "bar" -> ObjectProject(lpf.free('tmp0), lpf.constant(Data.Str("bar"))),
           "baz" -> ObjectProject(lpf.free('tmp0), lpf.constant(Data.Str("baz")))))) must
-        beTree(
+        beTreeEqual(
           lpf.let('tmp0, read("foo"),
             makeObj(
               "bar" -> ObjectProject(lpf.free('tmp0), lpf.constant(Data.Str("bar"))),
@@ -52,7 +52,7 @@ class OptimizerSpec extends quasar.Qspec with CompilerHelpers with TreeMatchers 
 
     "completely inline stupid lets" in {
       optimizer.simplify(lpf.let('tmp0, read("foo"), lpf.let('tmp1, lpf.free('tmp0), lpf.free('tmp1)))) must
-        beTree(read("foo"))
+        beTreeEqual(read("foo"))
     }
 
     "inline correct value for shadowed binding" in {
@@ -60,7 +60,7 @@ class OptimizerSpec extends quasar.Qspec with CompilerHelpers with TreeMatchers 
         lpf.let('tmp0, read("bar"),
           makeObj(
             "bar" -> ObjectProject(lpf.free('tmp0), lpf.constant(Data.Str("bar"))))))) must
-        beTree(
+        beTreeEqual(
           makeObj(
             "bar" -> ObjectProject(read("bar"), lpf.constant(Data.Str("bar")))))
     }
@@ -71,7 +71,7 @@ class OptimizerSpec extends quasar.Qspec with CompilerHelpers with TreeMatchers 
           lpf.let('tmp0, read("bar"),
             makeObj(
               "bar" -> ObjectProject(lpf.free('tmp0), lpf.constant(Data.Str("bar")))))))) must
-        beTree(
+        beTreeEqual(
           lpf.invoke(ObjectProject, Func.Input2(
             read("foo"),
             makeObj(
@@ -85,7 +85,7 @@ class OptimizerSpec extends quasar.Qspec with CompilerHelpers with TreeMatchers 
             makeObj(
               "bar" -> ObjectProject(lpf.free('tmp0), lpf.constant(Data.Str("bar"))),
               "baz" -> ObjectProject(lpf.free('tmp0), lpf.constant(Data.Str("baz")))))))) must
-        beTree(
+        beTreeEqual(
           lpf.invoke(ObjectProject, Func.Input2(
             read("foo"),
             lpf.let('tmp0, read("bar"),
@@ -106,7 +106,7 @@ class OptimizerSpec extends quasar.Qspec with CompilerHelpers with TreeMatchers 
                 ObjectProject(lpf.free('tmp1), lpf.constant(Data.Str("name")))),
               lpf.constant(Data.Str("foobar"))),
             lpf.free('tmp2))))) must
-        beTree(
+        beTreeEqual(
           lpf.let('tmp1,
             makeObj(
               "name" ->
@@ -124,7 +124,7 @@ class OptimizerSpec extends quasar.Qspec with CompilerHelpers with TreeMatchers 
       optimizer.preferProjections(
         DeleteField(lpf.read(file("zips")),
           lpf.constant(Data.Str("pop")))) must
-        beTree[Fix[LogicalPlan]](
+        beTreeEqual[Fix[LogicalPlan]](
           DeleteField(lpf.read(file("zips")),
             lpf.constant(Data.Str("pop"))))
     }
@@ -137,7 +137,7 @@ class OptimizerSpec extends quasar.Qspec with CompilerHelpers with TreeMatchers 
               "city" -> ObjectProject(lpf.free('meh), lpf.constant(Data.Str("city"))),
               "pop"  -> ObjectProject(lpf.free('meh), lpf.constant(Data.Str("pop")))),
             lpf.constant(Data.Str("pop"))))) must
-      beTree(
+      beTreeEqual(
         lpf.let('meh, lpf.read(file("zips")),
           makeObj(
             "city" ->
@@ -161,7 +161,7 @@ class OptimizerSpec extends quasar.Qspec with CompilerHelpers with TreeMatchers 
               "orig" -> lpf.free('meh2),
               "cleaned" ->
                 DeleteField(lpf.free('meh2), lpf.constant(Data.Str("pop"))))))) must
-      beTree(
+      beTreeEqual(
         lpf.let('meh, lpf.read(file("zips")),
           lpf.let('meh2,
             makeObj(

--- a/foundation/src/test/scala/quasar/matchers.scala
+++ b/foundation/src/test/scala/quasar/matchers.scala
@@ -25,11 +25,22 @@ import org.specs2.matcher._
 import scalaz._, Scalaz._
 
 trait TreeMatchers {
+  // TODO remove in favor of `beTreeEqual`
+  // uses `==`
   def beTree[A: RenderTree](expected: A): Matcher[A] = new Matcher[A] {
     def apply[S <: A](ex: Expectable[S]) = {
       val actual: A = ex.value
       val diff: String = (RenderTree[A].render(actual) diff expected.render).shows
       result(actual == expected, s"trees match:\n$diff", s"trees do not match:\n$diff", ex)
+    }
+  }
+
+  // uses `scalaz.Equal`
+  def beTreeEqual[A: RenderTree: Equal](expected: A): Matcher[A] = new Matcher[A] {
+    def apply[S <: A](s: Expectable[S]) = {
+      val v: A = s.value
+      val diff = (RenderTree[A].render(v) diff expected.render).shows
+      result(v ≟ expected, s"trees match:\n$diff", s"trees do not match:\n$diff", s)
     }
   }
 }

--- a/frontend/src/main/scala/quasar/frontend/logicalplan/LogicalPlan.scala
+++ b/frontend/src/main/scala/quasar/frontend/logicalplan/LogicalPlan.scala
@@ -32,6 +32,8 @@ import shapeless.{Nat, Sized}
 import pathy.Path.posixCodec
 
 sealed abstract class LogicalPlan[A] extends Product with Serializable {
+  // TODO this should be removed, but usage of `==` is so pervasive in
+  // external dependencies (and scalac) that removal may never be possible
   override def equals(that: scala.Any): Boolean = that match {
     case lp: LogicalPlan[A] => LogicalPlan.equal(Equal.equalA[A]).equal(this, lp)
     case _                  => false

--- a/frontend/src/main/scala/quasar/frontend/logicalplan/LogicalPlan.scala
+++ b/frontend/src/main/scala/quasar/frontend/logicalplan/LogicalPlan.scala
@@ -37,10 +37,8 @@ final case class Read[A](path: FPath) extends LogicalPlan[A]
 final case class Constant[A](data: Data) extends LogicalPlan[A]
 final case class Invoke[A, N <: Nat](func: GenericFunc[N], values: Func.Input[A, N])
     extends LogicalPlan[A] {
-  override def toString = {
-    func.shows + "(" + values.mkString(", ") + ")"
-  }
-  // TODO remove this #1677
+  // TODO this should be removed, but usage of `==` is so pervasive in
+  // external dependencies (and scalac) that removal may never be possible
   override def equals(that: scala.Any): Boolean = that match {
     case that @ Invoke(_, _) =>
       (this.func == that.func) && (this.values.unsized == that.values.unsized)
@@ -117,6 +115,19 @@ object LogicalPlan {
         }
     }
 
+  implicit val show: Delay[Show, LogicalPlan] =
+    new Delay[Show, LogicalPlan] {
+      def apply[A](sa: Show[A]): Show[LogicalPlan[A]] =
+        Show.show {
+          case Read(v)               => Cord("Read(") ++ v.show ++ Cord(")")
+          case Constant(v)           => Cord("Constant(") ++ v.show ++ Cord(")")
+          case Invoke(func, values)  => func.show ++ Cord("(") ++ values.foldLeft(Cord("")){ case (acc, v) => acc ++ sa.show(v) ++ Cord(",") } ++ Cord(")") // TODO remove trailing comma
+          case Free(n)               => Cord("Free(") ++ Cord(n.toString) ++ Cord(")")
+          case Let(n, f, b)          => Cord("Let(") ++ Cord(n.toString) ++ Cord(",") ++ sa.show(f) ++ Cord(",") ++ sa.show(b) ++ Cord(")")
+          case Typecheck(e, t, c, f) => Cord("Typecheck(") ++ sa.show(e) ++ Cord(",") ++ t.show ++ Cord(",") ++ sa.show(c) ++ Cord(",") ++ sa.show(f) ++ Cord(")")
+        }
+    }
+
   implicit val renderTree: Delay[RenderTree, LogicalPlan] =
     new Delay[RenderTree, LogicalPlan] {
       def apply[A](ra: RenderTree[A]): RenderTree[LogicalPlan[A]] =
@@ -152,7 +163,7 @@ object LogicalPlan {
         Equal.equal {
           case (Read(n1), Read(n2)) => refineTypeAbs(n1) ≟ refineTypeAbs(n2)
           case (Constant(d1), Constant(d2)) => d1 ≟ d2
-          case (InvokeUnapply(f1, v1), InvokeUnapply(f2, v2)) => f1 == f2 && v1.unsized ≟ v2.unsized
+          case (InvokeUnapply(f1, v1), InvokeUnapply(f2, v2)) => f1 == f2 && v1.unsized ≟ v2.unsized  // TODO impl `scalaz.Equal` for `GenericFunc`
           case (Free(n1), Free(n2)) => n1 ≟ n2
           case (Let(ident1, form1, in1), Let(ident2, form2, in2)) =>
             ident1 ≟ ident2 && form1 ≟ form2 && in1 ≟ in2

--- a/frontend/src/test/scala/quasar/frontend/logicalplan/LogicalPlanSpecs.scala
+++ b/frontend/src/test/scala/quasar/frontend/logicalplan/LogicalPlanSpecs.scala
@@ -32,19 +32,11 @@ import shapeless.contrib.scalaz.instances._
 import pathy.Path._
 
 class LogicalPlanSpecs extends Spec with ScalazMatchers {
-  // `Gen.oneOf` calls `Gen.suchThat` which in turn calls `==`
-  // We cannot compare `LogicalPlan` instances with `==` and instead prefer `scalaz.Equal`.
-  // Removing the call to `Gen.suchThat` may have a negative performance impact or
-  // may result in nonoptimal example simplification.
-  def oneOfNoEquals[T](gs: Gen[T]*): Gen[T] = {
-    Gen.choose(0, gs.size - 1).flatMap(gs(_))
-  }
-
   implicit val arbLogicalPlan: Delay[Arbitrary, LogicalPlan] =
     new Delay[Arbitrary, LogicalPlan] {
       def apply[A](arb: Arbitrary[A]) =
         Arbitrary {
-          oneOfNoEquals(readGen[A], addGen(arb), constGen[A], letGen(arb), freeGen[A](Nil))
+          Gen.oneOf(readGen[A], addGen(arb), constGen[A], letGen(arb), freeGen[A](Nil))
         }
     }
 

--- a/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -43,7 +43,12 @@ import pathy.Path._
 import scalaz._, Scalaz._
 import quasar.specs2.QuasarMatchers._
 
-class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.ScalaCheck with CompilerHelpers {
+class PlannerSpec extends
+    org.specs2.mutable.Specification with
+    org.specs2.ScalaCheck with
+    CompilerHelpers with
+    TreeMatchers {
+
   import StdLib.{set => s, _}
   import structural._
   import Grouped.grouped
@@ -3886,16 +3891,18 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
                 ObjectProject(lpf.free('right), lpf.constant(Data.Str("bar")))),
               relations.Eq[FLP](
                 ObjectProject(lpf.free('left), lpf.constant(Data.Str("baz"))),
-                ObjectProject(lpf.free('right), lpf.constant(Data.Str("zab")))))))) must
-      beRightDisjunction(
-        Fix(s.InnerJoin[FLP](lpf.free('left), lpf.free('right),
-          relations.And[FLP](
-            relations.Eq[FLP](
-              ObjectProject(lpf.free('left), lpf.constant(Data.Str("foo"))),
-              ObjectProject(lpf.free('right), lpf.constant(Data.Str("bar")))),
-            relations.Eq[FLP](
-              ObjectProject(lpf.free('left), lpf.constant(Data.Str("baz"))),
-              ObjectProject(lpf.free('right), lpf.constant(Data.Str("zab"))))))))
+                ObjectProject(lpf.free('right), lpf.constant(Data.Str("zab")))))))) must beLike {
+        case \/-(plan) =>
+          plan must beTreeEqual(
+            Fix(s.InnerJoin[FLP](lpf.free('left), lpf.free('right),
+              relations.And[FLP](
+                relations.Eq[FLP](
+                  ObjectProject(lpf.free('left), lpf.constant(Data.Str("foo"))),
+                  ObjectProject(lpf.free('right), lpf.constant(Data.Str("bar")))),
+                relations.Eq[FLP](
+                  ObjectProject(lpf.free('left), lpf.constant(Data.Str("baz"))),
+                  ObjectProject(lpf.free('right), lpf.constant(Data.Str("zab"))))))))
+      }
     }
 
     "swap a reversed condition" in {
@@ -3908,16 +3915,18 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
                 ObjectProject(lpf.free('left), lpf.constant(Data.Str("foo")))),
               relations.Eq[FLP](
                 ObjectProject(lpf.free('left), lpf.constant(Data.Str("baz"))),
-                ObjectProject(lpf.free('right), lpf.constant(Data.Str("zab")))))))) must
-      beRightDisjunction(
-        Fix(s.InnerJoin[FLP](lpf.free('left), lpf.free('right),
-          relations.And[FLP](
-            relations.Eq[FLP](
-              ObjectProject(lpf.free('left), lpf.constant(Data.Str("foo"))),
-              ObjectProject(lpf.free('right), lpf.constant(Data.Str("bar")))),
-            relations.Eq[FLP](
-              ObjectProject(lpf.free('left), lpf.constant(Data.Str("baz"))),
-              ObjectProject(lpf.free('right), lpf.constant(Data.Str("zab"))))))))
+                ObjectProject(lpf.free('right), lpf.constant(Data.Str("zab")))))))) must beLike {
+        case \/-(plan) =>
+          plan must beTreeEqual(
+            Fix(s.InnerJoin[FLP](lpf.free('left), lpf.free('right),
+              relations.And[FLP](
+                relations.Eq[FLP](
+                  ObjectProject(lpf.free('left), lpf.constant(Data.Str("foo"))),
+                  ObjectProject(lpf.free('right), lpf.constant(Data.Str("bar")))),
+                relations.Eq[FLP](
+                  ObjectProject(lpf.free('left), lpf.constant(Data.Str("baz"))),
+                  ObjectProject(lpf.free('right), lpf.constant(Data.Str("zab"))))))))
+      }
     }
 
     "swap multiple reversed conditions" in {
@@ -3930,16 +3939,18 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
                 ObjectProject(lpf.free('left), lpf.constant(Data.Str("foo")))),
               relations.Eq[FLP](
                 ObjectProject(lpf.free('right), lpf.constant(Data.Str("zab"))),
-                ObjectProject(lpf.free('left), lpf.constant(Data.Str("baz")))))))) must
-      beRightDisjunction(
-        Fix(s.InnerJoin[FLP](lpf.free('left), lpf.free('right),
-          relations.And[FLP](
-            relations.Eq[FLP](
-              ObjectProject(lpf.free('left), lpf.constant(Data.Str("foo"))),
-              ObjectProject(lpf.free('right), lpf.constant(Data.Str("bar")))),
-            relations.Eq[FLP](
-              ObjectProject(lpf.free('left), lpf.constant(Data.Str("baz"))),
-              ObjectProject(lpf.free('right), lpf.constant(Data.Str("zab"))))))))
+                ObjectProject(lpf.free('left), lpf.constant(Data.Str("baz")))))))) must beLike {
+        case \/-(plan) =>
+          plan must beTreeEqual(
+            Fix(s.InnerJoin[FLP](lpf.free('left), lpf.free('right),
+              relations.And[FLP](
+                relations.Eq[FLP](
+                  ObjectProject(lpf.free('left), lpf.constant(Data.Str("foo"))),
+                  ObjectProject(lpf.free('right), lpf.constant(Data.Str("bar")))),
+                relations.Eq[FLP](
+                  ObjectProject(lpf.free('left), lpf.constant(Data.Str("baz"))),
+                  ObjectProject(lpf.free('right), lpf.constant(Data.Str("zab"))))))))
+      }
     }
 
     "fail with “mixed” conditions" in {
@@ -3954,13 +3965,15 @@ class PlannerSpec extends org.specs2.mutable.Specification with org.specs2.Scala
                 ObjectProject(lpf.free('left), lpf.constant(Data.Str("foo")))),
               relations.Eq[FLP](
                 ObjectProject(lpf.free('left), lpf.constant(Data.Str("baz"))),
-                ObjectProject(lpf.free('right), lpf.constant(Data.Str("zab")))))))) must
-      beLeftDisjunction(UnsupportedJoinCondition(
-        relations.Eq[FLP](
-          math.Add[FLP](
-            ObjectProject(lpf.free('right), lpf.constant(Data.Str("bar"))),
-            ObjectProject(lpf.free('left), lpf.constant(Data.Str("baz")))),
-          ObjectProject(lpf.free('left), lpf.constant(Data.Str("foo"))))))
+                ObjectProject(lpf.free('right), lpf.constant(Data.Str("zab")))))))) must beLike {
+        case -\/(UnsupportedJoinCondition(cond)) =>
+          cond must beTreeEqual(
+            relations.Eq[FLP](
+              math.Add[FLP](
+                ObjectProject(lpf.free('right), lpf.constant(Data.Str("bar"))),
+                ObjectProject(lpf.free('left), lpf.constant(Data.Str("baz")))),
+              ObjectProject(lpf.free('left), lpf.constant(Data.Str("foo")))).embed)
+      }
     }
 
     "plan with extra squash and flattening" in {

--- a/sql/src/main/scala/quasar/sql/compiler.scala
+++ b/sql/src/main/scala/quasar/sql/compiler.scala
@@ -704,10 +704,12 @@ object Compiler {
       (Fix(t.map(_._1)),
         groupedKeys(t.map(_._1), Fix(t.map(_._1))).getOrElse(t.foldMap(_._2)))
     }
-    val keys: List[Fix[LP]] = boundCata(tree)(keysƒ)._2
+
+    // use `scalaz.IList` so we can use `scalaz.Equal[LP]`
+    val keys: IList[Fix[LP]] = IList.fromList(boundCata(tree)(keysƒ)._2)
 
     // Step 1: annotate nodes containing the keys.
-    val ann: Cofree[LP, Boolean] = boundAttribute(tree)(keys.contains)
+    val ann: Cofree[LP, Boolean] = boundAttribute(tree)(keys.element)
 
     // Step 2: transform from the top, inserting Arbitrary where a key is not
     // otherwise reduced.


### PR DESCRIPTION
Closes #1677 . Sort of. So I didn't get to go quite as far with this PR as I wanted. The goal was to delete the `override def equals` method on ` logicalplan.Invoke`, but because of the pervasive use of `==` in external dependencies and scalac, this was not possible. But this PR _does_ rely on the `scalaz.Equal` for `LogicalPlan` more than before, so it's an improvement.