### PR TITLE
Support specifying a root directory for a MarkLogic mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,11 +197,13 @@ e.g "spark://spark_master:7077|hdfs://primary_node:9000|/hadoop/users/"
 
 ##### MarkLogic
 
-To connect to MarkLogic, specify an [XCC URL](https://docs.marklogic.com/guide/xcc/concepts#id_55196) with a `format` query parameter as the `connectionUri`:
+To connect to MarkLogic, specify an [XCC URL](https://docs.marklogic.com/guide/xcc/concepts#id_55196) with a `format` query parameter and an optional root directory as the `connectionUri`:
 
-`xcc://<username>:<password>@<host>:<port>/<database>?format=[json|xml]`
+`xcc://<username>:<password>@<host>:<port>/<database>[/root/dir/path]?format=[json|xml]`
 
 the mount will query either JSON or XML documents based on the value of the `format` parameter. For backwards-compatibility, if the `format` parameter is omitted then XML is assumed.
+
+If a root directory path is specified, all operations and queries within the mount will be local to the MarkLogic directory at the specified path.
 
 Prerequisites
 - MarkLogic 8.0+

--- a/foundation/src/main/scala/quasar/contrib/pathy/package.scala
+++ b/foundation/src/main/scala/quasar/contrib/pathy/package.scala
@@ -72,12 +72,12 @@ package object pathy {
         apath.relativeTo(prefix).fold(apath)(rootDir </> _)
     }
 
-  /** Returns the first named segment of the given relative path. */
-  def firstSegmentName(f: RPath): Option[PathSegment] =
+  /** Returns the first named segment of the given path. */
+  def firstSegmentName(p: Path[_,_,_]): Option[PathSegment] =
     flatten(none, none, none,
       n => DirName(n).left.some,
       n => FileName(n).right.some,
-      f).toIList.unite.headOption
+      p).toIList.unite.headOption
 
   def prettyPrint(path: Path[_,_,_]): String =
     refineType(path).fold(

--- a/marklogic/src/main/scala/quasar/physical/marklogic/fs/MarkLogicConfig.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/fs/MarkLogicConfig.scala
@@ -17,15 +17,23 @@
 package quasar.physical.marklogic.fs
 
 import quasar.Predef._
+import quasar.contrib.pathy._
 import quasar.physical.marklogic.MonadErrMsgs
 
 import java.net.URI
 
+import pathy.Path.{rootDir => rtDir, _}
 import monocle.macros.Lenses
 import scalaz._, Scalaz._
 
 @Lenses
-final case class MarkLogicConfig(xccUri: URI, docType: MarkLogicConfig.DocType)
+final case class MarkLogicConfig(
+  xccUri: URI,
+  rootDir: ADir,
+  docType: MarkLogicConfig.DocType
+) {
+  def database: String = xccUri.getPath.drop(1)
+}
 
 object MarkLogicConfig {
   sealed abstract class DocType {
@@ -50,11 +58,25 @@ object MarkLogicConfig {
       Show.showFromToString
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Null"))
   def fromUriString[F[_]: MonadErrMsgs](str: String): F[MarkLogicConfig] = {
     def ensureScheme(u: URI): ValidationNel[String, Unit] =
-      Option(u.getScheme).exists(_ === "xcc").unlessM("Unrecognized URI scheme, expected 'xcc'.".failureNel)
+      Option(u.getScheme).exists(_ === "xcc")
+        .unlessM("Missing or unrecognized scheme, expected 'xcc'.".failureNel)
 
-    def extractDocType(u: URI): ValidationNel[String, DocType] =
+    def dbAndRest(u: URI): ValidationNel[String, (String, ADir)] =
+      Option(u.getPath).flatMap(posixCodec.parseAbsAsDir).map(sandboxAbs).flatMap { d =>
+        firstSegmentName(d) map (_.bimap(_.value, _.value).merge) map { db =>
+          (db, stripPrefixA(rtDir </> dir(db))(d))
+        }
+      } toSuccessNel "No database specified."
+
+    def xccUriAndRoot(u: URI): ValidationNel[String, (URI, ADir)] =
+      ensureScheme(u) *> dbAndRest(u) map { case (db, dir) =>
+        (new URI(u.getScheme, u.getUserInfo, u.getHost, u.getPort, "/" + db, null, null), dir)
+      }
+
+    def docType(u: URI): ValidationNel[String, DocType] =
       Option(u.getQuery).toList
         .flatMap(_ split '&')
         .flatMap(_ split '=' match {
@@ -70,7 +92,15 @@ object MarkLogicConfig {
 
     \/.fromTryCatchNonFatal(new URI(str))
       .leftMap(_.getMessage.wrapNel)
-      .flatMap(u => (ensureScheme(u) *> extractDocType(u) map (MarkLogicConfig(u, _))).disjunction)
+      .flatMap(u => (xccUriAndRoot(u) |@| docType(u))((a, t) => MarkLogicConfig(a._1, a._2, t)).disjunction)
       .fold(_.raiseError[F, MarkLogicConfig], _.point[F])
   }
+
+  implicit val equal: Equal[MarkLogicConfig] = {
+    implicit val uriEq: Equal[URI] = Equal.equalA[URI]
+    Equal.equalBy(c => (c.xccUri, c.rootDir, c.docType))
+  }
+
+  implicit val show: Show[MarkLogicConfig] =
+    Show.showFromToString[MarkLogicConfig]
 }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/fs/package.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/fs/package.scala
@@ -39,7 +39,7 @@ import scala.util.control.NonFatal
 import com.marklogic.xcc._
 import com.marklogic.xcc.exceptions._
 import matryoshka.data.Fix
-import pathy.Path._
+import pathy.Path.{rootDir => pRootDir, _}
 import scalaz.{Failure => _, _}, Scalaz.{ToIdOps => _, _}
 import scalaz.concurrent.Task
 
@@ -103,17 +103,20 @@ package object fs {
         MarkLogicConfig.fromUriString[EitherT[Free[S, ?], ErrorMessages, ?]](uri.value)
           .leftMap(_.left[EnvironmentError])
           .flatMap(cfg => cfg.docType.fold(
-            fileSystem[S, fmt.JSON](cfg.xccUri, readChunkSize),
-            fileSystem[S, fmt.XML](cfg.xccUri, readChunkSize)))
+            fileSystem[S, fmt.JSON](cfg.xccUri, cfg.rootDir, readChunkSize),
+            fileSystem[S, fmt.XML](cfg.xccUri, cfg.rootDir, readChunkSize)))
     }
 
   /** The MarkLogic FileSystem definition.
     *
     * @tparam FMT           type representing the document format for the filesystem
+    * @param  xccUri        the URI describing the details of the connection to the XCC server
+    * @param  rootDir       the MarkLogic directory upon which to base the mount
     * @param  readChunkSize the size of a single chunk when streaming records from MarkLogic
     */
   def fileSystem[S[_], FMT](
     xccUri: URI,
+    rootDir: ADir,
     readChunkSize: Positive
   )(implicit
     S0: Task :<: S,
@@ -123,14 +126,19 @@ package object fs {
     SP: StructuralPlanner[MLFSQ, FMT]
   ): DefErrT[Free[S, ?], DefinitionResult[Free[S, ?]]] = {
     val dropWritten = λ[MLFS ~> Free[MarkLogicFs, ?]](_.value)
+
+    val xformPaths =
+      if (rootDir === pRootDir) liftFT[FileSystem]
+      else chroot.fileSystem[FileSystem](rootDir)
+
     runMarkLogicFs(xccUri) map { case (run, shutdown) =>
       DefinitionResult[Free[S, ?]](
-        flatMapSNT(run) compose dropWritten compose interpretFileSystem(
+        flatMapSNT(run) compose dropWritten compose foldMapNT(interpretFileSystem(
           handleMLPlannerErrors(queryfile.interpret[MLFSQ, FMT](readChunkSize)),
           readfile.interpret[MLFS](readChunkSize),
           writefile.interpret[MLFS, FMT],
-          managefile.interpret[MLFS]),
-        shutdown)
+          managefile.interpret[MLFS]
+        )) compose xformPaths, shutdown)
     }
   }
 

--- a/marklogic/src/test/scala/quasar/physical/marklogic/fs/MarkLogicConfigSpec.scala
+++ b/marklogic/src/test/scala/quasar/physical/marklogic/fs/MarkLogicConfigSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.marklogic.fs
+
+import quasar.Predef._
+import quasar.physical.marklogic.ErrorMessages
+
+import java.net.URI
+
+import pathy.Path._
+import scalaz._
+import scalaz.std.option._
+
+final class MarkLogicConfigSpec extends quasar.Qspec {
+  import MarkLogicConfig.DocType
+
+  "fromUriString" >> {
+    val validUri = "xcc://user:pass@ml.example.com/somedb/foo/bar?format=json"
+
+    "builds config from a valid uri" >> {
+      MarkLogicConfig.fromUriString[ErrorMessages \/ ?](validUri)
+        .toOption must_= Some(MarkLogicConfig(
+          new URI("xcc://user:pass@ml.example.com/somedb"),
+          rootDir </> dir("foo") </> dir("bar"),
+          DocType.json))
+    }
+
+    "root dir is root when only db specified" >> {
+      MarkLogicConfig.fromUriString[ErrorMessages \/ ?](
+        "xcc://ml.example.com/adb"
+      ).toOption.map(_.rootDir) must_= Some(rootDir)
+    }
+
+    "uses XML doc type when no format parameter given" >> {
+      MarkLogicConfig.fromUriString[ErrorMessages \/ ?](
+        "xcc://ml.example.com/adb"
+      ).toOption.map(_.docType) must_= Some(DocType.xml)
+    }
+
+    "fails when no db specified" >> {
+      MarkLogicConfig.fromUriString[ErrorMessages \/ ?](
+        "xcc://ml.example.com/"
+      ).toOption must beNone
+    }
+
+    "fails when unknown format specified" >> {
+      MarkLogicConfig.fromUriString[ErrorMessages \/ ?](
+        "xcc://ml.example.com/db?format=fake"
+      ).toOption must beNone
+    }
+
+    "fails when non-xcc URL specified" >> {
+      MarkLogicConfig.fromUriString[ErrorMessages \/ ?](
+        "http://ml.example.com/db"
+      ).toOption must beNone
+    }
+  }
+}


### PR DESCRIPTION
Allows for specifying a physical path in the MarkLogic server when describing a mount to serve as the root directory for that mount, all operations and queries will be scoped within the specified directory.

Closes #1766.