### PR TITLE
Take advantage of Scalaz's Inject#unapply.

### DIFF
--- a/connector/src/main/scala/quasar/qscript/QScriptCore.scala
+++ b/connector/src/main/scala/quasar/qscript/QScriptCore.scala
@@ -146,9 +146,6 @@ object ReduceIndex {
     extends QScriptCore[T, A]
 
 object QScriptCore {
-  def unapply[T[_[_]], F[_], A](fa: F[A])(implicit C: QScriptCore[T, ?] :<: F): Option[QScriptCore[T, A]] =
-    C.prj(fa)
-
   implicit def equal[T[_[_]]: EqualT]: Delay[Equal, QScriptCore[T, ?]] =
     new Delay[Equal, QScriptCore[T, ?]] {
       def apply[A](eq: Equal[A]) =

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/EquiJoinPlanner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/EquiJoinPlanner.scala
@@ -59,10 +59,12 @@ final class EquiJoinPlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: NameGener
     }
   }
 
+  val QC = Inject[QScriptCore[T, ?], QScriptTotal[T, ?]]
+
   object BranchBucketCollection {
     def unapply(qs: FreeQS[T]): Option[BucketCollection] = (qs match {
       case Embed(CoEnv(\/-(CShiftedRead(c))))                              => c.some
-      case Embed(CoEnv(\/-(QScriptCore(
+      case Embed(CoEnv(\/-(QC(
         qscript.Filter(Embed(CoEnv(\/-(CShiftedRead(c)))),MetaGuard()))))) => c.some
       case _                                                               => none
     }) >>= (c => BucketCollection.fromPath(c.getConst.path).toOption)
@@ -72,8 +74,8 @@ final class EquiJoinPlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: NameGener
     def unapply(mf: FreeMap[T]): Boolean = mf match {
       case Embed(StaticArray(v :: Nil)) => v.resume match {
         case -\/(mfs.ProjectField(src, field)) => (src.resume, field.resume) match {
-          case (-\/(mfs.Meta(_)), -\/(mfs.Constant(Embed(ejson.Common(ejson.Str(v2)))))) => true
-          case _                                                                         => false
+          case (-\/(mfs.Meta(_)), -\/(mfs.Constant(Embed(MapFunc.EC(ejson.Str(v2)))))) => true
+          case _                                                                       => false
         }
         case v => false
       }

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/QScriptCorePlanner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/QScriptCorePlanner.scala
@@ -49,7 +49,7 @@ final class QScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: NameGe
         elems.traverse(_.bitraverse(
           // TODO: Revisit String key requirement
           {
-            case Embed(ejson.Common(ejson.Str(key))) =>
+            case Embed(MapFunc.EC(ejson.Str(key))) =>
               Data[T[N1QL]](QData.Str(key)).embed.η[M]
             case key =>
               EitherT(

--- a/ejson/src/main/scala/quasar/contrib/argonaut/package.scala
+++ b/ejson/src/main/scala/quasar/contrib/argonaut/package.scala
@@ -48,14 +48,17 @@ package object argonaut {
     new Corecursive[Json] {
       type Base[A] = ejson.Json[A]
 
+      val EC = Inject[ejson.Common, ejson.Json]
+      val EO = Inject[ejson.Obj,    ejson.Json]
+
       def embed(ft: ejson.Json[Json])(implicit BF: Functor[Base]) =
         ft match {
-          case ejson.Common(ejson.Null())  => jNull
-          case ejson.Common(ejson.Bool(b)) => jBool(b)
-          case ejson.Common(ejson.Dec(d))  => jNumber(d)
-          case ejson.Common(ejson.Str(s))  => jString(s)
-          case ejson.Common(ejson.Arr(a))  => jArray(a)
-          case ejson.Obj(ejson.Obj(o))     => jObject(JsonObject.fromTraversableOnce(o))
+          case EC(ejson.Null())  => jNull
+          case EC(ejson.Bool(b)) => jBool(b)
+          case EC(ejson.Dec(d))  => jNumber(d)
+          case EC(ejson.Str(s))  => jString(s)
+          case EC(ejson.Arr(a))  => jArray(a)
+          case EO(ejson.Obj(o))  => jObject(JsonObject.fromTraversableOnce(o))
         }
     }
 }

--- a/ejson/src/main/scala/quasar/ejson/EJson.scala
+++ b/ejson/src/main/scala/quasar/ejson/EJson.scala
@@ -30,9 +30,6 @@ final case class Str[A](value: String)     extends Common[A]
 final case class Dec[A](value: BigDecimal) extends Common[A]
 
 object Common {
-  def unapply[F[_], A](fa: F[A])(implicit C: Common :<: F): Option[Common[A]] =
-    C.prj(fa)
-
   implicit val traverse: Traverse[Common] = new Traverse[Common] {
     def traverseImpl[G[_], A, B](
       fa: Common[A])(
@@ -79,13 +76,6 @@ object Common {
 final case class Obj[A](value: ListMap[String, A])
 
 object Obj {
-  // TODO: This means we have the same names for the projection and the Obj
-  //       pattern matcher. It could go away if this unapply were defined on
-  //       `scalaz.Inject`. (scalaz/scalaz#1311)
-  @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
-  def unapply[F[_], A](fa: F[A])(implicit O: Obj :<: F): Option[Obj[A]] =
-    O.prj(fa)
-
   implicit val traverse: Traverse[Obj] = new Traverse[Obj] {
     def traverseImpl[G[_]: Applicative, A, B](fa: Obj[A])(f: A => G[B]):
         G[Obj[B]] =
@@ -118,9 +108,6 @@ final case class Char[A](value: scala.Char)  extends Extension[A]
 final case class Int[A](value: BigInt)       extends Extension[A]
 
 object Extension {
-  def unapply[F[_], A](fa: F[A])(implicit E: Extension :<: F): Option[Extension[A]] =
-    E.prj(fa)
-
   implicit val traverse: Traverse[Extension] = new Traverse[Extension] {
     def traverseImpl[G[_], A, B](
       fa: Extension[A])(

--- a/foundation/src/main/scala/quasar/fp/package.scala
+++ b/foundation/src/main/scala/quasar/fp/package.scala
@@ -298,10 +298,6 @@ package fp {
         }
     }
   }
-  object Inj {
-    def unapply[F[_], G[_], A](g: G[A])(implicit F: F :<: G): Option[F[A]] =
-      F.prj(g)
-  }
 
   // type Delay[F[_], G[_]] = F ~> λ[A => F[G[A]]]
   trait DelayedA[A] {

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/package.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/package.scala
@@ -18,7 +18,7 @@ package quasar.physical.marklogic
 
 import quasar.Predef._
 import quasar.contrib.scalaz.MonadError_
-import quasar.ejson.{Common, EJson, Str}
+import quasar.ejson.{EJson, Str}
 import quasar.fp.coproductShow
 import quasar.fp.ski.κ
 import quasar.contrib.pathy.{AFile, UriPathCodec}
@@ -101,8 +101,8 @@ package object qscript {
       case MapFunc.StaticMap(entries) =>
         for {
           xqyKV <- entries.traverse(_.bitraverse({
-                     case Embed(Common(Str(s))) => s.xs.point[F]
-                     case key                   => invalidQName[F, XQuery](key.convertTo[Fix[EJson]].shows)
+                     case Embed(MapFunc.EC(Str(s))) => s.xs.point[F]
+                     case key                       => invalidQName[F, XQuery](key.convertTo[Fix[EJson]].shows)
                    },
                    planMapFunc[T, F, FMT, Hole](_)(κ(src))))
           elts  <- xqyKV.traverse((SP.mkObjectEntry _).tupled)

--- a/mongodb/src/main/scala/quasar/physical/mongodb/expression/ExprOp3_0.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/expression/ExprOp3_0.scala
@@ -32,10 +32,6 @@ trait ExprOp3_0F[A]
 object ExprOp3_0F {
   final case class $dateToStringF[A](format: FormatString, date: A) extends ExprOp3_0F[A]
 
-  // TODO: if this is needed, comment explaining why
-  def unapply[EX[_], A](ex: EX[A])(implicit I: ExprOp3_0F :<: EX): Option[ExprOp3_0F[A]] =
-    I.prj(ex)
-
   implicit val equal:
       Delay[Equal, ExprOp3_0F] =
     new Delay[Equal, ExprOp3_0F] {
@@ -114,13 +110,4 @@ object FormatString {
 object $dateToStringF {
   def apply[EX[_], A](format: FormatString, date: A)(implicit I: ExprOp3_0F :<: EX): EX[A] =
     I.inj(ExprOp3_0F.$dateToStringF(format, date))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOp3_0F :<: EX): Option[(FormatString, A)] =
-    I.prj(expr) collect {
-      case ExprOp3_0F.$dateToStringF(format, date) => (format, date)
-    }
-}
-
-object $dateToString {
-  def unapply[T, EX[_]](expr: T)(implicit T: Recursive.Aux[T, EX], EX: Functor[EX], I: ExprOp3_0F :<: EX): Option[(FormatString, T)] =
-    $dateToStringF.unapply(T.project(expr))
 }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/expression/ExprOp3_2.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/expression/ExprOp3_2.scala
@@ -134,89 +134,49 @@ object ExprOp3_2F {
 object $sqrtF {
   def apply[EX[_], A](value: A)(implicit I: ExprOp3_2F :<: EX): EX[A] =
     I.inj(ExprOp3_2F.$sqrtF(value))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOp3_2F :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOp3_2F.$sqrtF(value) => (value)
-    }
 }
 
 object $absF {
   def apply[EX[_], A](value: A)(implicit I: ExprOp3_2F :<: EX): EX[A] =
     I.inj(ExprOp3_2F.$absF(value))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOp3_2F :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOp3_2F.$absF(value) => (value)
-    }
 }
 
 object $logF {
   def apply[EX[_], A](value: A, base: A)(implicit I: ExprOp3_2F :<: EX): EX[A] =
     I.inj(ExprOp3_2F.$logF(value, base))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOp3_2F :<: EX): Option[(A, A)] =
-    I.prj(expr) collect {
-      case ExprOp3_2F.$logF(value, base) => (value, base)
-    }
 }
 
 object $log10F {
   def apply[EX[_], A](value: A)(implicit I: ExprOp3_2F :<: EX): EX[A] =
     I.inj(ExprOp3_2F.$log10F(value))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOp3_2F :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOp3_2F.$log10F(value) => (value)
-    }
 }
 
 object $lnF {
   def apply[EX[_], A](value: A)(implicit I: ExprOp3_2F :<: EX): EX[A] =
     I.inj(ExprOp3_2F.$lnF(value))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOp3_2F :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOp3_2F.$lnF(value) => (value)
-    }
 }
 
 object $powF {
   def apply[EX[_], A](value: A, exp: A)(implicit I: ExprOp3_2F :<: EX): EX[A] =
     I.inj(ExprOp3_2F.$powF(value, exp))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOp3_2F :<: EX): Option[(A, A)] =
-    I.prj(expr) collect {
-      case ExprOp3_2F.$powF(value, base) => (value, base)
-    }
 }
 
 object $expF {
   def apply[EX[_], A](value: A)(implicit I: ExprOp3_2F :<: EX): EX[A] =
     I.inj(ExprOp3_2F.$expF(value))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOp3_2F :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOp3_2F.$expF(value) => (value)
-    }
 }
 
 object $truncF {
   def apply[EX[_], A](value: A)(implicit I: ExprOp3_2F :<: EX): EX[A] =
     I.inj(ExprOp3_2F.$truncF(value))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOp3_2F :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOp3_2F.$truncF(value) => (value)
-    }
 }
 
 object $ceilF {
   def apply[EX[_], A](value: A)(implicit I: ExprOp3_2F :<: EX): EX[A] =
     I.inj(ExprOp3_2F.$ceilF(value))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOp3_2F :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOp3_2F.$ceilF(value) => (value)
-    }
 }
 
 object $floorF {
   def apply[EX[_], A](value: A)(implicit I: ExprOp3_2F :<: EX): EX[A] =
     I.inj(ExprOp3_2F.$floorF(value))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOp3_2F :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOp3_2F.$floorF(value) => (value)
-    }
 }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/expression/ExprOp3_2.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/expression/ExprOp3_2.scala
@@ -41,10 +41,6 @@ object ExprOp3_2F {
   final case class $ceilF[A](value: A)         extends ExprOp3_2F[A]
   final case class $floorF[A](value: A)        extends ExprOp3_2F[A]
 
-  // TODO: if this is needed, comment explaining why
-  def unapply[EX[_], A](ex: EX[A])(implicit I: ExprOp3_2F :<: EX): Option[ExprOp3_2F[A]] =
-    I.prj(ex)
-
   implicit val equal: Delay[Equal, ExprOp3_2F] =
     new Delay[Equal, ExprOp3_2F] {
       def apply[A](eq: Equal[A]) = {
@@ -223,45 +219,4 @@ object $floorF {
     I.prj(expr) collect {
       case ExprOp3_2F.$floorF(value) => (value)
     }
-}
-
-object $sqrt {
-  def unapply[T, EX[_]](expr: T)(implicit T: Recursive.Aux[T, EX], EX: Functor[EX], I: ExprOp3_2F :<: EX): Option[T] =
-    $sqrtF.unapply(T.project(expr))
-}
-object $abs {
-  def unapply[T, EX[_]](expr: T)(implicit T: Recursive.Aux[T, EX], EX: Functor[EX], I: ExprOp3_2F :<: EX): Option[T] =
-    $absF.unapply(T.project(expr))
-}
-object $log {
-  def unapply[T, EX[_]](expr: T)(implicit T: Recursive.Aux[T, EX], EX: Functor[EX], I: ExprOp3_2F :<: EX): Option[(T, T)] =
-    $logF.unapply(T.project(expr))
-}
-object $log10 {
-  def unapply[T, EX[_]](expr: T)(implicit T: Recursive.Aux[T, EX], EX: Functor[EX], I: ExprOp3_2F :<: EX): Option[T] =
-    $log10F.unapply(T.project(expr))
-}
-object $ln {
-  def unapply[T, EX[_]](expr: T)(implicit T: Recursive.Aux[T, EX], EX: Functor[EX], I: ExprOp3_2F :<: EX): Option[T] =
-    $lnF.unapply(T.project(expr))
-}
-object $pow {
-  def unapply[T, EX[_]](expr: T)(implicit T: Recursive.Aux[T, EX], EX: Functor[EX], I: ExprOp3_2F :<: EX): Option[(T, T)] =
-    $powF.unapply(T.project(expr))
-}
-object $exp {
-  def unapply[T, EX[_]](expr: T)(implicit T: Recursive.Aux[T, EX], EX: Functor[EX], I: ExprOp3_2F :<: EX): Option[T] =
-    $expF.unapply(T.project(expr))
-}
-object $trunc {
-  def unapply[T, EX[_]](expr: T)(implicit T: Recursive.Aux[T, EX], EX: Functor[EX], I: ExprOp3_2F :<: EX): Option[T] =
-    $truncF.unapply(T.project(expr))
-}
-object $ceil {
-  def unapply[T, EX[_]](expr: T)(implicit T: Recursive.Aux[T, EX], EX: Functor[EX], I: ExprOp3_2F :<: EX): Option[T] =
-    $ceilF.unapply(T.project(expr))
-}
-object $floor {
-  def unapply[T, EX[_]](expr: T)(implicit T: Recursive.Aux[T, EX], EX: Functor[EX], I: ExprOp3_2F :<: EX): Option[T] =
-    $floorF.unapply(T.project(expr))
 }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/expression/ExprOpCore.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/expression/ExprOpCore.scala
@@ -519,101 +519,53 @@ object $orF {
 object $notF {
   def apply[EX[_], A](value: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$notF[A](value))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$notF(value) => value
-    }
 }
 
 object $setEqualsF {
   def apply[EX[_], A](left: A, right: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$setEqualsF[A](left, right))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[(A, A)] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$setEqualsF(left, right) => (left, right)
-    }
 }
 object $setIntersectionF {
   def apply[EX[_], A](left: A, right: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$setIntersectionF[A](left, right))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[(A, A)] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$setIntersectionF(left, right) => (left, right)
-    }
 }
 object $setDifferenceF {
   def apply[EX[_], A](left: A, right: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$setDifferenceF[A](left, right))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[(A, A)] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$setDifferenceF(left, right) => (left, right)
-    }
 }
 object $setUnionF {
   def apply[EX[_], A](left: A, right: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$setUnionF[A](left, right))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[(A, A)] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$setUnionF(left, right) => (left, right)
-    }
 }
 object $setIsSubsetF {
   def apply[EX[_], A](left: A, right: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$setIsSubsetF[A](left, right))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[(A, A)] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$setIsSubsetF(left, right) => (left, right)
-    }
 }
 
 object $anyElementTrueF {
   def apply[EX[_], A](value: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$anyElementTrueF[A](value))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$anyElementTrueF(value) => value
-    }
 }
 object $allElementsTrueF {
   def apply[EX[_], A](value: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$allElementsTrueF[A](value))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$anyElementTrueF(value) => value
-    }
 }
 
 object $cmpF {
   def apply[EX[_], A](left: A, right: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$cmpF[A](left, right))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[(A, A)] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$cmpF(left, right) => (left, right)
-    }
 }
 object $eqF {
   def apply[EX[_], A](left: A, right: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$eqF[A](left, right))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[(A, A)] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$eqF(left, right) => (left, right)
-    }
 }
 object $gtF {
   def apply[EX[_], A](left: A, right: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$gtF[A](left, right))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[(A, A)] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$gtF(left, right) => (left, right)
-    }
 }
 object $gteF {
   def apply[EX[_], A](left: A, right: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$gteF[A](left, right))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[(A, A)] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$gteF(left, right) => (left, right)
-    }
 }
 object $ltF {
   def apply[EX[_], A](left: A, right: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
@@ -634,10 +586,6 @@ object $lteF {
 object $neqF {
   def apply[EX[_], A](left: A, right: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$neqF[A](left, right))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[(A, A)] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$neqF(left, right) => (left, right)
-    }
 }
 
 object $addF {
@@ -651,111 +599,58 @@ object $addF {
 object $divideF {
   def apply[EX[_], A](left: A, right: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$divideF[A](left, right))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[(A, A)] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$divideF(left, right) => (left, right)
-    }
 }
 object $modF {
   def apply[EX[_], A](left: A, right: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$modF[A](left, right))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[(A, A)] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$modF(left, right) => (left, right)
-    }
 }
 object $multiplyF {
   def apply[EX[_], A](left: A, right: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$multiplyF[A](left, right))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[(A, A)] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$multiplyF(left, right) => (left, right)
-    }
 }
 object $subtractF {
   def apply[EX[_], A](left: A, right: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$subtractF[A](left, right))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[(A, A)] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$subtractF(left, right) => (left, right)
-    }
 }
 
 object $concatF {
   def apply[EX[_], A](first: A, second: A, others: A*)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$concatF[A](first, second, others: _*))
-  def unapplySeq[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[(A, A, Seq[A])] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$concatF(first, second, others @ _*) => (first, second, others.toList)
-    }
 }
 object $strcasecmpF {
   def apply[EX[_], A](left: A, right: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$strcasecmpF[A](left, right))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[(A, A)] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$strcasecmpF(left, right) => (left, right)
-    }
 }
 object $substrF {
   def apply[EX[_], A](value: A, start: A, count: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$substrF[A](value, start, count))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[(A, A, A)] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$substrF(value, start, count) => (value, start, count)
-    }
 }
 object $toLowerF {
   def apply[EX[_], A](value: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$toLowerF[A](value))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$toLowerF(value) => value
-    }
 }
 object $toUpperF {
   def apply[EX[_], A](value: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$toUpperF[A](value))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$toUpperF(value) => value
-    }
 }
 
 object $metaF {
   def apply[EX[_], A]()(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$metaF[A]())
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Boolean =
-    I.prj(expr) match {
-      case Some(ExprOpCoreF.$metaF()) => true
-      case _                    => false
-    }
 }
 
 object $sizeF {
   def apply[EX[_], A](array: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$sizeF[A](array))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$sizeF(array) => array
-    }
 }
 
 object $arrayMapF {
   def apply[EX[_], A](input: A, as: DocVar.Name, in: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$arrayMapF[A](input, as, in))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[(A, DocVar.Name, A)] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$arrayMapF(input, as, in) => (input, as, in)
-    }
 }
 object $letF {
   def apply[EX[_], A](vars: ListMap[DocVar.Name, A], in: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$letF[A](vars, in))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[(ListMap[DocVar.Name, A], A)] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$letF(vars, in) => (vars, in)
-    }
 }
 object $literalF {
   def apply[EX[_], A](value: Bson)(implicit I: ExprOpCoreF :<: EX): EX[A] =
@@ -769,99 +664,51 @@ object $literalF {
 object $dayOfYearF {
   def apply[EX[_], A](date: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$dayOfYearF[A](date))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$dayOfYearF(date) => date
-    }
 }
 object $dayOfMonthF {
   def apply[EX[_], A](date: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$dayOfMonthF[A](date))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$dayOfMonthF(date) => date
-    }
 }
 object $dayOfWeekF {
   def apply[EX[_], A](date: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$dayOfWeekF[A](date))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$dayOfWeekF(date) => date
-    }
 }
 object $yearF {
   def apply[EX[_], A](date: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$yearF[A](date))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$yearF(date) => date
-    }
 }
 object $monthF {
   def apply[EX[_], A](date: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$monthF[A](date))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$monthF(date) => date
-    }
 }
 object $weekF {
   def apply[EX[_], A](date: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$weekF[A](date))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$weekF(date) => date
-    }
 }
 object $hourF {
   def apply[EX[_], A](date: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$hourF[A](date))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$hourF(date) => date
-    }
 }
 object $minuteF {
   def apply[EX[_], A](date: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$minuteF[A](date))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$minuteF(date) => date
-    }
 }
 object $secondF {
   def apply[EX[_], A](date: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$secondF[A](date))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$secondF(date) => date
-    }
 }
 object $millisecondF {
   def apply[EX[_], A](date: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$millisecondF[A](date))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[A] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$millisecondF(date) => date
-    }
 }
 
 object $condF {
   def apply[EX[_], A](predicate: A, ifTrue: A, ifFalse: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$condF[A](predicate, ifTrue, ifFalse))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[(A, A, A)] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$condF(pred, t, f) => (pred, t, f)
-    }
 }
 object $ifNullF {
   def apply[EX[_], A](expr: A, replacement: A)(implicit I: ExprOpCoreF :<: EX): EX[A] =
     I.inj(ExprOpCoreF.$ifNullF[A](expr, replacement))
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[(A, A)] =
-    I.prj(expr) collect {
-      case ExprOpCoreF.$ifNullF(expr, replacement) => (expr, replacement)
-    }
 }
 
 // "Fixed" constructors/extractors inject/project to/from an arbitrary

--- a/mongodb/src/main/scala/quasar/physical/mongodb/expression/ExprOpCore.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/expression/ExprOpCore.scala
@@ -94,12 +94,7 @@ object ExprOpCoreF {
       extends ExprOpCoreF[A]
   final case class $ifNullF[A](expr: A, replacement: A) extends ExprOpCoreF[A]
 
-  // TODO: if this is needed, comment explaining why
-  def unapply[EX[_], A](expr: EX[A])(implicit I: ExprOpCoreF :<: EX): Option[ExprOpCoreF[A]] =
-    I.prj(expr)
-
-  implicit def equal:
-      Delay[Equal, ExprOpCoreF] =
+  implicit val equal: Delay[Equal, ExprOpCoreF] =
     new Delay[Equal, ExprOpCoreF] {
       def apply[A](eq: Equal[A]) = {
         implicit val EQ: Equal[A] = eq

--- a/mongodb/src/main/scala/quasar/physical/mongodb/optimize/optimize.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/optimize/optimize.scala
@@ -66,13 +66,13 @@ package object optimize {
           val unusedRefs =
             unused(getDefs(op.unFix), usedRefs).toList.flatMap(_.deref.toList)
           op.unFix match {
-            case WorkflowOpCoreF(p @ $ProjectF(_, _, _))   =>
+            case I(p @ $ProjectF(_, _, _))   =>
               val p1 = p.deleteAll(unusedRefs)
               if (p1.shape.value.isEmpty) p1.pipeline.src.unFix
               else I.inj(p1)
-            case WorkflowOpCoreF(g @ $GroupF(_, _, _))     => I.inj(g.deleteAll(unusedRefs.map(_.flatten.head)))
-            case WorkflowOpCoreF(s @ $SimpleMapF(_, _, _)) => I.inj(s.deleteAll(unusedRefs))
-            case o                                     => o
+            case I(g @ $GroupF(_, _, _))     => I.inj(g.deleteAll(unusedRefs.map(_.flatten.head)))
+            case I(s @ $SimpleMapF(_, _, _)) => I.inj(s.deleteAll(unusedRefs))
+            case o                           => o
           }
         }
 
@@ -156,7 +156,7 @@ package object optimize {
             $limit[F](count),
             $simpleMap[F](fn, scope)).unFix.some
 
-        case $match(Fix(WorkflowOpCoreF(p @ $ProjectF(src0, shape, id))), sel) =>
+        case $match(Fix(I(p @ $ProjectF(src0, shape, id))), sel) =>
           val defs = p.getAll.collect {
             case (n, $var(x))    => DocField(n) -> x
             case (n, $include()) => DocField(n) -> DocField(n)

--- a/mongodb/src/main/scala/quasar/physical/mongodb/optimize/optimize.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/optimize/optimize.scala
@@ -35,20 +35,20 @@ package object optimize {
 
     private def deleteUnusedFields0[F[_]: Functor: Refs](op: Fix[F], usedRefs: Option[Set[DocVar]])
       (implicit I: WorkflowOpCoreF :<: F): Fix[F] = {
-      def getRefs[A](op: F[Fix[F]], prev: Option[Set[DocVar]]):
+      def getRefs[A](op: F[_], prev: Option[Set[DocVar]]):
           Option[Set[DocVar]] = op match {
-        case $group(_, _, _)           => Some(Refs[F].refs(op).toSet)
+        case I($GroupF(_, _, _))           => Some(Refs[F].refs(op).toSet)
         // FIXME: Since we can’t reliably identify which fields are used by a
         //        JS function, we need to assume they all are, until we hit the
         //        next $GroupF or $ProjectF.
-        case $map(_, _, _)             => None
-        case $simpleMap(_, _, _)       => None
-        case $flatMap(_, _, _)         => None
-        case $reduce(_, _, _)          => None
-        case $project(_, _, IncludeId) => Some(Refs[F].refs(op).toSet + IdVar)
-        case $project(_, _, _)         => Some(Refs[F].refs(op).toSet)
-        case $foldLeft(_, _)           => prev.map(_ + IdVar)
-        case _                         => prev.map(_ ++ Refs[F].refs(op))
+        case I($MapF(_, _, _))             => None
+        case I($SimpleMapF(_, _, _))       => None
+        case I($FlatMapF(_, _, _))         => None
+        case I($ReduceF(_, _, _))          => None
+        case I($ProjectF(_, _, IncludeId)) => Some(Refs[F].refs(op).toSet + IdVar)
+        case I($ProjectF(_, _, _))         => Some(Refs[F].refs(op).toSet)
+        case I($FoldLeftF(_, _))           => prev.map(_ + IdVar)
+        case _                             => prev.map(_ ++ Refs[F].refs(op))
       }
 
       def unused(defs: Set[DocVar], refs: Set[DocVar]): Set[DocVar] =
@@ -88,7 +88,7 @@ package object optimize {
       */
     private def simplifyGroupƒ[F[_]: Coalesce: Functor](implicit ev: WorkflowOpCoreF :<: F):
         F[Fix[F]] => Option[F[Fix[F]]] = {
-      case $group(src, Grouped(cont), id) =>
+      case ev($GroupF(src, Grouped(cont), id)) =>
         val (newCont, proj) =
           cont.foldLeft[(ListMap[BsonField.Name, AccumOp[Fix[ExprOp]]], ListMap[BsonField.Name, Reshape.Shape[ExprOp]])](
             (ListMap(), ListMap())) {
@@ -125,7 +125,7 @@ package object optimize {
     def simplifyGroup[F[_]: Coalesce: Functor](op: Fix[F])(implicit ev: WorkflowOpCoreF :<: F): Fix[F] =
       op.transCata[Fix[F]](orOriginal(simplifyGroupƒ[F]))
 
-    private def reorderOpsƒ[F[_]: Coalesce](implicit I: WorkflowOpCoreF :<: F)
+    private def reorderOpsƒ[F[_]: Coalesce: Functor](implicit I: WorkflowOpCoreF :<: F)
         : F[Fix[F]] => Option[F[Fix[F]]] = {
       def rewriteSelector(sel: Selector, defs: Map[DocVar, DocVar]): Option[Selector] =
         sel.mapUpFieldsM { f =>
@@ -138,25 +138,25 @@ package object optimize {
         }
 
       {
-        case $skip(Fix($project(src0, shape, id)), count) =>
+        case I($SkipF(Embed(I($ProjectF(src0, shape, id))), count)) =>
           chain(src0,
             $skip[F](count),
-            $project[F](shape, id)).unFix.some
-        case $skip(Fix($simpleMap(src0, fn @ NonEmptyList(MapExpr(_), INil()), scope)), count) =>
+            $project[F](shape, id)).project.some
+        case I($SkipF(Embed(I($SimpleMapF(src0, fn @ NonEmptyList(MapExpr(_), INil()), scope))), count)) =>
           chain(src0,
             $skip[F](count),
-            $simpleMap[F](fn, scope)).unFix.some
+            $simpleMap[F](fn, scope)).project.some
 
-        case $limit(Fix($project(src0, shape, id)), count) =>
+        case I($LimitF(Embed(I($ProjectF(src0, shape, id))), count)) =>
           chain(src0,
             $limit[F](count),
-            $project[F](shape, id)).unFix.some
-        case $limit(Fix($simpleMap(src0, fn @ NonEmptyList(MapExpr(_), INil()), scope)), count) =>
+            $project[F](shape, id)).project.some
+        case I($LimitF(Embed(I($SimpleMapF(src0, fn @ NonEmptyList(MapExpr(_), INil()), scope))), count)) =>
           chain(src0,
             $limit[F](count),
-            $simpleMap[F](fn, scope)).unFix.some
+            $simpleMap[F](fn, scope)).project.some
 
-        case $match(Fix(I(p @ $ProjectF(src0, shape, id))), sel) =>
+        case I($MatchF(Embed(I(p @ $ProjectF(src0, shape, id))), sel)) =>
           val defs = p.getAll.collect {
             case (n, $var(x))    => DocField(n) -> x
             case (n, $include()) => DocField(n) -> DocField(n)
@@ -164,9 +164,9 @@ package object optimize {
           rewriteSelector(sel, defs).map(sel =>
             chain(src0,
               $match[F](sel),
-              $project[F](shape, id)).unFix)
+              $project[F](shape, id)).project)
 
-        case $match(Fix($simpleMap(src0, exprs @ NonEmptyList(MapExpr(jsFn), INil()), scope)), sel) => {
+        case I($MatchF(Embed(I($SimpleMapF(src0, exprs @ NonEmptyList(MapExpr(jsFn), INil()), scope))), sel)) => {
           import quasar.javascript._
           def defs(expr: JsCore): Map[DocVar, DocVar] =
             expr.simplify match {
@@ -181,7 +181,7 @@ package object optimize {
           rewriteSelector(sel, defs(jsFn.expr)).map(sel =>
             chain(src0,
               $match[F](sel),
-              $simpleMap[F](exprs, scope)).unFix)
+              $simpleMap[F](exprs, scope)).project)
         }
 
         case op => None
@@ -287,8 +287,8 @@ package object optimize {
       : Option[(Fix[F], Grouped[ExprOp], Reshape.Shape[ExprOp])] = {
       def collectShapes: GAlgebra[(Fix[F], ?), F, (List[Reshape[ExprOp]], Fix[F])] =
         {
-          case $project(src, shape, _) => ((x: List[Reshape[ExprOp]]) => shape :: x).first(src._2)
-          case x                       => (Nil, Fix(x.map(_._1)))
+          case I($ProjectF(src, shape, _)) => ((x: List[Reshape[ExprOp]]) => shape :: x).first(src._2)
+          case x                           => (Nil, Fix(x.map(_._1)))
         }
 
       val (rs, src) = g.src.para(collectShapes)

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/JoinHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/JoinHandler.scala
@@ -89,8 +89,8 @@ object JoinHandler {
         false)
 
     def wfSourceDb: Algebra[WF, Option[DatabaseName]] = {
-      case $read(Collection(db, _)) => db.some
-      case op => C.pipeline(op).flatMap(_.src)
+      case ev0($ReadF(Collection(db, _))) => db.some
+      case op                             => C.pipeline(op).flatMap(_.src)
       // TODO: deal with non-pipeline sources where it's possible to identify the DB
     }
 
@@ -193,7 +193,7 @@ object JoinHandler {
       : Option[(Collection, BsonField)] =
       arg match {
         case JoinSource(
-              Fix(CollectionBuilderF(Fix($read(coll)), Root(), None)),
+              Fix(CollectionBuilderF(Fix(ev0($ReadF(coll))), Root(), None)),
               List(Fix(ExprBuilderF(src, \/-($var(DocVar(_, Some(field))))))),
               _) if src ≟ arg.src =>
           (coll, field).some

--- a/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -1020,7 +1020,7 @@ object MongoDbQScriptPlanner {
         elems.traverse(handler) ∘ (ArrayBuilder(src, _))
       case MapFunc.StaticMap(elems) =>
         elems.traverse(_.bitraverse({
-          case Embed(ejson.Common(ejson.Str(key))) => BsonField.Name(key).point[M]
+          case Embed(MapFunc.EC(ejson.Str(key))) => BsonField.Name(key).point[M]
           case key => merr.raiseError[BsonField.Name](qscriptPlanningFailed(InternalError.fromMsg(s"Unsupported object key: ${key.shows}")))
         },
           handler)) ∘

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflow/WorkflowOp3_2.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflow/WorkflowOp3_2.scala
@@ -89,13 +89,6 @@ object $sample {
   }
 
 object WorkflowOp3_2F {
-  // NB: this extractor has to be used instead of the simpler ones provided for
-  // each op if you need to bind the op itself, and not just its fields.
-  // For example: `case $lookup(src, from, lf, ff, as) => ` vs.
-  // `case WorkflowOp3_2F(l @ $LookupF(_, _, _, _, _)) =>`
-  def unapply[F[_], A](fa: F[A])(implicit I: WorkflowOp3_2F :<: F): Option[WorkflowOp3_2F[A]] =
-    I.prj(fa)
-
   implicit val traverse: Traverse[WorkflowOp3_2F] =
     new Traverse[WorkflowOp3_2F] {
       def traverseImpl[G[_], A, B](fa: WorkflowOp3_2F[A])(f: A => G[B])

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflow/WorkflowOp3_2.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflow/WorkflowOp3_2.scala
@@ -57,12 +57,6 @@ object $lookup {
     as: BsonField)
     (implicit I: WorkflowOp3_2F :<: F): FixOp[F] =
       src => Fix(Coalesce[F].coalesce(I.inj($LookupF(src, from, localField, foreignField, as))))
-
-  def unapply[F[_], A](op: F[A])(implicit I: WorkflowOp3_2F :<: F)
-    : Option[(A, CollectionName, BsonField, BsonField, BsonField)] =
-    I.prj(op) collect {
-      case $LookupF(src, from, lf, ff, as) => (src, from, lf, ff, as)
-    }
 }
 
 final case class $SampleF[A](src: A, size: Int)
@@ -80,13 +74,7 @@ final case class $SampleF[A](src: A, size: Int)
 object $sample {
   def apply[F[_]: Coalesce](size: Int)(implicit I: WorkflowOp3_2F :<: F): FixOp[F] =
     src => Fix(Coalesce[F].coalesce(I.inj($SampleF(src, size))))
-
-  def unapply[F[_], A](op: F[A])(implicit I: WorkflowOp3_2F :<: F)
-    : Option[(A, Int)] =
-    I.prj(op) collect {
-      case $SampleF(src, size) => (src, size)
-    }
-  }
+}
 
 object WorkflowOp3_2F {
   implicit val traverse: Traverse[WorkflowOp3_2F] =

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflow/WorkflowOpCore.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflow/WorkflowOpCore.scala
@@ -833,13 +833,6 @@ object $foldLeft {
 }
 
 object WorkflowOpCoreF {
-  // NB: this extractor has to be used instead of the simpler ones provided for
-  // each op if you need to bind the op itself, and not just its fields.
-  // For example: `case $project(src, shape, id) => ` vs.
-  // `case WorkflowOpCoreF(p @ $ProjectF(_, _, _)) =>`
-  def unapply[F[_], A](fa: F[A])(implicit I: WorkflowOpCoreF :<: F): Option[WorkflowOpCoreF[A]] =
-    I.prj(fa)
-
   implicit val traverse: Traverse[WorkflowOpCoreF] =
     new Traverse[WorkflowOpCoreF] {
       def traverseImpl[G[_], A, B](fa: WorkflowOpCoreF[A])(f: A => G[B])

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflow/WorkflowOpCore.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflow/WorkflowOpCore.scala
@@ -43,24 +43,12 @@ final case class $PureF(value: Bson) extends WorkflowOpCoreF[Nothing]
 object $pure {
   def apply[F[_]: Coalesce](value: Bson)(implicit I: WorkflowOpCoreF :<: F) =
     Fix(Coalesce[F].coalesce(I.inj($PureF(value))))
-
-  def unapply[F[_], A](op: F[A])(implicit I: WorkflowOpCoreF :<: F)
-    : Option[Bson] =
-    I.prj(op) collect {
-      case $PureF(value) => (value)
-    }
 }
 
 final case class $ReadF(coll: Collection) extends WorkflowOpCoreF[Nothing]
 object $read {
   def apply[F[_]: Coalesce](coll: Collection)(implicit I: WorkflowOpCoreF :<: F) =
     Fix(Coalesce[F].coalesce(I.inj($ReadF(coll))))
-
-  def unapply[F[_], A](op: F[A])(implicit I: WorkflowOpCoreF :<: F)
-    : Option[Collection] =
-    I.prj(op) collect {
-      case $ReadF(coll) => (coll)
-    }
 }
 
 final case class $MatchF[A](src: A, selector: Selector)
@@ -79,12 +67,6 @@ object $match {
   def apply[F[_]: Coalesce](selector: Selector)
     (implicit I: WorkflowOpCoreF :<: F): FixOp[F] =
     src => Fix(Coalesce[F].coalesce(I.inj($MatchF(src, selector))))
-
-  def unapply[F[_], A](op: F[A])(implicit I: WorkflowOpCoreF :<: F)
-    : Option[(A, Selector)] =
-    I.prj(op) collect {
-      case $MatchF(src, sel) => (src, sel)
-    }
 }
 
 final case class $ProjectF[A](src: A, shape: Reshape[ExprOp], idExclusion: IdHandling)
@@ -173,12 +155,6 @@ object $project {
     $project[F](
       shape,
       shape.get(IdName).fold[IdHandling](IgnoreId)(κ(IncludeId)))
-
-  def unapply[F[_], A](op: F[A])(implicit I: WorkflowOpCoreF :<: F)
-    : Option[(A, Reshape[ExprOp], IdHandling)] =
-    I.prj(op) collect {
-      case $ProjectF(src, shape, id) => (src, shape, id)
-    }
 }
 
 final case class $RedactF[A](src: A, value: Fix[ExprOp])
@@ -205,12 +181,6 @@ object $redact {
   def apply[F[_]: Coalesce](value: Fix[ExprOp])
     (implicit I: WorkflowOpCoreF :<: F): FixOp[F] =
     src => Fix(Coalesce[F].coalesce(I.inj($RedactF(src, value))))
-
-  def unapply[F[_], A](op: F[A])(implicit I: WorkflowOpCoreF :<: F)
-    : Option[(A, Fix[ExprOp])] =
-    I.prj(op) collect {
-      case $RedactF(src, value) => (src, value)
-    }
 }
 
 final case class $LimitF[A](src: A, count: Long)
@@ -229,11 +199,6 @@ object $limit {
   def apply[F[_]: Coalesce](count: Long)
     (implicit I: WorkflowOpCoreF :<: F): FixOp[F] =
     src => Fix(Coalesce[F].coalesce(I.inj($LimitF(src, count))))
-
-  def unapply[F[_], A](op: F[A])(implicit I: WorkflowOpCoreF :<: F): Option[(A, Long)] =
-    I.prj(op).collect {
-      case $LimitF(src, count) => (src, count)
-    }
 }
 
 final case class $SkipF[A](src: A, count: Long)
@@ -252,11 +217,6 @@ object $skip {
   def apply[F[_]: Coalesce](count: Long)
     (implicit I: WorkflowOpCoreF :<: F): FixOp[F] =
     src => Fix(Coalesce[F].coalesce(I.inj($SkipF(src, count))))
-
-  def unapply[F[_], A](op: F[A])(implicit I: WorkflowOpCoreF :<: F): Option[(A, Long)] =
-    I.prj(op).collect {
-      case $SkipF(src, count) => (src, count)
-    }
 }
 
 final case class $UnwindF[A](src: A, field: DocVar)
@@ -276,12 +236,6 @@ object $unwind {
   def apply[F[_]: Coalesce](field: DocVar)
     (implicit I: WorkflowOpCoreF :<: F): FixOp[F] =
     src => Fix(Coalesce[F].coalesce(I.inj($UnwindF(src, field))))
-
-  def unapply[F[_], A](op: F[A])(implicit I: WorkflowOpCoreF :<: F)
-    : Option[(A, DocVar)] =
-    I.prj(op) collect {
-      case $UnwindF(src, field) => (src, field)
-    }
 }
 
 final case class $GroupF[A](src: A, grouped: Grouped[ExprOp], by: Reshape.Shape[ExprOp])
@@ -315,12 +269,6 @@ object $group {
   def apply[F[_]: Coalesce](grouped: Grouped[ExprOp], by: Reshape.Shape[ExprOp])
     (implicit I: WorkflowOpCoreF :<: F): FixOp[F] =
     src => Fix(Coalesce[F].coalesce(I.inj($GroupF(src, grouped, by))))
-
-  def unapply[F[_], A](op: F[A])(implicit I: WorkflowOpCoreF :<: F)
-    : Option[(A, Grouped[ExprOp], Reshape.Shape[ExprOp])] =
-    I.prj(op) collect {
-      case $GroupF(src, grouped, shape) => (src, grouped, shape)
-    }
 }
 
 final case class $SortF[A](src: A, value: NonEmptyList[(BsonField, SortDir)])
@@ -344,12 +292,6 @@ object $sort {
   def apply[F[_]: Coalesce](value: NonEmptyList[(BsonField, SortDir)])
     (implicit I: WorkflowOpCoreF :<: F): FixOp[F] =
     src => Fix(Coalesce[F].coalesce(I.inj($SortF(src, value))))
-
-  def unapply[F[_], A](op: F[A])(implicit I: WorkflowOpCoreF :<: F)
-    : Option[(A, NonEmptyList[(BsonField, SortDir)])] =
-    I.prj(op) collect {
-      case $SortF(src, value) => (src, value)
-    }
 }
 
 /**
@@ -377,12 +319,6 @@ object $out {
   def apply[F[_]: Coalesce](collection: CollectionName)
     (implicit I: WorkflowOpCoreF :<: F): FixOp[F] =
     src => Fix(Coalesce[F].coalesce(I.inj($OutF(src, collection))))
-
-  def unapply[F[_], A](op: F[A])(implicit I: WorkflowOpCoreF :<: F)
-    : Option[(A, CollectionName)] =
-    I.prj(op) collect {
-      case $OutF(src, collection) => (src, collection)
-    }
 }
 
 final case class $GeoNearF[A](
@@ -423,15 +359,6 @@ object $geoNear {
     (implicit I: WorkflowOpCoreF :<: F): FixOp[F] =
       src => Fix(Coalesce[F].coalesce(I.inj($GeoNearF(
         src, near, distanceField, limit, maxDistance, query, spherical, distanceMultiplier, includeLocs, uniqueDocs))))
-
-  def unapply[F[_], A](op: F[A])(implicit I: WorkflowOpCoreF :<: F)
-    : Option[(A, (Double, Double), BsonField, Option[Int], Option[Double],
-      Option[Selector], Option[Boolean], Option[Double], Option[BsonField],
-      Option[Boolean])] =
-    I.prj(op) collect {
-      case $GeoNearF(src, n, df, l, md, q, s, dm, il, ud) =>
-        (src, n, df, l, md, q, s, dm, il, ud)
-    }
 }
 
 sealed trait MapReduceF[A] extends WorkflowOpCoreF[A] {
@@ -514,12 +441,6 @@ object $map {
   def apply[F[_]: Coalesce](fn: Js.AnonFunDecl, scope: Scope)
     (implicit I: WorkflowOpCoreF :<: F): FixOp[F] =
     src => Fix(Coalesce[F].coalesce(I.inj($MapF(src, fn, scope))))
-
-  def unapply[F[_], A](op: F[A])(implicit I: WorkflowOpCoreF :<: F)
-    : Option[(A, Js.AnonFunDecl, Scope)] =
-    I.prj(op) collect {
-      case $MapF(src, fn, scope) => (src, fn, scope)
-    }
 }
 
 // FIXME: this one should become $MapF, with the other one being replaced by
@@ -681,12 +602,6 @@ object $simpleMap {
   def apply[F[_]: Coalesce](exprs: NonEmptyList[CardinalExpr[JsFn]], scope: Scope)
     (implicit I: WorkflowOpCoreF :<: F): FixOp[F] =
     src => Fix(Coalesce[F].coalesce(I.inj($SimpleMapF(src, exprs, scope))))
-
-  def unapply[F[_], A](op: F[A])(implicit I: WorkflowOpCoreF :<: F)
-    : Option[(A, NonEmptyList[CardinalExpr[JsFn]], Scope)] =
-    I.prj(op) collect {
-      case $SimpleMapF(src, exprs, scope) => (src, exprs, scope)
-    }
 }
 
 /**
@@ -754,12 +669,6 @@ object $flatMap {
   def apply[F[_]: Coalesce](fn: Js.AnonFunDecl, scope: Scope)
     (implicit I: WorkflowOpCoreF :<: F): FixOp[F] =
     src => Fix(Coalesce[F].coalesce(I.inj($FlatMapF(src, fn, scope))))
-
-  def unapply[F[_], A](op: F[A])(implicit I: WorkflowOpCoreF :<: F)
-    : Option[(A, Js.AnonFunDecl, Scope)] =
-    I.prj(op) collect {
-      case $FlatMapF(src, fn, scope) => (src, fn, scope)
-    }
 }
 
 /** Takes a function of two parameters – a key and an array of values. The
@@ -806,12 +715,6 @@ object $reduce {
   def apply[F[_]: Coalesce](fn: Js.AnonFunDecl, scope: Scope)
     (implicit I: WorkflowOpCoreF :<: F): FixOp[F] =
     src => Fix(Coalesce[F].coalesce(I.inj($ReduceF(src, fn, scope))))
-
-  def unapply[F[_], A](op: F[A])(implicit I: WorkflowOpCoreF :<: F)
-    : Option[(A, Js.AnonFunDecl, Scope)] =
-    I.prj(op) collect {
-      case $ReduceF(src, fn, scope) => (src, fn, scope)
-    }
 }
 
 /** Performs a sequence of operations, sequentially, merging their results.
@@ -822,14 +725,6 @@ object $foldLeft {
   def apply[F[_]: Coalesce](first: Fix[F], second: Fix[F], rest: Fix[F]*)
     (implicit I: WorkflowOpCoreF :<: F): Fix[F] =
     Fix(Coalesce[F].coalesce(I.inj($FoldLeftF(first, NonEmptyList.nel(second, IList.fromList(rest.toList))))))
-
-  // FIXME: the result should be in NonEmptyList, but it gives a compile error
-  // saying "this is a GADT skolem"
-  def unapply[F[_], A](op: F[A])(implicit I: WorkflowOpCoreF :<: F)
-    : Option[(A, List[A])] =
-    I.prj(op) collect {
-      case $FoldLeftF(head, tail) => (head, tail.toList)
-    }
 }
 
 object WorkflowOpCoreF {

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
@@ -990,7 +990,7 @@ object WorkflowBuilder {
       wb.unFix match {
         case spb @ ShapePreservingBuilderF(spbSrc, sortKeys, f) =>
           spb.dummyOp.unFix match {
-            case $sort(_, _) =>
+            case ev0($SortF(_, _)) =>
               foldBuilders(src, sortKeys).flatMap {
                 case (newSrc, dv, ks) =>
                   distincting(newSrc).map { dist =>

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflowtask/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflowtask/package.scala
@@ -98,16 +98,19 @@ package object workflowtask {
   private def shape(p: Pipeline): Option[List[BsonField.Name]] = {
     def src = shape(p.dropRight(1))
 
+    val WC = Inject[WorkflowOpCoreF, WorkflowF]
+    val W32 = Inject[WorkflowOp3_2F, WorkflowF]
+
     p.lastOption.flatMap(_.op match {
-      case IsShapePreserving(_)                    => src
+      case IsShapePreserving(_)                        => src
 
-      case $project((), Reshape(shape), _)         => Some(shape.keys.toList)
-      case $group((), Grouped(shape), _)           => Some(shape.keys.toList)
-      case $unwind((), _)                          => src
-      case $redact((), _)                          => None
-      case $geoNear((), _, _, _, _, _, _, _, _, _) => src.map(_ :+ BsonField.Name("dist"))
+      case WC($ProjectF((), Reshape(shape), _))         => Some(shape.keys.toList)
+      case WC($GroupF((), Grouped(shape), _))           => Some(shape.keys.toList)
+      case WC($UnwindF((), _))                          => src
+      case WC($RedactF((), _))                          => None
+      case WC($GeoNearF((), _, _, _, _, _, _, _, _, _)) => src.map(_ :+ BsonField.Name("dist"))
 
-      case $lookup((), _, _, _, as)                => src.map(_ :+ as.flatten.head)
+      case W32($LookupF((), _, _, _, as))               => src.map(_ :+ as.flatten.head)
     })
   }
 }

--- a/mongodb/src/test/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -3570,14 +3570,16 @@ class PlannerQScriptSpec extends
       wf.foldMap(op => if (p.lift(op.unFix).getOrElse(false)) 1 else 0)
     }
 
-    def countAccumOps(wf: Workflow) = countOps(wf, { case $group(_, _, _) => true })
-    def countUnwindOps(wf: Workflow) = countOps(wf, { case $unwind(_, _) => true })
-    def countMatchOps(wf: Workflow) = countOps(wf, { case $match(_, _) => true })
+    val WC = Inject[WorkflowOpCoreF, WorkflowF]
+
+    def countAccumOps(wf: Workflow) = countOps(wf, { case WC($GroupF(_, _, _)) => true })
+    def countUnwindOps(wf: Workflow) = countOps(wf, { case WC($UnwindF(_, _)) => true })
+    def countMatchOps(wf: Workflow) = countOps(wf, { case WC($MatchF(_, _)) => true })
 
     def noConsecutiveProjectOps(wf: Workflow) =
-      countOps(wf, { case $project(Fix($project(_, _, _)), _, _) => true }) aka "the occurrences of consecutive $project ops:" must_== 0
+      countOps(wf, { case WC($ProjectF(Embed(WC($ProjectF(_, _, _))), _, _)) => true }) aka "the occurrences of consecutive $project ops:" must_== 0
     def noConsecutiveSimpleMapOps(wf: Workflow) =
-      countOps(wf, { case $simpleMap(Fix($simpleMap(_, _, _)), _, _) => true }) aka "the occurrences of consecutive $simpleMap ops:" must_== 0
+      countOps(wf, { case WC($SimpleMapF(Embed(WC($SimpleMapF(_, _, _))), _, _)) => true }) aka "the occurrences of consecutive $simpleMap ops:" must_== 0
     def maxAccumOps(wf: Workflow, max: Int) =
       countAccumOps(wf) aka "the number of $group ops:" must beLessThanOrEqualTo(max)
     def maxUnwindOps(wf: Workflow, max: Int) =
@@ -3585,7 +3587,7 @@ class PlannerQScriptSpec extends
     def maxMatchOps(wf: Workflow, max: Int) =
       countMatchOps(wf) aka "the number of $match ops:" must beLessThanOrEqualTo(max)
     def brokenProjectOps(wf: Workflow) =
-      countOps(wf, { case $project(_, Reshape(shape), _) => shape.isEmpty }) aka "$project ops with no fields"
+      countOps(wf, { case WC($ProjectF(_, Reshape(shape), _)) => shape.isEmpty }) aka "$project ops with no fields"
 
     def danglingReferences(wf: Workflow) =
       wf.foldMap(_.unFix match {
@@ -3601,7 +3603,7 @@ class PlannerQScriptSpec extends
 
     def rootPushes(wf: Workflow) =
       wf.foldMap(_.unFix match {
-        case op @ $group(src, Grouped(map), _) if map.values.toList.contains($push($$ROOT)) && simpleShape(src).isEmpty => List(op)
+        case WC(op @ $GroupF(src, Grouped(map), _)) if map.values.toList.contains($push($$ROOT)) && simpleShape(src).isEmpty => List(op)
         case _ => Nil
       }) aka "group ops pushing $$ROOT"
 

--- a/mongodb/src/test/scala/quasar/physical/mongodb/workflowop.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/workflowop.scala
@@ -26,8 +26,8 @@ import quasar.physical.mongodb.accumulator._
 import quasar.physical.mongodb.expression._
 import quasar.physical.mongodb.workflow._
 
-import matryoshka.data.Fix
-
+import matryoshka._
+import matryoshka.implicits._
 import org.scalacheck._
 import org.scalacheck.rng.Seed
 import org.specs2.matcher.MustMatchers._
@@ -239,6 +239,8 @@ class WorkflowSpec extends quasar.Qspec with TreeMatchers {
           IgnoreId))
     }
 
+    val WC = Inject[WorkflowOpCoreF, WorkflowF]
+
     "not inline $projects with nesting" in {
       // NB: simulates a pair of type-checks, which cannot be inlined in a simple way
       // because the second digs into the structure created by the first.
@@ -256,8 +258,8 @@ class WorkflowSpec extends quasar.Qspec with TreeMatchers {
               $cond($literal(Bson.Bool(true)), $field("__tmp0", "foo"), $literal(Bson.Int32(1)))))),
           IgnoreId))
 
-      (op.unFix match {
-        case $project(Fix($project(_, Reshape(s1), _)), Reshape(s2), _) =>
+      (op.project match {
+        case WC($ProjectF(Embed(WC($ProjectF(_, Reshape(s1), _))), Reshape(s2), _)) =>
           s1.keys must_== Set(BsonField.Name("__tmp0"))
           s2.keys must_== Set(BsonField.Name("__tmp1"))
         case _ => failure
@@ -279,8 +281,8 @@ class WorkflowSpec extends quasar.Qspec with TreeMatchers {
             BsonField.Name("__tmp1") -> \/-($field("foo")))),
           IgnoreId))
 
-      (op.unFix match {
-        case $project(Fix($project(_, Reshape(s1), _)), Reshape(s2), _) =>
+      (op.project match {
+        case WC($ProjectF(Embed(WC($ProjectF(_, Reshape(s1), _))), Reshape(s2), _)) =>
           s1.keys must_== Set(BsonField.Name("__tmp0"))
           s2.keys must_== Set(BsonField.Name("__tmp1"))
         case _ => failure


### PR DESCRIPTION
This eliminates a ton of `unapply` methods on various functors that are intended to project a component of a Coproduct. This is now provided directly by the `Inject` instance.

There are still 16(?) unapply methods in the MongoDB connector. These are a bit more entrenched, so aren't being removed in this PR. All other `unapply`s in this style have been removed.