### PR TITLE
CB: Collapse inlining within ConcatArrays

### DIFF
--- a/couchbase/src/main/scala/quasar/physical/couchbase/N1QL.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/N1QL.scala
@@ -129,6 +129,7 @@ object N1QL extends N1QLInstances {
     resultExprs: NonEmptyList[ResultExpr[A]],
     keyspace: Option[Keyspace[A]],
     unnest: Option[Unnest[A]],
+    let: List[Binding[A]],
     filter: Option[Filter[A]],
     groupBy: Option[GroupBy[A]],
     orderBy: List[OrderBy[A]]
@@ -139,6 +140,7 @@ object N1QL extends N1QLInstances {
     final case class ResultExpr[A](expr: A, alias: Option[Id[A]])
     final case class Keyspace[A](expr: A, alias: Option[Id[A]])
     final case class Unnest[A](expr: A, alias: Option[Id[A]])
+    final case class Binding[A](id: Id[A], expr: A)
     final case class Filter[A](v: A)
     final case class GroupBy[A](v: A)
     final case class OrderBy[A](a: A, sortDir: SortDir)

--- a/couchbase/src/main/scala/quasar/physical/couchbase/N1QLRenderTreeInstance.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/N1QLRenderTreeInstance.scala
@@ -174,7 +174,7 @@ trait N1QLRenderTreeInstance {
           nonTerminal("Union", a1, a2)
         case ArrFor(a1, a2, a3) =>
           nonTerminal("ArrFor", a1, a2, a3)
-        case Select(v, re, ks, un, ft, gb, ob) =>
+        case Select(v, re, ks, un, lt, ft, gb, ob) =>
           def nt(tpe: String, label: Option[String], child: A) =
             NonTerminal(
               tpe :: Nil,
@@ -186,6 +186,7 @@ trait N1QLRenderTreeInstance {
             (re ∘ (i => nt("resultExpr", i.alias ∘ (_.v), i.expr))).toList :::
             (ks ∘ (i => nt("keyspace", i.alias ∘ (_.v), i.expr))).toList   :::
             (un ∘ (i => nt("unnest", i.alias ∘ (_.v), i.expr))).toList     :::
+            (lt ∘ (i => nt("let", i.id.v.some, i.expr))).toList            :::
             (ft ∘ (f => nonTerminal("filter", f.v))).toList                :::
             (gb ∘ (g => nonTerminal("groupBy", g.v))).toList               :::
             (ob ∘ (i => nt("orderBy", i.sortDir.shows.some, i.a))).toList)

--- a/couchbase/src/main/scala/quasar/physical/couchbase/N1QLTraverseInstance.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/N1QLTraverseInstance.scala
@@ -99,15 +99,16 @@ trait N1QLTraverseInstance {
       case ArrAgg(a1)              => f(a1) ∘ (ArrAgg(_))
       case Union(a1, a2)           => (f(a1) ⊛ f(a2))(Union(_, _))
       case ArrFor(a1, a2, a3)      => (f(a1) ⊛ f(a2) ⊛ f(a3))(ArrFor(_, _, _))
-      case Select(v, re, ks, un, fr, gb, ob) =>
+      case Select(v, re, ks, un, lt, fr, gb, ob) =>
         (re.traverse(i => f(i.expr) ∘ (ResultExpr(_, i.alias ∘ (a => Id[B](a.v))))) ⊛
          ks.traverse(i => f(i.expr) ∘ (Keyspace  (_, i.alias ∘ (a => Id[B](a.v))))) ⊛
          un.traverse(i => f(i.expr) ∘ (Unnest    (_, i.alias ∘ (a => Id[B](a.v))))) ⊛
+         lt.traverse(i => f(i.expr) ∘ (Binding(Id[B](i.id.v), _)))                  ⊛
          fr.traverse(i => f(i.v)    ∘ (Filter(_)))                                  ⊛
          gb.traverse(i => f(i.v)    ∘ (GroupBy(_)))                                 ⊛
          ob.traverse(i => f(i.a)    ∘ (OrderBy   (_, i.sortDir)))
         )(
-          Select(v, _, _, _, _, _, _)
+          Select(v, _, _, _, _, _, _, _)
         )
       case Case(wt, Else(e)) =>
         (wt.traverse { case WhenThen(w, t) => (f(w) ⊛ f(t))(WhenThen(_, _)) } ⊛

--- a/couchbase/src/main/scala/quasar/physical/couchbase/RenderQuery.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/RenderQuery.scala
@@ -188,12 +188,14 @@ object RenderQuery {
       s"($a1 union $a2)".right
     case ArrFor(a1, a2, a3) =>
       s"(array $a1 for $a2 in $a3 end)".right
-    case Select(v, re, ks, un, ft, gb, ob) =>
+    case Select(v, re, ks, un, lt, ft, gb, ob) =>
       def alias(a: Option[Id[String]]) = ~(a ∘ (i => s" as `${i.v}`"))
       val value       = v.v.fold("value ", "")
       val resultExprs = (re ∘ (r => r.expr ⊹ alias(r.alias))).intercalate(", ")
       val kSpace      = ~(ks ∘ (k => s" from ${k.expr}" ⊹ alias(k.alias)))
       val unnest      = ~(un ∘ (u => s" unnest ${u.expr}" ⊹ alias(u.alias)))
+      val let         = lt.toNel.foldMap(
+                          " let " ⊹ _.map(b => s"${b.id.v} = ${b.expr}").intercalate(", "))
       val filter      = ~(ft ∘ (f  => s" where ${f.v}"))
       val groupBy     = ~(gb ∘ (g  => s" group by ${g.v}"))
       val orderBy     =
@@ -201,7 +203,7 @@ object RenderQuery {
           case OrderBy(a, Ascending)  => s"$a ASC"
           case OrderBy(a, Descending) => s"$a DESC"
         }).toNel ∘ (" order by " ⊹ _.intercalate(", ")))
-      s"(select $value$resultExprs$kSpace$unnest$filter$groupBy$orderBy)".right
+      s"(select $value$resultExprs$kSpace$unnest$let$filter$groupBy$orderBy)".right
     case Case(wt, e) =>
       val wts = wt ∘ { case WhenThen(w, t) => s"when $w then $t" }
       s"(case ${wts.intercalate(" ")} else ${e.v} end)".right

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/MapFuncPlanner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/MapFuncPlanner.scala
@@ -370,29 +370,56 @@ final class MapFuncPlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: NameGenera
           ).wrapNel,
           Keyspace(a2, id1.some).some,
           unnest  = none,
+          let     = nil,
           filter  = none,
           groupBy = none,
-          orderBy = Nil).embed,
+          orderBy = nil).embed,
       Obj(Map(a1 -> a2)).embed))
     case MF.ConcatArrays(a1, a2) =>
-      IfNull(
-        ConcatStr(a1, a2).embed,
-        ConcatArr(
-          Case(
-            WhenThen(
-              IsString(a1).embed,
-              Split(a1, str("")).embed)
-          )(
-            Else(a1)
-          ).embed,
-          Case(
-            WhenThen(
-              IsString(a2).embed,
-              Split(a2, str("")).embed)
-          )(
-            Else(a2)
-          ).embed).embed
-      ).embed.η[M]
+      def containsAgg(v: T[N1QL]): Boolean = v.cataM[Unit \/ ?, Unit] {
+        case Avg(_) | Count(_) | Max(_) | Min(_) | Sum(_) | ArrAgg(_) => ().left
+        case _                                                        => ().right
+      }.isLeft
+
+      (containsAgg(a1) || containsAgg(a2)).fold(
+        IfNull(
+          ConcatStr(a1, a2).embed,
+          ConcatArr(
+            Case(
+              WhenThen(
+                IsString(a1).embed,
+                Split(a1, str("")).embed)
+            )(
+              Else(a1)
+            ).embed,
+            Case(
+              WhenThen(
+                IsString(a2).embed,
+                Split(a2, str("")).embed)
+            )(
+              Else(a2)
+            ).embed).embed
+        ).embed.η[M],
+        (genId[T[N1QL], M] ⊛ genId[T[N1QL], M]) { (id1, id2) =>
+          SelectElem(
+            Select(
+              Value(true),
+              ResultExpr(
+                IfNull(
+                  ConcatStr(id1.embed, id2.embed).embed,
+                  ConcatArr(Split(id1.embed, str("")).embed, id2.embed).embed,
+                  ConcatArr(id1.embed, Split(id2.embed, str("")).embed).embed,
+                  ConcatArr(id1.embed, id2.embed).embed).embed,
+                none
+              ).wrapNel,
+              keyspace = none,
+              unnest   = none,
+              List(Binding(id1, a1), Binding(id2, a2)),
+              filter   = none,
+              groupBy  = none,
+              orderBy  = nil).embed,
+            int(0)).embed
+        })
     case MF.ConcatMaps(a1, a2) =>
       ConcatObj(a1, a2).embed.η[M]
     case MF.ProjectField(a1, a2) =>
@@ -403,9 +430,10 @@ final class MapFuncPlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: NameGenera
           ResultExpr(SelectField(id1.embed, a2).embed, none).wrapNel,
           Keyspace(a1, id1.some).some,
           unnest  = none,
+          let     = nil,
           filter  = none,
           groupBy = none,
-          orderBy = Nil).embed,
+          orderBy = nil).embed,
         SelectField(a1, a2).embed))
     case MF.ProjectIndex(a1, a2) =>
       genId[T[N1QL], M] ∘ (id1 => selectOrElse(
@@ -415,9 +443,10 @@ final class MapFuncPlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: NameGenera
           ResultExpr(SelectElem(id1.embed, a2).embed, none).wrapNel,
           Keyspace(a1, id1.some).some,
           unnest  = none,
+          let     = nil,
           filter  = none,
           groupBy = none,
-          orderBy = Nil).embed,
+          orderBy = nil).embed,
         SelectElem(a1, a2).embed))
     case MF.DeleteField(a1, a2) =>
       ObjRemove(a1, a2).embed.η[M]
@@ -441,9 +470,10 @@ final class MapFuncPlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: NameGenera
             ResultExpr(grd(f, id.embed, id.embed), none).wrapNel,
             Keyspace(cont, id.some).some,
             unnest  = none,
+            let     = nil,
             filter  = none,
             groupBy = none,
-            orderBy = Nil).embed)
+            orderBy = nil).embed)
 
       def isArr(n: T[N1QL]): T[N1QL] = IsArr(n).embed
       def isObj(n: T[N1QL]): T[N1QL] = IsObj(n).embed

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/MapFuncPlanner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/MapFuncPlanner.scala
@@ -376,10 +376,10 @@ final class MapFuncPlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: NameGenera
           orderBy = nil).embed,
       Obj(Map(a1 -> a2)).embed))
     case MF.ConcatArrays(a1, a2) =>
-      def containsAgg(v: T[N1QL]): Boolean = v.cataM[Unit \/ ?, Unit] {
-        case Avg(_) | Count(_) | Max(_) | Min(_) | Sum(_) | ArrAgg(_) => ().left
-        case _                                                        => ().right
-      }.isLeft
+      def containsAgg(v: T[N1QL]): Boolean = v.cataM[Option, Unit] {
+        case Avg(_) | Count(_) | Max(_) | Min(_) | Sum(_) | ArrAgg(_) => none
+        case _                                                        => ().some
+      }.isEmpty
 
       (containsAgg(a1) || containsAgg(a2)).fold(
         IfNull(

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/QScriptCorePlanner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/QScriptCorePlanner.scala
@@ -69,9 +69,10 @@ final class QScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: NameGe
         ResultExpr(ff, none).wrapNel,
         Keyspace(wrapSelect(src), id1.some).some,
         unnest  = none,
+        let     = nil,
         filter  = none,
         groupBy = none,
-        orderBy = Nil).embed
+        orderBy = nil).embed
 
     case LeftShift(src, struct, id, repair) =>
       for {
@@ -109,9 +110,10 @@ final class QScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: NameGe
                        ResultExpr(id2.embed, none).wrapNel,
                        Keyspace(wrapSelect(src), id1.some).some,
                        Unnest(u, id2.some).some,
+                       let     = nil,
                        filter  = none,
                        groupBy = none,
-                       orderBy = Nil).embed.η[M]
+                       orderBy = nil).embed.η[M]
                  },
                  mapFuncPlanner[T, F].plan))
       } yield r
@@ -133,19 +135,21 @@ final class QScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: NameGe
           Value(false),
           ResultExpr(rep, id2.some).wrapNel,
           Keyspace(src, id1.some).some,
-          unnest = none,
-          filter = none,
+          unnest  = none,
+          let     = nil,
+          filter  = none,
           GroupBy(b).some,
-          orderBy = Nil).embed
+          orderBy = nil).embed
 
         Select(
           Value(true),
           ResultExpr(id2.embed, none).wrapNel,
           Keyspace(s, id3.some).some,
-          unnest = none,
+          unnest  = none,
+          let     = nil,
           Filter(IsNotNull(id2.embed).embed).some,
           groupBy = none,
-          orderBy = Nil).embed
+          orderBy = nil).embed
       }
 
     case qscript.Sort(src, bucket, order) =>
@@ -163,15 +167,17 @@ final class QScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: NameGe
            ResultExpr(ArrAgg(id1.embed).embed, none).wrapNel,
            Keyspace(src, id1.some).some,
            unnest  = none,
+           let     = nil,
            filter  = none,
            GroupBy(IfNull(b, id1.embed).embed).some,
-           orderBy = Nil).embed
+           orderBy = nil).embed
 
         Select(
           Value(true),
           ResultExpr(id3.embed, none).wrapNel,
           Keyspace(s, id2.some).some,
           Unnest(id2.embed, id3.some).some,
+          let     = nil,
           filter  = none,
           groupBy = none,
           orderBy = o.toList).embed
@@ -186,9 +192,10 @@ final class QScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: NameGe
         ResultExpr(id1.embed, none).wrapNel,
         Keyspace(src, id1.some).some,
         unnest  = none,
+        let     = nil,
         Filter(ff).some,
         groupBy = none,
-        orderBy = Nil).embed
+        orderBy = nil).embed
 
     case qscript.Union(src, lBranch, rBranch) =>
       for {
@@ -211,7 +218,7 @@ final class QScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: NameGe
     }
 
     case qscript.Unreferenced() =>
-      wrapSelect(Arr[T[N1QL]](Nil).embed).η[M]
+      wrapSelect(Arr[T[N1QL]](nil).embed).η[M]
   }
 
   def takeOrDrop(src: T[N1QL], from: FreeQS[T], takeOrDrop: FreeQS[T] \/ FreeQS[T]): M[T[N1QL]] =
@@ -236,9 +243,10 @@ final class QScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: NameGe
             ResultExpr(c, id3.some)),
           Keyspace(src, id1.some).some,
           unnest  = none,
+          let     = nil,
           filter  = none,
           groupBy = none,
-          orderBy = Nil).embed
+          orderBy = nil).embed
 
       val cnt = SelectElem(id3.embed, int(0)).embed
 
@@ -255,9 +263,10 @@ final class QScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: NameGe
         ResultExpr(id5.embed, none).wrapNel,
         Keyspace(s, id4.some).some,
         Unnest(SelectElem(id2.embed, slc).embed, id5.some).some,
+        let     = nil,
         filter  = none,
         groupBy = none,
-        orderBy = Nil).embed
+        orderBy = nil).embed
     }
 
 }

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/ShiftedReadPlanner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/ShiftedReadPlanner.scala
@@ -56,11 +56,12 @@ final class ShiftedReadPlanner[T[_[_]]: CorecursiveT, F[_]: Monad: NameGenerator
           ResultExpr(r, none).wrapNel,
           Keyspace(id(bc.bucket).embed, gId.some).some,
           unnest  = none,
+          let     = nil,
           filter  = bc.collection.nonEmpty.option(
                       Eq(id("type").embed, str(bc.collection).embed).embed
                     ) ∘ (Filter(_)),
           groupBy = none,
-          orderBy = Nil).embed
+          orderBy = nil).embed
       }
   }
 

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/package.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/package.scala
@@ -39,16 +39,16 @@ package object planner {
     (implicit T: Recursive.Aux[T, N1QL])
       : T =
     a.project match {
-      case Select(_, _, _, _, _, _, _) => whenSelect
-      case _                           => otherwise
+      case Select(_, _, _, _, _, _, _, _) => whenSelect
+      case _                              => otherwise
     }
 
   def wrapSelect[T[_[_]]: BirecursiveT](a: T[N1QL]): T[N1QL] =
     selectOrElse[T[N1QL]](
       a, a,
       Select(
-        Value(true), ResultExpr(a, none).wrapNel, keyspace = none,
-        unnest = none, filter = none, groupBy = none, orderBy = Nil).embed)
+        Value(true), ResultExpr(a, none).wrapNel, keyspace = none, unnest = none,
+        let = nil, filter = none, groupBy = none, orderBy = nil).embed)
 
   def unimplemented[A](name: String): PlannerError \/ A =
     InternalError.fromMsg(s"unimplemented $name").left

--- a/couchbase/src/test/scala/quasar/physical/couchbase/N1QLSpec.scala
+++ b/couchbase/src/test/scala/quasar/physical/couchbase/N1QLSpec.scala
@@ -58,6 +58,9 @@ trait N1QLArbitrary {
   implicit def arbUnnest[A: Arbitrary]: Arbitrary[Unnest[A]] =
     Arbitrary((arb[A] ⊛ arb[Option[Id[A]]])(Unnest(_, _)))
 
+  implicit def arbBindingExpr[A: Arbitrary]: Arbitrary[Binding[A]] =
+    Arbitrary((arb[Id[A]] ⊛ arb[A])(Binding(_, _)))
+
   implicit def arbFilter[A: Arbitrary]: Arbitrary[Filter[A]] =
     Arbitrary(arb[A] ∘ (Filter(_)))
 
@@ -152,11 +155,12 @@ trait N1QLArbitrary {
      arb[NonEmptyList[ResultExpr[A]]] ⊛
      arb[Option[Keyspace[A]]]         ⊛
      arb[Option[Unnest[A]]]           ⊛
+     arb[List[Binding[A]]]            ⊛
      arb[Option[Filter[A]]]           ⊛
      arb[Option[GroupBy[A]]]          ⊛
      arb[List[OrderBy[A]]]
     )(
-      Select(_, _, _, _, _, _, _)
+      Select(_, _, _, _, _, _, _, _)
     ),
     (arb[NonEmptyList[WhenThen[A]]]  ⊛
      arb[Else[A]]

--- a/it/src/main/resources/tests/filterOnFieldComparison.test
+++ b/it/src/main/resources/tests/filterOnFieldComparison.test
@@ -7,7 +7,7 @@
     },
     "data": "zips.data",
     "query": "select * from zips where pop < loc[1] order by _id limit 10",
-    "predicate": "containsExactly",
+    "predicate": "equalsExactly",
     "expected": [
         { "_id": "01338", "city": "BUCKLAND",        "loc": [-72.764124, 42.615174], "pop": 16, "state": "MA" },
         { "_id": "02163", "city": "CAMBRIDGE",       "loc": [-71.141879, 42.364005], "pop": 0,  "state": "MA" },

--- a/it/src/main/resources/tests/filterOnFieldComparison.test
+++ b/it/src/main/resources/tests/filterOnFieldComparison.test
@@ -1,13 +1,12 @@
 {
     "name": "filter on field comparison",
     "backends": {
-        "couchbase":         "skip",
         "marklogic":         "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
     "data": "zips.data",
-    "query": "select * from zips where pop < loc[1] limit 10",
+    "query": "select * from zips where pop < loc[1] order by _id limit 10",
     "predicate": "containsExactly",
     "expected": [
         { "_id": "01338", "city": "BUCKLAND",        "loc": [-72.764124, 42.615174], "pop": 16, "state": "MA" },

--- a/it/src/test/scala/quasar/physical/couchbase/CouchbaseStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/couchbase/CouchbaseStdLibSpec.scala
@@ -73,6 +73,7 @@ class CouchbaseStdLibSpec extends StdLibSpec {
                 ResultExpr(qq, Id("v").some).wrapNel,
                 keyspace = None,
                 unnest   = None,
+                let      = Nil,
                 filter   = None,
                 groupBy  = None,
                 orderBy  = Nil).embed


### PR DESCRIPTION
When possible collapse inlining within `ConcatArrays` for improved CB query engine performance due to reduced query size. `order by` is added to the query in `filterOnFieldComparison.test` to avoid related intermittent failures seen on Travis.

Fixes #1752