### PR TITLE
[1759] Executing a query should overwrite an existing file in MarkLogic

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+[1759] Executing a query should overwrite an existing file in MarkLogic

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ For compressed output use `Accept-Encoding: gzip`.
 
 Executes a SQL² query, contained in the request body, on the backend responsible for the request path.
 
-The `Destination` header must specify the *output path*, where the results of the query will become available if this API successfully completes.
+The `Destination` header must specify the *output path*, where the results of the query will become available if this API successfully completes. If the output path already exists, it will be overwritten with the query results.
 
 All paths referenced in the query, as well as the output path, are interpreted as relative to the request path, unless they begin with `/`.
 

--- a/connector/src/main/scala/quasar/fs/QueryFile.scala
+++ b/connector/src/main/scala/quasar/fs/QueryFile.scala
@@ -174,8 +174,9 @@ object QueryFile {
     }
   }
 
-  /** The result of the query is stored in an output file
-    * instead of being returned to the user immediately.
+  /** The result of the query is stored in an output file, overwriting any existing
+    * contents, instead of being returned to the user immediately.
+    *
     * The `LogicalPlan` is expected to only contain absolute paths even though
     * that is unfortunately not expressed in the types currently.
     */
@@ -244,6 +245,9 @@ object QueryFile {
 
     /** Returns the path to the result of executing the given `LogicalPlan`,
       * using the provided path if possible.
+      *
+      * If the given file path exists, it will be overwritten with the results
+      * from the query.
       *
       * Execution of certain plans may return a result file other than the
       * requested file if it is more efficient to do so (i.e. to avoid copying

--- a/couchbase/src/main/scala/quasar/physical/couchbase/common.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/common.scala
@@ -54,6 +54,14 @@ object common {
 
   val CBDataCodec = DataCodec.Precise
 
+  def deleteHavingPrefix(
+    bucket: Bucket,
+    prefix: String
+  ): Task[Unit] = {
+    val qStr = s"""DELETE FROM `${bucket.name}` WHERE type LIKE "${prefix}%""""
+    Task.delay(bucket.query(n1qlQuery(qStr))).void
+  }
+
   def docTypesFromPrefix(
     bucket: Bucket,
     prefix: String

--- a/couchbase/src/main/scala/quasar/physical/couchbase/fs/managefile.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/fs/managefile.scala
@@ -97,11 +97,7 @@ object managefile {
                      if (!docsExist) FileSystemError.pathErr(PathError.pathNotFound(path)).left
                      else ().right
                    ).point[Free[S, ?]])
-      qStr      =  s"""delete from `${bktCol.bucket}`
-                       where type like "${bktCol.collection}%""""
-      _         <- lift(Task.delay(
-                     bkt.query(n1qlQuery(qStr))
-                   )).into.liftM[FileSystemErrT]
+      _         <- lift(deleteHavingPrefix(bkt, bktCol.collection)).into[S].liftM[FileSystemErrT]
     } yield ()).run
 
   def tempFile[S[_]](

--- a/couchbase/src/main/scala/quasar/physical/couchbase/fs/queryfile.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/fs/queryfile.scala
@@ -110,6 +110,8 @@ object queryfile {
       bkt    <- lift(Task.delay(
                   ctx.cluster.openBucket(bktCol.bucket)
                 )).into.liftP
+      exists <- lift(existsWithPrefix(bkt, bktCol.collection)).into[S].liftP
+      _      <- lift(exists.whenM(deleteHavingPrefix(bkt, bktCol.collection))).into[S].liftP
       _      <- lift(docs.nonEmpty.whenM(Task.delay(
                   Observable
                     .from(docs)

--- a/it/src/test/scala/quasar/BackendCapability.scala
+++ b/it/src/test/scala/quasar/BackendCapability.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar
+
+import quasar.Predef.Unit
+import quasar.fp.ski.κ
+
+import monocle.Prism
+import scalaz._
+import scalaz.std.anyVal._
+
+sealed abstract class BackendCapability
+
+object BackendCapability {
+  case object Query extends BackendCapability
+  case object Write extends BackendCapability
+
+  lazy val All = ISet.fromFoldable(IList[BackendCapability](Query, Write))
+
+  val query = Prism.partial[BackendCapability, Unit] {
+    case Query => ()
+  } (κ(Query))
+
+  val write = Prism.partial[BackendCapability, Unit] {
+    case Write => ()
+  } (κ(Write))
+
+  implicit val order: Order[BackendCapability] =
+    Order.orderBy {
+      case Query => 0
+      case Write => 1
+    }
+
+  implicit val show: Show[BackendCapability] =
+    Show.showFromToString
+}

--- a/it/src/test/scala/quasar/BackendRef.scala
+++ b/it/src/test/scala/quasar/BackendRef.scala
@@ -16,17 +16,21 @@
 
 package quasar
 
-import quasar.Predef._
+import quasar.Predef.Boolean
 
+import monocle.macros.Lenses
 import scalaz._
-import scalaz.std.string._
+import scalaz.std.tuple._
 
-final case class BackendName(name: String) extends scala.AnyVal
+@Lenses
+final case class BackendRef(name: BackendName, capabilities: ISet[BackendCapability]) {
+  def supports(bc: BackendCapability): Boolean = capabilities member bc
+}
 
-object BackendName {
-  implicit val order: Order[BackendName] =
-    Order.orderBy(_.name)
+object BackendRef {
+  implicit val order: Order[BackendRef] =
+    Order.orderBy(r => (r.name, r.capabilities))
 
-  implicit val show: Show[BackendName] =
-    Show.shows(_.name)
+  implicit val show: Show[BackendRef] =
+    Show.showFromToString
 }

--- a/it/src/test/scala/quasar/ResultFileQueryRegressionSpec.scala
+++ b/it/src/test/scala/quasar/ResultFileQueryRegressionSpec.scala
@@ -29,8 +29,11 @@ import scalaz.stream.Process
 
 class ResultFileQueryRegressionSpec
   extends QueryRegressionTest[FileSystemIO](
-    QueryRegressionTest.externalFS.map(_.filterNot(fs =>
-      TestConfig.isMongoReadOnly(fs.name) || TestConfig.isCouchbase(fs.name)))
+    QueryRegressionTest.externalFS.map(_.filter(fs =>
+      fs.supports(BackendCapability.query()) &&
+      fs.supports(BackendCapability.write()) &&
+      // NB: These are prohibitively slow on Couchbase
+      !TestConfig.isCouchbase(fs.ref)))
   ) {
 
   val read = ReadFile.Ops[FileSystemIO]

--- a/it/src/test/scala/quasar/StreamingQueryRegressionSpec.scala
+++ b/it/src/test/scala/quasar/StreamingQueryRegressionSpec.scala
@@ -26,7 +26,9 @@ import eu.timepit.refined.auto._
 import matryoshka.Fix
 
 class StreamingQueryRegressionSpec
-  extends QueryRegressionTest[FileSystemIO](QueryRegressionTest.externalFS) {
+  extends QueryRegressionTest[FileSystemIO](
+    QueryRegressionTest.externalFS.map(_.filter(
+      _.supports(BackendCapability.query())))) {
 
   val suiteName = "Streaming Queries"
 

--- a/it/src/test/scala/quasar/TestConfig.scala
+++ b/it/src/test/scala/quasar/TestConfig.scala
@@ -40,18 +40,18 @@ object TestConfig {
   val TestPathPrefixEnvName = "QUASAR_TEST_PATH_PREFIX"
 
   /** External Backends. */
-  val MONGO_2_6       = BackendName("mongodb_2_6")
-  val MONGO_3_0       = BackendName("mongodb_3_0")
-  val MONGO_3_2       = BackendName("mongodb_3_2")
-  val MONGO_READ_ONLY = BackendName("mongodb_read_only")
-  val SKELETON        = BackendName("skeleton")
-  val POSTGRESQL      = BackendName("postgresql")
-  val SPARK_LOCAL     = BackendName("spark_local")
-  val SPARK_HDFS      = BackendName("spark_hdfs")
-  val MARKLOGIC       = BackendName("marklogic")
-  val COUCHBASE       = BackendName("couchbase")
+  val MONGO_2_6       = BackendRef(BackendName("mongodb_2_6")      , BackendCapability.All)
+  val MONGO_3_0       = BackendRef(BackendName("mongodb_3_0")      , BackendCapability.All)
+  val MONGO_3_2       = BackendRef(BackendName("mongodb_3_2")      , BackendCapability.All)
+  val MONGO_READ_ONLY = BackendRef(BackendName("mongodb_read_only"), ISet singleton BackendCapability.query())
+  val SKELETON        = BackendRef(BackendName("skeleton")         , ISet.empty)
+  val POSTGRESQL      = BackendRef(BackendName("postgresql")       , ISet singleton BackendCapability.write())
+  val SPARK_LOCAL     = BackendRef(BackendName("spark_local")      , BackendCapability.All)
+  val SPARK_HDFS      = BackendRef(BackendName("spark_hdfs")       , BackendCapability.All)
+  val MARKLOGIC       = BackendRef(BackendName("marklogic")        , BackendCapability.All)
+  val COUCHBASE       = BackendRef(BackendName("couchbase")        , BackendCapability.All)
 
-  lazy val backendNames: List[BackendName] = List(
+  lazy val backendRefs: List[BackendRef] = List(
     MONGO_2_6      ,
     MONGO_3_0      ,
     MONGO_3_2      ,
@@ -66,16 +66,10 @@ object TestConfig {
   final case class UnsupportedFileSystemConfig(c: MountConfig)
     extends RuntimeException(s"Unsupported filesystem config: $c")
 
-  /** True if this backend configuration is for a mongo connection where the
-    * user has the "read-only" role.
-    */
-  def isMongoReadOnly(backendName: BackendName): Boolean =
-    backendName == MONGO_READ_ONLY
-
   /** True if this backend configuration is for a couchbase connection.
     */
-  def isCouchbase(backendName: BackendName): Boolean =
-    backendName == COUCHBASE
+  def isCouchbase(backendRef: BackendRef): Boolean =
+    backendRef === COUCHBASE
 
   /** Returns the name of the environment variable used to configure the
     * given backend.
@@ -103,7 +97,7 @@ object TestConfig {
           Task.delay(_),
           Task.fail(new UnsupportedFileSystemConfig(c))))
 
-    def fileSystemNamed(n: BackendName, p: ADir): OptionT[Task, FileSystemUT[S]] = {
+    def lookupFileSystem(r: BackendRef, p: ADir): OptionT[Task, FileSystemUT[S]] = {
       def rsrc(connect: Task[(S ~> Task, Task[Unit])]): Task[TaskResource[(S ~> Task, Task[Unit])]] =
         TaskResource(connect, Strategy.DefaultStrategy)(_._2)
 
@@ -114,12 +108,12 @@ object TestConfig {
       }
 
       for {
-        test     <- fs(backendEnvName(n), p)
-        setup    <- fs(insertEnvName(n), p).run.liftM[OptionT]
+        test     <- fs(backendEnvName(r.name), p)
+        setup    <- fs(insertEnvName(r.name), p).run.liftM[OptionT]
         s        <- NameGenerator.salt.liftM[OptionT]
         testRef  <- rsrc(test).liftM[OptionT]
         setupRef <- setup.cata(rsrc, Task.now(testRef)).liftM[OptionT]
-      } yield FileSystemUT(n,
+      } yield FileSystemUT(r,
           embed(testRef.get.map(_._1)),
           embed(setupRef.get.map(_._1)),
           p </> dir("run_" + s),
@@ -128,21 +122,21 @@ object TestConfig {
 
     def noBackendsFound: Throwable = new RuntimeException(
       "No external backends to test. Consider setting one of these environment variables: " +
-      TestConfig.backendNames.map(TestConfig.backendEnvName).mkString(", ")
+      TestConfig.backendRefs.map(r => TestConfig.backendEnvName(r.name)).mkString(", ")
     )
 
     TestConfig.testDataPrefix flatMap { prefix =>
-      TestConfig.backendNames.toIList
-        .traverse(n => fileSystemNamed(n, prefix).run)
+      TestConfig.backendRefs.toIList
+        .traverse(r => lookupFileSystem(r, prefix).run)
         .map(_.unite)
         .flatMap(uts => if (uts.isEmpty) Task.fail(noBackendsFound) else Task.now(uts))
     }
   }
 
   /** Loads all the configurations for a particular type of FileSystem. */
-  def fileSystemConfigs(tpe: FileSystemType): Task[List[(BackendName, ConnectionUri, ConnectionUri)]] =
-    backendNames.foldMapM(n => TestConfig.loadConfigPair(n).run map (_.toList collect {
-      case (FileSystemConfig(`tpe`, testUri), FileSystemConfig(`tpe`, setupUri)) => (n, testUri, setupUri)
+  def fileSystemConfigs(tpe: FileSystemType): Task[List[(BackendRef, ConnectionUri, ConnectionUri)]] =
+    backendRefs.foldMapM(r => TestConfig.loadConfigPair(r.name).run map (_.toList collect {
+      case (FileSystemConfig(`tpe`, testUri), FileSystemConfig(`tpe`, setupUri)) => (r, testUri, setupUri)
     }))
 
   /** Load backend config from environment variable.

--- a/it/src/test/scala/quasar/fs/FileSystemTest.scala
+++ b/it/src/test/scala/quasar/fs/FileSystemTest.scala
@@ -68,6 +68,17 @@ abstract class FileSystemTest[S[_]](
       ()
     }).unsafePerformSync
 
+  /** Returns the given result if the backend is external or `Skipped` otherwise.
+    *
+    * TODO: This exists primarily to be able to skip tests that query on the
+    *       rudimentary "In-Memory" filesystem. Once we have a proper in-memory
+    *       evaluator that is expected to execute arbitrary queries, this should
+    *       be removed.
+    */
+  def externalOnly[A: AsResult](name: BackendName)(a: => A): Result =
+    if (TestConfig.backendNames element name) AsResult(a)
+    else skipped("External filesystems only.")
+
   def runT(run: Run): FileSystemErrT[F, ?] ~> FsTask =
     Hoist[FileSystemErrT].hoist(run)
 

--- a/it/src/test/scala/quasar/fs/FileSystemUT.scala
+++ b/it/src/test/scala/quasar/fs/FileSystemUT.scala
@@ -17,7 +17,7 @@
 package quasar.fs
 
 import quasar.Predef._
-import quasar.BackendName
+import quasar.{BackendCapability, BackendRef}
 import quasar.contrib.pathy._
 import quasar.fp.free, free._
 
@@ -26,7 +26,7 @@ import scalaz.concurrent.Task
 
 /** FileSystem Under Test
   *
-  * @param name the name of the filesystem
+  * @param ref description of the filesystem
   * @param testInterp an interpreter of the filesystem into the `Task` monad
   * @param setupInterp a second interpreter which has the ability to insert
   *   and otherwise write to the filesystem, even if `testInterp` does not
@@ -36,7 +36,7 @@ import scalaz.concurrent.Task
   *   ever run, but it's safe to call it either way.
   */
 final case class FileSystemUT[S[_]](
-  name:        BackendName,
+  ref:         BackendRef,
   testInterp:  S ~> Task,
   setupInterp: S ~> Task,
   testDir:     ADir,
@@ -45,20 +45,23 @@ final case class FileSystemUT[S[_]](
 
   type F[A] = Free[S, A]
 
-  def liftIO[A]: FileSystemUT[Coproduct[Task[?], S, ?]] =
+  def supports(bc: BackendCapability): Boolean =
+    ref supports bc
+
+  def liftIO: FileSystemUT[Coproduct[Task, S, ?]] =
     FileSystemUT(
-      name,
+      ref,
       NaturalTransformation.refl[Task] :+: testInterp,
       NaturalTransformation.refl[Task] :+: setupInterp,
       testDir,
       close)
 
   def contramap[T[_]](f: T ~> S): FileSystemUT[T] =
-    FileSystemUT(name, testInterp compose f, setupInterp compose f, testDir, close)
+    FileSystemUT(ref, testInterp compose f, setupInterp compose f, testDir, close)
 
   def contramapF[T[_]](f: T ~> Free[S, ?]): FileSystemUT[T] =
     FileSystemUT(
-      name,
+      ref,
       foldMapNT(testInterp) compose f,
       foldMapNT(setupInterp) compose f,
       testDir,

--- a/it/src/test/scala/quasar/fs/ManageFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/ManageFilesSpec.scala
@@ -17,7 +17,7 @@
 package quasar.fs
 
 import quasar.Predef._
-import quasar.{Data, TestConfig}
+import quasar.{BackendCapability, Data}
 import quasar.contrib.pathy._
 import quasar.fp._
 import quasar.fs.FileSystemTest.allFsUT
@@ -27,7 +27,7 @@ import pathy.scalacheck.PathyArbitrary._
 import scalaz._, Scalaz._
 import scalaz.stream._
 
-class ManageFilesSpec extends FileSystemTest[FileSystem](allFsUT.map(_.filterNot(fs => TestConfig.isMongoReadOnly(fs.name)))) {
+class ManageFilesSpec extends FileSystemTest[FileSystem](allFsUT.map(_ filter (_ supports BackendCapability.write()))) {
   import FileSystemTest._, FileSystemError._, PathError._
   import ManageFile._
 

--- a/it/src/test/scala/quasar/fs/QueryFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/QueryFilesSpec.scala
@@ -17,16 +17,22 @@
 package quasar.fs
 
 import quasar.Predef._
+import quasar.Data
 import quasar.contrib.pathy._
 import quasar.fp._
+import quasar.frontend.logicalplan.{LogicalPlan => LP, _}
+import quasar.std.StdLib
 
+import matryoshka.Fix
 import pathy.Path._
 import scalaz._, Scalaz._
+import scalaz.stream.Process
 
 class QueryFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT) {
-  import FileSystemTest._, FileSystemError._, PathError._
+  import FileSystemTest._, FileSystemError._, PathError._, StdLib._
 
   val query  = QueryFile.Ops[FileSystem]
+  val read   = ReadFile.Ops[FileSystem]
   val write  = WriteFile.Ops[FileSystem]
   val manage = ManageFile.Ops[FileSystem]
 
@@ -35,9 +41,43 @@ class QueryFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT) 
   def deleteForQuery(run: Run): FsTask[Unit] =
     runT(run)(manage.delete(queryPrefix))
 
+  val lpr = new LogicalPlanR[Fix]
+
+  def readRenamed(src: AFile, from: String, to: String): Fix[LP] =
+    lpr.invoke1(
+      identity.Squash,
+      lpr.invoke2(
+        structural.MakeObject,
+        lpr.constant(Data._str(to)),
+        lpr.invoke2(
+          structural.ObjectProject,
+          lpr.read(src),
+          lpr.constant(Data._str(from)))))
+
   fileSystemShould { fs =>
     "Querying Files" should {
       step(deleteForQuery(fs.setupInterpM).runVoid)
+
+      "executing query to an existing file overwrites with results" >> externalOnly(fs.name) {
+        val d = queryPrefix </> dir("execappends")
+        val a = d </> file("afile")
+        val b = d </> file("bfile")
+        val c = d </> file("out")
+
+        val setup = write.saveThese(a, oneDoc) *> write.saveThese(b, anotherDoc).void
+
+        runT(fs.setupInterpM)(setup).runVoid
+
+        val aToc = readRenamed(a, "a", "c")
+        val bToc = readRenamed(b, "b", "c")
+
+        val e = EitherT((query.execute(aToc, c) *> query.execute(bToc, c).void).run.value)
+        val p = e.liftM[Process].drain ++ read.scanAll(c)
+
+        runLogT(fs.testInterpM, p).runEither must beRight(containTheSameElementsAs(Vector[Data](
+          Data.Obj("c" -> Data._int(2))
+        )))
+      }
 
       "listing directory returns immediate child nodes" >> {
         val d = queryPrefix </> dir("lschildren")

--- a/it/src/test/scala/quasar/fs/QueryFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/QueryFilesSpec.scala
@@ -17,7 +17,7 @@
 package quasar.fs
 
 import quasar.Predef._
-import quasar.Data
+import quasar.{BackendCapability, Data}
 import quasar.contrib.pathy._
 import quasar.fp._
 import quasar.frontend.logicalplan.{LogicalPlan => LP, _}
@@ -58,7 +58,7 @@ class QueryFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT) 
     "Querying Files" should {
       step(deleteForQuery(fs.setupInterpM).runVoid)
 
-      "executing query to an existing file overwrites with results" >> externalOnly(fs.name) {
+      "executing query to an existing file overwrites with results" >> ifSupports(fs, BackendCapability.query()) {
         val d = queryPrefix </> dir("execappends")
         val a = d </> file("afile")
         val b = d </> file("bfile")

--- a/it/src/test/scala/quasar/fs/QueryFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/QueryFilesSpec.scala
@@ -58,7 +58,10 @@ class QueryFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT) 
     "Querying Files" should {
       step(deleteForQuery(fs.setupInterpM).runVoid)
 
-      "executing query to an existing file overwrites with results" >> ifSupports(fs, BackendCapability.query()) {
+      "executing query to an existing file overwrites with results" >> ifSupports(fs,
+        BackendCapability.query(),
+        BackendCapability.write()) {
+
         val d = queryPrefix </> dir("execappends")
         val a = d </> file("afile")
         val b = d </> file("bfile")

--- a/it/src/test/scala/quasar/fs/WriteFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/WriteFilesSpec.scala
@@ -17,7 +17,7 @@
 package quasar.fs
 
 import quasar.Predef._
-import quasar.TestConfig
+import quasar.BackendCapability
 import quasar.contrib.pathy._
 import quasar.fp._
 
@@ -27,7 +27,7 @@ import scalaz._, Scalaz._
 import scalaz.stream._
 
 class WriteFilesSpec extends FileSystemTest[FileSystem](
-  FileSystemTest.allFsUT.map(_.filterNot(fs => TestConfig.isMongoReadOnly(fs.name)))) {
+  FileSystemTest.allFsUT.map(_ filter (_ supports BackendCapability.write()))) {
 
   import FileSystemTest._, FileSystemError._
   import WriteFile._

--- a/it/src/test/scala/quasar/physical/couchbase/CouchbaseStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/couchbase/CouchbaseStdLibSpec.scala
@@ -131,7 +131,7 @@ class CouchbaseStdLibSpec extends StdLibSpec {
   TestConfig.fileSystemConfigs(FsType).flatMap(_ traverse_ { case (backend, uri, _) =>
     context(uri).fold(
       err => Task.fail(new RuntimeException(err.shows)),
-      ctx => Task.now(backend.name should tests(runner(ctx)))
+      ctx => Task.now(backend.name.shows should tests(runner(ctx)))
     ).void
   }).unsafePerformSync
 

--- a/it/src/test/scala/quasar/physical/marklogic/MarkLogicStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/marklogic/MarkLogicStdLibSpec.scala
@@ -125,6 +125,6 @@ class MarkLogicStdLibSpec extends StdLibSpec {
   }
 
   TestConfig.fileSystemConfigs(FsType).flatMap(_ traverse_ { case (backend, uri, _) =>
-    contentSourceAt(uri).map(cs => backend.name should tests(runner(cs))).void
+    contentSourceAt(uri).map(cs => backend.name.shows should tests(runner(cs))).void
   }).unsafePerformSync
 }

--- a/it/src/test/scala/quasar/physical/mongodb/MongoDbStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/MongoDbStdLibSpec.scala
@@ -50,8 +50,8 @@ abstract class MongoDbStdLibSpec extends StdLibSpec {
   def compile(queryModel: MongoQueryModel, coll: Collection, lp: Fix[LP])
       : PlannerError \/ (Crystallized[WorkflowF], BsonField.Name)
 
-  def is2_6(backend: BackendName): Boolean = backend == TestConfig.MONGO_2_6
-  def is3_2(backend: BackendName): Boolean = backend == TestConfig.MONGO_3_2
+  def is2_6(backend: BackendName): Boolean = backend === TestConfig.MONGO_2_6.name
+  def is3_2(backend: BackendName): Boolean = backend === TestConfig.MONGO_3_2.name
 
   MongoDbSpec.clientShould { (backend, prefix, setupClient, testClient) =>
     import MongoDbIO._

--- a/it/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
@@ -17,7 +17,7 @@
 package quasar.physical.mongodb.fs
 
 import quasar.Predef._
-import quasar._, DataArbitrary._, TestConfig.isMongoReadOnly
+import quasar._, DataArbitrary._
 import quasar.common._
 import quasar.contrib.pathy._
 import quasar.fp._
@@ -46,8 +46,9 @@ import scalaz.concurrent.Task
 import scalaz.stream._
 
 /** Unit tests for the MongoDB filesystem implementation. */
-class MongoDbFileSystemSpec extends FileSystemTest[FileSystemIO](mongoFsUT map (_ filterNot (fs => isMongoReadOnly(fs.name))))
-        with quasar.ExclusiveQuasarSpecification {
+class MongoDbFileSystemSpec
+  extends FileSystemTest[FileSystemIO](mongoFsUT map (_ filter (_ supports BackendCapability.write())))
+  with quasar.ExclusiveQuasarSpecification {
 
   // TODO[scalaz]: Shadow the scalaz.Monad.monadMTMAB SI-2712 workaround
   import EitherT.eitherTMonad

--- a/it/src/test/scala/quasar/physical/mongodb/fs/MongoDbSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/fs/MongoDbSpec.scala
@@ -44,10 +44,10 @@ object MongoDbSpec {
 
   def clientShould(examples: (BackendName, ADir, MongoClient, MongoClient) => Fragment): Fragments =
     TestConfig.testDataPrefix.flatMap { prefix =>
-      TestConfig.fileSystemConfigs(MongoDBFsType).flatMap(_.traverse { case (name, setupUri, testUri) =>
+      TestConfig.fileSystemConfigs(MongoDBFsType).flatMap(_.traverse { case (ref, setupUri, testUri) =>
         (connect(setupUri) |@| connect(testUri)) { (setupClient, testClient) =>
             Fragments(
-              examples(name, prefix, setupClient, testClient),
+              examples(ref.name, prefix, setupClient, testClient),
               step(testClient.close),
               step(setupClient.close))
           }

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -101,7 +101,7 @@ abstract class QueryRegressionTest[S[_]](
       step(print(s"Running $suiteName ["))
 
       tests.toList foreach { case (f, t) =>
-        regressionExample(f, t, fs.name, fs.setupInterpM, fs.testInterpM)
+        regressionExample(f, t, fs.ref.name, fs.setupInterpM, fs.testInterpM)
         step(print("."))
       }
 
@@ -300,7 +300,7 @@ abstract class QueryRegressionTest[S[_]](
 }
 
 object QueryRegressionTest {
-  lazy val knownFileSystems = TestConfig.backendNames.toSet
+  lazy val knownFileSystems = TestConfig.backendRefs.map(_.name).toSet
 
   val externalFS: Task[IList[FileSystemUT[FileSystemIO]]] =
     for {

--- a/it/src/test/scala/quasar/server/ServiceSpec.scala
+++ b/it/src/test/scala/quasar/server/ServiceSpec.scala
@@ -171,7 +171,8 @@ class ServiceSpec extends quasar.Qspec {
   "/data/fs" should {
 
     lazy val fileSystemConfigs = {
-      val fsCfgs = TestConfig.backendNames
+      val fsCfgs = TestConfig.backendRefs
+        .map(_.name)
         .traverse((TestConfig.backendEnvName _ >>> TestConfig.loadConfig _)(_).run)
         .map(_
           .unite


### PR DESCRIPTION
This doesn't seem to ever have been specified, so I've added a test to `QueryFilesSpec` that does so, essentially codifying the existing MongoDB connector behavior.

SlamData currently expects this behavior (for the cache card, which is how I discovered it), so if we want to change it we should probably do so in a breaking release.

Fixes #1759.