### PR TITLE
Update matryoshka-core to 0.16.4

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,7 +41,7 @@ object Dependencies {
     "io.argonaut"                %% "argonaut"                  %  argonautVersion,
     "io.argonaut"                %% "argonaut-scalaz"           %  argonautVersion,
     "org.typelevel"              %% "shapeless-scalaz"          %    slcVersion,
-    "com.slamdata"               %% "matryoshka-core"           %     "0.16.1",
+    "com.slamdata"               %% "matryoshka-core"           %     "0.16.4",
     "com.slamdata"               %% "pathy-core"                %   pathyVersion,
     "com.slamdata"               %% "pathy-argonaut"            %   pathyVersion    %     Test,
     "eu.timepit"                 %% "refined"                   %  refinedVersion,


### PR DESCRIPTION
With Matryoshka 0.16.4 we get RecursiveT to be serializable, which fixes
Spark issues. See https://github.com/slamdata/matryoshka/pull/57 for details