### PR TITLE
Replace OrderBy function with Sort node in LogicalPlan

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- [1693, 1694] Replace OrderBy function with Sort node in LogicalPlan

--- a/common/src/main/scala/quasar/common/SortDir.scala
+++ b/common/src/main/scala/quasar/common/SortDir.scala
@@ -14,15 +14,18 @@
  * limitations under the License.
  */
 
-package quasar.qscript
+package quasar.common
 
 import scalaz._
 
-sealed trait SortDir
+sealed abstract class SortDir
 
 object SortDir {
   final case object Ascending extends SortDir
   final case object Descending extends SortDir
+
+  val asc: SortDir  = Ascending
+  val desc: SortDir = Descending
 
   implicit val equal: Equal[SortDir] = Equal.equalRef
   implicit val show: Show[SortDir] = Show.showFromToString

--- a/connector/src/main/scala/quasar/qscript/MapFunc.scala
+++ b/connector/src/main/scala/quasar/qscript/MapFunc.scala
@@ -71,13 +71,11 @@ object MapFunc {
         case ConcatArraysN(as) =>
           as.foldRightM[Option, List[TCoMapFunc[T, A]]](
             Nil)(
-            (mf, acc) => (mf.project.run.toOption >>=
-              {
-                case MakeArray(value) => (value :: acc).some
-                case Constant(Embed(ejson.Common(ejson.Arr(values)))) =>
-                  (values.map(v => coMapFuncR[T, A](Constant(v).right).embed) ++ acc).some
-                case _ => None
-              }))
+            (mf, acc) => (mf.project.run.toOption collect {
+              case MakeArray(value) => (value :: acc)
+              case Constant(Embed(ejson.Common(ejson.Arr(values)))) =>
+                (values.map(v => coMapFuncR[T, A](Constant(v).right).embed) ++ acc)
+            }))
         case _ => None
       }
   }

--- a/connector/src/main/scala/quasar/qscript/Normalizable.scala
+++ b/connector/src/main/scala/quasar/qscript/Normalizable.scala
@@ -17,6 +17,7 @@
 package quasar.qscript
 
 import quasar.Predef._
+import quasar.common.SortDir
 import quasar.contrib.matryoshka._
 import quasar.ejson.EJson
 import quasar.fp._

--- a/connector/src/main/scala/quasar/qscript/Normalizable.scala
+++ b/connector/src/main/scala/quasar/qscript/Normalizable.scala
@@ -162,21 +162,15 @@ class NormalizableT[T[_[_]] : Recursive : Corecursive : EqualT : ShowT]
         }
       }
 
-      case Sort(src, bucket, order) => {
-        val orderOpt: List[Option[(FreeMap, SortDir)]] =
-          order.map {
-            _.leftMap(freeMFEq(_)) match {
-              case (Some(fm), dir) => Some((fm, dir))
-              case (_, _)          => None
-            }
-          }
+      case Sort(src, bucket, order) =>
+        val orderOpt: NonEmptyList[Option[(FreeMap, SortDir)]] =
+          order.map { case (fm, dir) => freeMFEq(fm) strengthR dir }
 
-        val orderNormOpt: Option[List[(FreeMap, SortDir)]] =
-          orderOpt.exists(_.nonEmpty).option(
-            Zip[List].zipWith(orderOpt, order)(_.getOrElse(_)))
+        val orderNormOpt: Option[NonEmptyList[(FreeMap, SortDir)]] =
+          orderOpt any (_.nonEmpty) option orderOpt.fzipWith(order)(_ | _)
 
         makeNorm(bucket, order)(freeMFEq(_), _ => orderNormOpt)(Sort(src, _, _))
-      }
+
       case Map(src, f)             => freeMFEq(f).map(Map(src, _))
       case LeftShift(src, s, i, r) => makeNorm(s, r)(freeMFEq(_), freeMFEq(_))(LeftShift(src, _, i, _))
       case Union(src, l, r)        => makeNorm(l, r)(freeTCEq(_), freeTCEq(_))(Union(src, _, _))

--- a/connector/src/main/scala/quasar/qscript/QScriptCore.scala
+++ b/connector/src/main/scala/quasar/qscript/QScriptCore.scala
@@ -18,6 +18,7 @@ package quasar.qscript
 
 import quasar.Predef._
 import quasar.{NonTerminal, Terminal, RenderTree, RenderTreeT}, RenderTree.ops._
+import quasar.common.SortDir
 import quasar.contrib.matryoshka._
 import quasar.fp._
 
@@ -106,6 +107,7 @@ object ReduceIndex {
 @Lenses final case class Sort[T[_[_]], A](
   src: A,
   bucket: FreeMap[T],
+  // FIXME: NonEmptyList
   order: List[(FreeMap[T], SortDir)])
     extends QScriptCore[T, A]
 

--- a/connector/src/main/scala/quasar/qscript/QScriptCore.scala
+++ b/connector/src/main/scala/quasar/qscript/QScriptCore.scala
@@ -107,8 +107,7 @@ object ReduceIndex {
 @Lenses final case class Sort[T[_[_]], A](
   src: A,
   bucket: FreeMap[T],
-  // FIXME: NonEmptyList
-  order: List[(FreeMap[T], SortDir)])
+  order: NonEmptyList[(FreeMap[T], SortDir)])
     extends QScriptCore[T, A]
 
 /** Creates a new dataset that contains the elements from the datasets created
@@ -249,7 +248,7 @@ object QScriptCore {
                 NonTerminal("Sort" :: nt, None,
                   RA.render(src) :: nested("Bucket", bucket) ::
                     NonTerminal("Order" :: "Sort" :: nt, None, order.map { case (x, dir) =>
-                      NonTerminal(dir.shows :: "Sort" :: nt, None, nested("By", x) :: Nil) }) ::
+                      NonTerminal(dir.shows :: "Sort" :: nt, None, nested("By", x) :: Nil) }.toList) ::
                     Nil)
               case Union(src, lBranch, rBranch) =>
                 NonTerminal("Union" :: nt, None, List(

--- a/connector/src/main/scala/quasar/qscript/Transform.scala
+++ b/connector/src/main/scala/quasar/qscript/Transform.scala
@@ -27,7 +27,7 @@ import quasar.qscript.MapFuncs._
 import quasar.sql.JoinDir
 import quasar.std.StdLib._
 
-import matryoshka._, Recursive.ops._, FunctorT.ops._, TraverseT.nonInheritedOps._
+import matryoshka._, Recursive.ops._, FunctorT.ops._
 import matryoshka.patterns._
 import scalaz.{:+: => _, Divide => _, _}, Scalaz.{ToIdOps => _, _}, Inject._, Leibniz._
 import shapeless.{nat, Sized}
@@ -138,9 +138,12 @@ class Transform
       rebaseBranch(rightF, rMap))
   }
 
-  private case class AutoJoinBase(src: T[F], buckets: List[prov.Provenance])
+  private case class AutoJoinBase(src: T[F], buckets: List[prov.Provenance]) {
+    def asTarget(vals: FreeMap): Target[F] = Target(Ann(buckets, vals), src)
+  }
   private case class AutoJoinResult(base: AutoJoinBase, lval: FreeMap, rval: FreeMap)
   private case class AutoJoin3Result(base: AutoJoinBase, lval: FreeMap, cval: FreeMap, rval: FreeMap)
+  private case class AutoJoinNResult(base: AutoJoinBase, vals: NonEmptyList[FreeMap])
 
   /** This unifies a pair of sources into a single one, with additional
     * expressions to access the combined bucketing info, as well as the left and
@@ -185,24 +188,28 @@ class Transform
   /** A convenience for a pair of autojoins, does the same thing, but returns
     * access to all three values.
     */
-  private def autojoin3(left: Target[F], center: Target[F], right: Target[F]):
-      AutoJoin3Result = {
-    val AutoJoinResult(AutoJoinBase(lsrc, lprov), lval, cval) =
-      autojoin(left, center)
-
-    val AutoJoinResult(base, bval, rval) =
-      autojoin(Target(Ann(lprov, HoleF), lsrc), right)
-
+  private def autojoin3(left: Target[F], center: Target[F], right: Target[F]): AutoJoin3Result = {
+    val AutoJoinResult(lbase, lval, cval) = autojoin(left, center)
+    val AutoJoinResult(base , bval, rval) = autojoin(lbase asTarget HoleF, right)
     AutoJoin3Result(base, lval >> bval, cval >> bval, rval)
+  }
+
+  private def autojoinN[G[_]: Foldable1](ts: G[Target[F]]): AutoJoinNResult = {
+    val (t, vs) = ts.foldMapLeft1((_, HoleF[T].wrapNel)) {
+      case ((l, vals), r) =>
+        val AutoJoinResult(b, lv, rv) = autojoin(l, r)
+        (b asTarget HoleF, rv <:: vals.map(_ >> lv))
+    }
+
+    AutoJoinNResult(AutoJoinBase(t.value, t.ann.provenance), vs.reverse map (_ >> t.ann.values))
   }
 
   private def merge3Map(
     values: Func.Input[Target[F], nat._3])(
-    func: (FreeMap, FreeMap, FreeMap) => MapFunc[FreeMap]):
-      Target[F] = {
-    val AutoJoin3Result(base, lval, cval, rval) =
-      autojoin3(values(0), values(1), values(2))
-    Target(Ann(base.buckets, Free.roll(func(lval, cval, rval))), base.src)
+    func: (FreeMap, FreeMap, FreeMap) => MapFunc[FreeMap]
+  ): Target[F] = {
+    val AutoJoin3Result(base, lval, cval, rval) = autojoin3(values(0), values(1), values(2))
+    base asTarget Free.roll(func(lval, cval, rval))
   }
 
   private def shiftValues(input: Target[F]): Target[F] = {
@@ -547,42 +554,18 @@ class Transform
 
       Target(a1.ann, QC.inj(Subset(merged.src, merged.lval, Drop, Free.roll(FI.inject(QC.inj(reifyResult(a2.ann, merged.rval)))))).embed).right
 
-    case lp.InvokeUnapply(set.OrderBy, Sized(a1, a2, a3)) =>
-      val AutoJoinResult(base, dataset, keys) = autojoin(a1, a2)
+    case lp.Sort(src, ords) =>
+      val (kexprs, dirs) = ords.unzip
+      val AutoJoinNResult(base, NonEmptyList(dset, keys)) = autojoinN(src <:: kexprs)
+      val orderings = keys.alignBoth(dirs.list).sequence \/> InternalError.fromMsg(s"Mismatched sort keys and dirs")
 
-      val keysList: List[FreeMap] = keys.toCoEnv[T].project match {
-        case StaticArray(as) => as.map(_.fromCoEnv)
-        case mf              => List(mf.embed.fromCoEnv)
-      }
-
-      val directionsList: PlannerError \/ List[SortDir] = {
-        val orderStrs: PlannerError \/ List[String] = {
-	  QC.prj(QC.inj(reifyResult(a3.ann, a3.value)).embed.transCata(rewrite.normalize).project) match {
-            case Some(Map(src, mf)) if QC.prj(src.project) ≟ Some(Unreferenced()) =>
-              mf.toCoEnv[T].project match {
-                case StaticArray(as) => as.traverse(x => StrLit.unapply(x.project)) \/> InternalError.fromMsg("unsupported ordering type")
-                case StrLit(str)     => List(str).right
-                case _               => InternalError.fromMsg("unsupported ordering function").left
-              }
-            case other => InternalError.fromMsg(s"Expected a constant, but received ${other.shows}").left
-          }
-	}
-        orderStrs.flatMap {
-          _.traverse {
-            case "ASC"  => SortDir.Ascending.right
-            case "DESC" => SortDir.Descending.right
-            case _      => InternalError.fromMsg("unsupported ordering direction").left
-          }
-        }
-      }
-
-      directionsList.map(dirs =>
+      orderings map (os =>
         Target(
-          Ann[T](base.buckets, dataset),
+          Ann[T](base.buckets, dset),
           QC.inj(Sort(
             base.src,
             prov.genBuckets(base.buckets).fold(NullLit[T, Hole]())(_._2),
-            keysList.zip(dirs))).embed))
+            os.toList)).embed))
 
     case lp.InvokeUnapply(set.Filter, Sized(a1, a2)) =>
       val AutoJoinResult(base, lval, rval) = autojoin(a1, a2)

--- a/connector/src/main/scala/quasar/qscript/Transform.scala
+++ b/connector/src/main/scala/quasar/qscript/Transform.scala
@@ -557,7 +557,7 @@ class Transform
     case lp.Sort(src, ords) =>
       val (kexprs, dirs) = ords.unzip
       val AutoJoinNResult(base, NonEmptyList(dset, keys)) = autojoinN(src <:: kexprs)
-      val orderings = keys.alignBoth(dirs.list).sequence \/> InternalError.fromMsg(s"Mismatched sort keys and dirs")
+      val orderings = keys.toNel.flatMap(_.alignBoth(dirs).sequence) \/> InternalError.fromMsg(s"Mismatched sort keys and dirs")
 
       orderings map (os =>
         Target(
@@ -565,7 +565,7 @@ class Transform
           QC.inj(Sort(
             base.src,
             prov.genBuckets(base.buckets).fold(NullLit[T, Hole]())(_._2),
-            os.toList)).embed))
+            os)).embed))
 
     case lp.InvokeUnapply(set.Filter, Sized(a1, a2)) =>
       val AutoJoinResult(base, lval, rval) = autojoin(a1, a2)

--- a/connector/src/test/scala/quasar/qscript/QScript.scala
+++ b/connector/src/test/scala/quasar/qscript/QScript.scala
@@ -18,6 +18,7 @@ package quasar.qscript
 
 import quasar.Predef._
 import quasar.{Data, Type}
+import quasar.common.SortDir
 import quasar.fp._
 import quasar.frontend.{logicalplan => lp}
 import quasar.qscript.MapFuncs._
@@ -108,7 +109,7 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
     "convert a basic order by" in {
       val lp = fullCompileExp("select * from zips order by city")
       val qs = convert(listContents.some, lp)
-      qs must equal(chain(
+      qs must beSome(beQScript(chain(
         ReadR(rootDir </> file("zips")),
         QC.inj(LeftShift((),
           HoleF,
@@ -134,20 +135,19 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
                   ProjectIndexR(RightSideF, IntLit(1)),
                   Free.roll(Undefined()))))))),
             Free.roll(MakeArray(
-              Free.roll(MakeArray(
-                ProjectFieldR(
-                  Free.roll(Guard(
-                    ProjectIndexR(RightSideF, IntLit(1)),
-                    Type.Obj(scala.Predef.Map(), Type.Top.some),
-                    ProjectIndexR(RightSideF, IntLit(1)),
-                    Free.roll(Undefined()))),
-                  StrLit("city")))))))))),
+              ProjectFieldR(
+                Free.roll(Guard(
+                  ProjectIndexR(RightSideF, IntLit(1)),
+                  Type.Obj(scala.Predef.Map(), Type.Top.some),
+                  ProjectIndexR(RightSideF, IntLit(1)),
+                  Free.roll(Undefined()))),
+                StrLit("city")))))))),
         QC.inj(Sort((),
           Free.roll(ConcatArrays(
             Free.roll(MakeArray(ProjectIndexR(ProjectIndexR(HoleF, IntLit(0)), IntLit(0)))),
             Free.roll(MakeArray(ProjectIndexR(ProjectIndexR(HoleF, IntLit(1)), IntLit(0)))))),
           List((ProjectIndexR(HoleF, IntLit(3)), SortDir.Ascending)))),
-        QC.inj(Map((), ProjectIndexR(HoleF, IntLit(2))))).some)
+        QC.inj(Map((), ProjectIndexR(HoleF, IntLit(2)))))))
     }
 
     "convert a basic reduction" in {
@@ -583,7 +583,7 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
   "convert distinct by" in {
     val lp = fullCompileExp("select distinct(city) from zips order by pop")
     val qs = convert(listContents.some, lp)
-    qs must equal(chain(
+    qs must beSome(beQScript(chain(
       ReadR(rootDir </> file("zips")),
       QC.inj(LeftShift((),
         HoleF,
@@ -617,14 +617,13 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
                       Free.roll(Undefined()))),
                     StrLit("pop")))))))))),
           Free.roll(MakeArray(
-            Free.roll(MakeArray(
-              ProjectFieldR(
-                Free.roll(Guard(
-                  ProjectIndexR(RightSideF, IntLit(1)),
-                  Type.Obj(ScalaMap(),Some(Type.Top)),
-                  ProjectIndexR(RightSideF, IntLit(1)),
-                  Free.roll(Undefined()))),
-                StrLit("pop")))))))))),
+            ProjectFieldR(
+              Free.roll(Guard(
+                ProjectIndexR(RightSideF, IntLit(1)),
+                Type.Obj(ScalaMap(),Some(Type.Top)),
+                ProjectIndexR(RightSideF, IntLit(1)),
+                Free.roll(Undefined()))),
+              StrLit("pop")))))))),
       QC.inj(Sort((),
         Free.roll(ConcatArrays(
           Free.roll(MakeArray(ProjectIndexR(ProjectIndexR(HoleF, IntLit(0)), IntLit(0)))),
@@ -633,7 +632,7 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
       QC.inj(Reduce((),
         Free.roll(DeleteField(ProjectIndexR(HoleF, IntLit(2)), StrLit("__sd__0"))),
         List(ReduceFuncs.Arbitrary(ProjectIndexR(HoleF, IntLit(2)))),
-        Free.roll(DeleteField(ReduceIndexF(0), StrLit("__sd__0")))))).some)
+        Free.roll(DeleteField(ReduceIndexF(0), StrLit("__sd__0"))))))))
   }
 
   "convert a multi-field reduce" in {

--- a/connector/src/test/scala/quasar/qscript/QScript.scala
+++ b/connector/src/test/scala/quasar/qscript/QScript.scala
@@ -145,7 +145,7 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           Free.roll(ConcatArrays(
             Free.roll(MakeArray(ProjectIndexR(ProjectIndexR(HoleF, IntLit(0)), IntLit(0)))),
             Free.roll(MakeArray(ProjectIndexR(ProjectIndexR(HoleF, IntLit(1)), IntLit(0)))))),
-          List((ProjectIndexR(HoleF, IntLit(3)), SortDir.Ascending)))),
+          (ProjectIndexR(HoleF, IntLit(3)), SortDir.asc).wrapNel)),
         QC.inj(Map((), ProjectIndexR(HoleF, IntLit(2)))))))
     }
 
@@ -627,7 +627,7 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
         Free.roll(ConcatArrays(
           Free.roll(MakeArray(ProjectIndexR(ProjectIndexR(HoleF, IntLit(0)), IntLit(0)))),
           Free.roll(MakeArray(ProjectIndexR(ProjectIndexR(HoleF, IntLit(1)), IntLit(0)))))),
-        List(ProjectIndexR(HoleF, IntLit(3)) -> SortDir.Ascending))),
+        (ProjectIndexR(HoleF, IntLit(3)) -> SortDir.asc).wrapNel)),
       QC.inj(Reduce((),
         Free.roll(DeleteField(ProjectIndexR(HoleF, IntLit(2)), StrLit("__sd__0"))),
         List(ReduceFuncs.Arbitrary(ProjectIndexR(HoleF, IntLit(2)))),

--- a/core/src/test/scala/quasar/optimizer.scala
+++ b/core/src/test/scala/quasar/optimizer.scala
@@ -17,9 +17,10 @@
 package quasar
 
 import quasar.Predef._
+import quasar.common.SortDir
 import quasar.frontend.logicalplan._
 import quasar.sql.CompilerHelpers
-import quasar.std._, StdLib.set._, StdLib.structural._
+import quasar.std._, StdLib.structural._
 
 import matryoshka._, FunctorT.ops._
 import org.scalacheck._
@@ -100,22 +101,18 @@ class OptimizerSpec extends quasar.Qspec with CompilerHelpers with TreeMatchers 
           makeObj(
             "name" -> ObjectProject(lpf.free('tmp0), lpf.constant(Data.Str("name")))),
           lpf.let('tmp2,
-            OrderBy[FLP](
+            lpf.sort(
               lpf.free('tmp1),
-              MakeArray[FLP](
-                ObjectProject(lpf.free('tmp1), lpf.constant(Data.Str("name")))),
-              lpf.constant(Data.Str("foobar"))),
+              (ObjectProject(lpf.free('tmp1), lpf.constant(Data.Str("name"))).embed, SortDir.asc).wrapNel),
             lpf.free('tmp2))))) must
         beTreeEqual(
           lpf.let('tmp1,
             makeObj(
               "name" ->
                 ObjectProject(read("person"), lpf.constant(Data.Str("name")))),
-            OrderBy[FLP](
+            lpf.sort(
               lpf.free('tmp1),
-              MakeArray[FLP](
-                ObjectProject(lpf.free('tmp1), lpf.constant(Data.Str("name")))),
-              lpf.constant(Data.Str("foobar")))))
+              (ObjectProject(lpf.free('tmp1), lpf.constant(Data.Str("name"))).embed, SortDir.asc).wrapNel)))
     }
   }
 

--- a/core/src/test/scala/quasar/sql/compiler.scala
+++ b/core/src/test/scala/quasar/sql/compiler.scala
@@ -18,9 +18,12 @@ package quasar.sql
 
 import quasar.Predef._
 import quasar.Data
+import quasar.common.SortDir
 import quasar.std._, StdLib._, agg._, array._, date._, identity._, math._
 
 import matryoshka.Fix
+import scalaz.NonEmptyList
+import scalaz.syntax.nel._
 
 class CompilerSpec extends quasar.Qspec with CompilerHelpers {
   // NB: imports are here to shadow duplicated names in [[quasar.sql]]. We
@@ -864,12 +867,9 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
                 "name" -> ObjectProject(lpf.free('__tmp0), lpf.constant(Data.Str("name"))),
                 "__sd__0" -> ObjectProject(lpf.free('__tmp0), lpf.constant(Data.Str("height"))))),
             DeleteField[FLP](
-              OrderBy[FLP](
+              lpf.sort(
                 lpf.free('__tmp1),
-                MakeArrayN[Fix](
-                  ObjectProject(lpf.free('__tmp1), lpf.constant(Data.Str("__sd__0")))),
-                MakeArrayN(
-                  lpf.constant(Data.Str("ASC")))),
+                (ObjectProject(lpf.free('__tmp1), lpf.constant(Data.Str("__sd__0"))).embed, SortDir.asc).wrapNel),
               lpf.constant(Data.Str("__sd__0"))))))
     }
 
@@ -889,14 +889,11 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
                   "name"    -> ObjectProject(lpf.free('__tmp1), lpf.constant(Data.Str("name"))),
                   "__sd__0" -> ObjectProject(lpf.free('__tmp1), lpf.constant(Data.Str("height"))))),
               DeleteField[FLP](
-                OrderBy[FLP](
+                lpf.sort(
                   lpf.free('__tmp2),
-                  MakeArrayN[Fix](
-                    ObjectProject(lpf.free('__tmp2), lpf.constant(Data.Str("name"))),
-                    ObjectProject(lpf.free('__tmp2), lpf.constant(Data.Str("__sd__0")))),
-                  MakeArrayN(
-                    lpf.constant(Data.Str("ASC")),
-                    lpf.constant(Data.Str("ASC")))),
+                  NonEmptyList(
+                    (ObjectProject(lpf.free('__tmp2), lpf.constant(Data.Str("name"))).embed, SortDir.asc),
+                    (ObjectProject(lpf.free('__tmp2), lpf.constant(Data.Str("__sd__0"))).embed, SortDir.asc))),
                 lpf.constant(Data.Str("__sd__0")))))))
     }
 
@@ -904,26 +901,20 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
       testLogicalPlanCompile(
         "select * from person order by height",
         lpf.let('__tmp0, Squash(read("person")),
-          OrderBy[FLP](
+          lpf.sort(
             lpf.free('__tmp0),
-            MakeArrayN[Fix](
-              ObjectProject(lpf.free('__tmp0), lpf.constant(Data.Str("height")))),
-            MakeArrayN(
-              lpf.constant(Data.Str("ASC"))))))
+            (ObjectProject(lpf.free('__tmp0), lpf.constant(Data.Str("height"))).embed, SortDir.asc).wrapNel)))
     }
 
     "compile simple order by with ascending and descending" in {
       testLogicalPlanCompile(
         "select * from person order by height desc, name",
         lpf.let('__tmp0, Squash(read("person")),
-          OrderBy[FLP](
+          lpf.sort(
             lpf.free('__tmp0),
-            MakeArrayN[Fix](
-              ObjectProject(lpf.free('__tmp0), lpf.constant(Data.Str("height"))),
-              ObjectProject(lpf.free('__tmp0), lpf.constant(Data.Str("name")))),
-            MakeArrayN(
-              lpf.constant(Data.Str("DESC")),
-              lpf.constant(Data.Str("ASC"))))))
+            NonEmptyList(
+              (ObjectProject(lpf.free('__tmp0), lpf.constant(Data.Str("height"))).embed, SortDir.desc),
+              (ObjectProject(lpf.free('__tmp0), lpf.constant(Data.Str("name"))).embed, SortDir.asc)))))
     }
 
     "compile simple order by with expression" in {
@@ -939,12 +930,9 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
                     ObjectProject(lpf.free('__tmp0), lpf.constant(Data.Str("height"))),
                     lpf.constant(Data.Dec(2.54)))))),
             DeleteField[FLP](
-              OrderBy[FLP](
+              lpf.sort(
                 lpf.free('__tmp1),
-                MakeArrayN[Fix](
-                  ObjectProject(lpf.free('__tmp1), lpf.constant(Data.Str("__sd__0")))),
-                MakeArrayN(
-                  lpf.constant(Data.Str("ASC")))),
+                (ObjectProject(lpf.free('__tmp1), lpf.constant(Data.Str("__sd__0"))).embed, SortDir.asc).wrapNel),
               lpf.constant(Data.Str("__sd__0"))))))
     }
 
@@ -955,10 +943,9 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
           Squash(
             makeObj(
               "name" -> ObjectProject(read("person"), lpf.constant(Data.Str("firstName"))))),
-          OrderBy[FLP](
+          lpf.sort(
             lpf.free('__tmp0),
-            MakeArrayN[Fix](ObjectProject(lpf.free('__tmp0), lpf.constant(Data.Str("name")))),
-            MakeArrayN(lpf.constant(Data.Str("ASC"))))))
+            (ObjectProject(lpf.free('__tmp0), lpf.constant(Data.Str("name"))).embed, SortDir.asc).wrapNel)))
     }
 
     "compile simple order by with expression in synthetic field" in {
@@ -974,12 +961,9 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
                     ObjectProject(lpf.free('__tmp0), lpf.constant(Data.Str("height"))),
                     lpf.constant(Data.Dec(2.54))))),
             DeleteField[FLP](
-              OrderBy[FLP](
+              lpf.sort(
                 lpf.free('__tmp1),
-                MakeArrayN[Fix](
-                  ObjectProject(lpf.free('__tmp1), lpf.constant(Data.Str("__sd__0")))),
-                MakeArrayN(
-                  lpf.constant(Data.Str("ASC")))),
+                (ObjectProject(lpf.free('__tmp1), lpf.constant(Data.Str("__sd__0"))).embed, SortDir.asc).wrapNel),
               lpf.constant(Data.Str("__sd__0"))))))
     }
 
@@ -1000,12 +984,9 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
                     lpf.constant(Data.Str("quux"))),
                   lpf.constant(Data.Int(3))))),
             DeleteField[FLP](
-              OrderBy[FLP](
+              lpf.sort(
                 lpf.free('__tmp1),
-                MakeArrayN[Fix](
-                  ObjectProject(lpf.free('__tmp1), lpf.constant(Data.Str("__sd__0")))),
-                MakeArrayN(
-                  lpf.constant(Data.Str("ASC")))),
+                (ObjectProject(lpf.free('__tmp1), lpf.constant(Data.Str("__sd__0"))).embed, SortDir.asc).wrapNel),
               lpf.constant(Data.Str("__sd__0"))))))
     }
 
@@ -1080,12 +1061,9 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
                         lpf.constant(Data.Dec(2.54))))),
                 Take[FLP](
                   Drop[FLP](
-                    OrderBy[FLP](  // order by cm
+                    lpf.sort(  // order by cm
                       lpf.free('__tmp3),
-                      MakeArrayN[Fix](
-                        ObjectProject(lpf.free('__tmp3), lpf.constant(Data.Str("cm")))),
-                      MakeArrayN(
-                        lpf.constant(Data.Str("ASC")))),
+                      (ObjectProject(lpf.free('__tmp3), lpf.constant(Data.Str("cm"))).embed, SortDir.asc).wrapNel),
                   lpf.constant(Data.Int(10))), // offset 10
                 lpf.constant(Data.Int(5))))))))    // limit 5
     }
@@ -1341,12 +1319,9 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
               "city" ->
                 ObjectProject(read("zips"), lpf.constant(Data.Str("city"))))),
           Distinct[FLP](
-            OrderBy[FLP](
+            lpf.sort(
               lpf.free('__tmp0),
-              MakeArrayN[Fix](
-                ObjectProject(lpf.free('__tmp0), lpf.constant(Data.Str("city")))),
-              MakeArrayN(
-                lpf.constant(Data.Str("ASC")))))))
+              (ObjectProject(lpf.free('__tmp0), lpf.constant(Data.Str("city"))).embed, SortDir.asc).wrapNel))))
     }
 
     "compile distinct with unrelated order by" in {
@@ -1360,12 +1335,9 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
                 "city" -> ObjectProject(lpf.free('__tmp0), lpf.constant(Data.Str("city"))),
                 "__sd__0" -> ObjectProject(lpf.free('__tmp0), lpf.constant(Data.Str("pop"))))),
             lpf.let('__tmp2,
-              OrderBy[FLP](
+              lpf.sort(
                 lpf.free('__tmp1),
-                MakeArrayN[Fix](
-                  ObjectProject(lpf.free('__tmp1), lpf.constant(Data.Str("__sd__0")))),
-                MakeArrayN(
-                  lpf.constant(Data.Str("DESC")))),
+                (ObjectProject(lpf.free('__tmp1), lpf.constant(Data.Str("__sd__0"))).embed, SortDir.desc).wrapNel),
               DeleteField[FLP](
                 DistinctBy[FLP](lpf.free('__tmp2),
                   DeleteField(lpf.free('__tmp2), lpf.constant(Data.Str("__sd__0")))),

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/QScriptCorePlanner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/QScriptCorePlanner.scala
@@ -169,7 +169,7 @@ final class QScriptCorePlanner[F[_]: Monad: NameGenerator, T[_[_]]: Recursive: C
                         case SortDir.Descending => "DESC"
                       }
                       processFreeMap(or, tmpName3) ∘ (ord => s"${n1ql(ord)} $dir")
-                    }.map(_.mkString(", "))
+                    }.map(_ intercalate (", "))
         bN1ql    =  n1ql(b)
         bN1qlN   =  s"ifnull($bN1ql, $tmpName1)"
         s        =  select(

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/QScriptCorePlanner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/QScriptCorePlanner.scala
@@ -19,7 +19,7 @@ package quasar.physical.couchbase.planner
 import quasar.Predef._
 import quasar.NameGenerator
 import quasar.Planner.InternalError
-import quasar.common.PhaseResult.detail
+import quasar.common.{PhaseResult, SortDir}, PhaseResult.detail
 import quasar.contrib.matryoshka._
 import quasar.ejson
 import quasar.fp._, eitherT._

--- a/frontend/src/main/scala/quasar/frontend/logicalplan/LogicalPlan.scala
+++ b/frontend/src/main/scala/quasar/frontend/logicalplan/LogicalPlan.scala
@@ -18,6 +18,7 @@ package quasar.frontend.logicalplan
 
 import quasar.Predef._
 import quasar._
+import quasar.common.SortDir
 import quasar.contrib.pathy.{FPath, refineTypeAbs}
 import quasar.contrib.shapeless._
 import quasar.fp._
@@ -53,6 +54,8 @@ object InvokeUnapply {
 }
 final case class Free[A](name: Symbol) extends LogicalPlan[A]
 final case class Let[A](let: Symbol, form: A, in: A) extends LogicalPlan[A]
+final case class Sort[A](src: A, order: NonEmptyList[(A, SortDir)])
+    extends LogicalPlan[A]
 // NB: This should only be inserted by the type checker. In future, this
 //     should only exist in BlackShield – the checker will annotate nodes
 //     where runtime checks are necessary, then they will be added during
@@ -76,6 +79,8 @@ object LogicalPlan {
           case Invoke(func, values) => values.traverse(f).map(Invoke(func, _))
           case Free(v)              => G.point(Free(v))
           case Let(ident, form, in) => (f(form) ⊛ f(in))(Let(ident, _, _))
+          case Sort(src, ords)      =>
+            (f(src) ⊛ ords.traverse { case (a, d) => f(a) strengthR d })(Sort(_, _))
           case Typecheck(expr, typ, cont, fallback) =>
             (f(expr) ⊛ f(cont) ⊛ f(fallback))(Typecheck(_, typ, _, _))
         }
@@ -87,6 +92,7 @@ object LogicalPlan {
           case Invoke(func, values) => Invoke(func, values.map(f))
           case Free(v)              => Free(v)
           case Let(ident, form, in) => Let(ident, f(form), f(in))
+          case Sort(src, ords)      => Sort(f(src), ords map (f.first))
           case Typecheck(expr, typ, cont, fallback) =>
             Typecheck(f(expr), typ, f(cont), f(fallback))
         }
@@ -98,6 +104,7 @@ object LogicalPlan {
           case Invoke(_, values)    => values.foldMap(f)
           case Free(_)              => B.zero
           case Let(_, form, in)     => f(form) ⊹ f(in)
+          case Sort(src, ords)      => f(src) ⊹ ords.foldMap { case (a, _) => f(a) }
           case Typecheck(expr, _, cont, fallback) =>
             f(expr) ⊹ f(cont) ⊹ f(fallback)
         }
@@ -109,6 +116,7 @@ object LogicalPlan {
           case Invoke(_, values)    => values.foldRight(z)(f)
           case Free(_)              => z
           case Let(ident, form, in) => f(form, f(in, z))
+          case Sort(src, ords)      => f(src, ords.foldRight(z) { case ((a, _), b) => f(a, b) })
           case Typecheck(expr, _, cont, fallback) =>
             f(expr, f(cont, f(fallback, z)))
         }
@@ -116,15 +124,18 @@ object LogicalPlan {
 
   implicit val show: Delay[Show, LogicalPlan] =
     new Delay[Show, LogicalPlan] {
-      def apply[A](sa: Show[A]): Show[LogicalPlan[A]] =
+      def apply[A](sa: Show[A]): Show[LogicalPlan[A]] = {
+        implicit val showA = sa
         Show.show {
           case Read(v)               => Cord("Read(") ++ v.show ++ Cord(")")
           case Constant(v)           => Cord("Constant(") ++ v.show ++ Cord(")")
           case Invoke(func, values)  => func.show ++ Cord("(") ++ values.foldLeft(Cord("")){ case (acc, v) => acc ++ sa.show(v) ++ Cord(",") } ++ Cord(")") // TODO remove trailing comma
           case Free(n)               => Cord("Free(") ++ Cord(n.toString) ++ Cord(")")
           case Let(n, f, b)          => Cord("Let(") ++ Cord(n.toString) ++ Cord(",") ++ sa.show(f) ++ Cord(",") ++ sa.show(b) ++ Cord(")")
+          case Sort(src, ords)       => Cord("Sort(") ++ sa.show(src) ++ Cord(", ") ++ ords.show ++ Cord(")")
           case Typecheck(e, t, c, f) => Cord("Typecheck(") ++ sa.show(e) ++ Cord(",") ++ t.show ++ Cord(",") ++ sa.show(c) ++ Cord(",") ++ sa.show(f) ++ Cord(")")
         }
+      }
     }
 
   implicit val renderTree: Delay[RenderTree, LogicalPlan] =
@@ -148,6 +159,11 @@ object LogicalPlan {
             case InvokeUnapply(func, args) => NonTerminal("Invoke" :: nodeType, Some(func.shows), args.unsized.map(ra.render))
             case Free(name)                => Terminal("Free" :: nodeType, Some(name.toString))
             case Let(ident, form, body)    => NonTerminal("Let" :: nodeType, Some(ident.toString), List(ra.render(form), ra.render(body)))
+            case Sort(src, ords)           =>
+              NonTerminal("Sort" :: nodeType, None,
+                (ra.render(src) :: ords.list.flatMap {
+                  case (a, d) => ra.render(a) :: IList(Terminal(nodeType, Some(d.shows)))
+                }).toList)
             case Typecheck(expr, typ, cont, fallback) =>
               NonTerminal("Typecheck" :: nodeType, Some(typ.shows),
                 List(ra.render(expr), ra.render(cont), ra.render(fallback)))
@@ -166,6 +182,7 @@ object LogicalPlan {
           case (Free(n1), Free(n2)) => n1 ≟ n2
           case (Let(ident1, form1, in1), Let(ident2, form2, in2)) =>
             ident1 ≟ ident2 && form1 ≟ form2 && in1 ≟ in2
+          case (Sort(s1, o1), Sort(s2, o2)) => s1 ≟ s2 && o1 ≟ o2
           case (Typecheck(expr1, typ1, cont1, fb1), Typecheck(expr2, typ2, cont2, fb2)) =>
             expr1 ≟ expr2 && typ1 ≟ typ2 && cont1 ≟ cont2 && fb1 ≟ fb2
           case _ => false

--- a/frontend/src/main/scala/quasar/frontend/logicalplan/LogicalPlanR.scala
+++ b/frontend/src/main/scala/quasar/frontend/logicalplan/LogicalPlanR.scala
@@ -18,6 +18,7 @@ package quasar.frontend.logicalplan
 
 import quasar.Predef._
 import quasar._
+import quasar.common.SortDir
 import quasar.contrib.pathy.FPath
 import quasar.contrib.shapeless._
 import quasar.fp._
@@ -47,6 +48,8 @@ class LogicalPlanR[T[_[_]]: Recursive: Corecursive] {
   def free(name: Symbol) = lp.free[T[LP]](name).embed
   def let(name: Symbol, form: T[LP], in: T[LP]) =
     lp.let(name, form, in).embed
+  def sort(src: T[LP], order: NonEmptyList[(T[LP], SortDir)]) =
+    lp.sort(src, order).embed
   def typecheck(expr: T[LP], typ: Type, cont: T[LP], fallback: T[LP]) =
     lp.typecheck(expr, typ, cont, fallback).embed
 
@@ -151,6 +154,9 @@ class LogicalPlanR[T[_[_]]: Recursive: Corecursive] {
           inferTypes(fTyp, form).map(lp.let[Typed[LP]](n, _, in0))
         }
 
+      case Sort(src, ords) =>
+        (inferTypes(typ, src) ⊛ ords.traverse { case (a, d) => inferTypes(Type.Top, a) strengthR d })(lp.sort[Typed[LP]](_, _))
+
       case Typecheck(expr, t, cont, fallback) =>
         (inferTypes(t, expr) ⊛ inferTypes(typ, cont) ⊛ inferTypes(typ, fallback))(
           lp.typecheck[Typed[LP]](_, t, _, _))
@@ -206,6 +212,7 @@ class LogicalPlanR[T[_[_]]: Recursive: Corecursive] {
 
   // TODO: This can perhaps be decomposed into separate folds for annotating
   //       with “found” types, folding constants, and adding runtime checks.
+  // FIXME: No exhaustiveness checking here
   val checkTypesƒ:
       ((Type, LP[ConstrainedPlan[T]])) => NameT[SemDisj, ConstrainedPlan[T]] = {
     case (inf, term) =>
@@ -266,6 +273,9 @@ class LogicalPlanR[T[_[_]]: Recursive: Corecursive] {
           unifyOrCheck(inf, in.inferred, let(name, appConst(value, constant(Data.NA)), appConst(in, constant(Data.NA))))
         // TODO: Get the possible type from the LetF
         case Free(v) => emit(ConstrainedPlan(inf, Nil, free(v)))
+
+        case Sort(expr, ords) =>
+          unifyOrCheck(inf, expr.inferred, sort(appConst(expr, constant(Data.NA)), ords map (_ leftMap (appConst(_, constant(Data.NA))))))
       }
   }
 

--- a/frontend/src/main/scala/quasar/frontend/logicalplan/Optimizer.scala
+++ b/frontend/src/main/scala/quasar/frontend/logicalplan/Optimizer.scala
@@ -162,6 +162,7 @@ class Optimizer[T[_[_]]: Recursive: Corecursive: EqualT] {
     case Let(_, _, body) => body._2
     case Constant(Data.Obj(map)) =>
       Some(map.keys.map(n => lpr.constant(Data.Str(n))).toList)
+    case Sort(src, _) => src._2
     case InvokeUnapply(DeleteField, Sized(src, field)) =>
       src._2.map(_.filterNot(_ == field._1))
     case InvokeUnapply(MakeObject, Sized(field, _)) => Some(List(field._1))
@@ -169,7 +170,6 @@ class Optimizer[T[_[_]]: Recursive: Corecursive: EqualT] {
     // NB: the remaining Invoke cases simply pass through or combine shapes
     //     from their inputs. It would be great if this information could be
     //     handled generically by the type system.
-    case InvokeUnapply(OrderBy, Sized(src, _, _)) => src._2
     case InvokeUnapply(Take, Sized(src, _)) => src._2
     case InvokeUnapply(Drop, Sized(src, _)) => src._2
     case InvokeUnapply(Filter, Sized(src, _)) => src._2

--- a/frontend/src/main/scala/quasar/frontend/logicalplan/package.scala
+++ b/frontend/src/main/scala/quasar/frontend/logicalplan/package.scala
@@ -18,6 +18,7 @@ package quasar.frontend
 
 import quasar.Predef._
 import quasar._
+import quasar.common.SortDir
 import quasar.contrib.pathy.FPath
 import quasar.namegen.NameGen
 
@@ -48,6 +49,11 @@ package object logicalplan {
     Prism.partial[LogicalPlan[A], (Symbol, A, A)] {
       case Let(v, f, b) => (v, f, b)
     } ((Let[A](_, _, _)).tupled)
+
+  def sort[A] =
+    Prism.partial[LogicalPlan[A], (A, NonEmptyList[(A, SortDir)])] {
+      case Sort(a, ords) => (a, ords)
+    } ((Sort[A](_, _)).tupled)
 
   def typecheck[A] =
     Prism.partial[LogicalPlan[A], (A, Type, A, A)] {

--- a/frontend/src/main/scala/quasar/functions.scala
+++ b/frontend/src/main/scala/quasar/functions.scala
@@ -170,7 +170,6 @@ trait GenericFuncInstances {
       case set.Take                       => "Take"
       case set.Drop                       => "Drop"
       case set.Range                      => "Range"
-      case set.OrderBy                    => "OrderBy"
       case set.Filter                     => "Filter"
       case set.InnerJoin                  => "InnerJoin"
       case set.LeftOuterJoin              => "LeftOuterJoin"

--- a/frontend/src/main/scala/quasar/sql/ast.scala
+++ b/frontend/src/main/scala/quasar/sql/ast.scala
@@ -86,7 +86,7 @@ object Sql {
                     case OrderBy(keys) =>
                       val nt = "OrderBy" :: astType
                       NonTerminal(nt, None,
-                        keys.map { case (t, x) => NonTerminal("OrderType" :: nt, Some(t.shows), ra.render(x) :: Nil)})
+                        keys.map { case (t, x) => NonTerminal("OrderType" :: nt, Some(t.shows), ra.render(x) :: Nil) }.toList)
                   } ::
                   Nil).foldMap(_.toList))
 
@@ -237,7 +237,7 @@ object GroupBy {
     }
 }
 
-@Lenses final case class OrderBy[A](keys: List[(OrderType, A)])
+@Lenses final case class OrderBy[A](keys: NonEmptyList[(OrderType, A)])
 object OrderBy {
   implicit val equal: Delay[Equal, OrderBy] =
     new Delay[Equal, OrderBy] {

--- a/frontend/src/main/scala/quasar/sql/package.scala
+++ b/frontend/src/main/scala/quasar/sql/package.scala
@@ -192,7 +192,7 @@ package object sql {
             ("group by" ::
               g.keys.map(_._2).mkString(", ") ::
               g.having.map("having " + _._2).toList).mkString(" ")),
-          orderBy.map(o => List("order by", o.keys.map(x => x._2._2 + " " + x._1.shows) mkString(", ")).mkString(" "))).foldMap(_.toList).mkString(" ") +
+          orderBy.map(o => List("order by", o.keys.map(x => x._2._2 + " " + x._1.shows) intercalate (", ")).mkString(" "))).foldMap(_.toList).mkString(" ") +
         ")"
       case Vari(symbol) => ":" + symbol
       case SetLiteral(exprs) => exprs.map(_._2).mkString("(", ", ", ")")

--- a/frontend/src/main/scala/quasar/sql/parser.scala
+++ b/frontend/src/main/scala/quasar/sql/parser.scala
@@ -433,7 +433,7 @@ private[sql] class SQLParser[T[_[_]]: Recursive: Corecursive]
     keyword("order") ~> keyword("by") ~> rep1sep(defined_expr ~ opt(keyword("asc") | keyword("desc")) ^^ {
       case i ~ (Some("asc") | None) => (ASC, i)
       case i ~ Some("desc") => (DESC, i)
-    }, op(",")) ^^ (OrderBy(_))
+    }, op(",")) ^? { case o :: os => OrderBy(NonEmptyList(o, os: _*)) }
 
   def expr: Parser[T[Sql]] = let_expr
 

--- a/frontend/src/main/scala/quasar/std/set.scala
+++ b/frontend/src/main/scala/quasar/std/set.scala
@@ -91,18 +91,6 @@ trait SetLib extends Library {
     },
     basicUntyper)
 
-  // TODO second param is an Array, third param is Array[String]
-  val OrderBy = TernaryFunc(
-    Sifting,
-    "Orders a set by the natural ordering of a projection on the set",
-    Type.Top,
-    Func.Input3(Type.Top, Type.Top, Type.Top),
-    noSimplification,
-    partialTyper[nat._3] {
-      case Sized(set, _, _) => set
-    },
-    untyper[nat._3](t => success(Func.Input3(t, Type.Top, Type.Top))))
-
   val Filter = BinaryFunc(
     Sifting,
     "Filters a set to include only elements where a projection is true",

--- a/frontend/src/test/scala/quasar/sql/ExprArbitrary.scala
+++ b/frontend/src/test/scala/quasar/sql/ExprArbitrary.scala
@@ -71,9 +71,10 @@ trait ExprArbitrary {
     (smallNonEmptyListOf(exprGen(depth)) ⊛ Gen.option(exprGen(depth)))(
       GroupBy(_, _))
 
-  private def orderByGen(depth: Int): Gen[OrderBy[Fix[Sql]]] =
-    smallNonEmptyListOf((Gen.oneOf(ASC, DESC) ⊛ exprGen(depth))((_, _))) ∘
-  (OrderBy(_))
+  private def orderByGen(depth: Int): Gen[OrderBy[Fix[Sql]]] = {
+    val order = Gen.oneOf(ASC, DESC) tuple exprGen(depth)
+    (order ⊛ smallNonEmptyListOf(order))((o, os) => OrderBy(NonEmptyList(o, os: _*)))
+  }
 
   private def exprGen(depth: Int): Gen[Fix[Sql]] = Gen.lzy {
     if (depth <= 0) simpleExprGen

--- a/frontend/src/test/scala/quasar/sql/SqlParserSpec.scala
+++ b/frontend/src/test/scala/quasar/sql/SqlParserSpec.scala
@@ -161,7 +161,7 @@ class SQLParserSpec extends quasar.Qspec {
             TableRelationAST(file("from"), "from".some).some,
             IdentR("where").some,
             GroupBy(List(IdentR("group")), None).some,
-            OrderBy(List((ASC, IdentR("order")))).some))
+            OrderBy((ASC: OrderType, IdentR("order")).wrapNel).some))
     }
 
     "parse ambiguous keyword as identifier" in {

--- a/it/src/main/resources/tests/citiesByTotalPopulation.test
+++ b/it/src/main/resources/tests/citiesByTotalPopulation.test
@@ -2,17 +2,22 @@
     "name": "top 5 cities by total population",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "skip",
         "couchbase":  "skipCI"
     },
     "data": "zips.data",
     "query": "select city, state, sum(pop) as population from zips group by city, state order by population desc limit 5",
     "predicate": "equalsExactly",
-    "ignoreFieldOrder": [ "couchbase" ],
+    "ignoreFieldOrder": [
+        "couchbase",
+        "mongodb_2_6",
+        "mongodb_3_0",
+        "mongodb_3_2",
+        "mongodb_read_only"
+    ],
     "expected": [
-        { "population": 2452177, "city": "CHICAGO",      "state": "IL" },
-        { "population": 2300504, "city": "BROOKLYN",     "state": "NY" },
-        { "population": 2102295, "city": "LOS ANGELES",  "state": "CA" },
-        { "population": 2095918, "city": "HOUSTON",      "state": "TX" },
-        { "population": 1610956, "city": "PHILADELPHIA", "state": "PA" }]
+        { "city": "CHICAGO",      "state": "IL", "population": 2452177 },
+        { "city": "BROOKLYN",     "state": "NY", "population": 2300504 },
+        { "city": "LOS ANGELES",  "state": "CA", "population": 2102295 },
+        { "city": "HOUSTON",      "state": "TX", "population": 2095918 },
+        { "city": "PHILADELPHIA", "state": "PA", "population": 1610956 }]
 }

--- a/it/src/main/resources/tests/largestZips.test
+++ b/it/src/main/resources/tests/largestZips.test
@@ -2,7 +2,6 @@
     "name": "largest zips",
     "backends": {
         "postgresql": "pending",
-        "marklogic":  "skip",
         "couchbase":  "skip"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/orderedWildcardWithProjection.test
+++ b/it/src/main/resources/tests/orderedWildcardWithProjection.test
@@ -6,22 +6,21 @@
         "mongodb_read_only": "pending",
         "mongodb_3_2":       "pending",
         "postgresql":        "pending",
-        "marklogic":         "skip",
         "couchbase":         "skip"
     },
     "data": "largeZips.data",
-    "query": "select *, pop * 10 from largeZips order by pop / 10 desc",
+    "query": "select *, pop * 10 as dpop from largeZips order by pop / 10 desc",
     "predicate": "equalsInitial",
     "ignoreFieldOrder": [ "couchbase" ],
     "expected": [
-        { "_id": "60623", "city": "CHICAGO",      "loc": [ -87.7157,   41.849015], "pop": 112047.0, "state": "IL", "1": 1120470.0 },
-        { "_id": "11226", "city": "BROOKLYN",     "loc": [ -73.956985, 40.646694], "pop": 111396.0, "state": "NY", "1": 1113960.0 },
-        { "_id": "10021", "city": "NEW YORK",     "loc": [ -73.958805, 40.768476], "pop": 106564.0, "state": "NY", "1": 1065640.0 },
-        { "_id": "10025", "city": "NEW YORK",     "loc": [ -73.968312, 40.797466], "pop": 100027.0, "state": "NY", "1": 1000270.0 },
-        { "_id": "90201", "city": "BELL GARDENS", "loc": [-118.17205,  33.969177], "pop":  99568.0, "state": "CA", "1":  995680.0 },
-        { "_id": "60617", "city": "CHICAGO",      "loc": [ -87.556012, 41.725743], "pop":  98612.0, "state": "IL", "1":  986120.0 },
-        { "_id": "90011", "city": "LOS ANGELES",  "loc": [-118.258189, 34.007856], "pop":  96074.0, "state": "CA", "1":  960740.0 },
-        { "_id": "60647", "city": "CHICAGO",      "loc": [ -87.704322, 41.920903], "pop":  95971.0, "state": "IL", "1":  959710.0 },
-        { "_id": "60628", "city": "CHICAGO",      "loc": [ -87.624277, 41.693443], "pop":  94317.0, "state": "IL", "1":  943170.0 },
-        { "_id": "90650", "city": "NORWALK",      "loc": [-118.081767, 33.90564 ], "pop":  94188.0, "state": "CA", "1":  941880.0 }]
+        { "_id": "60623", "city": "CHICAGO",      "loc": [ -87.7157,   41.849015], "pop": 112047.0, "state": "IL", "dpop": 1120470.0 },
+        { "_id": "11226", "city": "BROOKLYN",     "loc": [ -73.956985, 40.646694], "pop": 111396.0, "state": "NY", "dpop": 1113960.0 },
+        { "_id": "10021", "city": "NEW YORK",     "loc": [ -73.958805, 40.768476], "pop": 106564.0, "state": "NY", "dpop": 1065640.0 },
+        { "_id": "10025", "city": "NEW YORK",     "loc": [ -73.968312, 40.797466], "pop": 100027.0, "state": "NY", "dpop": 1000270.0 },
+        { "_id": "90201", "city": "BELL GARDENS", "loc": [-118.17205,  33.969177], "pop":  99568.0, "state": "CA", "dpop":  995680.0 },
+        { "_id": "60617", "city": "CHICAGO",      "loc": [ -87.556012, 41.725743], "pop":  98612.0, "state": "IL", "dpop":  986120.0 },
+        { "_id": "90011", "city": "LOS ANGELES",  "loc": [-118.258189, 34.007856], "pop":  96074.0, "state": "CA", "dpop":  960740.0 },
+        { "_id": "60647", "city": "CHICAGO",      "loc": [ -87.704322, 41.920903], "pop":  95971.0, "state": "IL", "dpop":  959710.0 },
+        { "_id": "60628", "city": "CHICAGO",      "loc": [ -87.624277, 41.693443], "pop":  94317.0, "state": "IL", "dpop":  943170.0 },
+        { "_id": "90650", "city": "NORWALK",      "loc": [-118.081767, 33.90564 ], "pop":  94188.0, "state": "CA", "dpop":  941880.0 }]
 }

--- a/it/src/main/resources/tests/sortProjectLimit.test
+++ b/it/src/main/resources/tests/sortProjectLimit.test
@@ -2,8 +2,7 @@
     "name": "sort, project, and limit",
 
     "backends": {
-        "postgresql": "pending",
-        "marklogic":  "skip"
+        "postgresql": "pending"
     },
 
     "data": "zips.data",

--- a/it/src/main/resources/tests/sortWildcardOnExpression.test
+++ b/it/src/main/resources/tests/sortWildcardOnExpression.test
@@ -6,7 +6,6 @@
         "mongodb_read_only": "pending",
         "mongodb_3_2":       "pending",
         "postgresql":        "pending",
-        "marklogic":         "skip",
         "couchbase":         "skip"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/statesByShortestFirstCity.test
+++ b/it/src/main/resources/tests/statesByShortestFirstCity.test
@@ -3,7 +3,6 @@
     "backends": {
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
-        "marklogic":         "skip",
         "couchbase":         "skip"
     },
     "description": "combines an aggregate function (min) with a function implemented in JS (length)",

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/QScriptCorePlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/QScriptCorePlanner.scala
@@ -110,7 +110,7 @@ private[qscript] final class QScriptCorePlanner[F[_]: QNameGenerator: PrologW: M
     case Sort(src, bucket, order) =>
       for {
         x        <- freshName[F]
-        xqyOrder <- NonEmptyList((bucket, SortDir.Ascending), order: _*).traverse { case (func, sortDir) =>
+        xqyOrder <- ((bucket, SortDir.asc) <:: order).traverse { case (func, sortDir) =>
                       mapFuncXQuery(func, ~x) flatMap { by =>
                         ejson.castAsAscribed[F].apply(by) strengthR SortDirection.fromQScript(sortDir)
                       }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/QScriptCorePlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/QScriptCorePlanner.scala
@@ -17,6 +17,7 @@
 package quasar.physical.marklogic.qscript
 
 import quasar.Predef.{Map => _, _}
+import quasar.common.SortDir
 import quasar.physical.marklogic.xquery._
 import quasar.physical.marklogic.xquery.syntax._
 import quasar.qscript._

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/package.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/package.scala
@@ -17,6 +17,7 @@
 package quasar.physical.marklogic
 
 import quasar.Predef._
+import quasar.common.SortDir
 import quasar.physical.marklogic.validation._
 import quasar.physical.marklogic.xml._
 
@@ -50,9 +51,9 @@ package object xquery {
     case object Descending extends SortDirection
     case object Ascending  extends SortDirection
 
-    def fromQScript(s: quasar.qscript.SortDir): SortDirection = s match {
-      case quasar.qscript.SortDir.Ascending  => Ascending
-      case quasar.qscript.SortDir.Descending => Descending
+    def fromQScript(s: SortDir): SortDirection = s match {
+      case SortDir.Ascending  => Ascending
+      case SortDir.Descending => Descending
     }
   }
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/execution.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/execution.scala
@@ -17,11 +17,11 @@
 package quasar.physical.mongodb
 
 import quasar.Predef._
+import quasar.common.SortDir
 import quasar.fp._
 import quasar.physical.mongodb.accumulator._
 import quasar.physical.mongodb.expression._
 import quasar.physical.mongodb.workflow._
-import quasar.qscript.SortDir
 
 import scalaz._, Scalaz._
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/mapreduce.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/mapreduce.scala
@@ -17,8 +17,8 @@
 package quasar.physical.mongodb
 
 import quasar.Predef._
+import quasar.common.SortDir
 import quasar.javascript._
-import quasar.qscript._
 
 import com.mongodb.client.model.MapReduceAction
 import monocle.macros.GenLens

--- a/mongodb/src/main/scala/quasar/physical/mongodb/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/package.scala
@@ -18,10 +18,10 @@ package quasar.physical
 
 import quasar.Predef._
 import quasar.TernaryFunc
+import quasar.common.SortDir
 import quasar.javascript.Js
 import quasar.fs.PhysicalError
 import quasar.namegen._
-import quasar.qscript._
 
 import com.mongodb.async.AsyncBatchCursor
 import org.bson.BsonDocument

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/MongoDbPlanner.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/MongoDbPlanner.scala
@@ -31,7 +31,7 @@ import quasar.frontend.{logicalplan => lp}, lp.{LogicalPlan => LP, _}
 import quasar.namegen._
 import quasar.physical.mongodb._
 import quasar.physical.mongodb.workflow._
-import quasar.qscript.{MapFunc, SortDir}
+import quasar.qscript.MapFunc
 import quasar.std.StdLib._
 
 import matryoshka._, Recursive.ops._, TraverseT.ops._
@@ -524,23 +524,6 @@ object MongoDbPlanner {
       case n                      => n.head._2.map(List(_))
     }
 
-    val HasSortDirs: Ann => OutputM[List[SortDir]] = {
-      def isSortDir(node: LP[Ann]): OutputM[SortDir] =
-        node match {
-          case HasData(Data.Str("ASC"))  => \/-(SortDir.Ascending)
-          case HasData(Data.Str("DESC")) => \/-(SortDir.Descending)
-          case x => -\/(InternalError fromMsg "malformed sort dir: " + x)
-        }
-
-      _ match {
-        case MakeArrayN.Attr(array) =>
-          array.traverse(d => isSortDir(d.tail))
-        case Cofree(_, Constant(Data.Arr(dirs))) =>
-          dirs.traverse(d => isSortDir(Constant(d)))
-        case n => isSortDir(n.tail).map(List(_))
-      }
-    }
-
     val HasSelector: Ann => OutputM[PartialSelector] = _.head._1._1
 
     val HasJs: Ann => OutputM[PartialJs] = _.head._1._2
@@ -701,10 +684,6 @@ object MongoDbPlanner {
           }
         case GroupBy =>
           lift(Arity2(HasWorkflow, HasKeys).map((WB.groupBy(_, _)).tupled))
-        case OrderBy =>
-          lift(Arity3(HasWorkflow, HasKeys, HasSortDirs).map {
-            case (p1, p2, dirs) => WB.sortBy(p1, p2, dirs)
-          })
 
         // TODO: pull these out into a groupFuncHandler (which will also provide stdDev)
         case Count      => groupExpr1(κ($sum($literal(Bson.Int32(1)))))
@@ -800,6 +779,11 @@ object MongoDbPlanner {
       case Free(name) =>
         state(-\/(InternalError fromMsg s"variable $name is unbound"))
       case Let(_, _, in) => state(in.head._2)
+      case Sort(src, ords) =>
+        state((HasWorkflow(src) |@| ords.traverse { case (a, sd) => HasWorkflow(a) strengthR sd }) { (src, os) =>
+          val (keys, dirs) = os.toList.unzip
+          WB.sortBy(src, keys, dirs)
+        })
       case Typecheck(exp, typ, cont, fallback) =>
         // NB: Even if certain checks aren’t needed by ExprOps, we have to
         //     maintain them because we may convert ExprOps to JS.

--- a/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -19,7 +19,7 @@ package quasar.physical.mongodb
 import scala.Predef.$conforms
 import quasar.Predef._
 import quasar._, Planner._, Type.{Const => _, Coproduct => _, _}
-import quasar.common.{PhaseResult, PhaseResults, PhaseResultT}
+import quasar.common.{PhaseResult, PhaseResults, PhaseResultT, SortDir}
 import quasar.contrib.matryoshka._
 import quasar.fp._
 import quasar.fp.ski._

--- a/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -549,7 +549,7 @@ object MongoDbQScriptPlanner {
                       accumulator(ai._1).left[Fix[ExprOp]])).toListMap)),
                 rep)).liftM[GenT]
           case Sort(src, bucket, order) =>
-            val (keys, dirs) = ((bucket, SortDir.Ascending) :: order).unzip
+            val (keys, dirs) = ((bucket, SortDir.Ascending) :: order.toList).unzip
             keys.traverse(getExprBuilder(funcHandler)(src, _))
               .map(WB.sortBy(src, _, dirs)).liftM[GenT]
           case Filter(src, f) =>

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflow/WorkflowOpCore.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflow/WorkflowOpCore.scala
@@ -19,6 +19,7 @@ package quasar.physical.mongodb.workflow
 import scala.Predef.$conforms
 import quasar.Predef._
 import quasar.{RenderTree, NonTerminal, Terminal}, RenderTree.ops._
+import quasar.common.SortDir
 import quasar.fp._
 import quasar.fp.ski._
 import quasar.javascript._, Js.JSRenderTree
@@ -28,7 +29,6 @@ import quasar.physical.mongodb.{Bson, BsonField, Collection, CollectionName, Gro
 import quasar.physical.mongodb.accumulator._
 import quasar.physical.mongodb.expression._
 import quasar.physical.mongodb.workflowtask._
-import quasar.qscript.SortDir
 
 import matryoshka._, Recursive.ops._
 import scalaz._, Scalaz._

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
@@ -18,6 +18,7 @@ package quasar.physical.mongodb
 
 import quasar.Predef._
 import quasar.{NonTerminal, RenderTree, Terminal}, RenderTree.ops._
+import quasar.common.SortDir
 import quasar.fp._
 import quasar.fp.ski._
 import quasar.namegen._
@@ -28,7 +29,6 @@ import quasar.physical.mongodb.accumulator._
 import quasar.physical.mongodb.expression._
 import quasar.physical.mongodb.workflow._
 import quasar.std.StdLib._
-import quasar.qscript.SortDir
 
 import matryoshka._, Recursive.ops._, FunctorT.ops._
 import scalaz._, Scalaz._

--- a/mongodb/src/test/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutionSpec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutionSpec.scala
@@ -17,11 +17,11 @@
 package quasar.physical.mongodb
 
 import quasar.Predef._
+import quasar.common.SortDir
 import quasar.javascript._
 import quasar.physical.mongodb.accumulator._
 import quasar.physical.mongodb.expression._
 import quasar.physical.mongodb.workflow._
-import quasar.qscript.SortDir
 
 import scala.collection.immutable.ListMap
 

--- a/mongodb/src/test/scala/quasar/physical/mongodb/optimize.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/optimize.scala
@@ -18,11 +18,11 @@ package quasar.physical.mongodb
 
 import quasar.Predef._
 import quasar.TreeMatchers
+import quasar.common.SortDir
 import quasar.physical.mongodb.accumulator._
 import quasar.physical.mongodb.expression._
 import quasar.physical.mongodb.optimize.pipeline._
 import quasar.physical.mongodb.workflow._
-import quasar.qscript._
 
 import scalaz._, Scalaz._
 

--- a/mongodb/src/test/scala/quasar/physical/mongodb/pipeline.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/pipeline.scala
@@ -18,10 +18,10 @@ package quasar.physical.mongodb
 
 import quasar._
 import quasar.Predef._
+import quasar.common.SortDir
 import quasar.physical.mongodb.accumulator._
 import quasar.physical.mongodb.expression._
 import quasar.physical.mongodb.workflow._
-import quasar.qscript.SortDir
 
 import org.scalacheck._
 import scalaz._

--- a/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -27,7 +27,6 @@ import quasar.physical.mongodb.accumulator._
 import quasar.physical.mongodb.expression._
 import quasar.physical.mongodb.planner._
 import quasar.physical.mongodb.workflow._
-import quasar.qscript.SortDir
 import quasar.sql.{fixpoint => sql, _}
 import quasar.std._
 
@@ -3686,10 +3685,11 @@ class PlannerSpec extends
     Gen.const(sql.BinopR(sql.IdentR("p"), sql.IdentR("q"), quasar.sql.Eq)))  // Comparing two fields requires a $project before the $match
 
   val noOrderBy: Gen[Option[OrderBy[Fix[Sql]]]] = Gen.const(None)
-  val orderBySeveral: Gen[Option[OrderBy[Fix[Sql]]]] = Gen.nonEmptyListOf(for {
-    x <- Gen.oneOf(genInnerInt, genInnerStr)
-    t <- Gen.oneOf(ASC, DESC)
-  } yield (t, x)).map(ps => Some(OrderBy(ps)))
+
+  val orderBySeveral: Gen[Option[OrderBy[Fix[Sql]]]] = {
+    val order = Gen.oneOf(ASC, DESC) tuple Gen.oneOf(genInnerInt, genInnerStr)
+    (order |@| Gen.listOf(order))((h, t) => Some(OrderBy(NonEmptyList(h, t: _*))))
+  }
 
   val maybeReducingExpr = Gen.oneOf(genOuterInt, genOuterStr)
 
@@ -3765,17 +3765,16 @@ class PlannerSpec extends
   "plan from LogicalPlan" should {
     import StdLib._
 
-    "plan simple OrderBy" in {
+    "plan simple Sort" in {
       val lp =
         lpf.let(
           'tmp0, read("db/foo"),
           lpf.let(
             'tmp1, makeObj("bar" -> ObjectProject(lpf.free('tmp0), lpf.constant(Data.Str("bar")))),
             lpf.let('tmp2,
-              s.OrderBy[FLP](
+              lpf.sort(
                 lpf.free('tmp1),
-                MakeArrayN[Fix](ObjectProject(lpf.free('tmp1), lpf.constant(Data.Str("bar")))),
-                MakeArrayN(lpf.constant(Data.Str("ASC")))),
+                (ObjectProject(lpf.free('tmp1), lpf.constant(Data.Str("bar"))).embed, SortDir.asc).wrapNel),
               lpf.free('tmp2))))
 
       plan(lp) must beWorkflow(chain[Workflow](
@@ -3786,16 +3785,15 @@ class PlannerSpec extends
         $sort(NonEmptyList(BsonField.Name("bar") -> SortDir.Ascending))))
     }
 
-    "plan OrderBy with expression" in {
+    "plan Sort with expression" in {
       val lp =
         lpf.let(
           'tmp0, read("db/foo"),
-          s.OrderBy[FLP](
+          lpf.sort(
             lpf.free('tmp0),
-            MakeArrayN[Fix](math.Divide[FLP](
+            (math.Divide[FLP](
               ObjectProject(lpf.free('tmp0), lpf.constant(Data.Str("bar"))),
-              lpf.constant(Data.Dec(10.0)))),
-            MakeArrayN(lpf.constant(Data.Str("ASC")))))
+              lpf.constant(Data.Dec(10.0))).embed, SortDir.asc).wrapNel))
 
       plan(lp) must beWorkflow(chain[Workflow](
         $read(collection("db", "foo")),
@@ -3810,7 +3808,7 @@ class PlannerSpec extends
           ExcludeId)))
     }
 
-    "plan OrderBy with expression and earlier pipeline op" in {
+    "plan Sort with expression and earlier pipeline op" in {
       val lp =
         lpf.let(
           'tmp0, read("db/foo"),
@@ -3821,10 +3819,9 @@ class PlannerSpec extends
               relations.Eq[FLP](
                 ObjectProject(lpf.free('tmp0), lpf.constant(Data.Str("baz"))),
                 lpf.constant(Data.Int(0)))),
-            s.OrderBy[FLP](
+            lpf.sort(
               lpf.free('tmp1),
-              MakeArrayN[Fix](ObjectProject(lpf.free('tmp1), lpf.constant(Data.Str("bar")))),
-              MakeArrayN(lpf.constant(Data.Str("ASC"))))))
+              (ObjectProject(lpf.free('tmp1), lpf.constant(Data.Str("bar"))).embed, SortDir.asc).wrapNel)))
 
       plan(lp) must beWorkflow(chain[Workflow](
         $read(collection("db", "foo")),
@@ -3833,7 +3830,7 @@ class PlannerSpec extends
         $sort(NonEmptyList(BsonField.Name("bar") -> SortDir.Ascending))))
     }
 
-    "plan OrderBy with expression (and extra project)" in {
+    "plan Sort expression (and extra project)" in {
       val lp =
         lpf.let(
           'tmp0, read("db/foo"),
@@ -3841,12 +3838,11 @@ class PlannerSpec extends
             'tmp9,
             makeObj(
               "bar" -> ObjectProject(lpf.free('tmp0), lpf.constant(Data.Str("bar")))),
-            s.OrderBy[FLP](
+            lpf.sort(
               lpf.free('tmp9),
-              MakeArrayN[Fix](math.Divide[FLP](
+              (math.Divide[FLP](
                 ObjectProject(lpf.free('tmp9), lpf.constant(Data.Str("bar"))),
-                lpf.constant(Data.Dec(10.0)))),
-              MakeArrayN(lpf.constant(Data.Str("ASC"))))))
+                lpf.constant(Data.Dec(10.0))).embed, SortDir.asc).wrapNel)))
 
       plan(lp) must beWorkflow(chain[Workflow](
         $read(collection("db", "foo")),

--- a/mongodb/src/test/scala/quasar/physical/mongodb/workflowbuilder.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/workflowbuilder.scala
@@ -18,13 +18,13 @@ package quasar.physical.mongodb
 
 import quasar.Predef._
 import quasar._, Planner._
+import quasar.common.SortDir
 import quasar.fp._
 import quasar.fp.ski._
 import quasar.javascript._
 import quasar.physical.mongodb.accumulator._
 import quasar.physical.mongodb.expression._
 import quasar.physical.mongodb.workflow._
-import quasar.qscript.SortDir
 
 import matryoshka._, FunctorT.ops._, Recursive.ops._
 import scalaz._, Scalaz._

--- a/mongodb/src/test/scala/quasar/physical/mongodb/workflowop.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/workflowop.scala
@@ -19,12 +19,12 @@ package quasar.physical.mongodb
 import quasar.Predef._
 import quasar.RenderTree
 import quasar.TreeMatchers
+import quasar.common.SortDir
 import quasar.fp._
 import quasar.javascript._
 import quasar.physical.mongodb.accumulator._
 import quasar.physical.mongodb.expression._
 import quasar.physical.mongodb.workflow._
-import quasar.qscript.SortDir
 
 import matryoshka.Fix
 import org.scalacheck._

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/Planner.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/Planner.scala
@@ -18,13 +18,13 @@ package quasar.physical.sparkcore.fs
 
 import quasar.Predef._
 import quasar._, quasar.Planner._
+import quasar.common.SortDir
 import quasar.contrib.matryoshka._
 import quasar.contrib.pathy.AFile
 import quasar.fp.ski._
 import quasar.qscript._
 import quasar.contrib.pathy.AFile
 import quasar.qscript.ReduceFuncs._
-import quasar.qscript.SortDir._
 
 import scala.math.{Ordering => SOrdering}
 import SOrdering.Implicits._
@@ -273,10 +273,10 @@ object Planner {
 
           val maybeBucket =
             freeCataM(bucket)(interpretM(κ(ι[Data].right[PlannerError]), CoreMap.change))
-          
+
           EitherT((maybeBucket |@| maybeSortBys) {
             case (bucket, sortBys) =>
-              val asc = sortBys(0)._2 === Ascending
+              val asc = sortBys(0)._2 === SortDir.Ascending
               val keys = bucket :: sortBys.map(_._1)
               src.sortBy(d => keys.map(_(d)), asc)
           }.point[Task]).liftM[SparkStateT]

--- a/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/PlannerSpec.scala
+++ b/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/PlannerSpec.scala
@@ -17,6 +17,7 @@
 package quasar.physical.sparkcore.fs
 
 import quasar.Predef._
+import quasar.common.SortDir
 import quasar.console
 import quasar.qscript.QScriptHelpers
 import quasar.qscript._

--- a/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/PlannerSpec.scala
+++ b/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/PlannerSpec.scala
@@ -137,7 +137,7 @@ class PlannerSpec extends quasar.Qspec with QScriptHelpers with DisjunctionMatch
           val src: RDD[Data] = sc.parallelize(data)
 
           def bucket = ProjectFieldR(HoleF, StrLit("country"))
-          def order = List((bucket, SortDir.Ascending))
+          def order = (bucket, SortDir.asc).wrapNel
           val sort = quasar.qscript.Sort(src, bucket, order)
 
           val state: SparkState[RDD[Data]] = ψ(sort)

--- a/sql/src/main/scala/quasar/sql/compiler.scala
+++ b/sql/src/main/scala/quasar/sql/compiler.scala
@@ -21,6 +21,7 @@ import quasar.{BinaryFunc, Data, Func, GenericFunc, Reduction, SemanticError, Si
   SemanticError._
 import quasar.contrib.pathy._
 import quasar.contrib.shapeless._
+import quasar.common.SortDir
 import quasar.fp._
 import quasar.fp.ski._
 import quasar.fp.binder._
@@ -446,11 +447,11 @@ trait Compiler[F[_]] {
                         stepBuilder(squashed.some) {
                           val sort = orderBy.map(orderBy =>
                             (CompilerState.rootTableReq ⊛
-                              CompilerState.addFields(names.foldMap(_.toList))(orderBy.keys.traverse { case (_, key) => compile0(key) }))((t, keys) =>
-                              Fix(set.OrderBy(
-                                t,
-                                Fix(structural.MakeArrayN(keys: _*)),
-                                Fix(structural.MakeArrayN(orderBy.keys.map { case (order, _) => lpr.constant(Data.Str(order.shows)) }: _*))))))
+                              CompilerState.addFields(names.foldMap(_.toList))(orderBy.keys.traverse { case (ot, key) => compile0(key) strengthR ot }))((t, ks) =>
+                              lpr.sort(t, ks map {
+                                case (k, ASC ) => (k, SortDir.Ascending)
+                                case (k, DESC) => (k, SortDir.Descending)
+                              })))
 
                           stepBuilder(sort) {
                             val distincted = isDistinct match {

--- a/sql/src/main/scala/quasar/sql/semantics.scala
+++ b/sql/src/main/scala/quasar/sql/semantics.scala
@@ -80,7 +80,7 @@ object SemanticAnalysis {
           } (
             kExpr => (projs, (orderType, kExpr) :: keys, index))
       }
-      select(d, projections ⊹ projs2, r, f, g, OrderBy(keys2).some).some
+      select(d, projections ⊹ projs2, r, f, g, keys2.toNel map (OrderBy(_))).some
     }
     case _ => None
   }

--- a/sql/src/test/scala/quasar/sql/semantics.scala
+++ b/sql/src/test/scala/quasar/sql/semantics.scala
@@ -23,11 +23,13 @@ import quasar.sql.fixpoint._
 
 import matryoshka._, FunctorT.ops._
 import pathy.Path._
+import scalaz._, Scalaz._
 
 class SemanticsSpec extends quasar.Qspec with TreeMatchers {
 
   "TransformSelect" should {
     val compiler = Compiler.trampoline
+    val asc: OrderType = ASC
 
     def transform[T[_[_]]: Recursive: Corecursive](q: T[Sql]): T[Sql] =
       q.transCata(orOriginal(projectSortKeysƒ))
@@ -38,14 +40,14 @@ class SemanticsSpec extends quasar.Qspec with TreeMatchers {
                      Some(TableRelationAST(file("person"), None)),
                      None,
                      None,
-                     Some(OrderBy((ASC, IdentR("height")) :: Nil)))
+                     Some(OrderBy((asc, IdentR("height")).wrapNel)))
       transform(q) must beTree(
                SelectR(SelectAll,
                       Proj(IdentR("name"), None) :: Proj(IdentR("height"), Some("__sd__0")) :: Nil,
                       Some(TableRelationAST(file("person"), None)),
                       None,
                       None,
-                      Some(OrderBy((ASC, IdentR("__sd__0")) :: Nil)))
+                      Some(OrderBy((asc, IdentR("__sd__0")).wrapNel)))
                )
     }
 
@@ -55,7 +57,7 @@ class SemanticsSpec extends quasar.Qspec with TreeMatchers {
                      Some(TableRelationAST(file("person"), None)),
                      None,
                      None,
-                     Some(OrderBy((ASC, IdentR("name")) :: Nil)))
+                     Some(OrderBy((asc, IdentR("name")).wrapNel)))
       transform(q) must beTree(q)
     }
 
@@ -65,7 +67,7 @@ class SemanticsSpec extends quasar.Qspec with TreeMatchers {
                      Some(TableRelationAST(file("person"), None)),
                      None,
                      None,
-                     Some(OrderBy((ASC, IdentR("name")) :: Nil)))
+                     Some(OrderBy((asc, IdentR("name")).wrapNel)))
       transform(q) must beTree(q)
     }
 
@@ -75,7 +77,7 @@ class SemanticsSpec extends quasar.Qspec with TreeMatchers {
                      Some(TableRelationAST(file("person"), None)),
                      None,
                      None,
-                     Some(OrderBy((ASC, IdentR("height")) :: Nil)))
+                     Some(OrderBy((asc, IdentR("height")).wrapNel)))
       transform(q) must beTree(q)
     }
 
@@ -85,9 +87,9 @@ class SemanticsSpec extends quasar.Qspec with TreeMatchers {
                      Some(TableRelationAST(file("person"), None)),
                      None,
                      None,
-                     Some(OrderBy((ASC, IdentR("height")) ::
-                                  (ASC, IdentR("name")) ::
-                                  Nil)))
+                     Some(OrderBy(NonEmptyList(
+                       (asc, IdentR("height")),
+                       (asc, IdentR("name"))))))
       transform(q) must beTree(
                SelectR(SelectAll,
                       Proj(IdentR("name"), None) ::
@@ -96,9 +98,9 @@ class SemanticsSpec extends quasar.Qspec with TreeMatchers {
                       Some(TableRelationAST(file("person"), None)),
                       None,
                       None,
-                      Some(OrderBy((ASC, IdentR("__sd__0")) ::
-                                   (ASC, IdentR("name")) ::
-                                   Nil))))
+                      Some(OrderBy(NonEmptyList(
+                        (asc, IdentR("__sd__0")),
+                        (asc, IdentR("name")))))))
     }
 
     "transform sub-select" in {
@@ -113,7 +115,7 @@ class SemanticsSpec extends quasar.Qspec with TreeMatchers {
                                 Some(TableRelationAST(file("bar"), None)),
                                 None,
                                 None,
-                                Some(OrderBy((ASC, IdentR("b")) :: Nil))),
+                                Some(OrderBy((asc, IdentR("b")).wrapNel))),
                          In)),
                      None,
                      None)
@@ -131,7 +133,7 @@ class SemanticsSpec extends quasar.Qspec with TreeMatchers {
                                 Some(TableRelationAST(file("bar"), None)),
                                 None,
                                 None,
-                                Some(OrderBy((ASC, IdentR("__sd__0")) :: Nil))),
+                                Some(OrderBy((asc, IdentR("__sd__0")).wrapNel))),
                          In)),
                      None,
                      None))


### PR DESCRIPTION
Replaces the `set.OrderBy` function with a new `Sort` node in `LogicalPlan` making sort planning much more straightforward.

Also swaps in `NonEmptyList` everywhere for the set of orderings, from `SQL^2` on down.

Fixes #1693.
Fixes #1694.