### PR TITLE
Add `log4j.properties` file to remove warning message when starting web server

### DIFF
--- a/web/src/main/resources/log4j.properties
+++ b/web/src/main/resources/log4j.properties
@@ -1,0 +1,1 @@
+log4j.rootLogger=ERROR


### PR DESCRIPTION
Fixes #1464.