### PR TITLE
array pruning for LeftShift

### DIFF
--- a/connector/src/main/scala/quasar/qscript/PruneArrays.scala
+++ b/connector/src/main/scala/quasar/qscript/PruneArrays.scala
@@ -58,7 +58,7 @@ object PATypes {
   def remap[A](env: StateAcc, state: StateAcc, in: F[A]): Output[F, A]
 }
 
-class PAHelpers[T[_[_]]: BirecursiveT] extends TTypes[T] {
+class PAHelpers[T[_[_]]: BirecursiveT: EqualT] extends TTypes[T] {
   import PATypes._
 
   type Mapping = ScalaMap[BigInt, BigInt]
@@ -81,7 +81,10 @@ class PAHelpers[T[_[_]]: BirecursiveT] extends TTypes[T] {
     val galg: GAlgebra[(FreeMap, ?), CoEnv[Hole, MapFunc, ?], StateAcc] =
       _.run.fold(κ(Set().some), accumulate)
 
-    func.para[StateAcc](galg)
+    if (func ≟ HoleF)
+      None
+    else
+      func.para[StateAcc](galg)
   }
 
   /** Remap all indices in `func` in structures like
@@ -155,7 +158,7 @@ object PruneArrays {
   // TODO examine branches
   implicit def equiJoin[T[_[_]]]: PruneArrays[EquiJoin[T, ?]] = default
 
-  implicit def projectBucket[T[_[_]]: BirecursiveT]
+  implicit def projectBucket[T[_[_]]: BirecursiveT: EqualT]
       : PruneArrays[ProjectBucket[T, ?]] =
     new PruneArrays[ProjectBucket[T, ?]] {
 

--- a/connector/src/test/scala/quasar/qscript/PruneArrays.scala
+++ b/connector/src/test/scala/quasar/qscript/PruneArrays.scala
@@ -641,9 +641,8 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
       initial.pruneArrays must equal(initial)
     }
 
-    // this can be rewritten - we just don't support that yet
-    "not rewrite left shift with unused array elements" in {
-      val src: Fix[QST] =
+    "rewrite left shift with array referenced through struct" in {
+      val initialSrc: Fix[QST] =
         QCT.inj(LeftShift(
           UnreferencedRT.embed,
           HoleF,
@@ -656,10 +655,244 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
 
       val initial: Fix[QST] =
         QCT.inj(LeftShift(
-          src,
+          initialSrc,
           ProjectIndexR(HoleF, IntLit[Fix, Hole](2)),
           ExcludeId,
           MakeMapR(StrLit("xyz"), Free.point(LeftSide)))).embed
+
+      val expectedSrc: Fix[QST] =
+        QCT.inj(LeftShift(
+          UnreferencedRT.embed,
+          HoleF,
+          ExcludeId,
+          MakeArrayR(IntLit(8)))).embed
+
+      val expected: Fix[QST] =
+        QCT.inj(LeftShift(
+          expectedSrc,
+          ProjectIndexR(HoleF, IntLit[Fix, Hole](0)),
+          ExcludeId,
+          MakeMapR(StrLit("xyz"), Free.point(LeftSide)))).embed
+
+      initial.pruneArrays must equal(expected)
+    }
+
+    "not rewrite left shift with array referenced non-statically through struct" in {
+      val initialSrc: Fix[QST] =
+        QCT.inj(LeftShift(
+          UnreferencedRT.embed,
+          HoleF,
+          ExcludeId,
+          ConcatArraysR(
+            ConcatArraysR(
+              MakeArrayR(IntLit(6)),
+              MakeArrayR(IntLit(7))),
+            MakeArrayR(IntLit(8))))).embed
+
+      val initial: Fix[QST] =
+        QCT.inj(LeftShift(
+          initialSrc,
+          ProjectIndexR(HoleF, AddR(IntLit(0), IntLit(1))),
+          ExcludeId,
+          MakeMapR(StrLit("xyz"), Free.point(LeftSide)))).embed
+
+      initial.pruneArrays must equal(initial)
+    }
+
+    "rewrite left shift with array referenced through left side and struct" in {
+      val initialSrc: Fix[QST] =
+        QCT.inj(LeftShift(
+          UnreferencedRT.embed,
+          HoleF,
+          ExcludeId,
+          ConcatArraysR(
+            ConcatArraysR(
+              MakeArrayR(IntLit(6)),
+              MakeArrayR(IntLit(7))),
+            MakeArrayR(IntLit(8))))).embed
+
+      val initial: Fix[QST] =
+        QCT.inj(LeftShift(
+          initialSrc,
+          ProjectIndexR(HoleF, IntLit[Fix, Hole](2)),
+          ExcludeId,
+          ProjectIndexR(Free.point(LeftSide), IntLit[Fix, JoinSide](1)))).embed
+
+      val expectedSrc: Fix[QST] =
+        QCT.inj(LeftShift(
+          UnreferencedRT.embed,
+          HoleF,
+          ExcludeId,
+          ConcatArraysR(
+            MakeArrayR(IntLit(7)),
+            MakeArrayR(IntLit(8))))).embed
+
+      val expected: Fix[QST] =
+        QCT.inj(LeftShift(
+          expectedSrc,
+          ProjectIndexR(HoleF, IntLit[Fix, Hole](1)),
+          ExcludeId,
+          ProjectIndexR(Free.point(LeftSide), IntLit[Fix, JoinSide](0)))).embed
+
+      initial.pruneArrays must equal(expected)
+    }
+
+    "rewrite left shift with array referenced through struct with a right side reference" in {
+      val initialSrc: Fix[QST] =
+        QCT.inj(LeftShift(
+          UnreferencedRT.embed,
+          HoleF,
+          ExcludeId,
+          ConcatArraysR(
+            ConcatArraysR(
+              MakeArrayR(IntLit(6)),
+              MakeArrayR(IntLit(7))),
+            MakeArrayR(ConcatArraysR(MakeArrayR(IntLit(8)), MakeArrayR(IntLit(9))))))).embed
+
+      val initial: Fix[QST] =
+        QCT.inj(LeftShift(
+          initialSrc,
+          ProjectIndexR(HoleF, IntLit[Fix, Hole](2)),
+          ExcludeId,
+          ProjectIndexR(Free.point(RightSide), IntLit[Fix, JoinSide](1)))).embed
+
+      val expectedSrc: Fix[QST] =
+        QCT.inj(LeftShift(
+          UnreferencedRT.embed,
+          HoleF,
+          ExcludeId,
+          MakeArrayR(ConcatArraysR(MakeArrayR(IntLit(8)), MakeArrayR(IntLit(9)))))).embed
+
+      // TODO this can be rewritten further so that `struct` is just `HoleF`
+      val expected: Fix[QST] =
+        QCT.inj(LeftShift(
+          expectedSrc,
+          ProjectIndexR(HoleF, IntLit[Fix, Hole](0)),
+          ExcludeId,
+          ProjectIndexR(Free.point(RightSide), IntLit[Fix, JoinSide](1)))).embed
+
+      initial.pruneArrays must equal(expected)
+    }
+
+    "rewrite left shift with array referenced through left and right side" in {
+      val initialSrc: Fix[QST] =
+        QCT.inj(LeftShift(
+          UnreferencedRT.embed,
+          HoleF,
+          ExcludeId,
+          ConcatArraysR(
+            ConcatArraysR(
+              MakeArrayR(IntLit(6)),
+              MakeArrayR(IntLit(7))),
+            MakeArrayR(IntLit(8))))).embed
+
+      val initial: Fix[QST] =
+        QCT.inj(LeftShift(
+          initialSrc,
+          HoleF,
+          ExcludeId,
+          AddR(
+            ProjectIndexR(Free.point(RightSide), IntLit[Fix, JoinSide](1)),
+            ProjectIndexR(Free.point(LeftSide), IntLit[Fix, JoinSide](2))))).embed
+
+      val expectedSrc: Fix[QST] =
+        QCT.inj(LeftShift(
+          UnreferencedRT.embed,
+          HoleF,
+          ExcludeId,
+          ConcatArraysR(
+            MakeArrayR(IntLit(7)),
+            MakeArrayR(IntLit(8))))).embed
+
+      // TODO this can be rewritten further so that `struct` is just `HoleF`
+      val expected: Fix[QST] =
+        QCT.inj(LeftShift(
+          expectedSrc,
+          HoleF,
+          ExcludeId,
+          AddR(
+            ProjectIndexR(Free.point(RightSide), IntLit[Fix, JoinSide](0)),
+            ProjectIndexR(Free.point(LeftSide), IntLit[Fix, JoinSide](1))))).embed
+
+      initial.pruneArrays must equal(expected)
+    }
+
+    "rewrite left shift with entire array unreferenced" in {
+      val initialSrc: Fix[QST] =
+        QCT.inj(LeftShift(
+          UnreferencedRT.embed,
+          HoleF,
+          ExcludeId,
+          ConcatArraysR(
+            ConcatArraysR(
+              MakeArrayR(IntLit(6)),
+              MakeArrayR(IntLit(7))),
+            MakeArrayR(IntLit(8))))).embed
+
+      val initial: Fix[QST] =
+        QCT.inj(LeftShift(
+          initialSrc,
+          HoleF,
+          ExcludeId,
+          AddR(IntLit[Fix, JoinSide](2), IntLit[Fix, JoinSide](3)))).embed
+
+      val expectedSrc: Fix[QST] =
+        QCT.inj(LeftShift(
+          UnreferencedRT.embed,
+          HoleF,
+          ExcludeId,
+          Free.roll(Constant(ejsonArr())))).embed
+
+      val expected: Fix[QST] =
+        QCT.inj(LeftShift(
+          expectedSrc,
+          HoleF,
+          ExcludeId,
+          AddR(IntLit[Fix, JoinSide](2), IntLit[Fix, JoinSide](3)))).embed
+
+      initial.pruneArrays must equal(expected)
+    }
+
+    "not rewrite left shift with entire array referenced by the right side" in {
+      val initialSrc: Fix[QST] =
+        QCT.inj(LeftShift(
+          UnreferencedRT.embed,
+          HoleF,
+          ExcludeId,
+          ConcatArraysR(
+            ConcatArraysR(
+              MakeArrayR(IntLit(6)),
+              MakeArrayR(IntLit(7))),
+            MakeArrayR(IntLit(8))))).embed
+
+      val initial: Fix[QST] =
+        QCT.inj(LeftShift(
+          initialSrc,
+          HoleF,
+          ExcludeId,
+          RightSideF)).embed
+
+      initial.pruneArrays must equal(initial)
+    }
+
+    "not rewrite left shift with entire array referenced by the left side" in {
+      val initialSrc: Fix[QST] =
+        QCT.inj(LeftShift(
+          UnreferencedRT.embed,
+          HoleF,
+          ExcludeId,
+          ConcatArraysR(
+            ConcatArraysR(
+              MakeArrayR(IntLit(6)),
+              MakeArrayR(IntLit(7))),
+            MakeArrayR(IntLit(8))))).embed
+
+      val initial: Fix[QST] =
+        QCT.inj(LeftShift(
+          initialSrc,
+          HoleF,
+          ExcludeId,
+          LeftSideF)).embed
 
       initial.pruneArrays must equal(initial)
     }

--- a/connector/src/test/scala/quasar/qscript/PruneArrays.scala
+++ b/connector/src/test/scala/quasar/qscript/PruneArrays.scala
@@ -190,6 +190,23 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
       initial.pruneArrays must equal(initial)
     }
 
+    "not rewrite map with entire array referenced" in {
+      val initial: Fix[QST] =
+        QCT.inj(Map(
+          QCT.inj(LeftShift(
+            UnreferencedRT.embed,
+            HoleF,
+            ExcludeId,
+            ConcatArraysR(
+              ConcatArraysR(
+                MakeArrayR(IntLit(6)),
+                MakeArrayR(IntLit(7))),
+              MakeArrayR(IntLit(8))))).embed,
+          HoleF)).embed
+
+      initial.pruneArrays must equal(initial)
+    }
+
     "rewrite map with unused array elements 1,2" in {
       val initial: Fix[QST] =
         QCT.inj(Map(

--- a/connector/src/test/scala/quasar/qscript/QScriptHelpers.scala
+++ b/connector/src/test/scala/quasar/qscript/QScriptHelpers.scala
@@ -177,6 +177,7 @@ trait QScriptHelpers extends CompilerHelpers with TTypes[Fix] {
     ejsonMap((
       ejson.CommonEJson(ejson.Str[Fix[EJson]]("j")).embed,
       ejsonArr(l, r)))
+
   def ejsonProjectField(field: Fix[EJson]) =
     ejsonMap((ejson.CommonEJson(ejson.Str[Fix[EJson]]("f")).embed, field))
 }


### PR DESCRIPTION
Prunes arrays in QScript `LeftShift`.

Fixes #1851 