### PR TITLE
CB: Reenable filterOnFieldComparison

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- Couchbase: Reenable filterOnFieldComparison

--- a/it/src/main/resources/tests/filterOnFieldComparison.test
+++ b/it/src/main/resources/tests/filterOnFieldComparison.test
@@ -1,7 +1,6 @@
 {
     "name": "filter on field comparison",
     "backends": {
-        "couchbase":         "skip",
         "marklogic":         "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"


### PR DESCRIPTION
Recent changes appear to have addressed the intermittent failure seen against `filterOnFieldComparison.test`.

Fixes: #1752 
