### PR TITLE
Allow users to compare types of values.

### DIFF
--- a/CHANGELOG/feature.md
+++ b/CHANGELOG/feature.md
@@ -1,0 +1,8 @@
+- Add a `TypeOf` operation (not a fix for #1802 yet, because it doesn’t
+  implement it for any connector)
+- adds a new PrimaryType type that reflects the simpler notion of type
+  used with “patterns” as we go forward (and also the notion of types
+  used by `TypeOf`)
+- use the sbt-travisci plugin
+- convert `Bson.Date` to use a `Long` instead of `Instant` (since
+  `Instant` encodes more values than `Bson.Date`)

--- a/build.sbt
+++ b/build.sbt
@@ -17,8 +17,6 @@ import scoverage._
 
 val BothScopes = "test->test;compile->compile"
 
-def isTravis: Boolean = sys.env contains "TRAVIS"
-
 // Exclusive execution settings
 lazy val ExclusiveTests = config("exclusive") extend Test
 
@@ -35,7 +33,6 @@ lazy val buildSettings = Seq(
   headers := Map(
     ("scala", Apache2_0("2014–2016", "SlamData Inc.")),
     ("java",  Apache2_0("2014–2016", "SlamData Inc."))),
-  scalaVersion := "2.11.8",
   scalaOrganization := "org.typelevel",
   outputStrategy := Some(StdoutOutput),
   initialize := {
@@ -97,7 +94,7 @@ lazy val buildSettings = Seq(
 // actually available to run.
 concurrentRestrictions in Global := {
   val maxTasks = 2
-  if (isTravis)
+  if (isTravisBuild.value)
     // Recreate the default rules with the task limit hard-coded:
     Seq(Tags.limitAll(maxTasks), Tags.limit(Tags.ForkedTestGroup, 1))
   else
@@ -227,7 +224,7 @@ lazy val foundation = project
     buildInfoKeys := Seq[BuildInfoKey](version, ScoverageKeys.coverageEnabled, isCIBuild, isIsolatedEnv, exclusiveTestTag),
     buildInfoPackage := "quasar.build",
     exclusiveTestTag := "exclusive",
-    isCIBuild := isTravis,
+    isCIBuild := isTravisBuild.value,
     isIsolatedEnv := java.lang.Boolean.parseBoolean(java.lang.System.getProperty("isIsolatedEnv")),
     libraryDependencies ++= Dependencies.foundation,
     wartremoverWarnings in (Compile, compile) -= Wart.NoNeedForMonad)

--- a/common/src/main/scala/quasar/common/PrimaryType.scala
+++ b/common/src/main/scala/quasar/common/PrimaryType.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.common
+
+import quasar.Predef._
+
+import monocle.Prism
+import scalaz._, Scalaz._
+
+/** An enumeration of types used as part of a [[Pattern]]. */
+sealed abstract class PrimaryType
+
+// NB: These are defined in order of their total ordering
+final case object Null extends PrimaryType
+final case object Bool extends PrimaryType
+final case object Byte extends PrimaryType
+final case object Char extends PrimaryType
+final case object Int extends PrimaryType
+final case object Dec extends PrimaryType
+final case object Arr extends PrimaryType
+final case object Map extends PrimaryType
+
+object PrimaryType {
+  def name = Prism[String, PrimaryType] {
+    case "null"      => Null.some
+    case "boolean"   => Bool.some
+    case "byte"      => Byte.some
+    case "character" => Char.some
+    case "integer"   => Int.some
+    case "decimal"   => Dec.some
+    case "array"     => Arr.some
+    case "map"       => Map.some
+    case _           => none
+  } {
+    case Null => "null"
+    case Bool => "boolean"
+    case Byte => "byte"
+    case Char => "character"
+    case Int  => "integer"
+    case Dec  => "decimal"
+    case Arr  => "array"
+    case Map  => "map"
+  }
+
+  implicit val equal: Equal[PrimaryType] = Equal.equalRef
+}

--- a/connector/src/main/scala/quasar/qscript/MapFunc.scala
+++ b/connector/src/main/scala/quasar/qscript/MapFunc.scala
@@ -319,6 +319,7 @@ object MapFunc {
         case Interval(a1) => f(a1) ∘ (Interval(_))
         case TimeOfDay(a1) => f(a1) ∘ (TimeOfDay(_))
         case ToTimestamp(a1) => f(a1) ∘ (ToTimestamp(_))
+        case TypeOf(a1) => f(a1) ∘ (TypeOf(_))
         case Negate(a1) => f(a1) ∘ (Negate(_))
         case Not(a1) => f(a1) ∘ (Not(_))
         case Length(a1) => f(a1) ∘ (Length(_))
@@ -402,6 +403,7 @@ object MapFunc {
         case (Interval(a1), Interval(b1)) => in.equal(a1, b1)
         case (TimeOfDay(a1), TimeOfDay(b1)) => in.equal(a1, b1)
         case (ToTimestamp(a1), ToTimestamp(b1)) => in.equal(a1, b1)
+        case (TypeOf(a1), TypeOf(b1)) => in.equal(a1, b1)
         case (Negate(a1), Negate(b1)) => in.equal(a1, b1)
         case (Not(a1), Not(b1)) => in.equal(a1, b1)
         case (Length(a1), Length(b1)) => in.equal(a1, b1)
@@ -490,6 +492,7 @@ object MapFunc {
           case Interval(a1) => shz("Interval", a1)
           case TimeOfDay(a1) => shz("TimeOfDay", a1)
           case ToTimestamp(a1) => shz("ToTimestamp", a1)
+          case TypeOf(a1) => shz("TypeOf", a1)
           case Negate(a1) => shz("Negate", a1)
           case Not(a1) => shz("Not", a1)
           case Length(a1) => shz("Length", a1)
@@ -588,6 +591,7 @@ object MapFunc {
           case Interval(a1) => nAry("Interval", a1)
           case TimeOfDay(a1) => nAry("TimeOfDay", a1)
           case ToTimestamp(a1) => nAry("ToTimestamp", a1)
+          case TypeOf(a1) => nAry("TypeOf", a1)
           case Negate(a1) => nAry("Negate", a1)
           case Not(a1) => nAry("Not", a1)
           case Length(a1) => nAry("Length", a1)
@@ -669,6 +673,7 @@ object MapFunc {
     case date.Interval => Interval(_)
     case date.TimeOfDay => TimeOfDay(_)
     case date.ToTimestamp => ToTimestamp(_)
+    case identity.TypeOf => TypeOf(_)
     case math.Negate => Negate(_)
     case relations.Not => Not(_)
     case string.Length => Length(_)
@@ -768,6 +773,9 @@ object MapFuncs {
   @Lenses final case class ToTimestamp[T[_[_]], A](a1: A) extends Unary[T, A]
   /** Fetches the [[quasar.Type.Timestamp]] for the current instant in time. */
   @Lenses final case class Now[T[_[_]], A]() extends Nullary[T, A]
+
+  // identity
+  @Lenses final case class TypeOf[T[_[_]], A](a1: A) extends Unary[T, A]
 
   // math
   @Lenses final case class Negate[T[_[_]], A](a1: A) extends Unary[T, A]

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/MapFuncPlanner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/MapFuncPlanner.scala
@@ -147,6 +147,8 @@ final class MapFuncPlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: NameGenera
       ).embed.η[M]
     case MF.ToTimestamp(a1) =>
       Timestamp(MillisToUTC(a1, none).embed).embed.η[M]
+    case MF.TypeOf(a1) =>
+      unimplementedP("TypeOf")
     case MF.ExtractCentury(a1) =>
       Ceil(Div(extract(a1, "year"), int(100)).embed).embed.η[M]
     case MF.ExtractDayOfMonth(a1) =>

--- a/frontend/src/main/scala/quasar/std/identity.scala
+++ b/frontend/src/main/scala/quasar/std/identity.scala
@@ -17,6 +17,7 @@
 package quasar.std
 
 import quasar._
+import quasar.common.PrimaryType
 import quasar.frontend.logicalplan.{LogicalPlan => LP, _}
 
 import matryoshka._
@@ -56,6 +57,34 @@ trait IdentityLib extends Library {
       case Sized(Type.Str)                  => Type.Id
     },
     basicUntyper)
+
+  val TypeOf = UnaryFunc(
+    Mapping,
+    "Returns the simple type of a value.",
+    Type.Str,
+    Func.Input1(Type.Top),
+    noSimplification,
+    {
+      case Sized(typ) =>
+        success(typ.toPrimaryType.fold(
+          if      (Type.Bottom.contains(typ))    Type.Bottom
+          // NB: These cases should be identified via metadata
+          else if (Type.Timestamp.contains(typ)) Type.Const(Data.Str("timestamp"))
+          else if (Type.Date.contains(typ))      Type.Const(Data.Str("date"))
+          else if (Type.Time.contains(typ))      Type.Const(Data.Str("time"))
+          else if (Type.Interval.contains(typ))  Type.Const(Data.Str("interval"))
+          else                                   Type.Str)(
+          t => Type.Const(Data.Str(PrimaryType.name.reverseGet(t)))))
+    }
+                        ,
+    partialUntyper[nat._1] {
+      case Type.Bottom => Func.Input1(Type.Bottom)
+      case Type.Const(Data.Str(name)) =>
+        Func.Input1(PrimaryType.name.getOption(name).fold[Type](
+          Type.Top)(
+          Type.fromPrimaryType))
+      case _ => Func.Input1(Type.Top)
+    })
 }
 
 object IdentityLib extends IdentityLib

--- a/marklogic/src/main/scala/quasar/physical/marklogic/fs/queryfile.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/fs/queryfile.scala
@@ -120,12 +120,13 @@ object queryfile {
         _       <- logPhase(PhaseResult.tree("QScript (Optimized)", optmzed.cata(linearize).reverse))
         main    <- plan(optmzed).leftMap(mlerr => mlerr match {
                      case InvalidQName(s) =>
-                       FileSystemError.planningFailed(lp, QPlanner.UnsupportedPlan(
-                         // TODO: Change to include the QScript context when supported
+                       FileSystemError.qscriptPlanningFailed(QPlanner.UnsupportedPlan(
                          constant(Data.Str(s)), Some(mlerr.shows)))
 
+                     case Unimplemented(f) =>
+                       FileSystemError.qscriptPlanningFailed(QPlanner.UnsupportedPlan(constant(Data.Str(f)), Some(mlerr.shows)))
                      case UnrepresentableEJson(ejs, _) =>
-                       FileSystemError.planningFailed(lp, QPlanner.NonRepresentableEJson(ejs.shows))
+                       FileSystemError.qscriptPlanningFailed(QPlanner.NonRepresentableEJson(ejs.shows))
                    })
         pp      <- prettyPrint(main.queryBody)
         xqyLog  =  MainModule.queryBody.modify(pp getOrElse _)(main).render

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MapFuncPlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MapFuncPlanner.scala
@@ -53,6 +53,7 @@ object MapFuncPlanner {
     case Interval(s)                  => xs.dayTimeDuration(s).point[F]
     case TimeOfDay(dt)                => qscript.asDateTime[F] apply dt map xs.time
     case ToTimestamp(millis)          => qscript.timestampToDateTime[F] apply millis
+    case TypeOf(x)                    => MonadPlanErr[F].raiseError(MarkLogicPlannerError.unimplemented("TypeOf"))
     case Now()                        => fn.currentDateTime.point[F]
 
     case ExtractCentury(time)         => qscript.asDateTime[F] apply time map (dt =>

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MarkLogicPlannerError.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/MarkLogicPlannerError.scala
@@ -35,11 +35,16 @@ sealed abstract class MarkLogicPlannerError
 
 object MarkLogicPlannerError {
   final case class InvalidQName(strLit: String) extends MarkLogicPlannerError
+  final case class Unimplemented(function: String) extends MarkLogicPlannerError
   final case class UnrepresentableEJson(ejson: Fix[EJson], msgs: ErrorMessages) extends MarkLogicPlannerError
 
   val invalidQName = Prism.partial[MarkLogicPlannerError, String] {
     case InvalidQName(s) => s
   } (InvalidQName)
+
+  val unimplemented = Prism.partial[MarkLogicPlannerError, String] {
+    case Unimplemented(f) => f
+  } (Unimplemented)
 
   val unrepresentableEJson = Prism.partial[MarkLogicPlannerError, (Fix[EJson], ErrorMessages)] {
     case UnrepresentableEJson(ejs, msgs) => (ejs, msgs)
@@ -52,6 +57,9 @@ object MarkLogicPlannerError {
     Show.shows {
       case InvalidQName(s) =>
         s"'$s' is not a valid XML QName."
+
+      case Unimplemented(f) =>
+        s"The function $f is not implemented."
 
       case UnrepresentableEJson(ejs, msgs) =>
         s"'${ejs.shows}' does not have an XQuery representation: ${msgs.intercalate(", ")}"

--- a/mongodb/src/main/scala/quasar/physical/mongodb/expression/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/expression/package.scala
@@ -67,7 +67,7 @@ package object expression {
       // matches the pattern the planner generates for converting epoch time
       // values to timestamps. Adding numbers to dates works in ExprOp, but not
       // in Javacript.
-      case $add($literal(Bson.Date(inst)), r) if inst.toEpochMilli ≟ 0 =>
+      case $add($literal(Bson.Date(milli)), r) if milli ≟ 0 =>
         r.para(toJs[T, EX])
           .map(r => JsFn(JsFn.defaultName,
             jscore.New(jscore.Name("Date"), List(r(jscore.Ident(JsFn.defaultName))))))

--- a/mongodb/src/main/scala/quasar/physical/mongodb/javascript/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/javascript/package.scala
@@ -21,13 +21,16 @@ import quasar._
 import quasar.javascript.Js
 import quasar.jscore._
 
+import java.time.Instant
+
 final case class javascript[R](embed: JsCoreF[R] => R) {
   val js = jscore.fixpoint[R](embed)
   import js._
 
   /** Convert a `Bson.Date` to a JavaScript `Date`. */
   def toJsDate(value: Bson.Date): R =
-    New(Name("Date"), List(Literal(Js.Str(value.value.toString))))
+    New(Name("Date"), List(
+      Literal(Js.Str(Instant.ofEpochMilli(value.millis).toString))))
 
   /** Convert a `Bson.ObjectId` to a JavaScript `ObjectId`. */
   def toJsObjectId(value: Bson.ObjectId): R =

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/FuncHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/FuncHandler.scala
@@ -21,7 +21,6 @@ import quasar.physical.mongodb.Bson
 import quasar.physical.mongodb.expression._
 import quasar.qscript.{Coalesce => _, _}, MapFuncs._
 
-import java.time.Instant
 import matryoshka._
 import scalaz.{Divide => _, _}, Scalaz._
 
@@ -92,7 +91,7 @@ object FuncHandler {
           case ExtractDayOfYear(a1) => $dayOfYear(a1)
           case ExtractEpoch(a1) =>
             $divide(
-              $subtract(a1, $literal(Bson.Date(Instant.ofEpochMilli(0)))),
+              $subtract(a1, $literal(Bson.Date(0))),
               $literal(Bson.Int32(1000)))
           case ExtractHour(a1) => $hour(a1)
           case ExtractIsoDayOfWeek(a1) =>
@@ -127,7 +126,7 @@ object FuncHandler {
           case ExtractYear(a1) => $year(a1)
 
           case ToTimestamp(a1) =>
-            $add($literal(Bson.Date(Instant.ofEpochMilli(0))), a1)
+            $add($literal(Bson.Date(0)), a1)
 
           case Between(a1, a2, a3)   => $and($lte(a2, a1),
                                               $lte(a1, a3))

--- a/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -340,18 +340,22 @@ object MongoDbQScriptPlanner {
         }
 
       def relDateOp1(f: Bson.Date => Selector.Condition, date: Data.Date, g: Data.Date => Data.Timestamp, index: Int): Output =
-        \/-((
-          { case x :: Nil => Selector.Doc(x -> f(Bson.Date(g(date).value))) },
-          List(There(index, Here))))
+        Bson.Date.fromInstant(g(date).value).fold[Output](
+          -\/(NonRepresentableData(g(date))))(
+          d => \/-((
+            { case x :: Nil => Selector.Doc(x -> f(d)) },
+            List(There(index, Here)))))
 
       def relDateOp2(conj: (Selector, Selector) => Selector, f1: Bson.Date => Selector.Condition, f2: Bson.Date => Selector.Condition, date: Data.Date, g1: Data.Date => Data.Timestamp, g2: Data.Date => Data.Timestamp, index: Int): Output =
-        \/-((
-          { case x :: Nil =>
-            conj(
-              Selector.Doc(x -> f1(Bson.Date(g1(date).value))),
-              Selector.Doc(x -> f2(Bson.Date(g2(date).value))))
-          },
-          List(There(index, Here))))
+        ((Bson.Date.fromInstant(g1(date).value) \/> NonRepresentableData(g1(date))) ⊛
+          (Bson.Date.fromInstant(g2(date).value) \/> NonRepresentableData(g2(date))))((d1, d2) =>
+          (
+            { case x :: Nil =>
+              conj(
+                Selector.Doc(x -> f1(d1)),
+                Selector.Doc(x -> f2(d2)))
+            },
+            List(There(index, Here))))
 
       def invoke2Nel(x: Output, y: Output)(f: (Selector, Selector) => Selector):
           Output =

--- a/mongodb/src/test/scala/quasar/physical/mongodb/bson.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/bson.scala
@@ -17,12 +17,11 @@
 package quasar.physical.mongodb
 
 import quasar.Predef._
-import quasar.fp._
 import quasar._
+import quasar.fp._
 import quasar.javascript._
 import quasar.jscore
 
-import java.time._
 import scalaz._, Scalaz._
 
 class BsonSpecs extends quasar.Qspec {
@@ -115,7 +114,7 @@ object BsonGen {
     arbitrary[Double].map(Dec.apply),
     listOf(arbitrary[Byte]).map(bytes => Binary.fromArray(bytes.toArray)),
     listOfN(12, arbitrary[Byte]).map(bytes => ObjectId.fromArray(bytes.toArray)),
-    const(Date(Instant.now)),
+    const(Date(0)),
     const(Timestamp(0, 0)),
     const(Regex("a.*", "")),
     const(JavaScript(Js.Null)),

--- a/mongodb/src/test/scala/quasar/physical/mongodb/expression/spec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/expression/spec.scala
@@ -151,12 +151,11 @@ class ExpressionSpec extends quasar.Qspec {
   }
 
   "toJs" should {
-    import java.time._
     import quasar.jscore._
 
     "handle addition with epoch date literal" in {
       $add(
-        $literal(Bson.Date(Instant.ofEpochMilli(0))),
+        $literal(Bson.Date(0)),
         $var(DocField(BsonField.Name("epoch")))).para(toJs[Fix[ExprOp], ExprOp]) must beRightDisjunction(
         JsFn(JsFn.defaultName, New(Name("Date"), List(Select(Ident(JsFn.defaultName), "epoch")))))
     }

--- a/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -18,7 +18,7 @@ package quasar.physical.mongodb
 
 import quasar.Predef._
 import quasar._, RenderTree.ops._
-import quasar.common._
+import quasar.common.{Map => _, _}
 import quasar.fp._
 import quasar.fp.ski._
 import quasar.javascript._
@@ -224,7 +224,7 @@ class PlannerSpec extends
                      $lt($literal(Bson.Null), $field("foo")),
                      $lt($field("foo"), $literal(Bson.Text("")))),
                    $and(
-                     $lte($literal(Bson.Date(Check.minInstant)), $field("foo")),
+                     $lte($literal(Check.minDate), $field("foo")),
                      $lt($field("foo"), $literal(Bson.Regex("", ""))))),
                  $add($field("foo"), $field("bar")),
                  $literal(Bson.Undefined)),
@@ -355,7 +355,7 @@ class PlannerSpec extends
            reshape("value" ->
              $cond(
                $and(
-                 $lte($literal(Bson.Date(Check.minInstant)), $field("baz")),
+                 $lte($literal(Check.minDate), $field("baz")),
                  $lt($field("baz"), $literal(Bson.Regex("", "")))),
                $dayOfMonth($field("baz")),
                $literal(Bson.Undefined))),
@@ -371,7 +371,7 @@ class PlannerSpec extends
              "value" ->
                $cond(
                  $and(
-                   $lte($literal(Bson.Date(Check.minInstant)), $field("baz")),
+                   $lte($literal(Check.minDate), $field("baz")),
                    $lt($field("baz"), $literal(Bson.Regex("", "")))),
                  $trunc(
                    $add(
@@ -392,7 +392,7 @@ class PlannerSpec extends
              "value" ->
                $cond(
                  $and(
-                   $lte($literal(Bson.Date(Check.minInstant)), $field("baz")),
+                   $lte($literal(Check.minDate), $field("baz")),
                    $lt($field("baz"), $literal(Bson.Regex("", "")))),
                  $add($dayOfWeek($field("baz")), $literal(Bson.Int32(-1))),
                  $literal(Bson.Undefined))),
@@ -408,7 +408,7 @@ class PlannerSpec extends
              "value" ->
                $cond(
                  $and(
-                   $lte($literal(Bson.Date(Check.minInstant)), $field("baz")),
+                   $lte($literal(Check.minDate), $field("baz")),
                    $lt($field("baz"), $literal(Bson.Regex("", "")))),
                  $cond($eq($dayOfWeek($field("baz")), $literal(Bson.Int32(1))),
                    $literal(Bson.Int32(7)),
@@ -426,7 +426,7 @@ class PlannerSpec extends
              "__tmp2" ->
                $cond(
                  $and(
-                   $lte($literal(Bson.Date(Check.minInstant)), $field("ts")),
+                   $lte($literal(Check.minDate), $field("ts")),
                    $lt($field("ts"), $literal(Bson.Regex("", "")))),
                  $eq($year($field("ts")), $literal(Bson.Int32(2016))),
                  $literal(Bson.Undefined)),
@@ -592,7 +592,7 @@ class PlannerSpec extends
                      $lt($literal(Bson.Null), $field("a")),
                      $lt($field("a"), $literal(Bson.Text("")))),
                    $and(
-                     $lte($literal(Bson.Date(Check.minInstant)), $field("a")),
+                     $lte($literal(Check.minDate), $field("a")),
                      $lt($field("a"), $literal(Bson.Regex("", ""))))),
                  $add($field("a"), $field("b")),
                  $literal(Bson.Undefined)),
@@ -1102,7 +1102,7 @@ class PlannerSpec extends
                       $lt($literal(Bson.Null), $field("bar")),
                       $lt($field("bar"), $literal(Bson.Text("")))),
                     $and(
-                      $lte($literal(Bson.Date(Check.minInstant)), $field("bar")),
+                      $lte($literal(Check.minDate), $field("bar")),
                       $lt($field("bar"), $literal(Bson.Regex("", ""))))),
                   $divide($field("bar"), $literal(Bson.Int32(10))),
                   $literal(Bson.Undefined))),
@@ -1244,7 +1244,7 @@ class PlannerSpec extends
                       $lt($literal(Bson.Null), $field("pop")),
                       $lt($field("pop"), $literal(Bson.Text("")))),
                     $and(
-                      $lte($literal(Bson.Date(Check.minInstant)), $field("pop")),
+                      $lte($literal(Check.minDate), $field("pop")),
                       $lt($field("pop"), $literal(Bson.Regex("", ""))))),
                   $divide($field("pop"), $literal(Bson.Int32(1000))),
                   $literal(Bson.Undefined))),
@@ -1286,7 +1286,7 @@ class PlannerSpec extends
                       $lt($literal(Bson.Null), $field("pop")),
                       $lt($field("pop"), $literal(Bson.Text("")))),
                     $and(
-                      $lte($literal(Bson.Date(Check.minInstant)), $field("pop")),
+                      $lte($literal(Check.minDate), $field("pop")),
                       $lt($field("pop"), $literal(Bson.Regex("", ""))))),
                   $divide($field("pop"), $literal(Bson.Int32(1000))),
                   $literal(Bson.Undefined))),
@@ -1469,7 +1469,7 @@ class PlannerSpec extends
               "0" ->
                 $cond(
                   $and(
-                    $lte($literal(Bson.Date(Check.minInstant)), $field("date")),
+                    $lte($literal(Check.minDate), $field("date")),
                     $lt($field("date"), $literal(Bson.Regex("", "")))),
                   $month($field("date")),
                   $literal(Bson.Undefined))))),
@@ -1609,7 +1609,7 @@ class PlannerSpec extends
                         $lt($literal(Bson.Null), $field("pop")),
                         $lt($field("pop"), $literal(Bson.Text("")))),
                       $and(
-                        $lte($literal(Bson.Date(Check.minInstant)), $field("pop")),
+                        $lte($literal(Check.minDate), $field("pop")),
                         $lt($field("pop"), $literal(Bson.Regex("", ""))))),
                     $field("pop"),
                     $literal(Bson.Undefined))),
@@ -1691,7 +1691,7 @@ class PlannerSpec extends
                       $lt($literal(Bson.Null), $field("pop")),
                       $lt($field("pop"), $literal(Bson.Text("")))),
                     $and(
-                      $lte($literal(Bson.Date(Check.minInstant)), $field("pop")),
+                      $lte($literal(Check.minDate), $field("pop")),
                       $lt($field("pop"), $literal(Bson.Regex("", ""))))),
                   $divide($field("pop"), $literal(Bson.Int32(1000))),
                   $literal(Bson.Undefined))),
@@ -2516,6 +2516,9 @@ class PlannerSpec extends
     }.pendingUntilFixed
 
     "plan filter with timestamp and interval" in {
+      val date0 = Bson.Date.fromInstant(Instant.parse("2014-11-17T00:00:00Z")).get
+      val date22 = Bson.Date.fromInstant(Instant.parse("2014-11-17T22:00:00Z")).get
+
       plan("""select * from days where date < timestamp("2014-11-17T22:00:00Z") and date - interval("PT12H") > timestamp("2014-11-17T00:00:00Z")""") must
         beWorkflow(chain[Workflow](
           $read(collection("db", "days")),
@@ -2528,7 +2531,7 @@ class PlannerSpec extends
                       $lt($literal(Bson.Null), $field("date")),
                       $lt($field("date"), $literal(Bson.Text("")))),
                     $and(
-                      $lte($literal(Bson.Date(Check.minInstant)), $field("date")),
+                      $lte($literal(Check.minDate), $field("date")),
                       $lt($field("date"), $literal(Bson.Regex("", ""))))),
                   $cond(
                     $or(
@@ -2539,10 +2542,10 @@ class PlannerSpec extends
                         $lte($literal(Bson.Bool(false)), $field("date")),
                         $lt($field("date"), $literal(Bson.Regex("", ""))))),
                     $and(
-                      $lt($field("date"), $literal(Bson.Date(Instant.parse("2014-11-17T22:00:00Z")))),
+                      $lt($field("date"), $literal(date22)),
                       $gt(
                         $subtract($field("date"), $literal(Bson.Dec(12*60*60*1000))),
-                        $literal(Bson.Date(Instant.parse("2014-11-17T00:00:00Z"))))),
+                        $literal(date0))),
                     $literal(Bson.Undefined)),
                   $literal(Bson.Undefined)),
               "__tmp7" -> $$ROOT),
@@ -2570,7 +2573,7 @@ class PlannerSpec extends
             reshape("value" ->
               $cond(
                 $and(
-                  $lte($literal(Bson.Date(Check.minInstant)), $field("ts")),
+                  $lte($literal(Check.minDate), $field("ts")),
                   $lt($field("ts"), $literal(Bson.Regex("", "")))),
                 $dateToString(Hour :: ":" :: Minute :: ":" :: Second :: "." :: Millisecond :: FormatString.empty, $field("ts")),
                 $literal(Bson.Undefined))),
@@ -2578,6 +2581,14 @@ class PlannerSpec extends
     }
 
     "plan filter on date" in {
+      val date23 = Bson.Date.fromInstant(Instant.parse("2015-01-23T00:00:00Z")).get
+      val date25 = Bson.Date.fromInstant(Instant.parse("2015-01-25T00:00:00Z")).get
+      val date26 = Bson.Date.fromInstant(Instant.parse("2015-01-26T00:00:00Z")).get
+      val date28 = Bson.Date.fromInstant(Instant.parse("2015-01-28T00:00:00Z")).get
+      val date29 = Bson.Date.fromInstant(Instant.parse("2015-01-29T00:00:00Z")).get
+      val date30 = Bson.Date.fromInstant(Instant.parse("2015-01-30T00:00:00Z")).get
+
+
       // Note: both of these boundaries require comparing with the start of the *next* day.
       plan("select * from logs " +
         "where ((ts > date(\"2015-01-22\") and ts <= date(\"2015-01-27\")) and ts != date(\"2015-01-25\")) " +
@@ -2593,19 +2604,19 @@ class PlannerSpec extends
                 Selector.And(
                   Selector.And(
                     Selector.Doc(
-                      BsonField.Name("ts") -> Selector.Gte(Bson.Date(Instant.parse("2015-01-23T00:00:00Z")))),
+                      BsonField.Name("ts") -> Selector.Gte(date23)),
                     Selector.Doc(
-                      BsonField.Name("ts") -> Selector.Lt(Bson.Date(Instant.parse("2015-01-28T00:00:00Z"))))),
+                      BsonField.Name("ts") -> Selector.Lt(date28))),
                   Selector.Or(
                     Selector.Doc(
-                      BsonField.Name("ts") -> Selector.Lt(Bson.Date(Instant.parse("2015-01-25T00:00:00Z")))),
+                      BsonField.Name("ts") -> Selector.Lt(date25)),
                     Selector.Doc(
-                      BsonField.Name("ts") -> Selector.Gte(Bson.Date(Instant.parse("2015-01-26T00:00:00Z")))))))),
+                      BsonField.Name("ts") -> Selector.Gte(date26)))))),
             Selector.And(
               Selector.Doc(
-                BsonField.Name("ts") -> Selector.Gte(Bson.Date(Instant.parse("2015-01-29T00:00:00Z")))),
+                BsonField.Name("ts") -> Selector.Gte(date29)),
               Selector.Doc(
-                BsonField.Name("ts") -> Selector.Lt(Bson.Date(Instant.parse("2015-01-30T00:00:00Z")))))))))
+                BsonField.Name("ts") -> Selector.Lt(date30)))))))
     }
 
     "plan js and filter with id" in {
@@ -2647,7 +2658,7 @@ class PlannerSpec extends
                   $and(
                     $lt($literal(Bson.Null), $field("epoch")),
                     $lt($field("epoch"), $literal(Bson.Text("")))),
-                  $add($literal(Bson.Date(Instant.ofEpochMilli(0))), $field("epoch")),
+                  $add($literal(Bson.Date(0)), $field("epoch")),
                   $literal(Bson.Undefined))),
             ExcludeId))
       }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,13 +1,14 @@
 resolvers += "Jenkins-CI" at "http://repo.jenkins-ci.org/repo"
 libraryDependencies += "org.kohsuke" % "github-api" % "1.59"
 
-addSbtPlugin("org.scoverage"         % "sbt-scoverage"   % "1.3.3")
-addSbtPlugin("com.eed3si9n"          % "sbt-assembly"    % "0.14.3")
-addSbtPlugin("com.github.gseitz"     % "sbt-release"     % "1.0.3")
-addSbtPlugin("com.jsuereth"          % "sbt-pgp"         % "1.0.0")
-addSbtPlugin("org.wartremover"       % "sbt-wartremover" % "1.2.1")
-addSbtPlugin("de.heikoseeberger"     % "sbt-header"      % "1.5.0")
-addSbtPlugin("com.eed3si9n"          % "sbt-buildinfo"   % "0.6.1")
+addSbtPlugin("com.eed3si9n"      % "sbt-assembly"    % "0.14.3")
+addSbtPlugin("com.eed3si9n"      % "sbt-buildinfo"   % "0.6.1")
+addSbtPlugin("de.heikoseeberger" % "sbt-header"      % "1.5.0")
+addSbtPlugin("com.jsuereth"      % "sbt-pgp"         % "1.0.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release"     % "1.0.3")
+addSbtPlugin("org.scoverage"     % "sbt-scoverage"   % "1.3.3")
+addSbtPlugin("com.dwijnand"      % "sbt-travisci"    % "1.0.0")
+addSbtPlugin("org.wartremover"   % "sbt-wartremover" % "1.2.1")
 
 val commonScalacOptions = Seq(
   "-deprecation",

--- a/sql/src/main/scala/quasar/sql/compiler.scala
+++ b/sql/src/main/scala/quasar/sql/compiler.scala
@@ -236,6 +236,7 @@ final class Compiler[M[_], T: Equal]
       "to_timestamp"            -> date.ToTimestamp,
       "squash"                  -> identity.Squash,
       "oid"                     -> identity.ToId,
+      "type_of"                 -> identity.TypeOf,
       "between"                 -> relations.Between,
       "where"                   -> set.Filter,
       "distinct"                -> set.Distinct,

--- a/web/src/test/scala/quasar/api/services/query/ExecuteServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/query/ExecuteServiceSpec.scala
@@ -21,7 +21,7 @@ import quasar._
 import quasar.api._, ApiErrorEntityDecoder._, ToApiError.ops._
 import quasar.api.matchers._
 import quasar.api.services.Fixture._
-import quasar.common._
+import quasar.common.{Map => _, _}
 import quasar.contrib.pathy._, PathArbitrary._
 import quasar.fp._
 import quasar.fp.ski._


### PR DESCRIPTION
- Add a `TypeOf` operation (not a fix for #1802 yet, because it doesn’t implement it for any connector)
- adds a new PrimaryType type that reflects the simpler notion of type used with “patterns” as we go forward (and also the notion of types used by `TypeOf`)
- use the sbt-travisci plugin
- convert `Bson.Date` to use a `Long` instead of `Instant` (since `Instant` encodes more values than `Bson.Date`)