### PR TITLE
Add casting to MarkLogic planner where beneficial

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,3 @@
+- [1504] Cast operands of various operations in MarkLogic planner
+  - Unify parsing of date/time XQuery literals and elements
+  - Update MarkLogic planner for Constants to go through Data

--- a/it/src/main/resources/tests/complex-vars.test
+++ b/it/src/main/resources/tests/complex-vars.test
@@ -2,8 +2,7 @@
   "name": "variable with a non-trivial value",
 
   "backends": {
-    "postgresql": "pending",
-    "marklogic":  "skip"
+    "postgresql": "pending"
   },
 
   "data": "days.data",

--- a/it/src/main/resources/tests/filterByJsWithOnlyReducing.test
+++ b/it/src/main/resources/tests/filterByJsWithOnlyReducing.test
@@ -4,16 +4,15 @@
   "backends": {
       "mongodb_read_only": "pending",
       "postgresql":        "pending",
-      "marklogic":         "skip",
       "couchbase":         "skip"
   },
 
   "data": "largeZips.data",
 
-  "query": "select max(pop), min(city) from largeZips where length(city) < 6",
+  "query": "select max(pop) as max_pop, min(city) as min_city from largeZips where length(city) < 6",
 
   "predicate": "containsExactly",
   "expected": [
-    { "0": 85710, "1": "ABAC" }
+    { "max_pop": 85710, "min_city": "ABAC" }
   ]
 }

--- a/it/src/main/resources/tests/flattenArray.test
+++ b/it/src/main/resources/tests/flattenArray.test
@@ -2,11 +2,17 @@
     "name": "flatten array",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "skip",
         "couchbase":  "skip"
     },
     "data": "zips.data",
-    "query": "SELECT loc[*] AS loc FROM zips LIMIT 1",
-    "predicate": "containsExactly",
-    "expected": [{ "loc" : -72.622739}]
+    "query": "SELECT loc[*] AS loc FROM zips",
+    "predicate": "containsAtLeast",
+    "expected": [
+      { "loc" : -72.622739 },
+      { "loc" :  34.933613 },
+      { "loc" : -78.504109 },
+      { "loc" :  34.994081 },
+      { "loc" : -79.261843 },
+      { "loc" :  34.588664 }
+    ]
 }

--- a/it/src/main/resources/tests/jsWithNonJsFilter.test
+++ b/it/src/main/resources/tests/jsWithNonJsFilter.test
@@ -3,7 +3,6 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "skip",
         "couchbase":         "skip"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/letBindingSelect.test
+++ b/it/src/main/resources/tests/letBindingSelect.test
@@ -3,7 +3,6 @@
 
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "skip",
         "couchbase":  "skip"
     },
 

--- a/it/src/main/resources/tests/manySimpleProjections.test
+++ b/it/src/main/resources/tests/manySimpleProjections.test
@@ -3,7 +3,6 @@
 
   "backends": {
     "postgresql": "pending",
-    "marklogic":  "skip",
     "couchbase":  "skip"
   },
 

--- a/it/src/main/resources/tests/matchRegexPatternWithExpressions.test
+++ b/it/src/main/resources/tests/matchRegexPatternWithExpressions.test
@@ -4,21 +4,20 @@
   "backends": {
     "mongodb_read_only": "pending",
     "postgresql":        "pending",
-    "marklogic":         "skip",
     "couchbase":         "skip"
   },
 
   "data": "largeZips.data",
 
   "query":
-    "select distinct city, city ~ \"OUL\", \"some text with BOULDER in it\" ~ city
+    "select distinct city, city ~ \"OUL\" as a, \"some text with BOULDER in it\" ~ city as b
       from largeZips
       where city ~ \"^B[^ ]+ER$\" and \"BOULDER or BEELER\" ~ city",
 
   "predicate": "containsExactly",
 
   "expected": [
-    { "city": "BOULDER", "1": true,  "2": true  },
-    { "city": "BEELER",  "1": false, "2": false }
+    { "city": "BOULDER", "a": true,  "b": true  },
+    { "city": "BEELER",  "a": false, "b": false }
   ]
 }

--- a/it/src/main/resources/tests/null/toFromString.test
+++ b/it/src/main/resources/tests/null/toFromString.test
@@ -3,11 +3,10 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "skip",
         "couchbase":         "skip"
     },
     "data": "nulls.data",
-    "query": "select null(name), to_string(val) from nulls where name = \"null\"",
+    "query": "select null(name) as n, to_string(val) as s from nulls where name = \"null\"",
     "predicate": "containsExactly",
-    "expected": [{ "0": null, "1": "null" }]
+    "expected": [{ "n": null, "s": "null" }]
 }

--- a/it/src/main/resources/tests/sortByJS.test
+++ b/it/src/main/resources/tests/sortByJS.test
@@ -4,7 +4,6 @@
   "backends": {
     "mongodb_read_only": "pending",
     "postgresql":        "pending",
-    "marklogic":         "skip",
     "couchbase":         "skip"
   },
 

--- a/it/src/main/resources/tests/temporal/convertTimestamp.test
+++ b/it/src/main/resources/tests/temporal/convertTimestamp.test
@@ -2,8 +2,7 @@
   "name": "convert epoch milliseconds value to timestamp",
 
   "backends": {
-    "postgresql": "pending",
-    "marklogic":  "skip"
+    "postgresql": "pending"
   },
 
   "data": "../days.data",

--- a/it/src/main/resources/tests/zipsByCityLength.test
+++ b/it/src/main/resources/tests/zipsByCityLength.test
@@ -3,7 +3,6 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "skip",
         "couchbase":         "skip"
     },
     "data": "largeZips.data",
@@ -12,6 +11,7 @@
                 where state != \"MI\"
                 group by length(city)",
     "predicate": "containsExactly",
+    "ignoreFieldOrder": true,
     "expected": [{ "cnt":   2, "len":  3 },
                  { "cnt":  65, "len":  4 },
                  { "cnt": 206, "len":  5 },

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -89,12 +89,22 @@ abstract class QueryRegressionTest[S[_]](
 
   lazy val tests = regressionTests(TestsRoot, knownFileSystems).unsafePerformSync
 
+  // NB: The printing is just to indicate progress (especially for travis-ci) as
+  //     these tests have the potential to be slow for a backend.
+  //
+  //     Ideally, we'd have specs2 log each example in the suite as it finishes, but
+  //     all attempts at doing this have been unsuccessful, if we succeed eventually
+  //     this printing can be removed.
   fileSystemShould { fs =>
     suiteName should {
+      step(print(s"Running $suiteName ["))
+
       tests.toList foreach { case (f, t) =>
         regressionExample(f, t, fs.name, fs.setupInterpM, fs.testInterpM)
+        step(print("."))
       }
 
+      step(println("]"))
       step(runT(fs.setupInterpM)(manage.delete(DataDir)).runVoid)
     }
   }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/prisms.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/prisms.scala
@@ -23,7 +23,7 @@ import java.util.Base64
 import monocle.Prism
 import org.threeten.bp._
 import org.threeten.bp.format._
-import org.threeten.bp.temporal.TemporalAccessor
+import org.threeten.bp.temporal.{TemporalAccessor, TemporalQuery}
 import scalaz._
 
 object prisms {
@@ -43,14 +43,14 @@ object prisms {
     case _ => None
   } (d => s"${d.getSeconds}.${d.getNano}")
 
-  val isoInstant:   Prism[String, Instant]   = temporal(Instant.from  , DateTimeFormatter.ISO_INSTANT)
-  val isoLocalDate: Prism[String, LocalDate] = temporal(LocalDate.from, DateTimeFormatter.ISO_LOCAL_DATE)
-  val isoLocalTime: Prism[String, LocalTime] = temporal(LocalTime.from, DateTimeFormatter.ISO_LOCAL_TIME)
+  val isoInstant:   Prism[String, Instant]   = temporal(Instant.FROM  , DateTimeFormatter.ISO_INSTANT)
+  val isoLocalDate: Prism[String, LocalDate] = temporal(LocalDate.FROM, DateTimeFormatter.ISO_DATE)
+  val isoLocalTime: Prism[String, LocalTime] = temporal(LocalTime.FROM, DateTimeFormatter.ISO_TIME)
 
   ////
 
   private val DurationEncoding = "(-?\\d+)(?:\\.(\\d+))?".r
 
-  private def temporal[T <: TemporalAccessor](f: TemporalAccessor => T, fmt: DateTimeFormatter): Prism[String, T] =
-    Prism[String, T](s => \/.fromTryCatchNonFatal(f(fmt.parse(s))).toOption)(fmt.format)
+  private def temporal[T <: TemporalAccessor](q: TemporalQuery[T], fmt: DateTimeFormatter): Prism[String, T] =
+    Prism[String, T](s => \/.fromTryCatchNonFatal(fmt.parse(s, q)).toOption)(fmt.format)
 }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MapFuncPlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MapFuncPlanner.scala
@@ -25,7 +25,7 @@ import quasar.physical.marklogic.xquery.syntax._
 import quasar.qscript.{MapFunc, MapFuncs}, MapFuncs._
 
 import matryoshka._, Recursive.ops._
-import scalaz.{Applicative, EitherT}
+import scalaz.{EitherT, Monad}
 import scalaz.std.option._
 import scalaz.syntax.monad._
 
@@ -82,26 +82,26 @@ object MapFuncPlanner {
 
     // math
     case Negate(x)                    => (-x).point[F]
-    case Add(x, y)                    => binOp[F](x, y)(_ + _)
-    case Multiply(x, y)               => binOp[F](x, y)(_ * _)
-    case Subtract(x, y)               => binOp[F](x, y)(_ - _)
-    case Divide(x, y)                 => binOp[F](x, y)(_ div _)
-    case Modulo(x, y)                 => binOp[F](x, y)(_ mod _)
-    case Power(b, e)                  => math.pow(b, e).point[F]
+    case Add(x, y)                    => castedBinOp[F](x, y)(_ + _)
+    case Multiply(x, y)               => castedBinOp[F](x, y)(_ * _)
+    case Subtract(x, y)               => castedBinOp[F](x, y)(_ - _)
+    case Divide(x, y)                 => castedBinOp[F](x, y)(_ div _)
+    case Modulo(x, y)                 => castedBinOp[F](x, y)(_ mod _)
+    case Power(b, e)                  => (ejson.castAsAscribed[F].apply(b) |@| ejson.castAsAscribed[F].apply(e))(math.pow)
 
     // relations
-    case Not(x)                       => fn.not(x).point[F]
+    case Not(x)                       => ejson.castAsAscribed[F].apply(x) map (fn.not)
     case MapFuncs.Eq(x, y)            => binOp[F](x, y)(_ eq _)
     case Neq(x, y)                    => binOp[F](x, y)(_ ne _)
-    case Lt(x, y)                     => binOp[F](x, y)(_ lt _)
-    case Lte(x, y)                    => binOp[F](x, y)(_ le _)
-    case Gt(x, y)                     => binOp[F](x, y)(_ gt _)
-    case Gte(x, y)                    => binOp[F](x, y)(_ ge _)
+    case Lt(x, y)                     => castedBinOp[F](x, y)(_ lt _)
+    case Lte(x, y)                    => castedBinOp[F](x, y)(_ le _)
+    case Gt(x, y)                     => castedBinOp[F](x, y)(_ gt _)
+    case Gte(x, y)                    => castedBinOp[F](x, y)(_ ge _)
     case IfUndefined(x, alternate)    => if_(fn.empty(x)).then_(alternate).else_(x).point[F]
-    case And(x, y)                    => binOp[F](x, y)(_ and _)
-    case Or(x, y)                     => binOp[F](x, y)(_ or _)
-    case Between(v1, v2, v3)          => ternOp[F](v1, v2, v3)((x1, x2, x3) => mkSeq_(x2 le x1) and mkSeq_(x1 le x3))
-    case Cond(p, t, f)                => if_(p).then_(t).else_(f).point[F]
+    case And(x, y)                    => castedBinOp[F](x, y)(_ and _)
+    case Or(x, y)                     => castedBinOp[F](x, y)(_ or _)
+    case Between(v1, v2, v3)          => castedTernOp[F](v1, v2, v3)((x1, x2, x3) => mkSeq_(x2 le x1) and mkSeq_(x1 le x3))
+    case Cond(p, t, f)                => if_(xs.boolean(p)).then_(t).else_(f).point[F]
 
     // set
     case Within(x, arr)               => qscript.elementLeftShift[F].apply(arr) map (xs => fn.exists(fn.indexOf(xs, x)))
@@ -183,17 +183,33 @@ object MapFuncPlanner {
 
   ////
 
-  private def binOp[F[_]: QNameGenerator: Applicative](x: XQuery, y: XQuery)(op: (XQuery, XQuery) => XQuery): F[XQuery] =
+  private def binOp0[F[_]: QNameGenerator: Monad](x: XQuery, y: XQuery)(op: (XQuery, XQuery) => F[XQuery]): F[XQuery] =
     if (flwor.isMatching(x) || flwor.isMatching(y))
-      (freshName[F] |@| freshName[F])((vx, vy) =>
-        mkSeq_(let_(vx := x, vy := y) return_ op(~vx, ~vy)))
+      for {
+        vx <- freshName[F]
+        vy <- freshName[F]
+        r  <- op(~vx, ~vy)
+      } yield mkSeq_(let_(vx := x, vy := y) return_ r)
     else
-      op(x, y).point[F]
+      op(x, y)
 
-  private def ternOp[F[_]: QNameGenerator: Applicative](x: XQuery, y: XQuery, z: XQuery)(op: (XQuery, XQuery, XQuery) => XQuery): F[XQuery] =
+  private def binOp[F[_]: QNameGenerator: Monad](x: XQuery, y: XQuery)(op: (XQuery, XQuery) => XQuery): F[XQuery] =
+    binOp0(x, y)(op(_, _).point[F])
+
+  private def castedBinOp[F[_]: QNameGenerator: PrologW](x: XQuery, y: XQuery)(op: (XQuery, XQuery) => XQuery): F[XQuery] =
+    binOp0(x, y)((vx, vy) => (ejson.castAsAscribed[F].apply(vx) |@| ejson.castAsAscribed[F].apply(vy))(op))
+
+  private def ternOp0[F[_]: QNameGenerator: Monad](x: XQuery, y: XQuery, z: XQuery)(op: (XQuery, XQuery, XQuery) => F[XQuery]): F[XQuery] =
     if (flwor.isMatching(x) || flwor.isMatching(y) || flwor.isMatching(z))
-      (freshName[F] |@| freshName[F] |@| freshName[F])((vx, vy, vz) =>
-        mkSeq_(let_(vx := x, vy := y, vz := z) return_ op(~vx, ~vy, ~vz)))
+      for {
+        vx <- freshName[F]
+        vy <- freshName[F]
+        vz <- freshName[F]
+        r  <- op(~vx, ~vy, ~vz)
+      } yield mkSeq_(let_(vx := x, vy := y, vz := z) return_ r)
     else
-      op(x, y, z).point[F]
+      op(x, y, z)
+
+  private def castedTernOp[F[_]: QNameGenerator: PrologW](x: XQuery, y: XQuery, z: XQuery)(op: (XQuery, XQuery, XQuery) => XQuery): F[XQuery] =
+    ternOp0(x, y, z)((vx, vy, vz) => (ejson.castAsAscribed[F].apply(vx) |@| ejson.castAsAscribed[F].apply(vy) |@| ejson.castAsAscribed[F].apply(vz))(op))
 }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/QScriptCorePlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/QScriptCorePlanner.scala
@@ -88,7 +88,9 @@ private[qscript] final class QScriptCorePlanner[F[_]: QNameGenerator: PrologW: M
       for {
         x        <- freshName[F]
         xqyOrder <- NonEmptyList((bucket, SortDir.Ascending), order: _*).traverse { case (func, sortDir) =>
-                      mapFuncXQuery(func, ~x) strengthR SortDirection.fromQScript(sortDir)
+                      mapFuncXQuery(func, ~x) flatMap { by =>
+                        ejson.castAsAscribed[F].apply(by) strengthR SortDirection.fromQScript(sortDir)
+                      }
                     }
       } yield src match {
         case IterativeFlwor(bindings, filter, _, _, result) =>
@@ -108,7 +110,6 @@ private[qscript] final class QScriptCorePlanner[F[_]: QNameGenerator: PrologW: M
     case Filter(src, f) =>
       for {
         x <- freshName[F]
-        // FIXME: This cast shouldn't be necessary once projecting produces typed values.
         p <- mapFuncXQuery(f, ~x) map (xs.boolean)
       } yield src match {
         case IterativeFlwor(bindings, filter, order, isStable, result) =>
@@ -158,13 +159,16 @@ private[qscript] final class QScriptCorePlanner[F[_]: QNameGenerator: PrologW: M
     } yield func(acc.render, x.render)(nxt)
   }
 
+  def castingCombiner(fm: FreeMap[T])(f: (XQuery, XQuery) => F[XQuery]): F[XQuery] =
+    combiner(fm)((acc, x) => ejson.castAsAscribed[F].apply(x) flatMap (f(acc, _)))
+
   def reduceFuncInit(rf: ReduceFunc[FreeMap[T]]): F[XQuery] = rf match {
     case Avg(fm)              => fx(x => mapFuncXQuery[T, F](fm, x) flatMap { v =>
                                    qscript.incAvgState[F].apply(1.xqy, v)
                                  })
     case Count(_)             => fx(_ => 1.xqy.point[F])
-    case Max(fm)              => fx(mapFuncXQuery[T, F](fm, _))
-    case Min(fm)              => fx(mapFuncXQuery[T, F](fm, _))
+    case Max(fm)              => fx(x => (ejson.castAsAscribed[F] |@| mapFuncXQuery[T, F](fm, x))(_ apply _).join)
+    case Min(fm)              => fx(x => (ejson.castAsAscribed[F] |@| mapFuncXQuery[T, F](fm, x))(_ apply _).join)
     case Sum(fm)              => fx(mapFuncXQuery[T, F](fm, _))
     case Arbitrary(fm)        => fx(mapFuncXQuery[T, F](fm, _))
     case UnshiftArray(fm)     => fx(x => mapFuncXQuery[T, F](fm, x) flatMap (ejson.singletonArray[F].apply(_)))
@@ -184,8 +188,8 @@ private[qscript] final class QScriptCorePlanner[F[_]: QNameGenerator: PrologW: M
   def reduceFuncCombine(rf: ReduceFunc[FreeMap[T]]): F[XQuery] = rf match {
     case Avg(fm)              => combiner(fm)(qscript.incAvg[F].apply(_, _))
     case Count(fm)            => combiner(fm)((c, _) => (c + 1.xqy).point[F])
-    case Max(fm)              => combiner(fm)((x, y) => (if_ (y gt x) then_ y else_ x).point[F])
-    case Min(fm)              => combiner(fm)((x, y) => (if_ (y lt x) then_ y else_ x).point[F])
+    case Max(fm)              => castingCombiner(fm)((x, y) => (if_ (y gt x) then_ y else_ x).point[F])
+    case Min(fm)              => castingCombiner(fm)((x, y) => (if_ (y lt x) then_ y else_ x).point[F])
     case Sum(fm)              => combiner(fm)((x, y) => fn.sum(mkSeq_(x, y)).point[F])
     case Arbitrary(fm)        => combiner(fm)((x, _) => x.point[F])
     case UnshiftArray(fm)     => combiner(fm)(ejson.arrayAppend[F].apply(_, _))

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/xs.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/xs.scala
@@ -43,6 +43,9 @@ object xs {
   def duration(xqy: XQuery): XQuery =
     XQuery(s"xs:duration($xqy)")
 
+  def hexBinary(xqy: XQuery): XQuery =
+    XQuery(s"xs:hexBinary($xqy)")
+
   def integer(xqy: XQuery): XQuery =
     XQuery(s"xs:integer($xqy)")
 


### PR DESCRIPTION
Adds type casts based on the `ejson:type` attribute of elements to the MarkLogic planner where they would be beneficial (operands to various operators, sort keys, etc) resulting in another handful of passing regression tests.

Also improves `Constant` planning by using the `EJson => Data` algebra and unifies date/time result parsing for XQuery literals and elements with the corresponding `ejson:type` attribute.

Closes #1504.