### PR TITLE
Basic XQuery FLWOR expression fusion for MarkLogic Planner

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,7 @@
+- [1625] XQuery FLWOR expression fusion for MarkLogic planner
+  - Improved FLWOR expressions and syntax
+  - Typed bindings in FLWOR expressions
+  - Support multiple for/let clauses
+  - First class support for positional bindings
+  - Replace NameGenerator usage with QNameGenerator
+  - Support bindings in quantified expression syntax

--- a/it/src/main/resources/tests/letBinding.test
+++ b/it/src/main/resources/tests/letBinding.test
@@ -3,7 +3,6 @@
 
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "skip",
         "couchbase":  "skip"
     },
 

--- a/marklogic/src/main/scala/quasar/physical/marklogic/fs/ops.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/fs/ops.scala
@@ -153,33 +153,40 @@ object ops {
         prefixed))
 
     def isDirXqy(pathUri: XQuery) = {
+      val d = $("d")
+
       val hasChildMLDirs =
         fn.exists(
-          for_("$d" -> xdmp.directory(pathUri, "1".xs))
-            .where_("$d".xqy("property::directory".xqy))
-            .return_("$d".xqy))
+          for_(d in xdmp.directory(pathUri, "1".xs))
+          .where_(d.ref("property::directory".xqy))
+          .return_(d.ref))
 
       fn.not(isMLDir(pathUri)) or hasChildMLDirs
     }
 
-    def isFileXqy(pathUri: XQuery) =
+    def isFileXqy(pathUri: XQuery) = {
+      val d = $("d")
+
       fn.exists(
-        for_("$d" -> xdmp.directory(pathUri, "1".xs))
-          .where_("$d".xqy(fn.not("property::directory".xqy)))
-          .return_("$d".xqy))
+        for_(d in xdmp.directory(pathUri, "1".xs))
+        .where_(d.ref(fn.not("property::directory".xqy)))
+        .return_(d.ref))
+    }
 
     def filesXqy(dirUris: XQuery) =
       fn.map(
         func("$u") { fn.substring("$u".xqy, "1".xqy, some(fn.stringLength("$u".xqy) - "1".xqy)) },
         fn.filter(func("$f") { isFileXqy("$f".xqy) }, dirUris))
 
+    val (pathUris, childPathUris, dirUris, fileUris) = ($("pathUris"), $("childPathUris"), $("dirUris"), $("fileUris"))
+
     val xqy = let_(
-      "$pathUris"      -> prefixPathsXqy,
-      "$childPathUris" -> childPathsXqy("$pathUris".xqy),
-      "$dirUris"       -> fn.filter(func("$u") { isDirXqy("$u".xqy) }, "$childPathUris".xqy),
-      "$fileUris"      -> filesXqy("$childPathUris".xqy)
+      pathUris      := prefixPathsXqy,
+      childPathUris := childPathsXqy(pathUris.ref),
+      dirUris       := fn.filter(func("$u") { isDirXqy("$u".xqy) }, childPathUris.ref),
+      fileUris      := filesXqy(childPathUris.ref)
     ) return_ (
-      mkSeq_("$dirUris".xqy, "$fileUris".xqy)
+      mkSeq_(dirUris.ref, fileUris.ref)
     )
 
     def parseDir(s: String): Option[PathSegment] =
@@ -198,23 +205,27 @@ object ops {
     val srcUri = pathUri(asDir(src))
     val dstUri = pathUri(asDir(dst))
 
-    def doMove =
+    def doMove = {
+      val (d, oldName, newName) = ($("d"), $("oldName"), $("newName"))
+
       SessionIO.executeQuery_(mkSeq_(
         if_(fn.exists(xdmp.documentProperties(dstUri.xs)("/prop:properties/prop:directory".xqy)))
           .then_ {
-            for_("$d" -> xdmp.directory(dstUri.xs, "1".xs))
-              .return_(xdmp.documentDelete(xdmp.nodeUri("$d".xqy)))
+            for_(d in xdmp.directory(dstUri.xs, "1".xs))
+            .return_(xdmp.documentDelete(xdmp.nodeUri(d.ref)))
           } else_ {
             xdmp.directoryCreate(dstUri.xs)
           },
 
-        for_("$d" -> xdmp.directory(srcUri.xs, "1".xs))
-          .let_(
-            "$oldName" -> xdmp.nodeUri("$d".xqy),
-            "$newName" -> fn.concat(dstUri.xs, fn.tokenize("$oldName".xqy, "/".xs)(fn.last)))
-          .return_(mkSeq_(
-            xdmp.documentInsert("$newName".xqy, fn.doc("$oldName".xqy)),
-            xdmp.documentDelete("$oldName".xqy)))))
+        for_(
+          d in xdmp.directory(srcUri.xs, "1".xs))
+        .let_(
+          oldName := xdmp.nodeUri(d.ref),
+          newName := fn.concat(dstUri.xs, fn.tokenize(oldName.ref, "/".xs)(fn.last)))
+        .return_(mkSeq_(
+          xdmp.documentInsert(newName.ref, fn.doc(oldName.ref)),
+          xdmp.documentDelete(oldName.ref)))))
+    }
 
     def deleteSrcIfEmpty =
       SessionIO.executeQuery_(deleteIfEmptyXqy(srcUri.xs))

--- a/marklogic/src/main/scala/quasar/physical/marklogic/fs/ops.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/fs/ops.scala
@@ -158,8 +158,8 @@ object ops {
       val hasChildMLDirs =
         fn.exists(
           for_(d in xdmp.directory(pathUri, "1".xs))
-          .where_(d.ref("property::directory".xqy))
-          .return_(d.ref))
+          .where_((~d)("property::directory".xqy))
+          .return_(~d))
 
       fn.not(isMLDir(pathUri)) or hasChildMLDirs
     }
@@ -169,8 +169,8 @@ object ops {
 
       fn.exists(
         for_(d in xdmp.directory(pathUri, "1".xs))
-        .where_(d.ref(fn.not("property::directory".xqy)))
-        .return_(d.ref))
+        .where_((~d)(fn.not("property::directory".xqy)))
+        .return_(~d))
     }
 
     def filesXqy(dirUris: XQuery) =
@@ -182,11 +182,11 @@ object ops {
 
     val xqy = let_(
       pathUris      := prefixPathsXqy,
-      childPathUris := childPathsXqy(pathUris.ref),
-      dirUris       := fn.filter(func("$u") { isDirXqy("$u".xqy) }, childPathUris.ref),
-      fileUris      := filesXqy(childPathUris.ref)
+      childPathUris := childPathsXqy(~pathUris),
+      dirUris       := fn.filter(func("$u") { isDirXqy("$u".xqy) }, ~childPathUris),
+      fileUris      := filesXqy(~childPathUris)
     ) return_ (
-      mkSeq_(dirUris.ref, fileUris.ref)
+      mkSeq_(~dirUris, ~fileUris)
     )
 
     def parseDir(s: String): Option[PathSegment] =
@@ -212,7 +212,7 @@ object ops {
         if_(fn.exists(xdmp.documentProperties(dstUri.xs)("/prop:properties/prop:directory".xqy)))
           .then_ {
             for_(d in xdmp.directory(dstUri.xs, "1".xs))
-            .return_(xdmp.documentDelete(xdmp.nodeUri(d.ref)))
+            .return_(xdmp.documentDelete(xdmp.nodeUri(~d)))
           } else_ {
             xdmp.directoryCreate(dstUri.xs)
           },
@@ -220,11 +220,11 @@ object ops {
         for_(
           d in xdmp.directory(srcUri.xs, "1".xs))
         .let_(
-          oldName := xdmp.nodeUri(d.ref),
-          newName := fn.concat(dstUri.xs, fn.tokenize(oldName.ref, "/".xs)(fn.last)))
+          oldName := xdmp.nodeUri(~d),
+          newName := fn.concat(dstUri.xs, fn.tokenize(~oldName, "/".xs)(fn.last)))
         .return_(mkSeq_(
-          xdmp.documentInsert(newName.ref, fn.doc(oldName.ref)),
-          xdmp.documentDelete(oldName.ref)))))
+          xdmp.documentInsert(~newName, fn.doc(~oldName)),
+          xdmp.documentDelete(~oldName)))))
     }
 
     def deleteSrcIfEmpty =

--- a/marklogic/src/main/scala/quasar/physical/marklogic/fs/queryfile.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/fs/queryfile.scala
@@ -116,10 +116,10 @@ object queryfile {
         val (slen, padct, prefix) = ($("slen"), $("padct"), $("prefix"))
         let_(
           slen   := fn.stringLength(str),
-          padct  := fn.max(mkSeq_("0".xqy, length - slen.ref)),
-          prefix := fn.stringJoin(for_($("_") in (1.xqy to padct.ref)) return_ padchar, "".xs))
+          padct  := fn.max(mkSeq_("0".xqy, length - (~slen))),
+          prefix := fn.stringJoin(for_($("_") in (1.xqy to ~padct)) return_ padchar, "".xs))
         .return_(
-          fn.concat(prefix.ref, str))
+          fn.concat(~prefix, str))
       }
 
     def saveTo[F[_]: QNameGenerator: PrologW](dst: AFile, results: XQuery): F[XQuery] = {
@@ -131,7 +131,7 @@ object queryfile {
         result <- freshName[F]
         fname  <- freshName[F]
         now    <- qscript.secondsSinceEpoch[F].apply(fn.currentDateTime)
-        dpart  <- lpadToLength[F]("0".xs, 8.xqy, xdmp.integerToHex(i.ref))
+        dpart  <- lpadToLength[F]("0".xs, 8.xqy, xdmp.integerToHex(~i))
       } yield {
         let_(
           ts     := xdmp.integerToHex(xs.integer(now * 1000.xqy)),
@@ -140,9 +140,9 @@ object queryfile {
           for_(
             result at i in mkSeq_(results))
           .let_(
-            fname := fn.concat(dstDirUri.xs, ts.ref, dpart))
+            fname := fn.concat(dstDirUri.xs, ~ts, dpart))
           .return_(
-            xdmp.documentInsert(fname.ref, result.ref))
+            xdmp.documentInsert(~fname, ~result))
         }
       }
     }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MapFuncPlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MapFuncPlanner.scala
@@ -158,8 +158,14 @@ object MapFuncPlanner {
           for {
             qn <- asQName(s)
             m  <- freshName[F]
-            n  <- mem.nodeDelete[F](~m)
-          } yield let_(m := src) return_ n
+            n1 <- mem.nodeDelete[F](~m `/` child(qn))
+            n2 <- mem.nodeDelete[F](src `/` child(qn))
+          } yield {
+            if (flwor.isMatching(src))
+              let_(m := src) return_ n1
+            else
+              n2
+          }
 
         case _ => qscript.deleteField[F] apply (src, xs.QName(field))
       }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/QScriptCorePlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/QScriptCorePlanner.scala
@@ -17,11 +17,11 @@
 package quasar.physical.marklogic.qscript
 
 import quasar.Predef.{Map => _, _}
-import quasar.NameGenerator
 import quasar.physical.marklogic.xquery._
 import quasar.physical.marklogic.xquery.syntax._
 import quasar.qscript._
 
+import eu.timepit.refined.auto._
 import matryoshka._
 import scalaz._, Scalaz._
 
@@ -33,7 +33,7 @@ import scalaz._, Scalaz._
 //       Without this contract we cannot safely fuse expressions by binding the
 //       return expression to a variable as, if it is a sequence, the results will,
 //       in the best case, also be sequences and exceptions in the worst.
-private[qscript] final class QScriptCorePlanner[F[_]: NameGenerator: PrologW: MonadPlanErr, T[_[_]]: Recursive: Corecursive]
+private[qscript] final class QScriptCorePlanner[F[_]: QNameGenerator: PrologW: MonadPlanErr, T[_[_]]: Recursive: Corecursive]
   extends MarkLogicPlanner[F, QScriptCore[T, ?]] {
 
   import expr.{func, for_, if_, let_}
@@ -42,24 +42,24 @@ private[qscript] final class QScriptCorePlanner[F[_]: NameGenerator: PrologW: Mo
   val plan: AlgebraM[F, QScriptCore[T, ?], XQuery] = {
     case Map(src, f) =>
       for {
-        x <- freshVar[F]
-        g <- mapFuncXQuery(f, x.xqy)
+        x <- freshName[F]
+        g <- mapFuncXQuery(f, ~x)
       } yield src match {
-        case XQuery.Flwor(tuples, lets, filter, order, isStable, result) if tuples.nonEmpty =>
-          XQuery.Flwor(tuples, lets ::: IList((x, result)), filter, order, isStable, g)
+        case IterativeFlwor(bindings, filter, order, isStable, result) =>
+          XQuery.Flwor(bindings :::> IList(BindingClause.let_(x := result)), filter, order, isStable, g)
 
         case _ =>
-          for_(x -> src) return_ g
+          for_(x in src) return_ g
       }
 
     case LeftShift(src, struct, repair) =>
       for {
-        l       <- freshVar[F]
-        r       <- freshVar[F]
-        extract <- mapFuncXQuery(struct, l.xqy)
+        l       <- freshName[F]
+        r       <- freshName[F]
+        extract <- mapFuncXQuery(struct, ~l)
         lshift  <- qscript.elementLeftShift[F] apply (extract)
-        merge   <- mergeXQuery(repair, l.xqy, r.xqy)
-      } yield for_ (l -> src, r -> lshift) return_ merge
+        merge   <- mergeXQuery(repair, ~l, ~r)
+      } yield for_ (l in src, r in lshift) return_ merge
 
     // TODO: Start leveraging the cts:* aggregation functions when possible
     case Reduce(src, bucket, reducers, repair) =>
@@ -70,60 +70,65 @@ private[qscript] final class QScriptCorePlanner[F[_]: NameGenerator: PrologW: Mo
         cmb   <- qscript.combineN[F] apply (mkSeq(cmbs))
         fnls  <- reducers traverse (reduceFuncFinalize)
         fnl   <- qscript.zipApply[F] apply (mkSeq(fnls))
-        y     <- freshVar[F]
-        rpr   <- planMapFunc(repair)(r => y.xqy((r.idx + 1).xqy))
-        rfnl  <- fx(x => let_(y -> fnl.fnapply(x)).return_(rpr).point[F])
+        y     <- freshName[F]
+        rpr   <- planMapFunc(repair)(r => (~y)((r.idx + 1).xqy))
+        rfnl  <- fx(x => let_(y in fnl.fnapply(x)).return_(rpr).point[F])
         bckt  <- fx(mapFuncXQuery[T, F](bucket, _))
         red   <- qscript.reduceWith[F] apply (init, cmb, rfnl, bckt, src)
       } yield red
 
     case Sort(src, bucket, order) =>
       for {
-        x        <- freshVar[F]
+        x        <- freshName[F]
         xqyOrder <- NonEmptyList((bucket, SortDir.Ascending), order: _*).traverse { case (func, sortDir) =>
-                      mapFuncXQuery(func, x.xqy) strengthR SortDirection.fromQScript(sortDir)
+                      mapFuncXQuery(func, ~x) strengthR SortDirection.fromQScript(sortDir)
                     }
       } yield src match {
-        case XQuery.Flwor(tuples, lets, filter, _, _, result) if tuples.nonEmpty =>
-          XQuery.Flwor(tuples, lets ::: IList((x, result)), filter, xqyOrder.list, false, x.xqy)
+        case IterativeFlwor(bindings, filter, _, _, result) =>
+          XQuery.Flwor(bindings :::> IList(BindingClause.let_(x := result)), filter, xqyOrder.list, false, ~x)
 
         case _ =>
-          for_(x -> src) orderBy (xqyOrder.head, xqyOrder.tail.toList: _*) return_ x.xqy
+          for_(x in src) orderBy (xqyOrder.head, xqyOrder.tail.toList: _*) return_ ~x
       }
 
     case Union(src, lBranch, rBranch) =>
       for {
-        s <- freshVar[F]
-        l <- rebaseXQuery(lBranch, s.xqy)
-        r <- rebaseXQuery(rBranch, s.xqy)
-      } yield let_(s -> src) return_ (l union r)
+        s <- freshName[F]
+        l <- rebaseXQuery(lBranch, ~s)
+        r <- rebaseXQuery(rBranch, ~s)
+      } yield let_(s := src) return_ (l union r)
 
     case Filter(src, f) =>
       for {
-        x <- freshVar[F]
+        x <- freshName[F]
         // FIXME: This cast shouldn't be necessary once projecting produces typed values.
-        p <- mapFuncXQuery(f, x.xqy) map (xs.boolean)
+        p <- mapFuncXQuery(f, ~x) map (xs.boolean)
       } yield src match {
-        case XQuery.Flwor(tuples, lets, filter, order, isStable, result) if tuples.nonEmpty =>
-          XQuery.Flwor(tuples, lets ::: IList((x, result)), Some(filter.fold(p)(_ and p)), order, isStable, x.xqy)
+        case IterativeFlwor(bindings, filter, order, isStable, result) =>
+          XQuery.Flwor(
+            bindings :::> IList(BindingClause.let_(x := result)),
+            Some(filter.fold(p)(_ and p)),
+            order,
+            isStable,
+            ~x)
 
         case _ =>
-          for_(x -> src) where_ p return_ x.xqy
+          for_(x in src) where_ p return_ ~x
       }
 
     // NB: XQuery sequences use 1-based indexing.
     case Subset(src, from, sel, count) =>
       for {
-        s   <- freshVar[F]
-        f   <- freshVar[F]
-        c   <- freshVar[F]
-        fm  <- rebaseXQuery(from, s.xqy)
-        ct  <- rebaseXQuery(count, s.xqy)
-      } yield let_(s -> src, f -> fm, c -> ct) return_ (sel match {
-        case Drop   => fn.subsequence(f.xqy, c.xqy + 1.xqy)
-        case Take   => fn.subsequence(f.xqy, 1.xqy, some(c.xqy))
+        s   <- freshName[F]
+        f   <- freshName[F]
+        c   <- freshName[F]
+        fm  <- rebaseXQuery(from, ~s)
+        ct  <- rebaseXQuery(count, ~s)
+      } yield let_(s := src, f := fm, c := ct) return_ (sel match {
+        case Drop   => fn.subsequence(~f, ~c + 1.xqy)
+        case Take   => fn.subsequence(~f, 1.xqy, some(~c))
         // TODO: Better sampling
-        case Sample => fn.subsequence(f.xqy, 1.xqy, some(c.xqy))
+        case Sample => fn.subsequence(~f, 1.xqy, some(~c))
       })
 
     case Unreferenced() =>
@@ -132,14 +137,19 @@ private[qscript] final class QScriptCorePlanner[F[_]: NameGenerator: PrologW: Mo
 
   ////
 
-  def fx(f: XQuery => F[XQuery]): F[XQuery] =
-    f("$x".xqy) map (func("$x")(_))
+  def fx(f: XQuery => F[XQuery]): F[XQuery] = {
+    val x = $("x")
+    f(~x) map (func(x.render)(_))
+  }
 
-  def combiner(fm: FreeMap[T])(f: (XQuery, XQuery) => F[XQuery]): F[XQuery] =
+  def combiner(fm: FreeMap[T])(f: (XQuery, XQuery) => F[XQuery]): F[XQuery] = {
+    val (acc, x) = ($("acc"), $("x"))
+
     for {
-      x1  <- mapFuncXQuery[T, F](fm, "$x".xqy)
-      nxt <- f("$acc".xqy, x1)
-    } yield func("$acc", "$x")(nxt)
+      x1  <- mapFuncXQuery[T, F](fm, ~x)
+      nxt <- f(~acc, x1)
+    } yield func(acc.render, x.render)(nxt)
+  }
 
   def reduceFuncInit(rf: ReduceFunc[FreeMap[T]]): F[XQuery] = rf match {
     case Avg(fm)              => fx(x => mapFuncXQuery[T, F](fm, x) flatMap { v =>
@@ -156,9 +166,12 @@ private[qscript] final class QScriptCorePlanner[F[_]: NameGenerator: PrologW: Mo
                                  })
   }
 
-  def reduceFuncFinalize(rf: ReduceFunc[_]): F[XQuery] = rf match {
-    case Avg(_) => func("$m")(map.get("$m".xqy, "avg".xs)).point[F]
-    case other  => qscript.identity[F] flatMap (_.ref)
+  def reduceFuncFinalize(rf: ReduceFunc[_]): F[XQuery] = {
+    val m = $("m")
+    rf match {
+      case Avg(_) => func(m.render)(map.get(~m, "avg".xs)).point[F]
+      case other  => qscript.identity[F] flatMap (_.ref)
+    }
   }
 
   def reduceFuncCombine(rf: ReduceFunc[FreeMap[T]]): F[XQuery] = rf match {
@@ -171,9 +184,9 @@ private[qscript] final class QScriptCorePlanner[F[_]: NameGenerator: PrologW: Mo
     case UnshiftArray(fm)     => combiner(fm)(ejson.arrayAppend[F].apply(_, _))
 
     case UnshiftMap(kfm, vfm) =>
-      val (m, x) = ("$m", "$x")
-      mapFuncXQuery[T, F](kfm, x.xqy).tuple(mapFuncXQuery[T, F](vfm, x.xqy)).flatMap {
-        case (k, v) => ejson.objectInsert[F].apply(m.xqy, k, v) map (func(m, x)(_))
+      val (m, x) = ($("m"), $("x"))
+      mapFuncXQuery[T, F](kfm, ~x).tuple(mapFuncXQuery[T, F](vfm, ~x)).flatMap {
+        case (k, v) => ejson.objectInsert[F].apply(~m, k, v) map (func(m.render, x.render)(_))
       }
   }
 }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/QScriptCorePlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/QScriptCorePlanner.scala
@@ -79,7 +79,7 @@ private[qscript] final class QScriptCorePlanner[F[_]: QNameGenerator: PrologW: M
         fnl   <- qscript.zipApply[F] apply (mkSeq(fnls))
         y     <- freshName[F]
         rpr   <- planMapFunc(repair)(r => (~y)((r.idx + 1).xqy))
-        rfnl  <- fx(x => let_(y in fnl.fnapply(x)).return_(rpr).point[F])
+        rfnl  <- fx(x => let_(y := fnl.fnapply(x)).return_(rpr).point[F])
         bckt  <- fx(mapFuncXQuery[T, F](bucket, _))
         red   <- qscript.reduceWith[F] apply (init, cmb, rfnl, bckt, src)
       } yield red

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/ShiftedReadPlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/ShiftedReadPlanner.scala
@@ -16,6 +16,7 @@
 
 package quasar.physical.marklogic.qscript
 
+import quasar.Predef._
 import quasar.NameGenerator
 import quasar.physical.marklogic.xquery._
 import quasar.physical.marklogic.xquery.syntax._
@@ -23,21 +24,34 @@ import quasar.qscript._
 
 import matryoshka._
 import pathy.Path._
-import scalaz._
+import scalaz._, Scalaz._
 
 private[qscript] final class ShiftedReadPlanner[F[_]: NameGenerator: PrologW]
   extends MarkLogicPlanner[F, Const[ShiftedRead, ?]] {
 
+  import expr._, axes.child
+
   val plan: AlgebraM[F, Const[ShiftedRead, ?], XQuery] = {
     case Const(ShiftedRead(absFile, idStatus)) =>
-      val asDir = fileParent(absFile) </> dir(fileName(absFile).value)
-      val dirRepr = posixCodec.printPath(asDir)
-
-      val includeId = idStatus match {
-        case IncludeId => fn.True
-        case ExcludeId => fn.False
+      for {
+        d     <- freshVar[F]
+        c     <- freshVar[F]
+        b     <- freshVar[F]
+        uri   =  posixCodec.printPath(fileParent(absFile) </> dir(fileName(absFile).value))
+        xform <- json.transformFromJson[F](c.xqy)
+        incId <- ejson.seqToArray_[F](mkSeq_(
+                   fn.concat("_".xs, xdmp.hmacSha1("quasar".xs, fn.documentUri(d.xqy))),
+                   b.xqy))
+      } yield {
+        for_(
+          d -> cts.search(fn.doc(), cts.directoryQuery(uri.xs, "1".xs)))
+        .let_(
+          c -> d.xqy `/` child.node(),
+          b -> (if_ (json.isObject(c.xqy)) then_ xform else_ c.xqy))
+        .return_(idStatus match {
+          case IncludeId => incId
+          case ExcludeId => b.xqy
+        })
       }
-
-      qscript.shiftedRead apply (dirRepr.xs, includeId)
   }
 }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/ThetaJoinPlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/ThetaJoinPlanner.scala
@@ -30,8 +30,8 @@ private[qscript] final class ThetaJoinPlanner[F[_]: NameGenerator: PrologW: Mona
   import expr.{for_, let_}
 
   // FIXME: Handle `JoinType`
-  // TODO:  If it is possible in certain situations to eliminate the outer `let` and inline the `src`
-  //        there would be opportunities for fusion here.
+  // TODO:  When `src` is unreferenced, should be able to elide the outer `let`,
+  //        may also be able to fuse into a single FLWOR depending on branches.
   val plan: AlgebraM[F, ThetaJoin[T, ?], XQuery] = {
     case ThetaJoin(src, lBranch, rBranch, on, f, combine) =>
       for {

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/ThetaJoinPlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/ThetaJoinPlanner.scala
@@ -30,6 +30,8 @@ private[qscript] final class ThetaJoinPlanner[F[_]: NameGenerator: PrologW: Mona
   import expr.{for_, let_}
 
   // FIXME: Handle `JoinType`
+  // TODO:  If it is possible in certain situations to eliminate the outer `let` and inline the `src`
+  //        there would be opportunities for fusion here.
   val plan: AlgebraM[F, ThetaJoin[T, ?], XQuery] = {
     case ThetaJoin(src, lBranch, rBranch, on, f, combine) =>
       for {

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/BindingClause.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/BindingClause.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.marklogic.xquery
+
+import quasar.Predef._
+
+import monocle.Prism
+import scalaz.NonEmptyList
+import scalaz.std.string._
+import scalaz.syntax.foldable._
+
+/** https://www.w3.org/TR/xquery/#id-for-let */
+sealed abstract class BindingClause {
+  import BindingClause._
+
+  def render: String = this match {
+    case ForClause(bs) => "for " + bs.map(_.render("in")).intercalate(", ")
+    case LetClause(bs) => "let " + bs.map(_.render(":=")).intercalate(", ")
+  }
+}
+
+object BindingClause {
+  final case class ForClause(bindings: NonEmptyList[PositionalBinding]) extends BindingClause
+  final case class LetClause(bindings: NonEmptyList[Binding]) extends BindingClause
+
+  val forClause = Prism.partial[BindingClause, NonEmptyList[PositionalBinding]] {
+    case ForClause(bindings) => bindings
+  } (ForClause)
+
+  val letClause = Prism.partial[BindingClause, NonEmptyList[Binding]] {
+    case LetClause(bindings) => bindings
+  } (LetClause)
+
+  def for_(b: PositionalBinding, bs: PositionalBinding*): BindingClause =
+    forClause(NonEmptyList(b, bs: _*))
+
+  def let_(b: Binding, bs: Binding*): BindingClause =
+    letClause(NonEmptyList(b, bs: _*))
+}

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/EncodeXQuery.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/EncodeXQuery.scala
@@ -17,7 +17,7 @@
 package quasar.physical.marklogic.xquery
 
 import quasar.Predef._
-import quasar.{Data, NameGenerator}
+import quasar.Data
 import quasar.{ejson => ejs}
 import quasar.physical.marklogic.{ErrorMessages, MonadErrMsgs_}
 import quasar.physical.marklogic.prisms._
@@ -41,7 +41,7 @@ object EncodeXQuery {
         _.run.fold(F.encodeXQuery, G.encodeXQuery)
     }
 
-  implicit def commonEncodeXQuery[M[_]: NameGenerator: PrologW]: EncodeXQuery[M, ejs.Common] =
+  implicit def commonEncodeXQuery[M[_]: PrologW]: EncodeXQuery[M, ejs.Common] =
     new EncodeXQuery[M, ejs.Common] {
       val encodeXQuery: AlgebraM[M, ejs.Common, XQuery] = {
         case ejs.Arr(xs) => ejson.seqToArray_[M](mkSeq(xs))

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/FunctionDecl.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/FunctionDecl.scala
@@ -124,7 +124,7 @@ object FunctionDecl {
     def as(rType: SequenceType): FunctionDecl1Dsl = copy(rt = rType)
 
     def apply[F[_]: Functor](body: XQuery => F[XQuery]): F[FunctionDecl1] =
-      body(p1.ref) map (FunctionDecl1(fn, p1, rt, _))
+      body(~p1) map (FunctionDecl1(fn, p1, rt, _))
 
     def apply(body: XQuery => XQuery): FunctionDecl1 =
       apply[Id](body)
@@ -134,7 +134,7 @@ object FunctionDecl {
     def as(rType: SequenceType): FunctionDecl2Dsl = copy(rt = rType)
 
     def apply[F[_]: Functor](body: (XQuery, XQuery) => F[XQuery]): F[FunctionDecl2] =
-      body(p1.ref, p2.ref) map (FunctionDecl2(fn, p1, p2, rt, _))
+      body(~p1, ~p2) map (FunctionDecl2(fn, p1, p2, rt, _))
 
     def apply(body: (XQuery, XQuery) => XQuery): FunctionDecl2 =
       apply[Id](body)
@@ -144,7 +144,7 @@ object FunctionDecl {
     def as(rType: SequenceType): FunctionDecl3Dsl = copy(rt = rType)
 
     def apply[F[_]: Functor](body: (XQuery, XQuery, XQuery) => F[XQuery]): F[FunctionDecl3] =
-      body(p1.ref, p2.ref, p3.ref) map (FunctionDecl3(fn, p1, p2, p3, rt, _))
+      body(~p1, ~p2, ~p3) map (FunctionDecl3(fn, p1, p2, p3, rt, _))
 
     def apply(body: (XQuery, XQuery, XQuery) => XQuery): FunctionDecl3 =
       apply[Id](body)
@@ -154,7 +154,7 @@ object FunctionDecl {
     def as(rType: SequenceType): FunctionDecl4Dsl = copy(rt = rType)
 
     def apply[F[_]: Functor](body: (XQuery, XQuery, XQuery, XQuery) => F[XQuery]): F[FunctionDecl4] =
-      body(p1.ref, p2.ref, p3.ref, p4.ref) map (FunctionDecl4(fn, p1, p2, p3, p4, rt, _))
+      body(~p1, ~p2, ~p3, ~p4) map (FunctionDecl4(fn, p1, p2, p3, p4, rt, _))
 
     def apply(body: (XQuery, XQuery, XQuery, XQuery) => XQuery): FunctionDecl4 =
       apply[Id](body)
@@ -164,7 +164,7 @@ object FunctionDecl {
     def as(rType: SequenceType): FunctionDecl5Dsl = copy(rt = rType)
 
     def apply[F[_]: Functor](body: (XQuery, XQuery, XQuery, XQuery, XQuery) => F[XQuery]): F[FunctionDecl5] =
-      body(p1.ref, p2.ref, p3.ref, p4.ref, p5.ref) map (FunctionDecl5(fn, p1, p2, p3, p4, p5, rt, _))
+      body(~p1, ~p2, ~p3, ~p4, ~p5) map (FunctionDecl5(fn, p1, p2, p3, p4, p5, rt, _))
 
     def apply(body: (XQuery, XQuery, XQuery, XQuery, XQuery) => XQuery): FunctionDecl5 =
       apply[Id](body)

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/FunctionDecl.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/FunctionDecl.scala
@@ -26,7 +26,7 @@ import scalaz.syntax.functor._
 
 sealed abstract class FunctionDecl {
   def name: QName
-  def parameters: NonEmptyList[TypedBinding]
+  def parameters: NonEmptyList[TypedBindingName]
   def returnType: SequenceType
   def body: XQuery
 
@@ -50,7 +50,7 @@ object FunctionDecl {
 
   final case class FunctionDecl1(
     name: QName,
-    param1: TypedBinding,
+    param1: TypedBindingName,
     returnType: SequenceType,
     body: XQuery
   ) extends FunctionDecl {
@@ -59,8 +59,8 @@ object FunctionDecl {
 
   final case class FunctionDecl2(
     name: QName,
-    param1: TypedBinding,
-    param2: TypedBinding,
+    param1: TypedBindingName,
+    param2: TypedBindingName,
     returnType: SequenceType,
     body: XQuery
   ) extends FunctionDecl {
@@ -69,9 +69,9 @@ object FunctionDecl {
 
   final case class FunctionDecl3(
     name: QName,
-    param1: TypedBinding,
-    param2: TypedBinding,
-    param3: TypedBinding,
+    param1: TypedBindingName,
+    param2: TypedBindingName,
+    param3: TypedBindingName,
     returnType: SequenceType,
     body: XQuery
   ) extends FunctionDecl {
@@ -80,10 +80,10 @@ object FunctionDecl {
 
   final case class FunctionDecl4(
     name: QName,
-    param1: TypedBinding,
-    param2: TypedBinding,
-    param3: TypedBinding,
-    param4: TypedBinding,
+    param1: TypedBindingName,
+    param2: TypedBindingName,
+    param3: TypedBindingName,
+    param4: TypedBindingName,
     returnType: SequenceType,
     body: XQuery
   ) extends FunctionDecl {
@@ -92,11 +92,11 @@ object FunctionDecl {
 
   final case class FunctionDecl5(
     name: QName,
-    param1: TypedBinding,
-    param2: TypedBinding,
-    param3: TypedBinding,
-    param4: TypedBinding,
-    param5: TypedBinding,
+    param1: TypedBindingName,
+    param2: TypedBindingName,
+    param3: TypedBindingName,
+    param4: TypedBindingName,
+    param5: TypedBindingName,
     returnType: SequenceType,
     body: XQuery
   ) extends FunctionDecl {
@@ -104,67 +104,67 @@ object FunctionDecl {
   }
 
   final case class FunctionDeclDsl(fname: QName) {
-    def apply(p1: TypedBinding): FunctionDecl1Dsl =
+    def apply(p1: TypedBindingName): FunctionDecl1Dsl =
       FunctionDecl1Dsl(fname, p1, SequenceType.Top)
 
-    def apply(p1: TypedBinding, p2: TypedBinding): FunctionDecl2Dsl =
+    def apply(p1: TypedBindingName, p2: TypedBindingName): FunctionDecl2Dsl =
       FunctionDecl2Dsl(fname, p1, p2, SequenceType.Top)
 
-    def apply(p1: TypedBinding, p2: TypedBinding, p3: TypedBinding): FunctionDecl3Dsl =
+    def apply(p1: TypedBindingName, p2: TypedBindingName, p3: TypedBindingName): FunctionDecl3Dsl =
       FunctionDecl3Dsl(fname, p1, p2, p3, SequenceType.Top)
 
-    def apply(p1: TypedBinding, p2: TypedBinding, p3: TypedBinding, p4: TypedBinding): FunctionDecl4Dsl =
+    def apply(p1: TypedBindingName, p2: TypedBindingName, p3: TypedBindingName, p4: TypedBindingName): FunctionDecl4Dsl =
       FunctionDecl4Dsl(fname, p1, p2, p3, p4, SequenceType.Top)
 
-    def apply(p1: TypedBinding, p2: TypedBinding, p3: TypedBinding, p4: TypedBinding, p5: TypedBinding): FunctionDecl5Dsl =
+    def apply(p1: TypedBindingName, p2: TypedBindingName, p3: TypedBindingName, p4: TypedBindingName, p5: TypedBindingName): FunctionDecl5Dsl =
       FunctionDecl5Dsl(fname, p1, p2, p3, p4, p5, SequenceType.Top)
   }
 
-  final case class FunctionDecl1Dsl(fn: QName, p1: TypedBinding, rt: SequenceType) {
+  final case class FunctionDecl1Dsl(fn: QName, p1: TypedBindingName, rt: SequenceType) {
     def as(rType: SequenceType): FunctionDecl1Dsl = copy(rt = rType)
 
     def apply[F[_]: Functor](body: XQuery => F[XQuery]): F[FunctionDecl1] =
-      body(p1.name.xqy) map (FunctionDecl1(fn, p1, rt, _))
+      body(p1.ref) map (FunctionDecl1(fn, p1, rt, _))
 
     def apply(body: XQuery => XQuery): FunctionDecl1 =
       apply[Id](body)
   }
 
-  final case class FunctionDecl2Dsl(fn: QName, p1: TypedBinding, p2: TypedBinding, rt: SequenceType) {
+  final case class FunctionDecl2Dsl(fn: QName, p1: TypedBindingName, p2: TypedBindingName, rt: SequenceType) {
     def as(rType: SequenceType): FunctionDecl2Dsl = copy(rt = rType)
 
     def apply[F[_]: Functor](body: (XQuery, XQuery) => F[XQuery]): F[FunctionDecl2] =
-      body(p1.name.xqy, p2.name.xqy) map (FunctionDecl2(fn, p1, p2, rt, _))
+      body(p1.ref, p2.ref) map (FunctionDecl2(fn, p1, p2, rt, _))
 
     def apply(body: (XQuery, XQuery) => XQuery): FunctionDecl2 =
       apply[Id](body)
   }
 
-  final case class FunctionDecl3Dsl(fn: QName, p1: TypedBinding, p2: TypedBinding, p3: TypedBinding, rt: SequenceType) {
+  final case class FunctionDecl3Dsl(fn: QName, p1: TypedBindingName, p2: TypedBindingName, p3: TypedBindingName, rt: SequenceType) {
     def as(rType: SequenceType): FunctionDecl3Dsl = copy(rt = rType)
 
     def apply[F[_]: Functor](body: (XQuery, XQuery, XQuery) => F[XQuery]): F[FunctionDecl3] =
-      body(p1.name.xqy, p2.name.xqy, p3.name.xqy) map (FunctionDecl3(fn, p1, p2, p3, rt, _))
+      body(p1.ref, p2.ref, p3.ref) map (FunctionDecl3(fn, p1, p2, p3, rt, _))
 
     def apply(body: (XQuery, XQuery, XQuery) => XQuery): FunctionDecl3 =
       apply[Id](body)
   }
 
-  final case class FunctionDecl4Dsl(fn: QName, p1: TypedBinding, p2: TypedBinding, p3: TypedBinding, p4: TypedBinding, rt: SequenceType) {
+  final case class FunctionDecl4Dsl(fn: QName, p1: TypedBindingName, p2: TypedBindingName, p3: TypedBindingName, p4: TypedBindingName, rt: SequenceType) {
     def as(rType: SequenceType): FunctionDecl4Dsl = copy(rt = rType)
 
     def apply[F[_]: Functor](body: (XQuery, XQuery, XQuery, XQuery) => F[XQuery]): F[FunctionDecl4] =
-      body(p1.name.xqy, p2.name.xqy, p3.name.xqy, p4.name.xqy) map (FunctionDecl4(fn, p1, p2, p3, p4, rt, _))
+      body(p1.ref, p2.ref, p3.ref, p4.ref) map (FunctionDecl4(fn, p1, p2, p3, p4, rt, _))
 
     def apply(body: (XQuery, XQuery, XQuery, XQuery) => XQuery): FunctionDecl4 =
       apply[Id](body)
   }
 
-  final case class FunctionDecl5Dsl(fn: QName, p1: TypedBinding, p2: TypedBinding, p3: TypedBinding, p4: TypedBinding, p5: TypedBinding, rt: SequenceType) {
+  final case class FunctionDecl5Dsl(fn: QName, p1: TypedBindingName, p2: TypedBindingName, p3: TypedBindingName, p4: TypedBindingName, p5: TypedBindingName, rt: SequenceType) {
     def as(rType: SequenceType): FunctionDecl5Dsl = copy(rt = rType)
 
     def apply[F[_]: Functor](body: (XQuery, XQuery, XQuery, XQuery, XQuery) => F[XQuery]): F[FunctionDecl5] =
-      body(p1.name.xqy, p2.name.xqy, p3.name.xqy, p4.name.xqy, p5.name.xqy) map (FunctionDecl5(fn, p1, p2, p3, p4, p5, rt, _))
+      body(p1.ref, p2.ref, p3.ref, p4.ref, p5.ref) map (FunctionDecl5(fn, p1, p2, p3, p4, p5, rt, _))
 
     def apply(body: (XQuery, XQuery, XQuery, XQuery, XQuery) => XQuery): FunctionDecl5 =
       apply[Id](body)

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/QNameGenerator.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/QNameGenerator.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.marklogic.xquery
+
+import quasar.Predef._
+import quasar.fp.ski.κ
+import quasar.effect.MonotonicSeq
+import quasar.physical.marklogic.xml.{NCName, QName}
+
+import eu.timepit.refined.api.Refined
+import simulacrum.typeclass
+import scalaz._
+import scalaz.syntax.functor._
+
+/** A source of QNames unique within `F[_]`, an implementation must have the
+  * property that, if Applicative[F], then (freshQName |@| freshQName)(_ != _).
+  */
+@typeclass trait QNameGenerator[F[_]] {
+  /** Returns a fresh QName, guaranteed to be unique among all the other QNames
+    * generated from `F`.
+    */
+  def freshQName: F[QName]
+}
+
+object QNameGenerator extends QNameGeneratorInstances
+
+sealed abstract class QNameGeneratorInstances extends QNameGeneratorInstances0 {
+  implicit def sequenceQNameGenerator[F[_]](implicit F: MonadState[F, Long]): QNameGenerator[F] =
+    new QNameGenerator[F] {
+      def freshQName = F.bind(F.get)(n => F.put(n + 1) as numericQName(n))
+    }
+
+  implicit def monotonicSeqQNameGenerator[S[_]](implicit S: MonotonicSeq :<: S): QNameGenerator[Free[S, ?]] =
+    new QNameGenerator[Free[S, ?]] {
+      def freshQName = MonotonicSeq.Ops[S].next map (numericQName)
+    }
+
+  private def numericQName(n: Long): QName = {
+    val name = if (n < 0) s"n_${scala.math.abs(n)}" else s"n$n"
+    QName.local(NCName(Refined.unsafeApply(name)))
+  }
+}
+
+sealed abstract class QNameGeneratorInstances0 {
+  implicit def eitherTQNameGenerator[F[_]: QNameGenerator : Functor, A]: QNameGenerator[EitherT[F, A, ?]] =
+    new QNameGenerator[EitherT[F, A, ?]] {
+      def freshQName = EitherT.right(QNameGenerator[F].freshQName)
+    }
+
+  implicit def readerTQNameGenerator[F[_]: QNameGenerator, A]: QNameGenerator[ReaderT[F, A, ?]] =
+    new QNameGenerator[ReaderT[F, A, ?]] {
+      def freshQName = ReaderT(κ(QNameGenerator[F].freshQName))
+    }
+
+  implicit def stateTQNameGenerator[F[_]: QNameGenerator : Monad, S]: QNameGenerator[StateT[F, S, ?]] =
+    new QNameGenerator[StateT[F, S, ?]] {
+      def freshQName = StateT(s => QNameGenerator[F].freshQName strengthL s)
+    }
+
+  implicit def writerTQNameGenerator[F[_]: QNameGenerator : Functor, W: Monoid]: QNameGenerator[WriterT[F, W, ?]] =
+    new QNameGenerator[WriterT[F, W, ?]] {
+      def freshQName = WriterT.put(QNameGenerator[F].freshQName)(Monoid[W].zero)
+    }
+}

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/XQuery.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/XQuery.scala
@@ -162,6 +162,10 @@ object XQuery {
     case Step(s) => s
   } (Step)
 
+  val flwor = Prism.partial[XQuery, (IList[(String, XQuery)], IList[(String, XQuery)], Option[XQuery], IList[(XQuery, SortDirection)], Boolean, XQuery)] {
+    case Flwor(tuples, lets, filter, order, isStable, result) => (tuples, lets, filter, order, isStable, result)
+  } (Flwor.tupled)
+
   implicit val show: Show[XQuery] =
     Show.showFromToString
 }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/ejson.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/ejson.scala
@@ -75,12 +75,10 @@ object ejson {
       declare(fname)(
         $("arr") as ST("element()")
       ).as(ST("element()")) { arr: XQuery =>
-        val elts = $("elts")
-        seqToArray[F].apply(fn.nodeName(arr), 0.xqy to mkSeq_(fn.count(~elts) - 1.xqy)) map { inner =>
-          let_(elts := (arr `/` child(aelt))) return_ {
-            if_ (fn.empty(~elts)) then_ arr else_ inner
-          }
-        }
+        val i = $("i")
+        seqToArray[F].apply(
+          fn.nodeName(arr),
+          for_ ($("_") at i in (arr `/` child(aelt))) return_ (~i - 1.xqy))
       }
     }.join
 
@@ -90,23 +88,15 @@ object ejson {
       declare(fname)(
         $("arr") as ST("element()")
       ).as(ST("element()")) { arr: XQuery =>
-        val (i, elts, zelts) = ($("i"), $("elts"), $("zelts"))
+        val (i, elt) = ($("i"), $("elt"))
 
         for {
-          ixelt <- mkArrayElt[F](~i)
-          pair  <- mkArray_[F](mkSeq_(ixelt, (~elts)(~i)))
+          ixelt <- mkArrayElt[F](~i - 1.xqy)
+          pair  <- mkArray_[F](mkSeq_(ixelt, ~elt))
           zpair <- mkArrayElt[F](pair)
-          zarr  <- mkArray[F] apply (fn.nodeName(arr), ~zelts)
-        } yield {
-          let_(elts := (arr `/` child(aelt))) return_ {
-            if_ (fn.empty(~elts))
-            .then_ { arr }
-            .else_ {
-              let_(zelts := for_(i in (1.xqy to fn.count(~elts))).return_(zpair))
-              .return_(zarr)
-            }
-          }
-        }
+          zelts =  for_(elt at i in (arr `/` child(aelt))) return_ zpair
+          zarr  <- mkArray[F] apply (fn.nodeName(arr), zelts)
+        } yield zarr
       }
     }.join
 

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/ejson.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/ejson.scala
@@ -75,10 +75,10 @@ object ejson {
       declare(fname)(
         $("arr") as ST("element()")
       ).as(ST("element()")) { arr: XQuery =>
-        val elts = "$elts"
-        seqToArray[F].apply(fn.nodeName(arr), 0.xqy to mkSeq_(fn.count(elts.xqy) - 1.xqy)) map { inner =>
-          let_(elts -> (arr `/` child(aelt))) return_ {
-            if_ (fn.empty(elts.xqy)) then_ arr else_ inner
+        val elts = $("elts")
+        seqToArray[F].apply(fn.nodeName(arr), 0.xqy to mkSeq_(fn.count(~elts) - 1.xqy)) map { inner =>
+          let_(elts := (arr `/` child(aelt))) return_ {
+            if_ (fn.empty(~elts)) then_ arr else_ inner
           }
         }
       }
@@ -90,19 +90,19 @@ object ejson {
       declare(fname)(
         $("arr") as ST("element()")
       ).as(ST("element()")) { arr: XQuery =>
-        val (i, elts, zelts) = ("$i", "$elts", "$zelts")
+        val (i, elts, zelts) = ($("i"), $("elts"), $("zelts"))
 
         for {
-          ixelt <- mkArrayElt[F](i.xqy)
-          pair  <- mkArray_[F](mkSeq_(ixelt, elts.xqy(i.xqy)))
+          ixelt <- mkArrayElt[F](~i)
+          pair  <- mkArray_[F](mkSeq_(ixelt, (~elts)(~i)))
           zpair <- mkArrayElt[F](pair)
-          zarr  <- mkArray[F] apply (fn.nodeName(arr), zelts.xqy)
+          zarr  <- mkArray[F] apply (fn.nodeName(arr), ~zelts)
         } yield {
-          let_(elts -> (arr `/` child(aelt))) return_ {
-            if_ (fn.empty(elts.xqy))
+          let_(elts := (arr `/` child(aelt))) return_ {
+            if_ (fn.empty(~elts))
             .then_ { arr }
             .else_ {
-              let_(zelts -> for_(i -> (1.xqy to fn.count(elts.xqy))).return_(zpair))
+              let_(zelts := for_(i in (1.xqy to fn.count(~elts))).return_(zpair))
               .return_(zarr)
             }
           }
@@ -187,16 +187,16 @@ object ejson {
         $("obj1") as ST("element()"),
         $("obj2") as ST("element()")
       ).as(ST(s"element($ename)")) { (obj1: XQuery, obj2: XQuery) =>
-        val (xs, ys, names, e, n1, n2) = ("$xs", "$ys", "$names", "$e", "$n1", "$n2")
+        val (xs, ys, names, e, n1, n2) = ($("xs"), $("ys"), $("names"), $("e"), $("n1"), $("n2"))
 
         mkObject[F] apply {
           let_(
-            xs    -> (obj2 `/` child.element()),
-            names -> fn.map("fn:node-name#1".xqy, xs.xqy),
-            ys    -> fn.filter(func(e) {
-                       every(n1 -> fn.nodeName(e.xqy), n2 -> names.xqy) satisfies (n1.xqy ne n2.xqy)
+            xs    := (obj2 `/` child.element()),
+            names := fn.map("fn:node-name#1".xqy, ~xs),
+            ys    := fn.filter(func(e.render) {
+                       every(n1 in fn.nodeName(~e), n2 in ~names) satisfies (~n1 ne ~n2)
                      }, obj1 `/` child.element()))
-          .return_(mkSeq_(ys.xqy, xs.xqy))
+          .return_(mkSeq_(~ys, ~xs))
         }
       }
     }.join

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/expr.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/expr.scala
@@ -24,7 +24,6 @@ import scalaz._
 import scalaz.std.string._
 import scalaz.std.iterable._
 import scalaz.syntax.foldable._
-import scalaz.syntax.show._
 import scalaz.syntax.std.option._
 
 @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
@@ -105,7 +104,7 @@ object expr {
       default(TypeswitchDefaultClause(None, xqy))
 
     def default(binding: BindingName, f: XQuery => XQuery): XQuery =
-      default(TypeswitchDefaultClause(Some(binding), f(binding.xqy)))
+      default(TypeswitchDefaultClause(Some(binding), f(binding.ref)))
 
     def default(dc: TypeswitchDefaultClause): XQuery = {
       val body = (cases.map(_.render) :+ dc.render).map("  " + _).mkString("\n")
@@ -113,14 +112,14 @@ object expr {
     }
   }
 
-  final case class TypeswitchCaseClause(matching: TypedBinding \/ SequenceType, result: XQuery) {
+  final case class TypeswitchCaseClause(matching: TypedBindingName \/ SequenceType, result: XQuery) {
     def render: String =
       s"case ${matching.fold(_.render, _.toString)} return $result"
   }
 
   final case class TypeswitchDefaultClause(binding: Option[BindingName], result: XQuery) {
     def render: String = {
-      val bind = binding.map(_.xqy.shows + " ")
+      val bind = binding.map(_.render + " ")
       s"default ${~bind}return $result"
     }
   }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/expr.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/expr.scala
@@ -112,7 +112,7 @@ object expr {
       default(TypeswitchDefaultClause(None, xqy))
 
     def default(binding: BindingName, f: XQuery => XQuery): XQuery =
-      default(TypeswitchDefaultClause(Some(binding), f(binding.ref)))
+      default(TypeswitchDefaultClause(Some(binding), f(~binding)))
 
     def default(dc: TypeswitchDefaultClause): XQuery = {
       val body = (cases.map(_.render) :+ dc.render).map("  " + _).mkString("\n")

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/package.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/package.scala
@@ -69,11 +69,8 @@ package object xquery {
   }
 
   final case class BindingName(value: QName) {
-    def unary_~ : XQuery = ref
+    def unary_~ : XQuery = XQuery(render)
     def as(tpe: SequenceType): TypedBindingName = TypedBindingName(this, tpe)
-    // TODO: Other ideas for syntax here are `~`, which would require parens in
-    //       certain cases but be much more terse in others.
-    def ref: XQuery = XQuery(render)
     def render: String = s"$$${value}"
   }
 
@@ -98,8 +95,7 @@ package object xquery {
   }
 
   final case class TypedBindingName(name: BindingName, tpe: SequenceType) {
-    def unary_~ : XQuery = ref
-    def ref: XQuery = name.ref
+    def unary_~ : XQuery = ~name
     def render: String = s"${name.render} as $tpe"
   }
 

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/package.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/package.scala
@@ -57,8 +57,9 @@ package object xquery {
   }
 
   final case class BindingName(value: QName) {
-    def as(tpe: SequenceType): TypedBinding = TypedBinding(this, tpe)
-    def xqy: XQuery = XQuery(s"$$${value}")
+    def as(tpe: SequenceType): TypedBindingName = TypedBindingName(this, tpe)
+    def ref: XQuery = XQuery(render)
+    def render: String = s"$$${value}"
   }
 
   object BindingName {
@@ -66,7 +67,7 @@ package object xquery {
       Order.orderBy(_.value)
 
     implicit val show: Show[BindingName] =
-      Show.shows(_.xqy.shows)
+      Show.shows(bn => s"BindingName(${bn.render})")
   }
 
   final case class SequenceType(override val toString: String) extends scala.AnyVal
@@ -81,16 +82,17 @@ package object xquery {
       Show.showFromToString
   }
 
-  final case class TypedBinding(name: BindingName, tpe: SequenceType) {
-    def render: String = s"${name.xqy} as $tpe"
+  final case class TypedBindingName(name: BindingName, tpe: SequenceType) {
+    def ref: XQuery = name.ref
+    def render: String = s"${name.render} as $tpe"
   }
 
-  object TypedBinding {
-    implicit val order: Order[TypedBinding] =
-      Order.orderBy(fp => (fp.name, fp.tpe))
+  object TypedBindingName {
+    implicit val order: Order[TypedBindingName] =
+      Order.orderBy(tn => (tn.name, tn.tpe))
 
-    implicit val show: Show[TypedBinding] =
-      Show.shows(fp => s"TypedBinding(${fp.render})")
+    implicit val show: Show[TypedBindingName] =
+      Show.shows(tn => s"TypedBindingName(${tn.render})")
   }
 
   def asArg(opt: Option[XQuery]): String =

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/qscript.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/qscript.scala
@@ -90,8 +90,8 @@ object qscript {
     qs.declare("combine-apply") map (_(
       $("fns") as ST("(function(item()) as item())*")
     ).as(ST("function(item()) as item()*")) { fns =>
-      val (f, x) = ("$f", "$x")
-      func(x) { fn.map(func(f) { f.xqy fnapply x.xqy }, fns) }
+      val (f, x) = ($("f"), $("x"))
+      func(x.render) { fn.map(func(f.render) { (~f) fnapply ~x }, fns) }
     })
 
   // qscript:combine-n($combiners as (function(item()*, item()) as item()*)*) as function(item()*, item()) as item()*
@@ -99,13 +99,11 @@ object qscript {
     qs.declare("combine-n") map (_(
       $("combiners") as ST("(function(item()*, item()) as item()*)*")
     ).as(ST("function(item()*, item()) as item()*")) { combiners =>
-      val (len, acc, i, x) = ($("len"), $("acc"), $("i"), $("x"))
+      val (f, i, acc, x) = ($("f"), $("i"), $("acc"), $("x"))
 
-      let_ (len := fn.count(combiners)) return_ {
-        func(acc.render, x.render) {
-          for_ (i in (1.xqy to ~len)) return_ {
-            combiners(~i) fnapply ((~acc)(~i), ~x)
-          }
+      func(acc.render, x.render) {
+        for_ (f at i in combiners) return_ {
+          (~f) fnapply ((~acc)(~i), ~x)
         }
       }
     })
@@ -309,13 +307,11 @@ object qscript {
     qs.declare("zip-apply") map (_(
       $("fns") as ST("(function(item()*) as item()*)*")
     ).as(ST("function(item()*) as item()*")) { fns =>
-      val (len, i, x) = ($("len"), $("i"), $("x"))
+      val (f, i, x) = ($("f"), $("i"), $("x"))
 
-      let_ (len := fn.count(fns)) return_ {
-        func(x.render) {
-          for_ (i in (1.xqy to ~len)) return_ {
-            fns(~i) fnapply ((~x)(~i))
-          }
+      func(x.render) {
+        for_ (f at i in fns) return_ {
+          (~f) fnapply ((~x)(~i))
         }
       }
     })

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/syntax.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/syntax.scala
@@ -48,9 +48,9 @@ object syntax {
   def $(bindingName: String Refined IsNCName): BindingName =
     BindingName(QName.local(NCName(bindingName)))
 
-  final implicit class TypedBindingOps(val tb: TypedBinding) extends scala.AnyVal {
+  final implicit class TypedBindingNameOps(val tb: TypedBindingName) extends scala.AnyVal {
     def return_[F[_]: Functor](result: XQuery => F[XQuery]): F[TypeswitchCaseClause] =
-      result(tb.name.xqy) map (TypeswitchCaseClause(tb.left, _))
+      result(tb.ref) map (TypeswitchCaseClause(tb.left, _))
 
     def return_(result: XQuery => XQuery): TypeswitchCaseClause =
       return_[Id.Id](result)

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/syntax.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/syntax.scala
@@ -83,7 +83,7 @@ object syntax {
       this := expression
 
     def return_[F[_]: Functor](result: XQuery => F[XQuery]): F[TypeswitchCaseClause] =
-      result(tb.ref) map (TypeswitchCaseClause(tb.left, _))
+      result(~tb) map (TypeswitchCaseClause(tb.left, _))
 
     def return_(result: XQuery => XQuery): TypeswitchCaseClause =
       return_[Id.Id](result)


### PR DESCRIPTION
Implements basic fusion for FLWOR expressions in the MarkLogic planner and converts `ShiftedRead` plan from a function call to a FLWOR expression in order to benefit from fusion.

The fusion implemented relies on contextual information within the planner and isn't completely general, though it could be made so once we have a complete fixpoint AST for XQuery.

Fusion for `ThetaJoin` branches sharing a non-trivial common src isn't implemented here, but is tracked in #1690.

Closes #1625 