### PR TITLE
[1717] Add a META function providing access to any metadata associated with a value

### DIFF
--- a/CHANGELOG/feature.md
+++ b/CHANGELOG/feature.md
@@ -1,0 +1,3 @@
+- [1717] Add a META function for accessing metadata associated with a value
+  - [1701] Implement for MarkLogic which returns attributes of XML elements.
+  - Implement for Couchbase using the meta() function.

--- a/connector/src/main/scala/quasar/qscript/MapFunc.scala
+++ b/connector/src/main/scala/quasar/qscript/MapFunc.scala
@@ -344,6 +344,7 @@ object MapFunc {
         case Null(a1) => f(a1) ∘ (Null(_))
         case ToString(a1) => f(a1) ∘ (ToString(_))
         case MakeArray(a1) => f(a1) ∘ (MakeArray(_))
+        case Meta(a1) => f(a1) ∘ (Meta(_))
 
         // binary
         case Add(a1, a2) => (f(a1) ⊛ f(a2))(Add(_, _))
@@ -426,6 +427,7 @@ object MapFunc {
         case (Null(a1), Null(b1)) => in.equal(a1, b1)
         case (ToString(a1), ToString(b1)) => in.equal(a1, b1)
         case (MakeArray(a1), MakeArray(b1)) => in.equal(a1, b1)
+        case (Meta(a1), Meta(b1)) => in.equal(a1, b1)
 
         case (Add(a1, a2), Add(b1, b2)) => in.equal(a1, b1) && in.equal(a2, b2)
         case (Multiply(a1, a2), Multiply(b1, b2)) => in.equal(a1, b1) && in.equal(a2, b2)
@@ -513,6 +515,7 @@ object MapFunc {
           case Null(a1) => shz("Null", a1)
           case ToString(a1) => shz("ToString", a1)
           case MakeArray(a1) => shz("MakeArray", a1)
+          case Meta(a1) => shz("Meta", a1)
 
           // binary
           case Add(a1, a2) => shz("Add", a1, a2)
@@ -610,6 +613,7 @@ object MapFunc {
           case Null(a1) => nAry("Null", a1)
           case ToString(a1) => nAry("ToString", a1)
           case MakeArray(a1) => nAry("MakeArray", a1)
+          case Meta(a1) => nAry("Meta", a1)
 
           // binary
           case Add(a1, a2) => nAry("Add", a1, a2)
@@ -687,6 +691,7 @@ object MapFunc {
       case string.Null => Null(_)
       case string.ToString => ToString(_)
       case structural.MakeArray => MakeArray(_)
+      case structural.Meta => Meta(_)
     }
   }
 
@@ -846,6 +851,7 @@ object MapFuncs {
     def a1 = src
     def a2 = field
   }
+  @Lenses final case class Meta[T[_[_]], A](a1: A) extends Unary[T, A]
 
   @Lenses final case class Range[T[_[_]], A](from: A, to: A) extends Binary[T, A] {
     def a1 = from

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/MapFuncPlanner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/MapFuncPlanner.scala
@@ -454,6 +454,9 @@ final class MapFuncPlanner[F[_]: Monad: NameGenerator, T[_[_]]: Recursive: ShowT
     case DeleteField(a1, a2)                      =>
       partialQueryString(s"object_remove(${n1ql(a1)}, ${n1ql(a2)})").point[M]
 
+    case Meta(a1) =>
+      partialQueryString(s"meta(${n1ql(a1)})").point[M]
+
     // helpers & QScript-specific
     case Range(a1, a2)             =>
       val a1N1ql = n1ql(a1)

--- a/frontend/src/main/scala/quasar/std/structural.scala
+++ b/frontend/src/main/scala/quasar/std/structural.scala
@@ -72,6 +72,19 @@ trait StructuralLib extends Library {
       case FlexArr(_, _, elemType)     => Func.Input1(elemType)
     })
 
+  val Meta = UnaryFunc(
+    Mapping,
+    "Returns the metadata associated with a value.",
+    Top,
+    Func.Input1(Top),
+    noSimplification,
+    {
+      // TODO: This should actually result in metadata when we switch to EJson.
+      case Sized(Const(_)) => success(Const(Data.NA))
+      case _               => success(Top)
+    },
+    basicUntyper[nat._1])
+
   val ObjectConcat: BinaryFunc = BinaryFunc(
     Mapping,
     "A right-biased merge of two objects into one object",

--- a/frontend/src/test/scala/quasar/std/StdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/StdLibSpec.scala
@@ -1035,6 +1035,11 @@ abstract class StdLibSpec extends Qspec {
           binary(ConcatOp(_, _).embed, Data._str(x), Data._str(y), Data._str(x + y))
         }
       }
+
+      "Meta" >> {
+        // FIXME: Implement once we've switched to EJson in LogicalPlan.
+        "returns metadata associated with a value" >> skipped("Requires EJson.")
+      }
     }
   }
 }

--- a/it/src/test/scala/quasar/physical/marklogic/xquery/QScriptLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/marklogic/xquery/QScriptLibSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.marklogic.xquery
+
+import quasar.Predef._
+import quasar.Data
+import quasar.physical.marklogic.xquery.syntax._
+
+import scalaz._
+
+final class QScriptLibSpec extends XQuerySpec {
+  import expr.{attribute, element}
+
+  xquerySpec(bn => s"XQuery QScript Library (${bn.name})") { eval =>
+    "meta" >> {
+      "returns element attributes as an element" >> {
+        val order = element("order".xs)(mkSeq_(
+          attribute("orderId".xs)(2345.xqy),
+          attribute("quantity".xs)(23.xqy),
+          "Wibble Wabble".xs
+        ))
+        eval(qscript.meta[M] apply order) must resultIn(Data.Obj(
+          "orderId"  -> Data._str("2345"),
+          "quantity" -> Data._str("23")
+        ))
+      }
+
+      "returns empty seq when not an element" >> {
+        eval(qscript.meta[M] apply "foobar".xs).toOption must beNone
+      }
+    }
+  }
+}

--- a/it/src/test/scala/quasar/physical/marklogic/xquery/XQuerySpec.scala
+++ b/it/src/test/scala/quasar/physical/marklogic/xquery/XQuerySpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.marklogic.xquery
+
+import quasar.Predef._
+import quasar.{BackendName, Data, TestConfig}
+import quasar.physical.marklogic.ErrorMessages
+import quasar.physical.marklogic.xcc._
+import quasar.physical.marklogic.fs._
+
+import com.marklogic.xcc.ContentSource
+import org.specs2.specification.core.Fragment
+import scalaz._, Scalaz._
+
+/** A base class for tests of XQuery expressions/functions. */
+abstract class XQuerySpec extends quasar.Qspec {
+  type M[A] = Writer[Prologs, A]
+
+  /** Convenience function for expecting results, i.e. xqy must resultIn(Data._str("foo")). */
+  def resultIn(expected: Data) = equal(expected.right[ErrorMessages])
+
+  def xquerySpec(desc: BackendName => String)(tests: (M[XQuery] => ErrorMessages \/ Data) => Fragment): Unit =
+    TestConfig.fileSystemConfigs(FsType).flatMap(_ traverse_ { case (backend, uri, _) =>
+      contentSourceAt(uri).map(cs => desc(backend) >> tests(evaluateXQuery(cs, _))).void
+    }).unsafePerformSync
+
+  ////
+
+  private def evaluateXQuery(cs: ContentSource, xqy: M[XQuery]): ErrorMessages \/ Data = {
+    val (prologs, body) = xqy.run
+
+    val result = for {
+      qr <- SessionIO.evaluateModule_(MainModule(Version.`1.0-ml`, prologs, body))
+      rs <- SessionIO.liftT(qr.toImmutableArray)
+      xi =  rs.headOption \/> "No results found.".wrapNel
+    } yield xi >>= xdmitem.toData[ErrorMessages \/ ?] _
+
+    (ContentSourceIO.runNT(cs) compose ContentSourceIO.runSessionIO)
+      .apply(result)
+      .unsafePerformSync
+  }
+}

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MapFuncPlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MapFuncPlanner.scala
@@ -151,8 +151,8 @@ object MapFuncPlanner {
 
       prj flatMap (ejson.manyToArray[F] apply _)
 
-    case DeleteField(src, field)      =>
-      qscript.deleteField[F] apply (src, field)
+    case DeleteField(src, field)      => qscript.deleteField[F] apply (src, field)
+    case Meta(x)                      => qscript.meta[F] apply x
 
     // other
     case Range(x, y)                  => (x to y).point[F]

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/ejson.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/ejson.scala
@@ -75,6 +75,19 @@ object ejson {
       }
     }
 
+  // ejson:attributes($elt as element()) as element()
+  def attributes[F[_]: PrologW]: F[FunctionDecl1] =
+    ejs.declare("attributes") flatMap (_(
+      $("elt") as ST("element()")
+    ).as(ST("element()")) { (elt: XQuery) =>
+      val a       = $("a")
+      val entries = renameOrWrap[F] apply (fn.nodeName(~a), fn.data(~a)) map { entry =>
+                      fn.map(func(a.render)(entry), elt `/` axes.attribute.*)
+                    }
+
+      entries flatMap (mkObject[F] apply _)
+    })
+
   // ejson:cast-as-ascribed($item as item()?) as item()?
   def castAsAscribed[F[_]: PrologW]: F[FunctionDecl1] =
     ejs.declare("cast-as-ascribed") flatMap (_(

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/fn.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/fn.scala
@@ -49,6 +49,9 @@ object fn {
   def distinctValues(seq: XQuery): XQuery =
     XQuery(s"fn:distinct-values($seq)")
 
+  def data(item: XQuery): XQuery =
+    XQuery(s"fn:data($item)")
+
   def doc(): XQuery =
     XQuery("fn:doc()")
 

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/qscript.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/qscript.scala
@@ -259,6 +259,15 @@ object qscript {
       }
     }
 
+  // qscript:meta($item as item()?) as element()?
+  def meta[F[_]: PrologW]: F[FunctionDecl1] =
+    qs.declare("meta") flatMap (_(
+      $("item") as ST("item()?")
+    ).as(ST("element()?")) { item: XQuery =>
+      val eltClause = $("e") as ST("element()") return_ (ejson.attributes[F] apply _)
+      eltClause map (ec => typeswitch(item)(ec) default emptySeq)
+    })
+
   // qscript:project-field($src as element()?, $field as xs:QName?) as item()*
   def projectField[F[_]: PrologW]: F[FunctionDecl2] =
     qs.declare("project-field") map (_(

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/FuncHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/FuncHandler.scala
@@ -32,7 +32,7 @@ final case class FuncHandler[T[_[_]], F[_]](run: MapFunc[T, ?] ~> λ[α => Optio
     new FuncHandler[T, H](λ[MapFunc[T, ?] ~> λ[α => Option[Free[H, α]]]](f =>
       self.run(f).map(_.mapSuspension(injF)) orElse
       other.run(f).map(_.mapSuspension(injG))))
-    }
+}
 
 object FuncHandler {
   type M[F[_], A] = Option[Free[F, A]]

--- a/sql/src/main/scala/quasar/sql/compiler.scala
+++ b/sql/src/main/scala/quasar/sql/compiler.scala
@@ -251,7 +251,8 @@ trait Compiler[F[_]] {
       "flatten_map"             -> structural.FlattenMap,
       "flatten_array"           -> structural.FlattenArray,
       "shift_map"               -> structural.ShiftMap,
-      "shift_array"             -> structural.ShiftArray)
+      "shift_array"             -> structural.ShiftArray,
+      "meta"                    -> structural.Meta)
 
     def compileCases(cases: List[Case[CoExpr]], default: Fix[LP])(f: Case[CoExpr] => CompilerM[(Fix[LP], Fix[LP])]) =
       cases.traverse(f).map(_.foldRight(default) {


### PR DESCRIPTION
The `META` function returns any metadata associated with the argument or `Undefined` otherwise.

Implementations for Couchbase (via the `meta()` function) and MarkLogic are included, MongoDB and Spark didn't seem to have an obvious (to me) implementation (@sellout @rabbitonweb feel free to suggest one).

I've added tests for the MarkLogic implementation but testing this in general via `StdLibSpec` requires `EJson` in `LogicalPlan` as we don't have a way to represent metadata in our `Data` type.

Closes #1717.
Closes #1701.