### PR TITLE
Fix MarkLogic 'union' implementation.

### DIFF
--- a/it/src/main/resources/tests/union.test
+++ b/it/src/main/resources/tests/union.test
@@ -2,11 +2,9 @@
     "name": "union",
     "backends": {
         "mongodb_read_only": "pending",
-        "mongodb_q_3_2": "pending",
+        "mongodb_q_3_2":     "pending",
         "postgresql":        "pending",
-        "couchbase":         "skip",
-        "marklogic_json":    "pending",
-        "marklogic_xml":     "pending"
+        "couchbase":         "skip"
     },
     "data": "zips.data",
     "query": "select _id as zip from zips union select city, state from zips",

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/QScriptCorePlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/QScriptCorePlanner.scala
@@ -132,7 +132,7 @@ private[qscript] final class QScriptCorePlanner[F[_]: Monad: QNameGenerator: Pro
         s <- freshName[F]
         l <- rebaseXQuery[T, F, FMT](lBranch, ~s)
         r <- rebaseXQuery[T, F, FMT](rBranch, ~s)
-      } yield let_(s := src) return_ (l union r)
+      } yield let_(s := src) return_ (mkSeq_(l) union mkSeq_(r))
 
     case Filter(src, f) =>
       for {


### PR DESCRIPTION
Arguments to the XQuery `union` operator weren't being grouped properly which could lead to ambiguity in certain cases, wrapping them in a sequence solved the issue.