### PR TITLE
Allow variables with quoted names like :`start time`

### DIFF
--- a/CHANGELOG/feature.md
+++ b/CHANGELOG/feature.md
@@ -1,0 +1,1 @@
+- allow variables with quoted names like `:\`start time\``

--- a/frontend/src/main/scala/quasar/sql/package.scala
+++ b/frontend/src/main/scala/quasar/sql/package.scala
@@ -204,7 +204,7 @@ package object sql {
               g.having.map("having " + _._2).toList).mkString(" ")),
           orderBy.map(o => List("order by", o.keys.map(x => x._2._2 + " " + x._1.shows) intercalate (", ")).mkString(" "))).foldMap(_.toList).mkString(" ") +
         ")"
-      case Vari(symbol) => ":" + symbol
+      case Vari(symbol) => ":" + _qq("`", symbol)
       case SetLiteral(exprs) => exprs.map(_._2).mkString("(", ", ", ")")
       case ArrayLiteral(exprs) => exprs.map(_._2).mkString("[", ", ", "]")
       case MapLiteral(exprs) => exprs.map {

--- a/frontend/src/test/scala/quasar/sql/SqlParserSpec.scala
+++ b/frontend/src/test/scala/quasar/sql/SqlParserSpec.scala
@@ -228,6 +228,10 @@ class SQLParserSpec extends quasar.Qspec {
       parse("""SELECT * FROM zips WHERE zips.dt > :start_time AND zips.dt <= :end_time """).toOption should beSome
     }
 
+    "parse variable with quoted name" in {
+      parse(""":`start time`""") should beRightDisjOrDiff(VariR("start time"))
+    }
+
     "parse simple query with variable as relation" in {
       parse("""SELECT * FROM :table""").toOption should beSome
     }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/bson.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/bson.scala
@@ -21,13 +21,13 @@ import quasar.fp._
 import quasar.javascript._
 import quasar.jscore, jscore.JsFn
 
+import java.time.Instant
 import scala.Any
 import scala.collection.JavaConverters._
 
 import monocle.Prism
 import org.bson._
 import org.bson.types
-import java.time.Instant
 import scalaz._, Scalaz._
 
 /**
@@ -60,7 +60,7 @@ object Bson {
     case rex:  BsonRegularExpression => Regex(rex.getPattern, rex.getOptions)
     case str:  BsonString            => Text(str.getValue)
     case sym:  BsonSymbol            => Symbol(sym.getSymbol)
-    case tms:  BsonTimestamp         => Timestamp.fromInstant(Instant.ofEpochSecond(tms.getTime.toLong), tms.getInc)
+    case tms:  BsonTimestamp         => Timestamp(tms.getTime, tms.getInc)
     case _:    BsonUndefined         => Undefined
       // NB: These types we can’t currently translate back to Bson, but we don’t
       //     expect them to appear.
@@ -202,8 +202,11 @@ object Bson {
     override def toString = s"Timestamp(${Instant.ofEpochSecond(epochSecond.toLong)}, ${ordinal.shows})"
   }
   object Timestamp {
-    def fromInstant(instant: Instant, ordinal: Int): Timestamp =
-      Timestamp((instant.toEpochMilli/1000).toInt, ordinal)
+    def fromInstant(instant: Instant, ordinal: Int): Option[Timestamp] = {
+      // TODO: Eliminate `toDouble` without hitting implicit widening
+      val secs = instant.getEpochSecond.toDouble
+      (secs.isValidInt).option(Timestamp(secs.toInt, ordinal))
+    }
   }
   final case object MinKey extends Bson {
     def repr = new BsonMinKey()

--- a/mongodb/src/main/scala/quasar/physical/mongodb/bson.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/bson.scala
@@ -201,13 +201,6 @@ object Bson {
       List(Js.num(epochSecond.toLong), Js.num(ordinal.toLong)))
     override def toString = s"Timestamp(${Instant.ofEpochSecond(epochSecond.toLong)}, ${ordinal.shows})"
   }
-  object Timestamp {
-    def fromInstant(instant: Instant, ordinal: Int): Option[Timestamp] = {
-      // TODO: Eliminate `toDouble` without hitting implicit widening
-      val secs = instant.getEpochSecond.toDouble
-      (secs.isValidInt).option(Timestamp(secs.toInt, ordinal))
-    }
-  }
   final case object MinKey extends Bson {
     def repr = new BsonMinKey()
     def toJs = Js.Ident("MinKey")

--- a/mongodb/src/main/scala/quasar/physical/mongodb/expression/Check.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/expression/Check.scala
@@ -176,7 +176,7 @@ object Check {
 
   val minBinary = ImmutableArray.fromArray(scala.Array[Byte]())
   val minInstant = Instant.ofEpochMilli(Long.MinValue)
-  val minTimestamp = Bson.Timestamp.fromInstant(minInstant, 0)
+  val minTimestamp = Bson.Timestamp(Int.MinValue, 0)
   val minOid =
     ImmutableArray.fromArray(scala.Array[Byte](0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
   val minRegex = Bson.Regex("", "")

--- a/mongodb/src/test/scala/quasar/physical/mongodb/bson.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/bson.scala
@@ -116,7 +116,7 @@ object BsonGen {
     listOf(arbitrary[Byte]).map(bytes => Binary.fromArray(bytes.toArray)),
     listOfN(12, arbitrary[Byte]).map(bytes => ObjectId.fromArray(bytes.toArray)),
     const(Date(Instant.now)),
-    const(Timestamp.fromInstant(Instant.now, 0)),
+    const(Timestamp(0, 0)),
     const(Regex("a.*", "")),
     const(JavaScript(Js.Null)),
     const(JavaScriptScope(Js.Null, ListMap.empty)),


### PR DESCRIPTION
Fixes #1837

Also fixes a bug where we could error in `bson.Timestamp.fromInstant` .