### PR TITLE
Fix nested array deref bug.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+Fix bug where a qscript would attempt to project out provenance too deep from arrays.

--- a/connector/src/main/scala/quasar/qscript/Provenance.scala
+++ b/connector/src/main/scala/quasar/qscript/Provenance.scala
@@ -128,7 +128,6 @@ class ProvenanceT[T[_[_]]: Corecursive: EqualT] extends TTypes[T] {
   def genBuckets(ps: List[Provenance]): Option[(List[Provenance], FreeMap)] =
     ps.traverse(genBucket).eval(0).unzip.traverse(_.join match {
       case Nil      => None
-      case h :: Nil => Free.roll(MakeArray[T, FreeMap](h)).some
       case h :: t   =>
         t.foldLeft(
           Free.roll(MakeArray[T, FreeMap](h)))(

--- a/connector/src/main/scala/quasar/qscript/Provenance.scala
+++ b/connector/src/main/scala/quasar/qscript/Provenance.scala
@@ -128,7 +128,7 @@ class ProvenanceT[T[_[_]]: Corecursive: EqualT] extends TTypes[T] {
   def genBuckets(ps: List[Provenance]): Option[(List[Provenance], FreeMap)] =
     ps.traverse(genBucket).eval(0).unzip.traverse(_.join match {
       case Nil      => None
-      case h :: Nil => h.some
+      case h :: Nil => Free.roll(MakeArray[T, FreeMap](h)).some
       case h :: t   =>
         t.foldLeft(
           Free.roll(MakeArray[T, FreeMap](h)))(

--- a/connector/src/main/scala/quasar/qscript/Transform.scala
+++ b/connector/src/main/scala/quasar/qscript/Transform.scala
@@ -564,7 +564,7 @@ class Transform
           Ann[T](base.buckets, dset),
           QC.inj(Sort(
             base.src,
-            prov.genBuckets(base.buckets).fold(NullLit[T, Hole]())(_._2),
+            prov.genBuckets(base.buckets.drop(1)).fold(NullLit[T, Hole]())(_._2),
             os)).embed))
 
     case lp.InvokeUnapply(set.Filter, Sized(a1, a2)) =>

--- a/connector/src/test/scala/quasar/qscript/QScript.scala
+++ b/connector/src/test/scala/quasar/qscript/QScript.scala
@@ -137,9 +137,7 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
                   Free.roll(Undefined()))),
                 StrLit("city")))))))),
         QC.inj(Sort((),
-          Free.roll(ConcatArrays(
-            Free.roll(MakeArray(ProjectIndexR(ProjectIndexR(HoleF, IntLit(0)), IntLit(0)))),
-            Free.roll(MakeArray(ProjectIndexR(ProjectIndexR(HoleF, IntLit(1)), IntLit(0)))))),
+          NullLit(),
           (ProjectIndexR(HoleF, IntLit(3)), SortDir.asc).wrapNel)),
         QC.inj(Map((), ProjectIndexR(HoleF, IntLit(2)))))))
     }
@@ -626,9 +624,7 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
                 Free.roll(Undefined()))),
               StrLit("pop")))))))),
       QC.inj(Sort((),
-        Free.roll(ConcatArrays(
-          Free.roll(MakeArray(ProjectIndexR(ProjectIndexR(HoleF, IntLit(0)), IntLit(0)))),
-          Free.roll(MakeArray(ProjectIndexR(ProjectIndexR(HoleF, IntLit(1)), IntLit(0)))))),
+        NullLit(),
         (ProjectIndexR(HoleF, IntLit(3)) -> SortDir.asc).wrapNel)),
       QC.inj(Reduce((),
         Free.roll(MakeArray(

--- a/connector/src/test/scala/quasar/qscript/QScript.scala
+++ b/connector/src/test/scala/quasar/qscript/QScript.scala
@@ -115,18 +115,13 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           IncludeId,
           Free.roll(ConcatArrays(
             Free.roll(ConcatArrays(
-              // FIXME: #1622
               Free.roll(ConcatArrays(
                 Free.roll(MakeArray(
-                  ProjectIndexR(
-                    ProjectIndexR(ProjectIndexR(RightSideF, IntLit(0)), IntLit(0)),
-                    IntLit(0)))),
+                  Free.roll(MakeArray(
+                    ProjectIndexR(RightSideF, IntLit(0)))))),
                 Free.roll(MakeArray(
-                  ProjectIndexR(
-                    ProjectIndexR(
-                      ProjectIndexR(ProjectIndexR(RightSideF, IntLit(0)), IntLit(0)),
-                      IntLit(0)),
-                    IntLit(0)))))),
+                  Free.roll(MakeArray(
+                    ProjectIndexR(RightSideF, IntLit(0)))))))),
               Free.roll(MakeArray(
                 Free.roll(Guard(
                   ProjectIndexR(RightSideF, IntLit(1)),
@@ -426,7 +421,8 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           IncludeId,
           Free.roll(ConcatArrays(
             Free.roll(ConcatArrays(
-              Free.roll(MakeArray(ProjectIndexR(RightSideF, IntLit(0)))),
+              Free.roll(MakeArray(
+                Free.roll(MakeArray(ProjectIndexR(RightSideF, IntLit(0)))))),
               Free.roll(MakeArray(ProjectIndexR(RightSideF, IntLit(1)))))),
             Free.roll(Constant(ejsonArr(ejsonStr("loc")))))))),
         QC.inj(LeftShift((),
@@ -446,7 +442,8 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
               Free.roll(MakeArray(RightSideF)))),
             Free.roll(Constant(ejsonArr(ejsonInt(10)))))))),
         QC.inj(Reduce((),
-          ProjectIndexR(ProjectIndexR(HoleF, IntLit(0)), IntLit(1)),
+          Free.roll(MakeArray(
+            ProjectIndexR(ProjectIndexR(HoleF, IntLit(0)), IntLit(1)))),
           List(
             ReduceFuncs.UnshiftArray(
               Free.roll(Multiply(
@@ -475,9 +472,10 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           Free.roll(ConcatArrays(
             Free.roll(ConcatArrays(
               Free.roll(ConcatArrays(
-                Free.roll(MakeArray(ProjectIndexR(RightSideF, IntLit(0)))),
-                // FIXME: #1622
-                Free.roll(MakeArray(ProjectIndexR(ProjectIndexR(ProjectIndexR(ProjectIndexR(RightSideF, IntLit(0)), IntLit(0)), IntLit(0)), IntLit(0)))))),
+                Free.roll(MakeArray(
+                  Free.roll(MakeArray(ProjectIndexR(RightSideF, IntLit(0)))))),
+                Free.roll(MakeArray(
+                  Free.roll(MakeArray(ProjectIndexR(RightSideF, IntLit(0)))))))),
               Free.roll(MakeArray(ProjectIndexR(RightSideF, IntLit(1)))))),
             Free.roll(MakeArray(
               Free.roll(Between(
@@ -563,7 +561,8 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           ExcludeId,
           Free.roll(ConcatArrays(
             Free.roll(MakeArray(
-              ProjectIndexR(ProjectIndexR(RightSideF, IntLit(1)), IntLit(0)))),
+              Free.roll(MakeArray(
+                ProjectIndexR(ProjectIndexR(RightSideF, IntLit(1)), IntLit(0)))))),
             Free.roll(MakeArray(RightSideF))))))),
         Free.roll(QCT.inj(LeftShift(
           Free.roll(RT.inj(Const(Read(rootDir </> file("person"))))),
@@ -571,10 +570,12 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           ExcludeId,
           Free.roll(ConcatArrays(
             Free.roll(MakeArray(
-              ProjectIndexR(ProjectIndexR(RightSideF, IntLit(1)), IntLit(0)))),
+              Free.roll(MakeArray(
+                ProjectIndexR(ProjectIndexR(RightSideF, IntLit(1)), IntLit(0)))))),
             Free.roll(MakeArray(RightSideF))))))))),
       QC.inj(Reduce((),
-        ProjectIndexR(HoleF, IntLit(1)),
+        Free.roll(MakeArray(
+          ProjectIndexR(HoleF, IntLit(1)))),
         List(ReduceFuncs.Arbitrary[FreeMap](ProjectIndexR(HoleF, IntLit(1)))),
         ReduceIndexF(0))))))
   }
@@ -589,12 +590,13 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
         IncludeId,
         Free.roll(ConcatArrays(
           Free.roll(ConcatArrays(
-            // FIXME: #1622
             Free.roll(ConcatArrays(
               Free.roll(MakeArray(
-                ProjectIndexR(ProjectIndexR(ProjectIndexR(ProjectIndexR(ProjectIndexR(ProjectIndexR(RightSideF, IntLit(0)), IntLit(0)), IntLit(0)), IntLit(0)), IntLit(0)), IntLit(0)))),
+                Free.roll(MakeArray(
+                  ProjectIndexR(RightSideF, IntLit(0)))))),
               Free.roll(MakeArray(
-                ProjectIndexR(ProjectIndexR(ProjectIndexR(ProjectIndexR(ProjectIndexR(ProjectIndexR(ProjectIndexR(RightSideF, IntLit(0)), IntLit(0)), IntLit(0)), IntLit(0)), IntLit(0)), IntLit(0)), IntLit(0)))))),
+                Free.roll(MakeArray(
+                  ProjectIndexR(RightSideF, IntLit(0)))))))),
             Free.roll(MakeArray(
               Free.roll(ConcatMaps(
                 Free.roll(MakeMap(
@@ -629,7 +631,8 @@ class QScriptSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           Free.roll(MakeArray(ProjectIndexR(ProjectIndexR(HoleF, IntLit(1)), IntLit(0)))))),
         (ProjectIndexR(HoleF, IntLit(3)) -> SortDir.asc).wrapNel)),
       QC.inj(Reduce((),
-        Free.roll(DeleteField(ProjectIndexR(HoleF, IntLit(2)), StrLit("__sd__0"))),
+        Free.roll(MakeArray(
+          Free.roll(DeleteField(ProjectIndexR(HoleF, IntLit(2)), StrLit("__sd__0"))))),
         List(ReduceFuncs.Arbitrary(ProjectIndexR(HoleF, IntLit(2)))),
         Free.roll(DeleteField(ReduceIndexF(0), StrLit("__sd__0"))))))))
   }

--- a/it/src/main/resources/tests/guardedExpression.test
+++ b/it/src/main/resources/tests/guardedExpression.test
@@ -1,6 +1,7 @@
 {
   "name": "regex on non-string field",
   "backends": {
+      "couchbase":         "skip",
       "mongodb_read_only": "pending",
       "postgresql":        "pending"
   },


### PR DESCRIPTION
There should be some integration tests that can be enabled with this fix. I'd like to see what happens when integration is run - not sure if tests will come to life (they're pending) or if I need to go in there and turn them on (they're skipped) or if I need to add some integration tests (the necessary ones don't exist yet). 

In any case, a good example query of what now comes to life is: `select distinct(city) from zips order by pop`. That query requires actually using the reified bucketing information in order to compute the sorting buckets. (There is just one bucket, but we have to give that information to the backend!)