### PR TITLE
Handle non-ascii in disposition's filename

### DIFF
--- a/web/src/main/scala/quasar/api/MessageFormat.scala
+++ b/web/src/main/scala/quasar/api/MessageFormat.scala
@@ -206,8 +206,7 @@ object MessageFormat {
   @SuppressWarnings(Array("org.wartremover.warts.NoNeedForMonad"))
   def fromMediaType(mediaType: MediaRange): Option[MessageFormat] = {
     val disposition = mediaType.extensions.get("disposition").flatMap(str =>
-      HttpHeaderParser.CONTENT_DISPOSITION(str).toOption.map(cd =>
-        `Content-Disposition`(cd.dispositionType, cd.parameters)))
+      HttpHeaderParser.CONTENT_DISPOSITION(str).toOption)
     if (mediaType satisfies Csv.mediaType) {
       def toChar(str: String): Option[Char] = str.toList match {
         case c :: Nil => Some(c)

--- a/web/src/main/scala/quasar/api/MessageFormat.scala
+++ b/web/src/main/scala/quasar/api/MessageFormat.scala
@@ -75,26 +75,8 @@ trait Decoder {
   }
 }
 
-// [#1861] Workaround to support a small slice of RFC 5987 for this isolated case
-// NonUnitStatements due to http4s's Writer
-@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
-final case class ContentDispositionʹ(dispositionType: String, parameters: Map[String, String])
-  extends Header.Parsed {
-  import org.http4s.util.Writer
-  override def key = `Content-Disposition`
-  override lazy val value = super.value
-  override def renderValue(writer: Writer): writer.type = {
-    writer.append(dispositionType)
-    parameters.foreach(p =>
-      p._1.endsWith("*").fold(
-        writer << "; " << p._1 << "=" << p._2,
-        writer << "; " << p._1 << "=\"" << p._2 << '"'))
-    writer
-  }
-}
-
 sealed trait MessageFormat extends Decoder {
-  def disposition: Option[ContentDispositionʹ]
+  def disposition: Option[`Content-Disposition`]
   def encode[F[_]](data: Process[F, Data]): Process[F, String]
   protected def dispositionExtension: Map[String, String] =
     disposition.map(disp => Map("disposition" -> disp.value)).getOrElse(Map.empty)
@@ -103,7 +85,7 @@ object MessageFormat {
   final case class JsonContentType(
     mode: JsonPrecision,
     format: JsonFormat,
-    disposition: Option[ContentDispositionʹ]
+    disposition: Option[`Content-Disposition`]
   ) extends MessageFormat {
     val LineSep = "\r\n"
     def mediaType = {
@@ -147,7 +129,7 @@ object MessageFormat {
 
   val Default = JsonContentType(JsonPrecision.Readable, JsonFormat.LineDelimited, None)
 
-  final case class Csv(columnDelimiter: Char, rowDelimiter: String, quoteChar: Char, escapeChar: Char, disposition: Option[ContentDispositionʹ]) extends MessageFormat {
+  final case class Csv(columnDelimiter: Char, rowDelimiter: String, quoteChar: Char, escapeChar: Char, disposition: Option[`Content-Disposition`]) extends MessageFormat {
     import Csv._
 
     val CsvColumnsFromInitialRowsCount = 1000
@@ -225,7 +207,7 @@ object MessageFormat {
   def fromMediaType(mediaType: MediaRange): Option[MessageFormat] = {
     val disposition = mediaType.extensions.get("disposition").flatMap(str =>
       HttpHeaderParser.CONTENT_DISPOSITION(str).toOption.map(cd =>
-        ContentDispositionʹ(cd.dispositionType, cd.parameters)))
+        `Content-Disposition`(cd.dispositionType, cd.parameters)))
     if (mediaType satisfies Csv.mediaType) {
       def toChar(str: String): Option[Char] = str.toList match {
         case c :: Nil => Some(c)

--- a/web/src/main/scala/quasar/api/services/RestApi.scala
+++ b/web/src/main/scala/quasar/api/services/RestApi.scala
@@ -88,7 +88,12 @@ object RestApi {
     svcs.mapValues(_.toHttpServiceF(f))
 
   def defaultMiddleware: HttpMiddleware =
-    cors compose gzip compose HeaderParam compose passOptions compose errorHandling
+    cors                            compose
+    gzip                            compose
+    RFC5987ContentDispositionRender compose
+    HeaderParam                     compose
+    passOptions                     compose
+    errorHandling
 
   val cors: HttpMiddleware =
     CORS(_, CORSConfig(

--- a/web/src/test/scala/quasar/api/services/DataServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/DataServiceSpec.scala
@@ -176,7 +176,7 @@ class DataServiceSpec extends quasar.Qspec with FileSystemFixture with Http4s {
           response.status must_== Status.Ok
         }
         "support disposition" >> prop { filesystem: SingleFileMemState =>
-          val disposition = ContentDispositionʹ("attachement", Map("filename" -> "data.json"))
+          val disposition = `Content-Disposition`("attachement", Map("filename" -> "data.json"))
           val request = Request(
             uri = pathUri(filesystem.file),
             headers = Headers(Accept(jsonReadableLine.copy(disposition = Some(disposition)).mediaType)))
@@ -184,7 +184,7 @@ class DataServiceSpec extends quasar.Qspec with FileSystemFixture with Http4s {
           response.headers.get(`Content-Disposition`.name) must_== Some(disposition)
         }
         "support disposition non-ascii filename" >> prop { filesystem: SingleFileMemState =>
-          val disposition = ContentDispositionʹ("attachement", Map("filename*" -> "UTF-8''Na%C3%AFve%20file.txt"))
+          val disposition = `Content-Disposition`("attachement", Map("filename*" -> "UTF-8''Na%C3%AFve%20file.txt"))
           val request = Request(
             uri = pathUri(filesystem.file),
             headers = Headers(Accept(jsonReadableLine.copy(disposition = Some(disposition)).mediaType)))

--- a/web/src/test/scala/quasar/api/services/DataServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/DataServiceSpec.scala
@@ -176,12 +176,20 @@ class DataServiceSpec extends quasar.Qspec with FileSystemFixture with Http4s {
           response.status must_== Status.Ok
         }
         "support disposition" >> prop { filesystem: SingleFileMemState =>
-          val disposition = `Content-Disposition`("attachement", Map("filename" -> "data.json"))
+          val disposition = ContentDispositionʹ("attachement", Map("filename" -> "data.json"))
           val request = Request(
             uri = pathUri(filesystem.file),
             headers = Headers(Accept(jsonReadableLine.copy(disposition = Some(disposition)).mediaType)))
           val response = service(filesystem.state)(request).unsafePerformSync
-          response.headers.get(`Content-Disposition`) must_== Some(disposition)
+          response.headers.get(`Content-Disposition`.name) must_== Some(disposition)
+        }
+        "support disposition non-ascii filename" >> prop { filesystem: SingleFileMemState =>
+          val disposition = ContentDispositionʹ("attachement", Map("filename*" -> "UTF-8''Na%C3%AFve%20file.txt"))
+          val request = Request(
+            uri = pathUri(filesystem.file),
+            headers = Headers(Accept(jsonReadableLine.copy(disposition = Some(disposition)).mediaType)))
+          val response = service(filesystem.state)(request).unsafePerformSync
+          response.headers.get(`Content-Disposition`.name) must_== Some(disposition)
         }
         "support offset and limit" >> {
           "return expected result if user supplies valid values" >> prop {


### PR DESCRIPTION
In lieu of crafting a PR to support RFC 5987 in http4s this is a quick workaround due to the ASAP nature of the originating issue.

Fixes: #1861 