### PR TITLE
Pretty print MarkLogic XQuery plans

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- Pretty print XQuery in phase results from MarkLogic planner.

--- a/connector/src/main/scala/quasar/planner.scala
+++ b/connector/src/main/scala/quasar/planner.scala
@@ -79,7 +79,13 @@ object Planner {
       }
   }
 
-  final case class InternalError(message: String) extends PlannerError
+  final case class InternalError(msg: String, cause: Option[Exception]) extends PlannerError {
+    def message = msg + ~cause.map(ex => s" (caused by: $ex)")
+  }
+
+  object InternalError {
+    def fromMsg(msg: String): PlannerError = apply(msg, None)
+  }
 
   implicit val PlannerErrorRenderTree: RenderTree[PlannerError] = new RenderTree[PlannerError] {
     def render(v: PlannerError) = Terminal(List("Error"), Some(v.message))

--- a/core/src/main/scala/quasar/fs/mount/view.scala
+++ b/core/src/main/scala/quasar/fs/mount/view.scala
@@ -78,7 +78,7 @@ object view {
 
       for {
         lp <- resolveViewRefs[S](readLP).leftMap(se =>
-                planningFailed(readLP, Planner.InternalError(se.shows)))
+                planningFailed(readLP, Planner.InternalError fromMsg se.shows))
         h  <- refineConstantPlan(lp).fold(dataHandle(_).liftM[FileSystemErrT], queryHandle)
       } yield h
     }
@@ -267,7 +267,7 @@ object view {
 
     def resolve[A](lp: Fix[LP], op: Fix[LP] => ExecM[A]) =
       resolveViewRefs[S](lp).run.flatMap(_.fold(
-        e => planningFailed(lp, Planner.InternalError(e.shows)).raiseError[ExecM, A],
+        e => planningFailed(lp, Planner.InternalError fromMsg e.shows).raiseError[ExecM, A],
         p => op(p)).run.run)
 
     def listViews(dir: ADir): Free[S, Set[PathSegment]] =

--- a/couchbase/src/main/scala/quasar/physical/couchbase/common.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/common.scala
@@ -39,19 +39,20 @@ object common {
 
   final case class BucketCollection(bucket: String, collection: String)
 
+  object BucketCollection {
+    def fromPath(p: APath): PathError \/ BucketCollection =
+      Path.flatten(None, None, None, Some(_), Some(_), p)
+        .toIList.unite.uncons(
+          PathError.invalidPath(p, "no bucket specified").left,
+          (h, t) => BucketCollection(h, t.intercalate("/")).right)
+  }
+
   // type field in Couchbase documents
   final case class DocType(v: String)
 
   final case class Cursor(result: Vector[Data])
 
   val CBDataCodec = DataCodec.Precise
-
-  // FIXME: Return PathError instead of FSError
-  def bucketCollectionFromPath(f: APath): FileSystemError \/ BucketCollection =
-    Path.flatten(None, None, None, Some(_), Some(_), f)
-      .toIList.unite.uncons(
-        FileSystemError.pathErr(PathError.invalidPath(f, "no bucket specified")).left,
-        (h, t) => BucketCollection(h, t.intercalate("/")).right)
 
   def docTypesFromPrefix(
     bucket: Bucket,

--- a/couchbase/src/main/scala/quasar/physical/couchbase/common.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/common.scala
@@ -46,6 +46,7 @@ object common {
 
   val CBDataCodec = DataCodec.Precise
 
+  // FIXME: Return PathError instead of FSError
   def bucketCollectionFromPath(f: APath): FileSystemError \/ BucketCollection =
     Path.flatten(None, None, None, Some(_), Some(_), f)
       .toIList.unite.uncons(

--- a/couchbase/src/main/scala/quasar/physical/couchbase/fs/package.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/fs/package.scala
@@ -18,12 +18,13 @@ package quasar.physical.couchbase
 
 import quasar.Predef._
 import quasar.connector.EnvironmentError, EnvironmentError.{connectionFailed, invalidCredentials}
+import quasar.contrib.pathy.APath
 import quasar.effect.{KeyValueStore, MonotonicSeq, Read}
 import quasar.effect.uuid.GenUUID
 import quasar.fp._, free._
 import quasar.fs._, ReadFile.ReadHandle, WriteFile.WriteHandle, QueryFile.ResultHandle
 import quasar.fs.mount._, FileSystemDef.DefErrT
-import quasar.physical.couchbase.common.{Context, Cursor}
+import quasar.physical.couchbase.common.{BucketCollection, Context, Cursor}
 
 import java.net.ConnectException
 import java.util.concurrent.TimeUnit.SECONDS
@@ -148,4 +149,7 @@ package object fs {
             close)
         }
     }
+
+  def bucketCollectionFromPath(p: APath): FileSystemError \/ BucketCollection =
+    BucketCollection.fromPath(p) leftMap (FileSystemError.pathErr(_))
 }

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/QScriptCorePlanner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/QScriptCorePlanner.scala
@@ -18,7 +18,7 @@ package quasar.physical.couchbase.planner
 
 import quasar.Predef._
 import quasar.NameGenerator
-import quasar.Planner.{InternalError, PlannerError}
+import quasar.Planner.InternalError
 import quasar.common.PhaseResult.detail
 import quasar.contrib.matryoshka._
 import quasar.ejson
@@ -48,7 +48,7 @@ final class QScriptCorePlanner[F[_]: Monad: NameGenerator, T[_[_]]: Recursive: C
               key.point[M]
             case key =>
               EitherT(
-                (InternalError(s"Unsupported object key: ${key.shows}"): PlannerError)
+                InternalError.fromMsg(s"Unsupported object key: ${key.shows}")
                   .left[String].point[PR])
           },
           v => processFreeMapDefault(v.fromCoEnv, tmpName)

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/UnreachablePlanner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/UnreachablePlanner.scala
@@ -25,5 +25,6 @@ import scalaz._, Scalaz._
 
 final class UnreachablePlanner[F[_]: Applicative, QS[_]] extends Planner[F, QS] {
   def plan: AlgebraM[M, QS, N1QL] =
-    κ(EitherT.fromDisjunction(InternalError("unreachable").left))
+    κ(EitherT.fromDisjunction(InternalError.fromMsg("unreachable").left))
+
 }

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/common.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/common.scala
@@ -32,7 +32,7 @@ object common {
     EitherT(
       couchbase.common.bucketCollectionFromPath(path).bimap[PlannerError, N1QL](
         // TODO: Improve error handling
-        err => quasar.Planner.InternalError(err.shows),
+        err => quasar.Planner.InternalError.fromMsg(err.shows),
         bc => {
           val v = "ifmissing(v.`value`, v)"
           val r = idStatus match {

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/common.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/common.scala
@@ -24,15 +24,13 @@ import quasar.physical.couchbase.N1QL.{Read => _, _}
 import quasar.Planner.PlannerError
 import quasar.qscript.{IdStatus, IdOnly, IncludeId, ExcludeId}
 
-import matryoshka._
 import scalaz._, Scalaz._
 
 object common {
   def readPath[F[_]: Applicative](path: APath, idStatus: IdStatus): PlannerErrT[F, N1QL] =
     EitherT(
-      couchbase.common.bucketCollectionFromPath(path).bimap[PlannerError, N1QL](
-        // TODO: Improve error handling
-        err => quasar.Planner.InternalError.fromMsg(err.shows),
+      couchbase.common.BucketCollection.fromPath(path).bimap[PlannerError, N1QL](
+        quasar.Planner.PlanPathError(_),
         bc => {
           val v = "ifmissing(v.`value`, v)"
           val r = idStatus match {

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/package.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/package.scala
@@ -38,7 +38,7 @@ package object planner {
     NameGenerator[F].prefixedName("_")
 
   def unimplemented[A](name: String): PlannerError \/ A =
-    InternalError(s"unimplemented $name").left
+    InternalError.fromMsg(s"unimplemented $name").left
 
   def unimplementedP[F[_]: Applicative, A](name: String): CBPhaseLog[F, A] =
     EitherT(unimplemented[A](name).point[PhaseResultT[F, ?]])

--- a/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
@@ -77,7 +77,7 @@ class MongoDbExprStdLibSpec extends MongoDbStdLibSpec {
           case IsPipeline(p) => p.src
           case _             => false
         }
-        if (singlePipeline) wf.right else InternalError("compiled to map-reduce").left
+        if (singlePipeline) wf.right else InternalError.fromMsg("compiled to map-reduce").left
       }
       .strengthR(BsonField.Name("result"))
   }

--- a/it/src/test/scala/quasar/physical/mongodb/JsStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/JsStdLibSpec.scala
@@ -66,7 +66,7 @@ class MongoDbJsStdLibSpec extends MongoDbStdLibSpec {
     for {
       t  <- lp.cata(MongoDbPlanner.jsExprƒ)
       (pj, ifs) = t
-      js <- pj.lift(List.fill(ifs.length)(JsFn.identity)) \/> InternalError("no JS compilation")
+      js <- pj.lift(List.fill(ifs.length)(JsFn.identity)) \/> InternalError.fromMsg("no JS compilation")
       wf =  chain[Fix[WorkflowF]](
               $read(coll),
               $simpleMap(NonEmptyList(MapExpr(js)), ListMap.empty))

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MapFuncPlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MapFuncPlanner.scala
@@ -112,8 +112,7 @@ object MapFuncPlanner {
     case Bool(s)                      => xs.boolean(s).point[F]
     case Integer(s)                   => xs.integer(s).point[F]
     case Decimal(s)                   => xs.double(s).point[F]
-    case Null(s)                      => (ejson.null_[F] |@| qscript.qError[F](s"Invalid coercion to 'null': $s".xs))(
-                                           (n, e) => if_ (s eq "null".xs) then_ n else_ e)
+    case Null(s)                      => ejson.null_[F] map (n => if_ (s eq "null".xs) then_ n else_ emptySeq)
     case ToString(x)                  => qscript.toString[F] apply x
     case Search(in, ptn, ci)          => fn.matches(in, ptn, Some(if_ (ci) then_ "i".xs else_ "".xs)).point[F]
     case Substring(s, loc, len)       => qscript.safeSubstring[F] apply (s, loc + 1.xqy, len)

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xcc/SessionIO.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xcc/SessionIO.scala
@@ -52,6 +52,9 @@ object SessionIO {
   def connectionUri: OptionT[SessionIO, URI] =
     OptionT(SessionIO(s => Option(s.getConnectionUri)))
 
+  val currentServerPointInTime: SessionIO[BigInt] =
+    SessionIO(_.getCurrentServerPointInTime) map (BigInt(_))
+
   def evaluateModule(main: MainModule, options: RequestOptions): SessionIO[QueryResults] =
     evaluateModule0(main, options) map (new QueryResults(_))
 
@@ -79,9 +82,6 @@ object SessionIO {
 
   def executeQuery_(query: XQuery): SessionIO[Executed] =
     executeQuery(query, new RequestOptions)
-
-  val currentServerPointInTime: SessionIO[BigInt] =
-    SessionIO(_.getCurrentServerPointInTime) map (BigInt(_))
 
   def insertContent[F[_]: Foldable](content: F[Content]): SessionIO[Executed] =
     SessionIO(_.insertContent(content.to[Array])).as(executed)

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/qscript.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/qscript.scala
@@ -33,8 +33,7 @@ object qscript {
   import syntax._, expr._, axes.{attribute, child}
   import FunctionDecl._
 
-  val qs     = NamespaceDecl(qscriptNs)
-  val errorN = qs name qscriptError.local
+  val qs = NamespaceDecl(qscriptNs)
 
   private val epoch = xs.dateTime("1970-01-01T00:00:00Z".xs)
 
@@ -265,9 +264,6 @@ object qscript {
       val n = $("n")
       fn.filter(func(n.render)(fn.nodeName(~n) eq field), src `/` child.element())
     })
-
-  def qError[F[_]: PrologW](desc: XQuery, errObj: Option[XQuery] = None): F[XQuery] =
-    errorN.xqy[F] map (err => fn.error(err, Some(desc), errObj))
 
   // qscript:reduce-with(
   //   $initial  as function(item()*        ) as item()*,

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/xdmp.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/xdmp.scala
@@ -60,6 +60,9 @@ object xdmp {
   def nodeUri(node: XQuery): XQuery =
     XQuery(s"xdmp:node-uri($node)")
 
+  def prettyPrint(qstring: XQuery): XQuery =
+    XQuery(s"xdmp:pretty-print($qstring)")
+
   def quarterFromDate(date: XQuery): XQuery =
     XQuery(s"xdmp:quarter-from-date($date)")
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/MongoDbPlanner.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/MongoDbPlanner.scala
@@ -380,7 +380,7 @@ object MongoDbPlanner {
       }
 
       def reversibleRelop(f: GenericFunc[nat._2]): Output =
-        (relFunc(f) |@| flip(f).flatMap(relFunc))(relop).getOrElse(-\/(InternalError("couldn’t decipher operation")))
+        (relFunc(f) |@| flip(f).flatMap(relFunc))(relop).getOrElse(-\/(InternalError fromMsg "couldn’t decipher operation"))
 
       (func, args) match {
         case (Gt, Sized(_, IsDate(d2)))  => relDateOp1(Selector.Gte, d2, date.startOfNextDay, 0)
@@ -529,7 +529,7 @@ object MongoDbPlanner {
         node match {
           case HasData(Data.Str("ASC"))  => \/-(SortDir.Ascending)
           case HasData(Data.Str("DESC")) => \/-(SortDir.Descending)
-          case x => -\/(InternalError("malformed sort dir: " + x))
+          case x => -\/(InternalError fromMsg "malformed sort dir: " + x)
         }
 
       _ match {
@@ -798,7 +798,7 @@ object MongoDbPlanner {
           v1.swapped(_.flatMap(e => v2.toOption <\/ e))
         State(s => orElse(wb.run(s), js.run(s)).fold(e => s -> -\/(e), t => t._1 -> \/-(t._2)))
       case Free(name) =>
-        state(-\/(InternalError("variable " + name + " is unbound")))
+        state(-\/(InternalError fromMsg s"variable $name is unbound"))
       case Let(_, _, in) => state(in.head._2)
       case Typecheck(exp, typ, cont, fallback) =>
         // NB: Even if certain checks aren’t needed by ExprOps, we have to

--- a/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -89,7 +89,7 @@ object MongoDbQScriptPlanner {
       OutputM[JsCore] =
     fm.cataM(interpretM[OutputM, MapFunc[T, ?], A, JsCore](recovery(_).right, javascript))
 
-  def unimplemented(name: String) = InternalError(s"unimplemented $name").left
+  def unimplemented(name: String) = InternalError.fromMsg(s"unimplemented $name").left
 
   // TODO: Should have a JsFn version of this for $reduce nodes.
   val accumulator: ReduceFunc[Fix[ExprOp]] => AccumOp[Fix[ExprOp]] = {
@@ -223,7 +223,7 @@ object MongoDbQScriptPlanner {
             case Type.Date             => isDate
           }
         jsCheck(typ).fold[OutputM[JsCore]](
-          InternalError("uncheckable type").left)(
+          InternalError.fromMsg("uncheckable type").left)(
           f => If(f(expr), cont, fallback).right)
 
       case Range(_, _)        => unimplemented("Range JS")
@@ -335,7 +335,7 @@ object MongoDbQScriptPlanner {
           case (IsBson(v1), _) =>
             \/-(({ case List(f2) => Selector.Doc(ListMap(f2 -> Selector.Expr(r(v1)))) }, List(There(1, Here))))
 
-          case (_, _) => -\/(InternalError(node.map(_._1).shows))
+          case (_, _) => -\/(InternalError fromMsg node.map(_._1).shows)
         }
 
       def relDateOp1(f: Bson.Date => Selector.Condition, date: Data.Date, g: Data.Date => Data.Timestamp, index: Int): Output =
@@ -374,7 +374,7 @@ object MongoDbQScriptPlanner {
       }
 
       def reversibleRelop(x: (T[MapFunc[T, ?]], Output), y: (T[MapFunc[T, ?]], Output))(f: MapFunc[T, _]): Output =
-        (relFunc(f) ⊛ flip(f).flatMap(relFunc))(relop(x, y)(_, _)).getOrElse(-\/(InternalError("couldn’t decipher operation")))
+        (relFunc(f) ⊛ flip(f).flatMap(relFunc))(relop(x, y)(_, _)).getOrElse(-\/(InternalError fromMsg "couldn’t decipher operation"))
 
       func match {
         case Constant(_)        => \/-(default)
@@ -453,7 +453,7 @@ object MongoDbQScriptPlanner {
                 ((f: BsonField) => Selector.Doc(f -> Selector.Type(BsonType.Date)))
             }
           selCheck(typ).fold[OutputM[PartialSelector]](
-            -\/(InternalError(node.map(_._1).shows)))(
+            -\/(InternalError fromMsg node.map(_._1).shows))(
             f =>
             \/-(cont._2.fold[PartialSelector](
               κ(({ case List(field) => f(field) }, List(There(0, Here)))),
@@ -462,7 +462,7 @@ object MongoDbQScriptPlanner {
                   There(0, Here) :: p2.map(There(1, _)))
               })))
 
-        case _ => -\/(InternalError(node.map(_._1).shows))
+        case _ => -\/(InternalError fromMsg node.map(_._1).shows)
       }
     }
 
@@ -483,10 +483,10 @@ object MongoDbQScriptPlanner {
 
     def unimplemented[WF[_]](name: String)
         : StateT[OutputM, NameGen, WorkflowBuilder[WF]] =
-      StateT(κ((InternalError(s"unimplemented $name"): PlannerError).left[(NameGen, WorkflowBuilder[WF])]))
+      StateT(κ(InternalError.fromMsg(s"unimplemented $name").left[(NameGen, WorkflowBuilder[WF])]))
 
     def shouldNotBeReached[WF[_]]: StateT[OutputM, NameGen, WorkflowBuilder[WF]] =
-      StateT(κ((InternalError("should not be reached"): PlannerError).left[(NameGen, WorkflowBuilder[WF])]))
+      StateT(κ(InternalError.fromMsg("should not be reached").left[(NameGen, WorkflowBuilder[WF])]))
   }
 
   object Planner {
@@ -697,7 +697,7 @@ object MongoDbQScriptPlanner {
       case MapFunc.StaticMap(elems) =>
         elems.traverse(_.bitraverse({
           case Embed(ejson.Common(ejson.Str(key))) => BsonField.Name(key).right
-          case key => InternalError(s"Unsupported object key: ${key.shows}").left
+          case key => InternalError.fromMsg(s"Unsupported object key: ${key.shows}").left
         },
           handleFreeMap(funcHandler, _))) ∘
         (es => DocBuilder(src, es.toListMap))
@@ -784,7 +784,7 @@ object MongoDbQScriptPlanner {
     case free @ CoEnv(\/-(MapFuncs.Guard(Embed(CoEnv(-\/(SrcHole))), typ, cont, _))) =>
       if (typ.contains(subType)) cont.project.right
       else if (!subType.contains(typ))
-        InternalError("can only contain " + subType + ", but a(n) " + typ + " is expected").left
+        InternalError.fromMsg("can only contain " + subType + ", but a(n) " + typ + " is expected").left
       else free.right
     case x => x.right
   }

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/CoreMap.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/CoreMap.scala
@@ -299,7 +299,7 @@ object CoreMap extends Serializable {
       case (Data.Int(a), Data.Int(b)) if(a <= b) => Data.Set((a to b).map(Data.Int(_)).toList)
     }).right
     case Guard(f1, fPattern, f2,ff3) => ((x:Data) => f2(x)).right
-    case _ => InternalError("not implemented").left
+    case _ => InternalError.fromMsg("not implemented").left
   }
 
   private def add(d1: Data, d2: Data): Data = (d1, d2) match {

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/Planner.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/Planner.scala
@@ -78,7 +78,7 @@ object Planner {
   type SparkStateT[F[_], A] = StateT[F, SparkContext, A]
 
   def unimplemented(what: String): SparkState[RDD[Data]] =
-    EitherT[Task, PlannerError, RDD[Data]](InternalError(s"unimplemented $what").left[RDD[Data]].point[Task]).liftM[StateT[?[_], SparkContext, ?]]
+    EitherT[Task, PlannerError, RDD[Data]](InternalError.fromMsg(s"unimplemented $what").left[RDD[Data]].point[Task]).liftM[StateT[?[_], SparkContext, ?]]
 
   type Aux[T[_[_]], F[_]] = Planner[F] { type IT[G[_]] = T[G] }
 
@@ -87,7 +87,7 @@ object Planner {
       type IT[G[_]] = T[G]
       def plan(fromFile: (SparkContext, AFile) => Task[RDD[String]]): AlgebraM[SparkState, F, RDD[Data]] =
         _ =>  StateT((sc: SparkContext) => {
-        EitherT(InternalError(s"unreachable $what").left[(SparkContext, RDD[Data])].point[Task])
+        EitherT(InternalError.fromMsg(s"unreachable $what").left[(SparkContext, RDD[Data])].point[Task])
       })
     }
 
@@ -146,8 +146,8 @@ object Planner {
 
         val countEval: SparkState[Long] = countState >>= (rdd => EitherT(Task.delay(rdd.first match {
           case Data.Int(v) if v.isValidLong => v.toLong.right[PlannerError]
-          case Data.Int(v) => InternalError(s"Provided Integer $v is not a Long").left[Long]
-          case a => InternalError(s"$a is not a Long number").left[Long]
+          case Data.Int(v) => InternalError.fromMsg(s"Provided Integer $v is not a Long").left[Long]
+          case a => InternalError.fromMsg(s"$a is not a Long number").left[Long]
         })).liftM[StateT[?[_], SparkContext, ?]])
         (fromState |@| countEval)((rdd, count) =>
           rdd.zipWithIndex.filter(di => predicate(di._2, count)).map(_._1))

--- a/web/src/main/scala/quasar/api/ToApiError.scala
+++ b/web/src/main/scala/quasar/api/ToApiError.scala
@@ -242,9 +242,11 @@ sealed abstract class ToApiErrorInstances extends ToApiErrorInstances0 {
           InternalServerError withReason "Unsupported JavaScript in query plan.",
           err.message,
           "value" := value)
-      case InternalError(msg) =>
-        fromMsg_(
-          InternalServerError withReason "Failed to plan query.", msg)
+      case InternalError(msg, cause) =>
+        fromMsg(
+          InternalServerError withReason "Failed to plan query.",
+          msg
+        ) :?+ ("cause" :?= cause.map(_.toString))
       case UnboundVariable(v) =>
         fromMsg_(
           InternalServerError withReason "Unbound variable.", v.toString)


### PR DESCRIPTION
Pretty prints the logged XQuery plans for MarkLogic, making it much easier to visually inspect them. Also has the benefit of catching MarkLogic planner syntax bugs prior to execution.