### PR TITLE
Eliminate unused expressions in WorkflowBuilder.

### DIFF
--- a/mongodb/src/main/scala/quasar/physical/mongodb/optimize/optimize.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/optimize/optimize.scala
@@ -202,10 +202,10 @@ package object optimize {
         case (Nil, r :: rs) => inlineProject0(r, rs).map(_.left)
 
         case (l :: ls, r :: rs) => r.get(l).flatMap {
-          case  -\/ (r)          => get0(ls, r :: rs)
-          case   \/-($include()) => get0(leaves, rs)
-          case   \/-($var(d))    => get0(d.path ++ ls, rs)
-          case   \/-(e) => if (ls.isEmpty) fixExpr(e, rs).map(_.right) else none
+          case -\/ (r)          => get0(ls, r :: rs)
+          case  \/-($include()) => get0(leaves, rs)
+          case  \/-($var(d))    => get0(d.path ++ ls, rs)
+          case  \/-(e) => if (ls.isEmpty) fixExpr(e, rs).map(_.right) else none
         }
       }
     }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/JoinHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/JoinHandler.scala
@@ -95,9 +95,7 @@ object JoinHandler {
     }
 
     def sourceDb: Algebra[WorkflowBuilderF[WF, ?], Option[DatabaseName]] = {
-      case CollectionBuilderF(Fix($read(Collection(db, _))), _, _) => db.some
       case CollectionBuilderF(op, _, _)       => op.cata(wfSourceDb)
-
       case ArrayBuilderF(src, _)              => src
       case ArraySpliceBuilderF(src, _)        => src
       case DocBuilderF(src, _)                => src


### PR DESCRIPTION
Fixes #1895

Previously this optimization happened in Workflow, which meant that expressions
could be irreversibly converted to JS even though it was unnecessary for the
optimized form.

Also includes some formatting clean-up.