### PR TITLE
CB: Revert "Reenable filterOnFieldComparison"

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- Couchbase: Skip filterOnFieldComparison.test

--- a/it/src/main/resources/tests/filterOnFieldComparison.test
+++ b/it/src/main/resources/tests/filterOnFieldComparison.test
@@ -1,6 +1,7 @@
 {
     "name": "filter on field comparison",
     "backends": {
+        "couchbase":         "skip",
         "marklogic":         "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"


### PR DESCRIPTION
`filterOnFieldComparison.test` is still failing intermittently on Travis due to result set order. Specifying ordering currently results in sizable N1QL that leads to cbq-engine slows. That should be addressed by #1784 and then `filterOnFieldComparison.test` can be reenabled against CB.

#1752 is reopened.