### PR TITLE
[1706] Make an array when a projection results in multiple items.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- [1706] Make an array when a projection results in multiple items.

--- a/it/src/test/scala/quasar/physical/marklogic/xquery/EJsonLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/marklogic/xquery/EJsonLibSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.marklogic.xquery
+
+import quasar.Predef._
+import quasar.{Data, TestConfig}
+import quasar.physical.marklogic.ErrorMessages
+import quasar.physical.marklogic.xcc._
+import quasar.physical.marklogic.fs._
+import quasar.physical.marklogic.xquery.syntax._
+
+import com.marklogic.xcc.ContentSource
+import scalaz._, Scalaz._
+
+final class EJsonLibSpec extends quasar.Qspec {
+  type M[A] = Writer[Prologs, A]
+
+  def evaluateXQuery(xqy: M[XQuery], cs: ContentSource): ErrorMessages \/ Data = {
+    val (prologs, body) = xqy.run
+
+    val result = for {
+      qr <- SessionIO.evaluateModule_(MainModule(Version.`1.0-ml`, prologs, body))
+      rs <- SessionIO.liftT(qr.toImmutableArray)
+      xi =  rs.headOption \/> "No results found.".wrapNel
+    } yield xi >>= xdmitem.toData[ErrorMessages \/ ?] _
+
+    (ContentSourceIO.runNT(cs) compose ContentSourceIO.runSessionIO)
+      .apply(result)
+      .unsafePerformSync
+  }
+
+  TestConfig.fileSystemConfigs(FsType).flatMap(_ traverse_ { case (backend, uri, _) =>
+    contentSourceAt(uri).map { cs =>
+      val eval: M[XQuery] => ErrorMessages \/ Data = evaluateXQuery(_, cs)
+      s"XQuery EJSON Library (${backend.name})" >> {
+        "many-to-array" >> {
+          "passes through empty seq" >> {
+            eval(ejson.manyToArray[M] apply expr.emptySeq).toOption must beNone
+          }
+
+          "passes through single item" >> {
+            eval(ejson.manyToArray[M] apply "foo".xs) must_= Data._str("foo").right
+          }
+
+          "returns array for more than one item" >> {
+            val three = mkSeq_("foo".xs, "bar".xs, "baz".xs)
+            eval(ejson.manyToArray[M] apply three) must_= Data._arr(List(
+              Data._str("foo"),
+              Data._str("bar"),
+              Data._str("baz")
+            )).right
+          }
+        }
+      }
+    }.void
+  }).unsafePerformSync
+}

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MapFuncPlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MapFuncPlanner.scala
@@ -135,7 +135,7 @@ object MapFuncPlanner {
     case ProjectIndex(arr, idx)       => ejson.arrayElementAt[F] apply (arr, idx + 1.xqy)
 
     case ProjectField(src, field)     =>
-      field match {
+      val prj = field match {
         case XQuery.Step(_) =>
           (src `/` field).point[F]
 
@@ -148,6 +148,8 @@ object MapFuncPlanner {
 
         case _ => qscript.projectField[F] apply (src, xs.QName(field))
       }
+
+      prj flatMap (ejson.manyToArray[F] apply _)
 
     case DeleteField(src, field)      =>
       qscript.deleteField[F] apply (src, field)

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/ejson.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/ejson.scala
@@ -125,6 +125,16 @@ object ejson {
       ) default fn.False
     })
 
+  // ejson:many-to-array($items as item()*) as item()*
+  def manyToArray[F[_]: PrologW]: F[FunctionDecl1] =
+    ejs.declare("many-to-array") flatMap (_(
+      $("items") as ST.Top
+    ).as(ST.Top) { items: XQuery =>
+      seqToArray_[F](items) map { arr =>
+        if_(fn.count(items) gt 1.xqy) then_ arr else_ items
+      }
+    })
+
   // ejson:make-array($name as xs:QName, $elements as element(ejson:array-element)*) as element()
   def mkArray[F[_]: PrologW]: F[FunctionDecl2] =
     (ejs.name("make-array").qn[F] |@| arrayEltN.qn |@| typeAttrN.xs) { (fname, aelt, tpexs) =>


### PR DESCRIPTION
It is common in XML for an element to have multiple child elements with the same name, when such an element is projected in a query the result should be an array of all the matching elements. This adds support to the MarkLogic planner to support this behavior.

Fixes #1706.