### PR TITLE
Skip failing couchbase integration test.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- Skip failing integration test in couchbase.

--- a/it/src/main/resources/tests/filterOnFieldComparison.test
+++ b/it/src/main/resources/tests/filterOnFieldComparison.test
@@ -6,6 +6,7 @@
         "mongodb_read_only": "pending",
         "mongodb_3_2":       "pending",
         "postgresql":        "pending",
+        "couchbase":         "skip",
         "marklogic":         "skip"
     },
     "data": "zips.data",


### PR DESCRIPTION
This test is failing somewhat consistently. It's filed in issue #1752 