### PR TITLE
Implement TypeOf for MongoDB.

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,7 +663,6 @@ time      | `"10:30:05"`    | `{ "$time": "10:30:05" }` | HH:MM[:SS[:.SSS]]
 interval  | `"PT12H34M"`    | `{ "$interval": "P7DT12H34M" }` | Note: year/month not currently supported.
 binary    | `"TE1OTw=="`    | `{ "$binary": "TE1OTw==" }` | BASE64-encoded.
 object id | `"abc"`         | `{ "$oid": "abc" }` |
-error     | `null`          | `{ "$na": null }` | A runtime error occurred producing or representing this value.
 
 
 ### CSV

--- a/connector/src/main/scala/quasar/fs/WriteError.scala
+++ b/connector/src/main/scala/quasar/fs/WriteError.scala
@@ -19,7 +19,7 @@ package quasar.fs
 import quasar.Predef._
 import quasar.{Data, DataCodec}
 
-import argonaut._, Argonaut._, EncodeJsonScalaz._
+import argonaut._, Argonaut._
 
 import scalaz.Show
 

--- a/connector/src/main/scala/quasar/qscript/MapFunc.scala
+++ b/connector/src/main/scala/quasar/qscript/MapFunc.scala
@@ -775,6 +775,10 @@ object MapFuncs {
   @Lenses final case class Now[T[_[_]], A]() extends Nullary[T, A]
 
   // identity
+  /** Returns a string describing the type of the value. If the value has a
+    * metadata map containing an "_ejson.type" entry, that value is returned.
+    * Otherwise, it returns a string naming a [[quasar.common.PrimaryType]].
+    */
   @Lenses final case class TypeOf[T[_[_]], A](a1: A) extends Unary[T, A]
 
   // math

--- a/couchbase/src/main/scala/quasar/physical/couchbase/RenderQuery.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/RenderQuery.scala
@@ -44,7 +44,7 @@ object RenderQuery {
     case Data(QData.Str(v)) =>
       ("'" ⊹ v.flatMap { case ''' => "''"; case v   => v.toString } ⊹ "'").right
     case Data(v) =>
-      DataCodec.render(v).leftAs(NonRepresentableData(v))
+      DataCodec.render(v) \/> NonRepresentableData(v)
     case Id(v) =>
       s"`$v`".right
     case Obj(m) =>

--- a/couchbase/src/main/scala/quasar/physical/couchbase/fs/writefile.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/fs/writefile.scala
@@ -94,16 +94,12 @@ object writefile {
   ): Free[S, Vector[FileSystemError]] =
     (for {
       st   <- writeHandles.get(h).toRight(Vector(FileSystemError.unknownWriteHandle(h)))
-      data <- EitherT(lift(Task.delay(chunk.foldMap(d =>
-                DataCodec.render(d).bimap(
-                  err => Vector(FileSystemError.writeFailed(d, err.shows)),
-                  str => Vector(
-                    JsonObject
-                      .create()
-                      .put("type", st.collection)
-                      .put("value", jsonTranscoder.stringToJsonObject(str))
-                  ))
-              ))).into)
+      data <- lift(Task.delay(chunk.map(DataCodec.render).unite
+                .map(str =>
+                  JsonObject
+                    .create()
+                    .put("type", st.collection)
+                    .put("value", jsonTranscoder.stringToJsonObject(str))))).into.liftM[EitherT[?[_], Vector[FileSystemError], ?]]
       docs <- data.traverse(d => GenUUID.Ops[S].asks(uuid =>
                 JsonDocument.create(uuid.toString, d)
               )).liftM[EitherT[?[_], Vector[FileSystemError], ?]]

--- a/frontend/src/main/scala/quasar/types.scala
+++ b/frontend/src/main/scala/quasar/types.scala
@@ -233,7 +233,7 @@ trait TypeInstances {
       case Bottom =>
         jString("Bottom")
       case Const(d) =>
-        Json("Const" -> DataCodec.Precise.encode(d).getOrElse(Json.obj("$na" -> jNull)))
+        Json("Const" -> DataCodec.Precise.encode(d).toOption.join.getOrElse(jString("Undefined")))
       case Null =>
         jString("Null")
       case Str =>

--- a/frontend/src/main/scala/quasar/types.scala
+++ b/frontend/src/main/scala/quasar/types.scala
@@ -233,7 +233,7 @@ trait TypeInstances {
       case Bottom =>
         jString("Bottom")
       case Const(d) =>
-        Json("Const" -> DataCodec.Precise.encode(d).toOption.join.getOrElse(jString("Undefined")))
+        Json("Const" -> DataCodec.Precise.encode(d).getOrElse(jString("Undefined")))
       case Null =>
         jString("Null")
       case Str =>

--- a/frontend/src/test/scala/quasar/codec.scala
+++ b/frontend/src/test/scala/quasar/codec.scala
@@ -72,7 +72,7 @@ class DataCodecSpecs extends quasar.Qspec {
       "encode set"       in { DataCodec.render(Data.Set(List(Data.Int(0), Data.Int(1), Data.Int(2)))) must beLeftDisjunction }
       "encode binary"    in { DataCodec.render(Data.Binary.fromArray(Array[Byte](76, 77, 78, 79))) must beRightDisjunction("""{ "$binary": "TE1OTw==" }""") }
       "encode objectId"  in { DataCodec.render(Data.Id("abc")) must beRightDisjunction("""{ "$oid": "abc" }""") }
-      "encode NA"        in { DataCodec.render(Data.NA) must beRightDisjunction("""{ "$na": null }""") }
+      "encode NA"        in { DataCodec.render(Data.NA) must beRightDisjunction("Undefined") }
     }
 
     "round-trip" >> prop { (data: Data) =>
@@ -150,7 +150,7 @@ class DataCodecSpecs extends quasar.Qspec {
       "encode binary"    in { DataCodec.render(Data.Binary.fromArray(Array[Byte](76, 77, 78, 79))) must beRightDisjunction("\"TE1OTw==\"") }
       "encode empty binary" in { DataCodec.render(Data.Binary.fromArray(Array[Byte]())) must beRightDisjunction("\"\"") }
       "encode objectId"  in { DataCodec.render(Data.Id("abc")) must beRightDisjunction("\"abc\"") }
-      "encode NA"        in { DataCodec.render(Data.NA) must beRightDisjunction("null") }
+      "encode NA"        in { DataCodec.render(Data.NA) must beRightDisjunction("Undefined") }
     }
 
     "round-trip" >> prop { (data: Data) =>

--- a/frontend/src/test/scala/quasar/codec.scala
+++ b/frontend/src/test/scala/quasar/codec.scala
@@ -29,6 +29,10 @@ class DataCodecSpecs extends quasar.Qspec {
   implicit val DataShow = new Show[Data] { override def show(v: Data) = v.toString }
   implicit val ShowStr = new Show[String] { override def show(v: String) = v }
 
+  def roundTrip(d: Data)(implicit C: DataCodec)
+      : Option[DataEncodingError \/ Data] =
+    DataCodec.render(d).map(DataCodec.parse(_))
+
   "Precise" should {
     implicit val codec = DataCodec.Precise
 
@@ -45,39 +49,39 @@ class DataCodecSpecs extends quasar.Qspec {
     "render" should {
       // NB: these tests verify that all the formatting matches our documentation
 
-      "encode null"      in { DataCodec.render(Data.Null)     must beRightDisjunction("null") }
-      "encode true"      in { DataCodec.render(Data.True)     must beRightDisjunction("true") }
-      "encode false"     in { DataCodec.render(Data.False)    must beRightDisjunction("false") }
-      "encode int"       in { DataCodec.render(Data.Int(0))   must beRightDisjunction("0") }
-      "encode dec"       in { DataCodec.render(Data.Dec(1.1)) must beRightDisjunction("1.1") }
-      "encode dec with no fractional part" in { DataCodec.render(Data.Dec(2.0)) must beRightDisjunction("2.0") }
-      "encode timestamp" in { DataCodec.render(Data.Timestamp(Instant.parse("2015-01-31T10:30:00Z"))) must beRightDisjunction("""{ "$timestamp": "2015-01-31T10:30:00Z" }""") }
-      "encode date"      in { DataCodec.render(Data.Date(LocalDate.parse("2015-01-31")))              must beRightDisjunction("""{ "$date": "2015-01-31" }""") }
-      "encode time"      in { DataCodec.render(Data.Time(LocalTime.parse("10:30:00.000")))            must beRightDisjunction("""{ "$time": "10:30:00.000" }""") }
-      "encode interval"  in { DataCodec.render(Data.Interval(Duration.parse("PT12H34M")))             must beRightDisjunction("""{ "$interval": "PT12H34M" }""") }
+      "encode null"      in { DataCodec.render(Data.Null)     must beSome("null") }
+      "encode true"      in { DataCodec.render(Data.True)     must beSome("true") }
+      "encode false"     in { DataCodec.render(Data.False)    must beSome("false") }
+      "encode int"       in { DataCodec.render(Data.Int(0))   must beSome("0") }
+      "encode dec"       in { DataCodec.render(Data.Dec(1.1)) must beSome("1.1") }
+      "encode dec with no fractional part" in { DataCodec.render(Data.Dec(2.0)) must beSome("2.0") }
+      "encode timestamp" in { DataCodec.render(Data.Timestamp(Instant.parse("2015-01-31T10:30:00Z"))) must beSome("""{ "$timestamp": "2015-01-31T10:30:00Z" }""") }
+      "encode date"      in { DataCodec.render(Data.Date(LocalDate.parse("2015-01-31")))              must beSome("""{ "$date": "2015-01-31" }""") }
+      "encode time"      in { DataCodec.render(Data.Time(LocalTime.parse("10:30:00.000")))            must beSome("""{ "$time": "10:30:00.000" }""") }
+      "encode interval"  in { DataCodec.render(Data.Interval(Duration.parse("PT12H34M")))             must beSome("""{ "$interval": "PT12H34M" }""") }
       "encode obj" in {
         // NB: more than 4, to verify order is preserved
         DataCodec.render(Data.Obj(ListMap("a" -> Data.Int(1), "b" -> Data.Int(2), "c" -> Data.Int(3), "d" -> Data.Int(4), "e" -> Data.Int(5)))) must
-          beRightDisjunction("""{ "a": 1, "b": 2, "c": 3, "d": 4, "e": 5 }""")
+          beSome("""{ "a": 1, "b": 2, "c": 3, "d": 4, "e": 5 }""")
       }
       "encode obj with leading '$'s" in {
         DataCodec.render(Data.Obj(ListMap("$a" -> Data.Int(1), "$date" -> Data.Timestamp(Instant.parse("2015-01-31T10:30:00Z"))))) must
-          beRightDisjunction("""{ "$obj": { "$a": 1, "$date": { "$timestamp": "2015-01-31T10:30:00Z" } } }""")
+          beSome("""{ "$obj": { "$a": 1, "$date": { "$timestamp": "2015-01-31T10:30:00Z" } } }""")
       }
       "encode obj with $obj" in {
         DataCodec.render(Data.Obj(ListMap("$obj" -> Data.Obj(ListMap("$obj" -> Data.Int(1)))))) must
-          beRightDisjunction("""{ "$obj": { "$obj": { "$obj": { "$obj": 1 } } } }""")
+          beSome("""{ "$obj": { "$obj": { "$obj": { "$obj": 1 } } } }""")
       }
-      "encode array"     in { DataCodec.render(Data.Arr(List(Data.Int(0), Data.Int(1), Data.Int(2)))) must beRightDisjunction("[ 0, 1, 2 ]") }
-      "encode set"       in { DataCodec.render(Data.Set(List(Data.Int(0), Data.Int(1), Data.Int(2)))) must beLeftDisjunction }
-      "encode binary"    in { DataCodec.render(Data.Binary.fromArray(Array[Byte](76, 77, 78, 79))) must beRightDisjunction("""{ "$binary": "TE1OTw==" }""") }
-      "encode objectId"  in { DataCodec.render(Data.Id("abc")) must beRightDisjunction("""{ "$oid": "abc" }""") }
-      "encode NA"        in { DataCodec.render(Data.NA) must beRightDisjunction("Undefined") }
+      "encode array"     in { DataCodec.render(Data.Arr(List(Data.Int(0), Data.Int(1), Data.Int(2)))) must beSome("[ 0, 1, 2 ]") }
+      "encode set"       in { DataCodec.render(Data.Set(List(Data.Int(0), Data.Int(1), Data.Int(2)))) must beNone }
+      "encode binary"    in { DataCodec.render(Data.Binary.fromArray(Array[Byte](76, 77, 78, 79))) must beSome("""{ "$binary": "TE1OTw==" }""") }
+      "encode objectId"  in { DataCodec.render(Data.Id("abc")) must beSome("""{ "$oid": "abc" }""") }
+      "encode NA"        in { DataCodec.render(Data.NA) must beNone }
     }
 
     "round-trip" >> prop { (data: Data) =>
       representable(data) ==> {
-        DataCodec.render(data).flatMap(DataCodec.parse) must beRightDisjunction(data)
+        roundTrip(data) must beSome(data.right[DataEncodingError])
       }
     }.flakyTest("with arg: Interval(PT-175468H-10M-0.6S). As far as I can tell, this is a problem with java.time.Instant which is not preserving the exact nature of the Instant object through calls to toString() and parse()")
 
@@ -85,7 +89,7 @@ class DataCodecSpecs extends quasar.Qspec {
       // These types get lost on the way through rendering and re-parsing:
 
       "re-parse very large Int value as Dec" in {
-        DataCodec.render(Data.Int(LargeInt)).flatMap(DataCodec.parse) must beRightDisjunction(Data.Dec(new java.math.BigDecimal(LargeInt.underlying)))
+        roundTrip(Data.Int(LargeInt)) must beSome(Data.Dec(new java.math.BigDecimal(LargeInt.underlying)).right[DataEncodingError])
       }
 
 
@@ -126,36 +130,36 @@ class DataCodecSpecs extends quasar.Qspec {
     "render" should {
       // NB: these tests verify that all the formatting matches our documentation
 
-      "encode null"      in { DataCodec.render(Data.Null)     must beRightDisjunction("null") }
-      "encode true"      in { DataCodec.render(Data.True)     must beRightDisjunction("true") }
-      "encode false"     in { DataCodec.render(Data.False)    must beRightDisjunction("false") }
-      "encode int"       in { DataCodec.render(Data.Int(0))   must beRightDisjunction("0") }
-      "encode dec"       in { DataCodec.render(Data.Dec(1.1)) must beRightDisjunction("1.1") }
-      "encode dec with no fractional part" in { DataCodec.render(Data.Dec(2.0)) must beRightDisjunction("2.0") }
-      "encode timestamp" in { DataCodec.render(Data.Timestamp(Instant.parse("2015-01-31T10:30:00Z"))) must beRightDisjunction("\"2015-01-31T10:30:00Z\"") }
-      "encode date"      in { DataCodec.render(Data.Date(LocalDate.parse("2015-01-31")))              must beRightDisjunction("\"2015-01-31\"") }
-      "encode time"      in { DataCodec.render(Data.Time(LocalTime.parse("10:30:00.000")))            must beRightDisjunction("\"10:30\"") }
-      "encode interval"  in { DataCodec.render(Data.Interval(Duration.parse("PT12H34M")))             must beRightDisjunction("\"PT12H34M\"") }
+      "encode null"      in { DataCodec.render(Data.Null)     must beSome("null") }
+      "encode true"      in { DataCodec.render(Data.True)     must beSome("true") }
+      "encode false"     in { DataCodec.render(Data.False)    must beSome("false") }
+      "encode int"       in { DataCodec.render(Data.Int(0))   must beSome("0") }
+      "encode dec"       in { DataCodec.render(Data.Dec(1.1)) must beSome("1.1") }
+      "encode dec with no fractional part" in { DataCodec.render(Data.Dec(2.0)) must beSome("2.0") }
+      "encode timestamp" in { DataCodec.render(Data.Timestamp(Instant.parse("2015-01-31T10:30:00Z"))) must beSome("\"2015-01-31T10:30:00Z\"") }
+      "encode date"      in { DataCodec.render(Data.Date(LocalDate.parse("2015-01-31")))              must beSome("\"2015-01-31\"") }
+      "encode time"      in { DataCodec.render(Data.Time(LocalTime.parse("10:30:00.000")))            must beSome("\"10:30\"") }
+      "encode interval"  in { DataCodec.render(Data.Interval(Duration.parse("PT12H34M")))             must beSome("\"PT12H34M\"") }
       "encode obj" in {
         // NB: more than 4, to verify order is preserved
         DataCodec.render(Data.Obj(ListMap("a" -> Data.Int(1), "b" -> Data.Int(2), "c" -> Data.Int(3), "d" -> Data.Int(4), "e" -> Data.Int(5)))) must
-          beRightDisjunction("""{ "a": 1, "b": 2, "c": 3, "d": 4, "e": 5 }""")
+          beSome("""{ "a": 1, "b": 2, "c": 3, "d": 4, "e": 5 }""")
       }
       "encode obj with leading '$'s" in {
         DataCodec.render(Data.Obj(ListMap("$a" -> Data.Int(1), "$date" -> Data.Timestamp(Instant.parse("2015-01-31T10:30:00Z"))))) must
-          beRightDisjunction("""{ "$a": 1, "$date": "2015-01-31T10:30:00Z" }""")
+          beSome("""{ "$a": 1, "$date": "2015-01-31T10:30:00Z" }""")
         }
-      "encode array"     in { DataCodec.render(Data.Arr(List(Data.Int(0), Data.Int(1), Data.Int(2)))) must beRightDisjunction("[ 0, 1, 2 ]") }
-      "encode set"       in { DataCodec.render(Data.Set(List(Data.Int(0), Data.Int(1), Data.Int(2)))) must beLeftDisjunction }
-      "encode binary"    in { DataCodec.render(Data.Binary.fromArray(Array[Byte](76, 77, 78, 79))) must beRightDisjunction("\"TE1OTw==\"") }
-      "encode empty binary" in { DataCodec.render(Data.Binary.fromArray(Array[Byte]())) must beRightDisjunction("\"\"") }
-      "encode objectId"  in { DataCodec.render(Data.Id("abc")) must beRightDisjunction("\"abc\"") }
-      "encode NA"        in { DataCodec.render(Data.NA) must beRightDisjunction("Undefined") }
+      "encode array"     in { DataCodec.render(Data.Arr(List(Data.Int(0), Data.Int(1), Data.Int(2)))) must beSome("[ 0, 1, 2 ]") }
+      "encode set"       in { DataCodec.render(Data.Set(List(Data.Int(0), Data.Int(1), Data.Int(2)))) must beNone }
+      "encode binary"    in { DataCodec.render(Data.Binary.fromArray(Array[Byte](76, 77, 78, 79))) must beSome("\"TE1OTw==\"") }
+      "encode empty binary" in { DataCodec.render(Data.Binary.fromArray(Array[Byte]())) must beSome("\"\"") }
+      "encode objectId"  in { DataCodec.render(Data.Id("abc")) must beSome("\"abc\"") }
+      "encode NA"        in { DataCodec.render(Data.NA) must beNone }
     }
 
     "round-trip" >> prop { (data: Data) =>
       representable(data) ==> {
-        DataCodec.render(data).flatMap(DataCodec.parse) must beRightDisjunction(data)
+        roundTrip(data) must beSome(data.right[DataEncodingError])
       }
     }
 
@@ -165,42 +169,42 @@ class DataCodecSpecs extends quasar.Qspec {
       "re-parse Str as Timestamp" in {
         val ts = Data.Timestamp(Instant.now)
         val str = Data.Str(ts.value.toString)
-        DataCodec.render(str).flatMap(DataCodec.parse) must beRightDisjunction(ts)
+        roundTrip(str) must beSome(ts.right[DataEncodingError])
       }
 
       "re-parse Str as Date" in {
         val date = Data.Date(LocalDate.now)
         val str = Data.Str(date.value.toString)
-        DataCodec.render(str).flatMap(DataCodec.parse) must beRightDisjunction(date)
+        roundTrip(str) must beSome(date.right[DataEncodingError])
       }
 
       "re-parse Str as Time" in {
         val time = Data.Time(LocalTime.now)
         val str = Data.Str(time.value.toString)
-        DataCodec.render(str).flatMap(DataCodec.parse) must beRightDisjunction(time)
+        roundTrip(str) must beSome(time.right[DataEncodingError])
       }
 
       "re-parse Str as Interval" in {
         val interval = Data.Interval(Duration.ofSeconds(1))
         val str = Data.Str(interval.value.toString)
-        DataCodec.render(str).flatMap(DataCodec.parse) must beRightDisjunction(interval)
+        roundTrip(str) must beSome(interval.right[DataEncodingError])
       }
 
 
       // These types get lost on the way through rendering and re-parsing:
 
       "re-parse very large Int value as Dec" in {
-        DataCodec.render(Data.Int(LargeInt)).flatMap(DataCodec.parse) must beRightDisjunction(Data.Dec(new java.math.BigDecimal(LargeInt.underlying)))
+        roundTrip(Data.Int(LargeInt)) must beSome(Data.Dec(new java.math.BigDecimal(LargeInt.underlying)).right[DataEncodingError])
       }
 
       "re-parse Binary as Str" in {
         val binary = Data.Binary.fromArray(Array[Byte](0, 1, 2, 3))
-        DataCodec.render(binary).flatMap(DataCodec.parse) must beRightDisjunction(Data.Str("AAECAw=="))
+        roundTrip(binary) must beSome(Data.Str("AAECAw==").right[DataEncodingError])
       }
 
       "re-parse Id as Str" in {
         val id = Data.Id("abc")
-        DataCodec.render(id).flatMap(DataCodec.parse) must beRightDisjunction(Data.Str("abc"))
+        roundTrip(id) must beSome(Data.Str("abc").right[DataEncodingError])
       }
     }
   }

--- a/frontend/src/test/scala/quasar/types.scala
+++ b/frontend/src/test/scala/quasar/types.scala
@@ -738,7 +738,7 @@ class TypesSpec extends quasar.Qspec {
       val exp = DataCodec.Precise.encode(data)
       exp.isRight ==> {
         (Right(typJson(Const(data))): scala.Either[DataEncodingError, Json]) must_===
-          exp.map(jd => Json((("Const", jd)))).toEither
+          exp.map(jd => Json((("Const", jd.getOrElse(jString("Undefined")))))).toEither
       }
     }
 

--- a/frontend/src/test/scala/quasar/types.scala
+++ b/frontend/src/test/scala/quasar/types.scala
@@ -22,8 +22,6 @@ import quasar.fp._
 import quasar.fp.ski._
 import quasar.specs2._, QuasarMatchers._
 
-import scala.Right
-
 import argonaut._, Argonaut._
 import argonaut.JsonScalaz._
 import scalaz.Scalaz._
@@ -736,9 +734,9 @@ class TypesSpec extends quasar.Qspec {
 
     "encode constant types as their data encoding" >> prop { data: Data =>
       val exp = DataCodec.Precise.encode(data)
-      exp.isRight ==> {
-        (Right(typJson(Const(data))): scala.Either[DataEncodingError, Json]) must_===
-          exp.map(jd => Json((("Const", jd.getOrElse(jString("Undefined")))))).toEither
+      exp.isDefined ==> {
+        (typJson(Const(data)).some: Option[Json]) must_===
+          exp.map(jd => Json((("Const", jd))))
       }
     }
 

--- a/interface/src/main/scala/quasar/main/prettify.scala
+++ b/interface/src/main/scala/quasar/main/prettify.scala
@@ -134,18 +134,16 @@ object Prettify {
   def render(data: Data): Aligned[String] = data match {
     case Data.Str(str) => Aligned.Left(str)
     case _ => Aligned.Right(DataCodec.Readable.encode(data).fold(
-      _ => s"unexpected: $data",
-      json => json.fold(
-        "undefined")(
-        _.fold(
-          "null",
-          _.toString,
-          _.asJson.pretty(minspace),
-          ι,
-          // NB: the non-atomic types never appear here because the Data has
-          //     been flattened.
-          _ => s"unexpected: $data",
-          _ => s"unexpected: $data"))))
+      s"unexpected: $data")(
+      _.fold(
+        "null",
+        _.toString,
+        _.asJson.pretty(minspace),
+        ι,
+        // NB: the non-atomic types never appear here because the Data has
+        //     been flattened.
+        κ(s"unexpected: $data"),
+        κ(s"unexpected: $data"))))
   }
 
   def parse(str: String): Option[Data] = {

--- a/interface/src/main/scala/quasar/main/prettify.scala
+++ b/interface/src/main/scala/quasar/main/prettify.scala
@@ -136,15 +136,16 @@ object Prettify {
     case _ => Aligned.Right(DataCodec.Readable.encode(data).fold(
       _ => s"unexpected: $data",
       json => json.fold(
-        "null",
-        _.toString,
-        _.asJson.pretty(minspace),
-        ι,
-        // NB: the non-atomic types never appear here because the Data has been
-        // flattened.
-        _ => s"unexpected: $data",
-        _ => s"unexpected: $data"
-      )))
+        "undefined")(
+        _.fold(
+          "null",
+          _.toString,
+          _.asJson.pretty(minspace),
+          ι,
+          // NB: the non-atomic types never appear here because the Data has
+          //     been flattened.
+          _ => s"unexpected: $data",
+          _ => s"unexpected: $data"))))
   }
 
   def parse(str: String): Option[Data] = {

--- a/it/src/main/resources/tests/mongodb/temporal/time.test
+++ b/it/src/main/resources/tests/mongodb/temporal/time.test
@@ -24,7 +24,7 @@
 
     "predicate": "containsExactly",
     "expected": [
-        { "day": "Tuesday",   "tod": "08:00:00.000", "not a date": {"$na": null}, "missing": {"$na": null} },
-        { "day": "Wednesday", "tod": "09:00:00.000", "not a date": {"$na": null}, "missing": {"$na": null} },
-        { "day": "Thursday",  "tod": "10:00:00.000", "not a date": {"$na": null}, "missing": {"$na": null} }]
+        { "day": "Tuesday",   "tod": "08:00:00.000" },
+        { "day": "Wednesday", "tod": "09:00:00.000" },
+        { "day": "Thursday",  "tod": "10:00:00.000" }]
 }

--- a/it/src/main/resources/tests/temporal/time.test
+++ b/it/src/main/resources/tests/temporal/time.test
@@ -22,7 +22,7 @@
     "predicate": "containsExactly",
     "ignoreFieldOrder": ["couchbase"],
     "expected": [
-        { "day": "Tuesday",   "tod": { "$time": "08:00:00.000" }, "not a date": {"$na": null}, "missing": {"$na": null} },
-        { "day": "Wednesday", "tod": { "$time": "09:00:00.000" }, "not a date": {"$na": null}, "missing": {"$na": null} },
-        { "day": "Thursday",  "tod": { "$time": "10:00:00.000" }, "not a date": {"$na": null}, "missing": {"$na": null} }]
+        { "day": "Tuesday",   "tod": { "$time": "08:00:00.000" } },
+        { "day": "Wednesday", "tod": { "$time": "09:00:00.000" } },
+        { "day": "Thursday",  "tod": { "$time": "10:00:00.000" } }]
 }

--- a/it/src/main/resources/tests/typeOf.test
+++ b/it/src/main/resources/tests/typeOf.test
@@ -1,0 +1,22 @@
+{
+    "name": "use type_of function",
+    "backends": {
+        "couchbase": "pending",
+        "marklogic": "pending",
+        "postgresql": "pending",
+        "spark_hdfs": "pending",
+        "spark_local": "pending"
+    },
+    "data": "nested_foo.data",
+    "query": "select foo, type_of(foo) as type from nested_foo",
+    "predicate": "containsExactly",
+    "FIXME": "There should be three `{ }`, but they are rewritten away",
+    "expected": [{ "foo": "zap",                            "type": "array" },
+                 { "foo": [15, [{ "baz": ["quux"] }]],      "type": "array" },
+                 { "foo": ["15z", [{ "baz": ["qx"] }]],     "type": "array" },
+                 { "foo": [18, ["meh", { "baz": ["qx"] }]], "type": "array" },
+                 { "foo": [16, [{ "baz": "mooooo" }]],      "type": "array" },
+                 { "foo": { "bar": 15, "baz": ["qx"] },     "type": "map"   },
+                 { "foo": { "bar": "a15", "baz": ["qx"] },  "type": "map"   },
+                 { "foo": [17, [{ "baz": ["qx"] }]],        "type": "array" }]
+}

--- a/it/src/main/resources/tests/undefinedJsInExpr.test
+++ b/it/src/main/resources/tests/undefinedJsInExpr.test
@@ -1,6 +1,7 @@
 {
     "name": "propagate undefined and null in JS",
     "backends": {
+        "couchbase":         "pending",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"

--- a/it/src/main/resources/tests/undefinedJsInExpr.test
+++ b/it/src/main/resources/tests/undefinedJsInExpr.test
@@ -8,6 +8,6 @@
     "data": "zips.data",
     "query": "select distinct length(meh) as meh_len, meh.mep, length(meh.mep) as mep_len from zips",
     "predicate": "containsExactly",
-    "expected": [
-        { "meh_len": { "$na": null }, "mep": { "$na": null }, "mep_len": { "$na": null } }]
+    "FIXME": "There should be a `{ }`, but it is rewritten away",
+    "expected": []
 }

--- a/it/src/test/scala/quasar/regression/PredicateSpec.scala
+++ b/it/src/test/scala/quasar/regression/PredicateSpec.scala
@@ -37,7 +37,7 @@ class PredicateSpec extends quasar.Qspec {
   import Predicate._
 
   implicit val jsonArbitrary: Arbitrary[Json] = Arbitrary {
-    arbitrary[Data].map(DataCodec.Precise.encode(_).map(_.getOrElse(jString("Undefined"))).toOption.get)
+    arbitrary[Data].map(DataCodec.Precise.encode(_).getOrElse(jString("Undefined")))
   }
 
   // NB: for debugging, prints nicely and preserves field order

--- a/it/src/test/scala/quasar/regression/PredicateSpec.scala
+++ b/it/src/test/scala/quasar/regression/PredicateSpec.scala
@@ -24,7 +24,7 @@ import quasar.fp._
 
 import scala.Predef.$conforms
 
-import argonaut._
+import argonaut._, Argonaut._
 import org.scalacheck.Prop
 import org.specs2.execute._
 import org.specs2.matcher._
@@ -37,7 +37,7 @@ class PredicateSpec extends quasar.Qspec {
   import Predicate._
 
   implicit val jsonArbitrary: Arbitrary[Json] = Arbitrary {
-    arbitrary[Data].map(DataCodec.Precise.encode(_).toOption.get)
+    arbitrary[Data].map(DataCodec.Precise.encode(_).map(_.getOrElse(jString("Undefined"))).toOption.get)
   }
 
   // NB: for debugging, prints nicely and preserves field order

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -37,7 +37,7 @@ import scala.concurrent.duration._
 import scala.io.Source
 import scala.util.matching.Regex
 
-import argonaut._, Argonaut._, JsonMonocle._
+import argonaut._, Argonaut._
 import matryoshka._
 import matryoshka.data.Fix
 import org.specs2.execute._
@@ -171,10 +171,9 @@ abstract class QueryRegressionTest[S[_]](
     json => json.obj.fold(
       json.some)(
       _.toList match {
-        case ("value", result) :: Nil =>
-          (jObjectPrism.getOption(result) >>= (_("$na")))
-            .fold(result.some)(κ(None))
-        case _ => json.some
+        case Nil                      => None
+        case ("value", result) :: Nil => result.some
+        case _                        => json.some
       })
 
   val TestContext = new MathContext(13, RoundingMode.DOWN)
@@ -355,5 +354,5 @@ object QueryRegressionTest {
     EncodeJson(d =>
       DataCodec.Precise
         .encode(d)
-        .fold(err => scala.sys.error(err.message), ι))
+        .fold(err => scala.sys.error(err.message), _.getOrElse(jString("Undefined"))))
 }

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -351,8 +351,5 @@ object QueryRegressionTest {
     }
 
   implicit val dataEncodeJson: EncodeJson[Data] =
-    EncodeJson(d =>
-      DataCodec.Precise
-        .encode(d)
-        .fold(err => scala.sys.error(err.message), _.getOrElse(jString("Undefined"))))
+    EncodeJson(DataCodec.Precise.encode(_).getOrElse(jString("Undefined")))
 }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/bsoncodec.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/bsoncodec.scala
@@ -152,11 +152,6 @@ object BsonCodec {
     case Bson.Arr(value)       => C.inj(ejson.Arr(value)).right
     case Bson.Doc(value)       =>
       E.inj(ejson.Map(value.toList.map(_.leftMap(Bson.Text(_))))).right
-      // TODO: Remove Undefined values from maps, but currently this breaks tests
-      // E.inj(ejson.Map(value.toList.map(_.bitraverse(Bson.Text(_).some, {
-      //   case Bson.Undefined => None
-      //   case bson           => bson.some
-      // }).toList).join)).right
     case Bson.Null             => C.inj(ejson.Null()).right
     case Bson.Bool(value)      => C.inj(ejson.Bool(value)).right
     case Bson.Text(value)      => C.inj(ejson.Str(value)).right

--- a/postgresql/src/main/scala/quasar/physical/postgresql/fs/writefile.scala
+++ b/postgresql/src/main/scala/quasar/physical/postgresql/fs/writefile.scala
@@ -96,11 +96,7 @@ object writefile {
   ): Free[S, Vector[FileSystemError]] =
     (for {
       tbl  <- writeHandles.get(h).toRight(Vector(FileSystemError.unknownWriteHandle(h)))
-      data <- EitherT(chunk.foldMap(d =>
-                DataCodec.render(d).bimap(
-                  err => Vector(FileSystemError.writeFailed(d, err.shows)),
-                  List(_))
-              ).point[Free[S, ?]])
+      data =  chunk.map(DataCodec.render).unite
       qry  =  insertQueryStr(tbl.v) _
       _    <- lift(data.traverse(d =>
                 Update[HNil](qry(d), none).toUpdate0(HNil).run.void

--- a/repl/src/main/scala/quasar/repl/Repl.scala
+++ b/repl/src/main/scala/quasar/repl/Repl.scala
@@ -259,13 +259,13 @@ object Repl {
       case DebugLevel.Verbose => P.println(showPhaseResults(log) + "\n")
     }
 
-  def summarize[S[_]](max: Int, format: OutputFormat)(rows: IndexedSeq[Data])(implicit
-    P: ConsoleIO.Ops[S]
-  ): Free[S, Unit] = {
+  def summarize[S[_]]
+    (max: Int, format: OutputFormat)
+    (rows: IndexedSeq[Data])
+    (implicit P: ConsoleIO.Ops[S])
+      : Free[S, Unit] = {
     def formatJson(codec: DataCodec)(data: Data): Option[String] =
-      codec.encode(data).fold(
-        err => ("error: " + err.shows).some,
-        _.map(_.pretty(minspace)))
+      codec.encode(data).map(_.pretty(minspace))
 
     if (rows.lengthCompare(0) <= 0) P.println("No results found")
     else {

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/hdfs/queryfile.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/hdfs/queryfile.scala
@@ -64,14 +64,10 @@ class queryfile(fileSystem: Task[FileSystem]) {
     })
     val bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"))
 
-    rdd.map(data => DataCodec.render(data)(DataCodec.Precise)).collect().foreach {
-      case \/-(v) =>
+    rdd.flatMap(DataCodec.render(_)(DataCodec.Precise).toList).collect().foreach(v => {
         bw.write(v)
         bw.newLine()
-      case -\/(der) =>
-        bw.write(s"encoding error: ${der.message}")
-        bw.newLine()
-    }
+    })
     bw.close()
     hdfs.close()
   }

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/local/queryfile.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/local/queryfile.scala
@@ -42,10 +42,7 @@ object queryfile {
   def store(rdd: RDD[Data], out: AFile): Task[Unit] = Task.delay {
     val ioFile = new File(posixCodec.printPath(out))
     val pw = new PrintWriter(new FileOutputStream(ioFile, true))
-    rdd.map(data => DataCodec.render(data)(DataCodec.Precise)).collect().foreach {
-      case \/-(v) => pw.write(s"$v\n")
-      case -\/(der) => pw.write(s"encoding error: ${der.message}")
-    }
+    rdd.flatMap(DataCodec.render(_)(DataCodec.Precise).toList).collect().foreach(v => pw.write(s"$v\n"))
     pw.close()
   }
 

--- a/web/src/main/scala/quasar/api/MessageFormat.scala
+++ b/web/src/main/scala/quasar/api/MessageFormat.scala
@@ -18,13 +18,12 @@ package quasar.api
 
 import quasar.Predef._
 
-import quasar.{DataEncodingError, Data, DataCodec}
+import quasar.{Data, DataCodec}
 import quasar.csv._
 import quasar.fp._
 import quasar.fp.ski._
 import quasar.main.Prettify
 
-import argonaut.EncodeJson
 import org.http4s._
 import org.http4s.parser.HttpHeaderParser
 import org.http4s.headers._
@@ -94,8 +93,7 @@ object MessageFormat {
       format.mediaType.withExtensions(extensions)
     }
     override def encode[F[_]](data: Process[F, Data]): Process[F, String] = {
-      val encodedData =
-        data.map(DataCodec.render(_)(mode.codec).fold(EncodeJson.of[DataEncodingError].encode(_).toString, ι))
+      val encodedData = data.map(DataCodec.render(_)(mode.codec)).unite
       format match {
         case JsonFormat.SingleArray =>
           Process.emit("[" + LineSep) ++ encodedData.intersperse("," + LineSep) ++ Process.emit(LineSep + "]" + LineSep)

--- a/web/src/main/scala/quasar/api/ToApiError.scala
+++ b/web/src/main/scala/quasar/api/ToApiError.scala
@@ -339,7 +339,7 @@ sealed abstract class ToApiErrorInstances extends ToApiErrorInstances0 {
   ////
 
   private def encodeData(data: Data): Option[Json] =
-    DataCodec.Precise.encode(data).toOption.join
+    DataCodec.Precise.encode(data)
 }
 
 sealed abstract class ToApiErrorInstances0 {

--- a/web/src/main/scala/quasar/api/ToApiError.scala
+++ b/web/src/main/scala/quasar/api/ToApiError.scala
@@ -339,7 +339,7 @@ sealed abstract class ToApiErrorInstances extends ToApiErrorInstances0 {
   ////
 
   private def encodeData(data: Data): Option[Json] =
-    DataCodec.Precise.encode(data).toOption
+    DataCodec.Precise.encode(data).toOption.join
 }
 
 sealed abstract class ToApiErrorInstances0 {


### PR DESCRIPTION
Fixes #1802

Also eliminates undefined values from result sets. (This misbehaves
slightly in a couple tests, where results that _should_ be an empty
object are eliminated, but this is better than returning bad results to
a user.)