### PR TITLE
Fix MarkLogic array concatenation and enable all MapFunc tests

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,3 @@
+- Treat strings as arrays for purposes for concatenation in MarkLogic
+  - [1503] Allow array operations to work on any XML element
+  - Enable all StdLib tests for MarkLogic and add new ones for ArrayConcat

--- a/frontend/src/main/scala/quasar/std/structural.scala
+++ b/frontend/src/main/scala/quasar/std/structural.scala
@@ -149,19 +149,21 @@ trait StructuralLib extends Library {
     Func.Input2(AnyArray ⨿ Str, AnyArray ⨿ Str),
     noSimplification,
     partialTyperV[nat._2] {
-      case Sized(t1, t2) if t1.arrayLike && t2.contains(AnyArray ⨿ Str) => ArrayConcat.tpe(Func.Input2(t1, FlexArr(0, None, Top)))
-      case Sized(t1, t2) if t1.contains(AnyArray ⨿ Str) && t2.arrayLike => ArrayConcat.tpe(Func.Input2(FlexArr(0, None, Top), t2))
-      case Sized(t1, t2) if t1.arrayLike && t2.arrayLike                => ArrayConcat.tpe(Func.Input2(t1, t2))
+      case Sized(t1, t2) if t1.arrayLike && t2.contains(AnyArray ⨿ Str)     => ArrayConcat.tpe(Func.Input2(t1, FlexArr(0, None, Top)))
+      case Sized(t1, t2) if t1.contains(AnyArray ⨿ Str) && t2.arrayLike     => ArrayConcat.tpe(Func.Input2(FlexArr(0, None, Top), t2))
+      case Sized(t1, t2) if t1.arrayLike && t2.arrayLike                    => ArrayConcat.tpe(Func.Input2(t1, t2))
 
       case Sized(Const(Data.Str(str1)), Const(Data.Str(str2)))              => success(Const(Data.Str(str1 ++ str2)))
       case Sized(t1, t2) if Str.contains(t1) && t2.contains(AnyArray ⨿ Str) => success(Type.Str)
       case Sized(t1, t2) if t1.contains(AnyArray ⨿ Str) && Str.contains(t2) => success(Type.Str)
       case Sized(t1, t2) if Str.contains(t1) && Str.contains(t2)            => StringLib.Concat.tpe(Func.Input2(t1, t2))
 
-      case Sized(t1, t2) if t1 == t2 => success(t1)
+      case Sized(t1, t2) if t1 == t2                                        => success(t1)
 
-      case Sized(t1, t2) if Str.contains(t1) && t2.arrayLike => failure(NonEmptyList(GenericError("cannot concat string with array")))
-      case Sized(t1, t2) if t1.arrayLike && Str.contains(t2) => failure(NonEmptyList(GenericError("cannot concat array with string")))
+      case Sized(Const(Data.Str(s)), Const(Data.Arr(ys)))                   => success(Const(Data.Arr(s.map(c => Data._str(c.toString)).toList ::: ys)))
+      case Sized(Const(Data.Arr(xs)), Const(Data.Str(s)))                   => success(Const(Data.Arr(xs ::: s.map(c => Data._str(c.toString)).toList)))
+      case Sized(t1, t2) if Str.contains(t1) && t2.arrayLike                => ArrayConcat.tpe(Func.Input2(FlexArr(0, None, Str), t2))
+      case Sized(t1, t2) if t1.arrayLike && Str.contains(t2)                => ArrayConcat.tpe(Func.Input2(t1, FlexArr(0, None, Str)))
     },
     partialUntyperV[nat._2] {
       case x if x.contains(AnyArray ⨿ Str) => success(Func.Input2(AnyArray ⨿ Str, AnyArray ⨿ Str))

--- a/frontend/src/test/scala/quasar/std/StdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/StdLibSpec.scala
@@ -1015,24 +1015,24 @@ abstract class StdLibSpec extends Qspec {
       //        demands it and can't seem to find one in this context.
       implicit def listToTraversable[A](as: List[A]): Traversable[A] = as
 
-      "ArrayConcat" >> {
-        "array  || array" >> prop { (xs: List[String], ys: List[String]) =>
-          val (xstrs, ystrs) = (xs map (Data._str(_)), ys map (Data._str(_)))
-          binary(ArrayConcat(_, _).embed, Data._arr(xstrs), Data._arr(ystrs), Data._arr(xstrs ::: ystrs))
+      "ConcatOp" >> {
+        "array  || array" >> prop { (xs: List[BigInt], ys: List[BigInt]) =>
+          val (xints, yints) = (xs map (Data._int(_)), ys map (Data._int(_)))
+          binary(ConcatOp(_, _).embed, Data._arr(xints), Data._arr(yints), Data._arr(xints ::: yints))
         }
 
-        "array  || string" >> prop { (xs: List[String], y: String) =>
-          val (xstrs, ystrs) = (xs map (Data._str(_)), y.toList map (c => Data._str(c.toString)))
-          binary(ArrayConcat(_, _).embed, Data._arr(xstrs), Data._str(y), Data._arr(xstrs ::: ystrs))
+        "array  || string" >> prop { (xs: List[BigInt], y: String) =>
+          val (xints, ystrs) = (xs map (Data._int(_)), y.toList map (c => Data._str(c.toString)))
+          binary(ConcatOp(_, _).embed, Data._arr(xints), Data._str(y), Data._arr(xints ::: ystrs))
         }
 
-        "string || array" >> prop { (x: String, ys: List[String]) =>
-          val (xstrs, ystrs) = (x.toList map (c => Data._str(c.toString)), ys map (Data._str(_)))
-          binary(ArrayConcat(_, _).embed, Data._str(x), Data._arr(ystrs), Data._arr(xstrs ::: ystrs))
+        "string || array" >> prop { (x: String, ys: List[BigInt]) =>
+          val (xstrs, yints) = (x.toList map (c => Data._str(c.toString)), ys map (Data._int(_)))
+          binary(ConcatOp(_, _).embed, Data._str(x), Data._arr(yints), Data._arr(xstrs ::: yints))
         }
 
         "string || string" >> prop { (x: String, y: String) =>
-          binary(ArrayConcat(_, _).embed, Data._str(x), Data._str(y), Data._str(x + y))
+          binary(ConcatOp(_, _).embed, Data._str(x), Data._str(y), Data._str(x + y))
         }
       }
     }

--- a/frontend/src/test/scala/quasar/std/StdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/StdLibSpec.scala
@@ -20,12 +20,14 @@ import quasar.Predef._
 import quasar.{Data, Qspec, Type}
 import quasar.frontend.logicalplan._
 
-import matryoshka._
-import org.specs2.execute._
-import org.specs2.matcher._
+import scala.math.abs
+
+import matryoshka.Fix
+import org.specs2.execute.Result
+import org.specs2.matcher.{Expectable, Matcher}
 import org.scalacheck.{Arbitrary, Gen}
 import org.threeten.bp.{Instant, LocalDate, ZoneOffset}
-import scala.math.abs
+import scalaz.Equal
 
 /** Abstract spec for the standard library, intended to be implemented for each
   * library implementation, of which there are one or more per backend.
@@ -43,7 +45,7 @@ abstract class StdLibSpec extends Qspec {
             s"$x is a Number and matches $exp",
             s"$x is a Number but does not match $exp", s)
         case _ =>
-          result(v == expected,
+          result(Equal[Data].equal(v, expected),
             s"$v matches $expected",
             s"$v does not match $expected", s)
       }
@@ -73,8 +75,6 @@ abstract class StdLibSpec extends Qspec {
     "StringLib" >> {
       import StringLib._
 
-      // TODO: This may need to move to a more general section in order to also include
-      //       Array || Array, String || Array, Array || String
       "Concat" >> {
         "any strings" >> prop { (str1: String, str2: String) =>
           binary(Concat(_, _).embed, Data.Str(str1), Data.Str(str2), Data.Str(str1 + str2))
@@ -1004,6 +1004,35 @@ abstract class StdLibSpec extends Qspec {
 
         "false" >> prop { (x: Data, y: Data) =>
           ternary(Cond(_, _, _).embed, Data.Bool(false), x, y, y)
+        }
+      }
+    }
+
+    "StructuralLib" >> {
+      import StructuralLib._
+
+      // FIXME: No idea why this is necessary, but ScalaCheck arbContainer
+      //        demands it and can't seem to find one in this context.
+      implicit def listToTraversable[A](as: List[A]): Traversable[A] = as
+
+      "ArrayConcat" >> {
+        "array  || array" >> prop { (xs: List[String], ys: List[String]) =>
+          val (xstrs, ystrs) = (xs map (Data._str(_)), ys map (Data._str(_)))
+          binary(ArrayConcat(_, _).embed, Data._arr(xstrs), Data._arr(ystrs), Data._arr(xstrs ::: ystrs))
+        }
+
+        "array  || string" >> prop { (xs: List[String], y: String) =>
+          val (xstrs, ystrs) = (xs map (Data._str(_)), y.toList map (c => Data._str(c.toString)))
+          binary(ArrayConcat(_, _).embed, Data._arr(xstrs), Data._str(y), Data._arr(xstrs ::: ystrs))
+        }
+
+        "string || array" >> prop { (x: String, ys: List[String]) =>
+          val (xstrs, ystrs) = (x.toList map (c => Data._str(c.toString)), ys map (Data._str(_)))
+          binary(ArrayConcat(_, _).embed, Data._str(x), Data._arr(ystrs), Data._arr(xstrs ::: ystrs))
+        }
+
+        "string || string" >> prop { (x: String, y: String) =>
+          binary(ArrayConcat(_, _).embed, Data._str(x), Data._str(y), Data._str(x + y))
         }
       }
     }

--- a/frontend/src/test/scala/quasar/std/StdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/StdLibSpec.scala
@@ -73,6 +73,8 @@ abstract class StdLibSpec extends Qspec {
     "StringLib" >> {
       import StringLib._
 
+      // TODO: This may need to move to a more general section in order to also include
+      //       Array || Array, String || Array, Array || String
       "Concat" >> {
         "any strings" >> prop { (str1: String, str2: String) =>
           binary(Concat(_, _).embed, Data.Str(str1), Data.Str(str2), Data.Str(str1 + str2))

--- a/it/src/main/resources/tests/mongodb/wildcardWithExtraProjections.test
+++ b/it/src/main/resources/tests/mongodb/wildcardWithExtraProjections.test
@@ -1,0 +1,24 @@
+{
+  "name": "wildcard with additional projections and filtering (MongoDB)",
+  "backends": {
+    "mongodb_read_only": "pending",
+    "postgresql":        "skip",
+    "marklogic":         "skip",
+    "couchbase":         "skip"
+  },
+  "data": "zips.data",
+  "query": "select *, concat(city, concat(\", \", state)), city = \"BOULDER\" from zips where city like \"BOULDER%\"",
+  "predicate": "containsExactly",
+  "expected": [
+    { "value": {  "_id": "80301", "city": "BOULDER",          "loc": [ -105.21426, 40.049733 ],  "pop": 18174.0, "state": "CO", "1": "BOULDER, CO",          "2": true  } },
+    { "value": {  "_id": "80302", "city": "BOULDER",          "loc": [ -105.285131, 40.017235 ], "pop": 29384.0, "state": "CO", "1": "BOULDER, CO",          "2": true  } },
+    { "value": {  "_id": "80303", "city": "BOULDER",          "loc": [ -105.239178, 39.991381 ], "pop": 39860.0, "state": "CO", "1": "BOULDER, CO",          "2": true  } },
+    { "value": {  "_id": "80304", "city": "BOULDER",          "loc": [ -105.277073, 40.037482 ], "pop": 21550.0, "state": "CO", "1": "BOULDER, CO",          "2": true  } },
+    { "value": {  "_id": "59632", "city": "BOULDER",          "loc": [ -112.113757, 46.230647 ], "pop": 1737.0,  "state": "MT", "1": "BOULDER, MT",          "2": true  } },
+    { "value": {  "_id": "84716", "city": "BOULDER",          "loc": [ -111.426646, 37.916606 ], "pop": 131.0,   "state": "UT", "1": "BOULDER, UT",          "2": true  } },
+    { "value": {  "_id": "82923", "city": "BOULDER",          "loc": [ -109.540105, 42.688146 ], "pop": 112.0,   "state": "WY", "1": "BOULDER, WY",          "2": true  } },
+    { "value": {  "_id": "89005", "city": "BOULDER CITY",     "loc": [ -114.834413, 35.972711 ], "pop": 12920.0, "state": "NV", "1": "BOULDER CITY, NV",     "2": false } },
+    { "value": {  "_id": "95006", "city": "BOULDER CREEK",    "loc": [ -122.133053, 37.149934 ], "pop": 9434.0,  "state": "CA", "1": "BOULDER CREEK, CA",    "2": false } },
+    { "value": {  "_id": "54512", "city": "BOULDER JUNCTION", "loc": [ -89.632454, 46.111183 ],  "pop": 563.0,   "state": "WI", "1": "BOULDER JUNCTION, WI", "2": false } }
+  ]
+}

--- a/it/src/main/resources/tests/mongodb/wildcardWithExtraProjections.test
+++ b/it/src/main/resources/tests/mongodb/wildcardWithExtraProjections.test
@@ -6,8 +6,8 @@
     "marklogic":         "skip",
     "couchbase":         "skip"
   },
-  "data": "zips.data",
-  "query": "select *, concat(city, concat(\", \", state)), city = \"BOULDER\" from zips where city like \"BOULDER%\"",
+  "data": "../zips.data",
+  "query": "select *, concat(city, concat(\", \", state)), city = \"BOULDER\" from `../zips` where city like \"BOULDER%\"",
   "predicate": "containsExactly",
   "expected": [
     { "value": {  "_id": "80301", "city": "BOULDER",          "loc": [ -105.21426, 40.049733 ],  "pop": 18174.0, "state": "CO", "1": "BOULDER, CO",          "2": true  } },

--- a/it/src/main/resources/tests/wildcardWithExtraProjections.test
+++ b/it/src/main/resources/tests/wildcardWithExtraProjections.test
@@ -1,24 +1,26 @@
 {
-  "name": "wildcard with additional projections (and filtering)",
+  "name": "wildcard with additional projections and filtering",
   "backends": {
-    "mongodb_read_only": "pending",
+    "mongodb_2_6":       "skip",
+    "mongodb_3_0":       "skip",
+    "mongodb_read_only": "skip",
+    "mongodb_3_2":       "skip",
     "postgresql":        "pending",
-    "marklogic":         "skip",
     "couchbase":         "skip"
   },
   "data": "zips.data",
-  "query": "select *, concat(city, concat(\", \", state)), city = \"BOULDER\" from zips where city like \"BOULDER%\"",
+  "query": "select *, concat(city, concat(\", \", state)) as city_state, city = \"BOULDER\" as boulderish from zips where city like \"BOULDER%\"",
   "predicate": "containsExactly",
   "expected": [
-    { "value": {  "_id": "80301", "city": "BOULDER",          "loc": [ -105.21426, 40.049733 ],  "pop": 18174.0, "state": "CO", "1": "BOULDER, CO",          "2": true  } },
-    { "value": {  "_id": "80302", "city": "BOULDER",          "loc": [ -105.285131, 40.017235 ], "pop": 29384.0, "state": "CO", "1": "BOULDER, CO",          "2": true  } },
-    { "value": {  "_id": "80303", "city": "BOULDER",          "loc": [ -105.239178, 39.991381 ], "pop": 39860.0, "state": "CO", "1": "BOULDER, CO",          "2": true  } },
-    { "value": {  "_id": "80304", "city": "BOULDER",          "loc": [ -105.277073, 40.037482 ], "pop": 21550.0, "state": "CO", "1": "BOULDER, CO",          "2": true  } },
-    { "value": {  "_id": "59632", "city": "BOULDER",          "loc": [ -112.113757, 46.230647 ], "pop": 1737.0,  "state": "MT", "1": "BOULDER, MT",          "2": true  } },
-    { "value": {  "_id": "84716", "city": "BOULDER",          "loc": [ -111.426646, 37.916606 ], "pop": 131.0,   "state": "UT", "1": "BOULDER, UT",          "2": true  } },
-    { "value": {  "_id": "82923", "city": "BOULDER",          "loc": [ -109.540105, 42.688146 ], "pop": 112.0,   "state": "WY", "1": "BOULDER, WY",          "2": true  } },
-    { "value": {  "_id": "89005", "city": "BOULDER CITY",     "loc": [ -114.834413, 35.972711 ], "pop": 12920.0, "state": "NV", "1": "BOULDER CITY, NV",     "2": false } },
-    { "value": {  "_id": "95006", "city": "BOULDER CREEK",    "loc": [ -122.133053, 37.149934 ], "pop": 9434.0,  "state": "CA", "1": "BOULDER CREEK, CA",    "2": false } },
-    { "value": {  "_id": "54512", "city": "BOULDER JUNCTION", "loc": [ -89.632454, 46.111183 ],  "pop": 563.0,   "state": "WI", "1": "BOULDER JUNCTION, WI", "2": false } }
+    { "_id": "80301", "city": "BOULDER",          "loc": [ -105.21426, 40.049733 ],  "pop": 18174.0, "state": "CO", "city_state": "BOULDER, CO",          "boulderish": true  },
+    { "_id": "80302", "city": "BOULDER",          "loc": [ -105.285131, 40.017235 ], "pop": 29384.0, "state": "CO", "city_state": "BOULDER, CO",          "boulderish": true  },
+    { "_id": "80303", "city": "BOULDER",          "loc": [ -105.239178, 39.991381 ], "pop": 39860.0, "state": "CO", "city_state": "BOULDER, CO",          "boulderish": true  },
+    { "_id": "80304", "city": "BOULDER",          "loc": [ -105.277073, 40.037482 ], "pop": 21550.0, "state": "CO", "city_state": "BOULDER, CO",          "boulderish": true  },
+    { "_id": "59632", "city": "BOULDER",          "loc": [ -112.113757, 46.230647 ], "pop": 1737.0,  "state": "MT", "city_state": "BOULDER, MT",          "boulderish": true  },
+    { "_id": "84716", "city": "BOULDER",          "loc": [ -111.426646, 37.916606 ], "pop": 131.0,   "state": "UT", "city_state": "BOULDER, UT",          "boulderish": true  },
+    { "_id": "82923", "city": "BOULDER",          "loc": [ -109.540105, 42.688146 ], "pop": 112.0,   "state": "WY", "city_state": "BOULDER, WY",          "boulderish": true  },
+    { "_id": "89005", "city": "BOULDER CITY",     "loc": [ -114.834413, 35.972711 ], "pop": 12920.0, "state": "NV", "city_state": "BOULDER CITY, NV",     "boulderish": false },
+    { "_id": "95006", "city": "BOULDER CREEK",    "loc": [ -122.133053, 37.149934 ], "pop": 9434.0,  "state": "CA", "city_state": "BOULDER CREEK, CA",    "boulderish": false },
+    { "_id": "54512", "city": "BOULDER JUNCTION", "loc": [ -89.632454, 46.111183 ],  "pop": 563.0,   "state": "WI", "city_state": "BOULDER JUNCTION, WI", "boulderish": false }
   ]
 }

--- a/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
@@ -56,7 +56,7 @@ class MongoDbExprStdLibSpec extends MongoDbStdLibSpec {
 
     case (math.Power, _) if !is3_2(backend) => Skipped("not implemented in aggregation on MongoDB < 3.2").left
 
-    case (structural.ArrayConcat, _)   => notHandled.left
+    case (structural.ConcatOp, _)   => notHandled.left
 
     case _                  => ().right
   }

--- a/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
@@ -56,6 +56,8 @@ class MongoDbExprStdLibSpec extends MongoDbStdLibSpec {
 
     case (math.Power, _) if !is3_2(backend) => Skipped("not implemented in aggregation on MongoDB < 3.2").left
 
+    case (structural.ArrayConcat, _)   => notHandled.left
+
     case _                  => ().right
   }
 

--- a/it/src/test/scala/quasar/physical/mongodb/JsStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/JsStdLibSpec.scala
@@ -55,6 +55,8 @@ class MongoDbJsStdLibSpec extends MongoDbStdLibSpec {
     case (date.ExtractWeek, _)         => Skipped("TODO").left
     case (date.ExtractQuarter, _)      => Skipped("TODO").left
 
+    case (structural.ArrayConcat, _)   => Skipped("TODO").left
+
     case _                  => ().right
   }
 

--- a/it/src/test/scala/quasar/physical/mongodb/JsStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/JsStdLibSpec.scala
@@ -47,7 +47,7 @@ class MongoDbJsStdLibSpec extends MongoDbStdLibSpec {
         if x == 0 && y < 0 =>
       Skipped("Infinity is not translated properly?").left
 
-    case (relations.Cond, _)     => Skipped("TODO").left
+    case (relations.Cond, _)           => Skipped("TODO").left
 
     case (date.ExtractDayOfYear, _)    => Skipped("TODO").left
     // case (date.ExtractIsoDayOfWeek, _) => Skipped("TODO").left
@@ -55,9 +55,9 @@ class MongoDbJsStdLibSpec extends MongoDbStdLibSpec {
     case (date.ExtractWeek, _)         => Skipped("TODO").left
     case (date.ExtractQuarter, _)      => Skipped("TODO").left
 
-    case (structural.ArrayConcat, _)   => Skipped("TODO").left
+    case (structural.ConcatOp, _)      => Skipped("TODO").left
 
-    case _                  => ().right
+    case _                             => ().right
   }
 
   def compile(queryModel: MongoQueryModel, coll: Collection, lp: Fix[LogicalPlan])

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MapFuncPlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MapFuncPlanner.scala
@@ -26,7 +26,6 @@ import quasar.qscript.{MapFunc, MapFuncs}, MapFuncs._
 
 import matryoshka._, Recursive.ops._
 import scalaz.{Const, EitherT, Monad}
-import scalaz.std.option._
 import scalaz.syntax.monad._
 
 object MapFuncPlanner {
@@ -117,7 +116,7 @@ object MapFuncPlanner {
                                            (n, e) => if_ (s eq "null".xs) then_ n else_ e)
     case ToString(x)                  => qscript.toString[F] apply x
     case Search(in, ptn, ci)          => fn.matches(in, ptn, Some(if_ (ci) then_ "i".xs else_ "".xs)).point[F]
-    case Substring(s, loc, len)       => fn.substring(s, loc + 1.xqy, some(len)).point[F]
+    case Substring(s, loc, len)       => qscript.safeSubstring[F] apply (s, loc + 1.xqy, len)
 
     // structural
     case MakeArray(x)                 => ejson.singletonArray[F] apply x

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MapFuncPlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MapFuncPlanner.scala
@@ -131,8 +131,7 @@ object MapFuncPlanner {
         case _ => ejson.singletonObject[F] apply (k, v)
       }
 
-    // FIXME: Also needs to handle strings, and arrays + strings?
-    case ConcatArrays(x, y)           => ejson.arrayConcat[F] apply (x, y)
+    case ConcatArrays(x, y)           => qscript.concat[F] apply (x, y)
     case ConcatMaps(x, y)             => ejson.objectConcat[F] apply (x, y)
     case ProjectIndex(arr, idx)       => ejson.arrayElementAt[F] apply (arr, idx + 1.xqy)
 

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/DefaultCollationDecl.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/DefaultCollationDecl.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.marklogic.xquery
+
+import quasar.Predef._
+import quasar.physical.marklogic.xml._
+import quasar.physical.marklogic.xquery.syntax._
+
+import eu.timepit.refined.auto._
+import monocle.macros.Lenses
+import scalaz._
+import scalaz.syntax.show._
+
+@Lenses
+final case class DefaultCollationDecl(uri: NSUri) {
+  def render: String = s"declare default collation ${uri.xs.shows}"
+}
+
+object DefaultCollationDecl {
+  val codepoint = DefaultCollationDecl(NSUri("http://marklogic.com/collation/codepoint"))
+
+  implicit val order: Order[DefaultCollationDecl] =
+    Order.orderBy(_.uri)
+
+  implicit val show: Show[DefaultCollationDecl] =
+    Show.shows(nd => s"DefaultCollationDecl(${nd.render})")
+}

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/Prolog.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/Prolog.scala
@@ -28,6 +28,7 @@ sealed abstract class Prolog {
   import Prolog._
 
   def render: String = this match {
+    case DefColl(dc)   => dc.render
     case FuncDecl(fd)  => fd.render
     case ModImport(mi) => mi.render
     case NSDecl(ns)    => ns.render
@@ -35,11 +36,16 @@ sealed abstract class Prolog {
 }
 
 object Prolog {
+  final case class DefColl(defaultCollation: DefaultCollationDecl) extends Prolog
   final case class FuncDecl(functionDecl: FunctionDecl) extends Prolog
   final case class ModImport(moduleImport: ModuleImport) extends Prolog
   final case class NSDecl(namespaceDecl: NamespaceDecl) extends Prolog
 
   val Separator: String = ";"
+
+  val defColl = Prism.partial[Prolog, DefaultCollationDecl] {
+    case DefColl(dc) => dc
+  } (DefColl)
 
   val funcDecl = Prism.partial[Prolog, FunctionDecl] {
     case FuncDecl(fd) => fd
@@ -57,10 +63,11 @@ object Prolog {
     Getter(_.render)
 
   implicit val order: Order[Prolog] =
-    Order.orderBy(p => (funcDecl.getOption(p), modImport.getOption(p), nsDecl.getOption(p)))
+    Order.orderBy(p => (funcDecl.getOption(p), defColl.getOption(p), modImport.getOption(p), nsDecl.getOption(p)))
 
   implicit val show: Show[Prolog] =
     Show.shows {
+      case DefColl(dc)   => dc.shows
       case FuncDecl(fd)  => fd.shows
       case ModImport(mi) => mi.shows
       case NSDecl(ns)    => ns.shows

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/ejson.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/ejson.scala
@@ -47,6 +47,7 @@ object ejson {
       mkArrayElt[F](item) flatMap (mem.nodeInsertChild(arr, _))
     })
 
+  // FIXME: This needs to work with any element, not just those with ejson types
   // ejson:array-concat($arr1 as element(), $arr2 as element()) as element(ejson:ejson)
   def arrayConcat[F[_]: PrologW]: F[FunctionDecl2] =
     (ejs.name("array-concat").qn[F] |@| ejsonN.qn |@| arrayEltN.qn) { (fname, ename, aelt) =>

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/ejson.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/ejson.scala
@@ -148,36 +148,17 @@ object ejson {
       }
     })
 
-  // TODO: DRY up these predicates, they have the same impl.
-  // ejson:is-array($node as node()) as xs:boolean
-  def isArray[F[_]: PrologW]: F[FunctionDecl1] =
-    (ejs.name("is-array").qn[F] |@| typeAttrN.qn) { (fname, tname) =>
-      declare(fname)(
-        $("node") as ST("node()")
-      ).as(ST("xs:boolean")) { node =>
-        fn.not(fn.empty(node(axes.attribute(tname) === "array".xs)))
-      }
-    }
+  // ejson:has-ascribed-type($tpe as xs:string, $node as node()) as xs:boolean
+  def hasAscribedType[F[_]: PrologW]: F[FunctionDecl2] =
+    ejs.declare("has-ascribed-type") flatMap (_(
+      $("tpe")  as ST("xs:string"),
+      $("node") as ST("node()")
+    ).as(ST("xs:boolean")) { (tpe: XQuery, node: XQuery) =>
+      ascribedType[F].apply(node) map (_ eq tpe)
+    })
 
-  // ejson:is-null($node as node()) as xs:boolean
-  def isNull[F[_]: PrologW]: F[FunctionDecl1] =
-    (ejs.name("is-null").qn[F] |@| typeAttrN.qn) { (fname, tname) =>
-      declare(fname)(
-        $("node") as ST("node()")
-      ).as(ST("xs:boolean")) { node =>
-        fn.not(fn.empty(node(axes.attribute(tname) === "null".xs)))
-      }
-    }
-
-  // ejson:is-object($node as node()) as xs:boolean
-  def isObject[F[_]: PrologW]: F[FunctionDecl1] =
-    (ejs.name("is-object").qn[F] |@| typeAttrN.qn) { (fname, tname) =>
-      declare(fname)(
-        $("node") as ST("node()")
-      ).as(ST("xs:boolean")) { node =>
-        fn.not(fn.empty(node(axes.attribute(tname) === "object".xs)))
-      }
-    }
+  def isArray[F[_]: PrologW](node: XQuery): F[XQuery] =
+    hasAscribedType[F].apply("array".xs, node)
 
   // ejson:make-array($name as xs:QName, $elements as element(ejson:array-element)*) as element()
   def mkArray[F[_]: PrologW]: F[FunctionDecl2] =

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/fn.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/fn.scala
@@ -31,6 +31,9 @@ object fn {
   def ceiling(n: XQuery): XQuery =
     XQuery(s"fn:ceiling($n)")
 
+  def codepointsToString(cps: XQuery): XQuery =
+    XQuery(s"fn:codepoints-to-string($cps)")
+
   def concat(x: XQuery, xs: XQuery*): XQuery =
     XQuery(s"fn:concat${mkSeq_(x, xs: _*)}")
 
@@ -138,6 +141,9 @@ object fn {
 
   def stringJoin(strs: XQuery, sep: XQuery): XQuery =
     XQuery(s"fn:string-join($strs, $sep)")
+
+  def stringToCodepoints(str: XQuery): XQuery =
+    XQuery(s"fn:string-to-codepoints($str)")
 
   def substring(str: XQuery, startLoc: XQuery, length: Option[XQuery] = None): XQuery =
     XQuery(s"fn:substring($str, ${startLoc}${asArg(length)})")

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/qscript.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/qscript.scala
@@ -165,7 +165,7 @@ object qscript {
     qs.declare("element-left-shift") flatMap (_(
       $("elt") as ST("element()")
     ).as(ST("item()*")) { elt =>
-      (ejson.arrayEltN.qn[F] |@| ejson.isArray[F].apply(elt))((aelt, eltIsArray) =>
+      (ejson.arrayEltN.qn[F] |@| ejson.isArray[F](elt))((aelt, eltIsArray) =>
         if_ (eltIsArray)
         .then_ { elt `/` child(aelt)  }
         .else_ { elt `/` child.node() })

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/qscript.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/qscript.scala
@@ -38,10 +38,10 @@ object qscript {
 
   private val epoch = xs.dateTime("1970-01-01T00:00:00Z".xs)
 
-  // qscript:as-date($item as item()) as xs:date?
+  // qscript:as-date($item as item()?) as xs:date?
   def asDate[F[_]: PrologW]: F[FunctionDecl1] =
     qs.declare("as-date") map (_(
-      $("item") as ST("item()")
+      $("item") as ST("item()?")
     ).as(ST("xs:date?")) { item =>
       if_(isCastable(item, ST("xs:date")))
       .then_ { xs.date(item) }
@@ -52,10 +52,10 @@ object qscript {
       }
     })
 
-  // qscript:as-dateTime($item as item()) as xs:dateTime?
+  // qscript:as-dateTime($item as item()?) as xs:dateTime?
   def asDateTime[F[_]: PrologW]: F[FunctionDecl1] =
     qs.declare("as-dateTime") map (_(
-      $("item") as ST("item()")
+      $("item") as ST("item()?")
     ).as(ST("xs:dateTime?")) { item =>
       if_(isCastable(item, ST("xs:dateTime")))
       .then_ { xs.dateTime(item) }
@@ -66,11 +66,11 @@ object qscript {
       }
     })
 
-  // qscript:as-map-key($item as item()) as xs:string
+  // qscript:as-map-key($item as item()?) as xs:string
   def asMapKey[F[_]: PrologW]: F[FunctionDecl1] =
     qs.name("as-map-key").qn[F] map { fname =>
       declare(fname)(
-        $("item") as ST("item()")
+        $("item") as ST("item()?")
       ).as(ST("xs:string")) { item =>
         typeswitch(item)(
           ($("a") as ST("attribute()")) return_ (a =>
@@ -198,11 +198,11 @@ object qscript {
       elt `/` child.element()
     })
 
-  // qscript:isoyear-from-dateTime($dt as xs:dateTime) as xs:integer
+  // qscript:isoyear-from-dateTime($dt as xs:dateTime?) as xs:integer
   def isoyearFromDateTime[F[_]: PrologW]: F[FunctionDecl1] =
     qs.declare("isoyear-from-dateTime") map (_(
-      $("dt") as ST("xs:dateTime")
-    ).as(ST("xs:integer")) { dt: XQuery =>
+      $("dt") as ST("xs:dateTime?")
+    ).as(ST("xs:integer?")) { dt: XQuery =>
       if_((fn.monthFromDateTime(dt) eq 1.xqy) and (xdmp.weekFromDate(xs.date(dt)) ge 52.xqy))
       .then_ { fn.yearFromDateTime(dt) - 1.xqy }
       .else_ {
@@ -248,10 +248,11 @@ object qscript {
   def isDocumentNode(node: XQuery): XQuery =
     xdmp.nodeKind(node) === "document".xs
 
+  // qscript:length($arrOrStr as item()?) as xs:integer?
   def length[F[_]: PrologW]: F[FunctionDecl1] =
     qs.name("length").qn[F] map { fname =>
       declare(fname)(
-        $("arrOrStr") as ST("item()")
+        $("arrOrStr") as ST("item()?")
       ).as(ST("xs:integer?")) { arrOrStr: XQuery =>
         val ct = $("ct")
         typeswitch(arrOrStr)(
@@ -268,11 +269,11 @@ object qscript {
       }
     }
 
-  // qscript:project-field($src as element(), $field as xs:QName) as item()*
+  // qscript:project-field($src as element()?, $field as xs:QName?) as item()*
   def projectField[F[_]: PrologW]: F[FunctionDecl2] =
     qs.declare("project-field") map (_(
-      $("src")   as ST("element()"),
-      $("field") as ST("xs:QName")
+      $("src")   as ST("element()?"),
+      $("field") as ST("xs:QName?")
     ).as(ST.Top) { (src: XQuery, field: XQuery) =>
       val n = $("n")
       fn.filter(func(n.render)(fn.nodeName(~n) eq field), src `/` child.element())
@@ -318,27 +319,27 @@ object qscript {
       }
     })
 
-  // qscript:seconds-since-epoch($dt as xs:dateTime) as xs:double
+  // qscript:seconds-since-epoch($dt as xs:dateTime?) as xs:double?
   def secondsSinceEpoch[F[_]: PrologW]: F[FunctionDecl1] =
     qs.declare("seconds-since-epoch") map (_(
-      $("dt") as ST("xs:dateTime")
-    ).as(ST("xs:double")) { dt =>
+      $("dt") as ST("xs:dateTime?")
+    ).as(ST("xs:double?")) { dt =>
       mkSeq_(dt - epoch) div xs.dayTimeDuration("PT1S".xs)
     })
 
-  // qscript:timestamp-to-dateTime($millis as xs:integer) as xs:dateTime
+  // qscript:timestamp-to-dateTime($millis as xs:integer?) as xs:dateTime?
   def timestampToDateTime[F[_]: PrologW]: F[FunctionDecl1] =
     qs.declare("timestamp-to-dateTime") map (_(
-      $("millis") as ST("xs:integer")
-    ).as(ST("xs:dateTime")) { millis =>
+      $("millis") as ST("xs:integer?")
+    ).as(ST("xs:dateTime?")) { millis =>
       epoch + xs.dayTimeDuration(fn.concat("PT".xs, xs.string(millis div 1000.xqy), "S".xs))
     })
 
-  // qscript:timezone-offset-seconds($dt as xs:dateTime) as xs:integer
+  // qscript:timezone-offset-seconds($dt as xs:dateTime?) as xs:integer?
   def timezoneOffsetSeconds[F[_]: PrologW]: F[FunctionDecl1] =
     qs.declare("timezone-offset-seconds") map (_(
-      $("dt") as ST("xs:dateTime")
-    ).as(ST("xs:integer")) { dt =>
+      $("dt") as ST("xs:dateTime?")
+    ).as(ST("xs:integer?")) { dt =>
       fn.timezoneFromDateTime(dt) div xs.dayTimeDuration("PT1S".xs)
     })
 
@@ -350,10 +351,10 @@ object qscript {
       fn.map("fn:codepoints-to-string#1".xqy, fn.stringToCodepoints(s))
     })
 
-  // qscript:to-string($item as item()) as xs:string?
+  // qscript:to-string($item as item()?) as xs:string
   def toString[F[_]: PrologW]: F[FunctionDecl1] =
     qs.declare("to-string") flatMap (_(
-      $("item") as ST("item()")
+      $("item") as ST("item()?")
     ).as(ST("xs:string")) { item: XQuery =>
       ejson.typeOf[F].apply(item) map { tpe =>
         if_(tpe eq "null".xs)
@@ -376,10 +377,10 @@ object qscript {
       }
     })
 
-  // qscript:zip-map-element-keys($elt as element()) as element()
+  // qscript:zip-map-element-keys($elt as element()?) as element()
   def zipMapElementKeys[F[_]: PrologW]: F[FunctionDecl1] =
     qs.declare("zip-map-element-keys") flatMap (_(
-      $("elt") as ST("element()")
+      $("elt") as ST("element()?")
     ).as(ST(s"element()")) { elt =>
       val (c, n) = ($("child"), $("name"))
 

--- a/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/CoreMapStdLibSpec.scala
+++ b/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/CoreMapStdLibSpec.scala
@@ -38,10 +38,11 @@ class CoreMapStdLibSpec extends StdLibSpec {
 
   /** Identify constructs that are expected not to be implemented. */
   val shortCircuit: AlgebraM[Result \/ ?, MapFunc[Fix, ?], Unit] = {
-    case ExtractIsoYear(_) => TODO
-    case ExtractWeek(_)    => TODO
-    case Power(_, _)       => Skipped("TODO: handle large value").left
-    case _                 => ().right
+    case ExtractIsoYear(_)  => TODO
+    case ExtractWeek(_)     => TODO
+    case Power(_, _)        => Skipped("TODO: handle large value").left
+    case ConcatArrays(_, _) => Skipped("TODO: handle mixed string/array").left
+    case _                  => ().right
   }
 
   // TODO: figure out how to pass the args to shortCircuit so they can be inspected


### PR DESCRIPTION
Fixes array concat to work with strings and arrays in MarkLogic. Also enables all the `StdLibSpec`s for MarkLogic and adds a few new ones exercising `ArrayConcat`.

In the process, also relaxed various array operations to work on any XML element by not requiring child elements to have a particular name.

Fixes #1503.