### PR TITLE
Add Order instances for EJson.

### DIFF
--- a/connector/src/main/scala/quasar/fs/QueryFile.scala
+++ b/connector/src/main/scala/quasar/fs/QueryFile.scala
@@ -20,6 +20,7 @@ import quasar.Predef._
 import quasar._, Planner._, RenderTree.ops._, RenderTreeT.ops._
 import quasar.common.{PhaseResult, PhaseResults, PhaseResultT, PhaseResultW}
 import quasar.connector.CompileM
+import quasar.contrib.matryoshka._
 import quasar.contrib.pathy._
 import quasar.contrib.scalaz._, eitherT._
 import quasar.effect.LiftedOps
@@ -49,7 +50,7 @@ object QueryFile {
   }
 
   def convertAndNormalize
-    [T[_[_]]: BirecursiveT: EqualT: ShowT, QS[_]: Traverse: Normalizable]
+    [T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT, QS[_]: Traverse: Normalizable]
     (lp: T[LogicalPlan])
     (eval: QS[T[QS]] => QS[T[QS]])
     (implicit
@@ -75,7 +76,7 @@ object QueryFile {
   }
 
   def simplifyAndNormalize
-    [T[_[_]]: BirecursiveT: EqualT: ShowT,
+    [T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT,
       IQS[_]: Functor,
       QS[_]: Traverse: Normalizable]
     (implicit
@@ -113,7 +114,7 @@ object QueryFile {
     * LogicalPlan no longer needs to be exposed.
     */
   def convertToQScript
-    [T[_[_]]: BirecursiveT: EqualT: RenderTreeT: ShowT, QS[_]: Traverse: Normalizable]
+    [T[_[_]]: BirecursiveT: OrderT: EqualT: RenderTreeT: ShowT, QS[_]: Traverse: Normalizable]
     (lp: T[LogicalPlan])
     (implicit
       CQ: Coalesce.Aux[T, QS, QS],
@@ -139,7 +140,7 @@ object QueryFile {
   }
 
   def convertToQScriptRead
-    [T[_[_]]: BirecursiveT: EqualT: RenderTreeT: ShowT, M[_]: Monad, QS[_]: Traverse: Normalizable]
+    [T[_[_]]: BirecursiveT: OrderT: EqualT: RenderTreeT: ShowT, M[_]: Monad, QS[_]: Traverse: Normalizable]
     (listContents: DiscoverPath.ListContents[M])
     (lp: T[LogicalPlan])
     (implicit

--- a/connector/src/main/scala/quasar/qscript/Coalesce.scala
+++ b/connector/src/main/scala/quasar/qscript/Coalesce.scala
@@ -18,6 +18,7 @@ package quasar.qscript
 
 import quasar.Predef._
 import quasar.contrib.pathy.{ADir, AFile}
+import quasar.contrib.matryoshka._
 import quasar.fp._
 import quasar.fp.ski._
 import quasar.qscript.MapFunc._
@@ -60,23 +61,23 @@ trait Coalesce[IN[_]] {
 }
 
 trait CoalesceInstances {
-  def coalesce[T[_[_]]: BirecursiveT: EqualT: ShowT] = new CoalesceT[T]
+  def coalesce[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT] = new CoalesceT[T]
 
-  implicit def qscriptCore[T[_[_]]: BirecursiveT: EqualT: ShowT, G[_]]
+  implicit def qscriptCore[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT, G[_]]
     (implicit QC: QScriptCore[T, ?] :<: G)
       : Coalesce.Aux[T, QScriptCore[T, ?], G] =
     coalesce[T].qscriptCore[G]
 
-  implicit def projectBucket[T[_[_]]: BirecursiveT: EqualT: ShowT, F[_]]
+  implicit def projectBucket[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT, F[_]]
       : Coalesce.Aux[T, ProjectBucket[T, ?], F] =
     coalesce[T].projectBucket[F]
 
-  implicit def thetaJoin[T[_[_]]: BirecursiveT: EqualT: ShowT, G[_]]
+  implicit def thetaJoin[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT, G[_]]
     (implicit TJ: ThetaJoin[T, ?] :<: G)
       : Coalesce.Aux[T, ThetaJoin[T, ?], G] =
     coalesce[T].thetaJoin[G]
 
-  implicit def equiJoin[T[_[_]]: BirecursiveT: EqualT: ShowT, G[_]]
+  implicit def equiJoin[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT, G[_]]
     (implicit EJ: EquiJoin[T, ?] :<: G)
       : Coalesce.Aux[T, EquiJoin[T, ?], G] =
     coalesce[T].equiJoin[G]
@@ -145,7 +146,7 @@ trait CoalesceInstances {
     default
 }
 
-class CoalesceT[T[_[_]]: BirecursiveT: EqualT: ShowT] extends TTypes[T] {
+class CoalesceT[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT] extends TTypes[T] {
   private def CoalesceTotal = Coalesce[T, QScriptTotal, QScriptTotal]
 
   private type QST = QScriptTotal[T[CoEnv[Hole, QScriptTotal, ?]]]

--- a/connector/src/main/scala/quasar/qscript/EquiJoin.scala
+++ b/connector/src/main/scala/quasar/qscript/EquiJoin.scala
@@ -18,6 +18,7 @@ package quasar.qscript
 
 import quasar.Predef._
 import quasar.{NonTerminal, RenderTree, RenderTreeT}, RenderTree.ops._
+import quasar.contrib.matryoshka._
 import quasar.fp._
 
 import matryoshka._
@@ -41,7 +42,7 @@ import scalaz._, Scalaz._
   combine: JoinFunc[T])
 
 object EquiJoin {
-  implicit def equal[T[_[_]]: EqualT]:
+  implicit def equal[T[_[_]]: OrderT: EqualT]:
       Delay[Equal, EquiJoin[T, ?]] =
     new Delay[Equal, EquiJoin[T, ?]] {
       def apply[A](eq: Equal[A]) =
@@ -98,7 +99,7 @@ object EquiJoin {
           (EquiJoin(_, fa.lBranch, fa.rBranch, fa.lKey, fa.rKey, fa.f, fa.combine))
     }
 
-  implicit def mergeable[T[_[_]]: BirecursiveT: EqualT: ShowT]
+  implicit def mergeable[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT]
       : Mergeable.Aux[T, EquiJoin[T, ?]] =
     new Mergeable[EquiJoin[T, ?]] {
       type IT[F[_]] = T[F]

--- a/connector/src/main/scala/quasar/qscript/MapFunc.scala
+++ b/connector/src/main/scala/quasar/qscript/MapFunc.scala
@@ -18,6 +18,7 @@ package quasar.qscript
 
 import quasar.Predef._
 import quasar._, RenderTree.ops._
+import quasar.contrib.matryoshka._
 import quasar.ejson._
 import quasar.fp._
 import quasar.fp.ski._
@@ -216,7 +217,7 @@ object MapFunc {
       }) ∘ (_.embed)
   }
 
-  def normalize[T[_[_]]: BirecursiveT: EqualT: ShowT, A: Show]
+  def normalize[T[_[_]]: BirecursiveT: OrderT: ShowT, A: Show]
       : CoEnv[A, MapFunc[T, ?], FreeMapA[T, A]] => CoEnv[A, MapFunc[T, ?], FreeMapA[T, A]] =
     repeatedly(rewrite[T, A]) ⋘
       orOriginal(foldConstant[T, A].apply(_) ∘ (const => rollMF[T, A](Constant(const))))
@@ -224,7 +225,7 @@ object MapFunc {
   // TODO: This could be split up as it is in LP, with each function containing
   //       its own normalization.
   @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
-  def rewrite[T[_[_]]: BirecursiveT: EqualT: ShowT, A: Show]:
+  def rewrite[T[_[_]]: BirecursiveT: OrderT: ShowT, A: Show]:
       CoMapFuncR[T, A] => Option[CoMapFuncR[T, A]] = {
     _.run.fold(
       κ(None),
@@ -369,7 +370,7 @@ object MapFunc {
       }
   }
 
-  implicit def equal[T[_[_]]: EqualT, A]: Delay[Equal, MapFunc[T, ?]] =
+  implicit def equal[T[_[_]]: OrderT, A]: Delay[Equal, MapFunc[T, ?]] =
     new Delay[Equal, MapFunc[T, ?]] {
       def apply[A](in: Equal[A]): Equal[MapFunc[T, A]] = Equal.equal {
         // nullary

--- a/connector/src/main/scala/quasar/qscript/Merge.scala
+++ b/connector/src/main/scala/quasar/qscript/Merge.scala
@@ -18,6 +18,7 @@ package quasar.qscript
 
 import quasar.Predef._
 import quasar.Planner._
+import quasar.contrib.matryoshka._
 import quasar.fp.{ ExternallyManaged => EM, _ }
 
 import matryoshka._
@@ -26,7 +27,7 @@ import matryoshka.implicits._
 import matryoshka.patterns._
 import scalaz._, Scalaz._
 
-class Merge[T[_[_]]: BirecursiveT: EqualT: ShowT] extends TTypes[T] {
+class Merge[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT] extends TTypes[T] {
   case class ZipperSides(
     lSide: FreeMap,
     rSide: FreeMap)

--- a/connector/src/main/scala/quasar/qscript/Normalizable.scala
+++ b/connector/src/main/scala/quasar/qscript/Normalizable.scala
@@ -18,6 +18,7 @@ package quasar.qscript
 
 import quasar.Predef._
 import quasar.common.SortDir
+import quasar.contrib.matryoshka._
 import quasar.ejson.EJson
 import quasar.fp._
 import quasar.fp.ski._
@@ -36,25 +37,25 @@ import simulacrum.typeclass
 trait NormalizableInstances {
   import Normalizable._
 
-  def normalizable[T[_[_]]: BirecursiveT: EqualT: ShowT] =
+  def normalizable[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT] =
     new NormalizableT[T]
 
   implicit def const[A]: Normalizable[Const[A, ?]] =
     make(λ[Const[A, ?] ~> (Option ∘ Const[A, ?])#λ](_ => None))
 
-  implicit def qscriptCore[T[_[_]]: BirecursiveT: EqualT: ShowT]
+  implicit def qscriptCore[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT]
       : Normalizable[QScriptCore[T, ?]] =
     normalizable[T].QScriptCore
 
-  implicit def projectBucket[T[_[_]]: BirecursiveT: EqualT: ShowT]
+  implicit def projectBucket[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT]
       : Normalizable[ProjectBucket[T, ?]] =
     normalizable[T].ProjectBucket
 
-  implicit def thetaJoin[T[_[_]]: BirecursiveT: EqualT: ShowT]
+  implicit def thetaJoin[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT]
       : Normalizable[ThetaJoin[T, ?]] =
     normalizable[T].ThetaJoin
 
-  implicit def equiJoin[T[_[_]]: BirecursiveT: EqualT: ShowT]
+  implicit def equiJoin[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT]
       : Normalizable[EquiJoin[T, ?]] =
     normalizable[T].EquiJoin
 
@@ -68,7 +69,7 @@ trait NormalizableInstances {
   }
 }
 
-class NormalizableT[T[_[_]]: BirecursiveT : EqualT : ShowT]
+class NormalizableT[T[_[_]]: BirecursiveT : OrderT: EqualT : ShowT]
     extends TTypes[T] {
   import Normalizable._
   lazy val rewrite = new Rewrite[T]

--- a/connector/src/main/scala/quasar/qscript/ProjectBucket.scala
+++ b/connector/src/main/scala/quasar/qscript/ProjectBucket.scala
@@ -18,6 +18,7 @@ package quasar.qscript
 
 import quasar.Predef._
 import quasar.{NonTerminal, RenderTree, RenderTreeT}, RenderTree.ops._
+import quasar.contrib.matryoshka._
 import quasar.fp._
 
 import matryoshka._
@@ -48,7 +49,7 @@ sealed abstract class ProjectBucket[T[_[_]], A] {
     extends ProjectBucket[T, A]
 
 object ProjectBucket {
-  implicit def equal[T[_[_]]: EqualT]: Delay[Equal, ProjectBucket[T, ?]] =
+  implicit def equal[T[_[_]]: OrderT]: Delay[Equal, ProjectBucket[T, ?]] =
     new Delay[Equal, ProjectBucket[T, ?]] {
       def apply[A](eq: Equal[A]) =
         Equal.equal {
@@ -105,7 +106,7 @@ object ProjectBucket {
       }
     }
 
-  implicit def mergeable[T[_[_]]: CorecursiveT: EqualT]:
+  implicit def mergeable[T[_[_]]: CorecursiveT: OrderT]:
       Mergeable.Aux[T, ProjectBucket[T, ?]] =
     new Mergeable[ProjectBucket[T, ?]] {
       type IT[F[_]] = T[F]

--- a/connector/src/main/scala/quasar/qscript/Provenance.scala
+++ b/connector/src/main/scala/quasar/qscript/Provenance.scala
@@ -17,6 +17,7 @@
 package quasar.qscript.provenance
 
 import quasar.Predef._
+import quasar.contrib.matryoshka._
 import quasar.ejson.EJson
 import quasar.fp._
 import quasar.qscript._
@@ -44,7 +45,7 @@ sealed abstract class Provenance[T[_[_]]]
 object Provenance {
   // TODO: This might not be the proper notion of equality – this just tells us
   //       which things align properly for autojoins.
-  implicit def equal[T[_[_]]: EqualT]: Equal[Provenance[T]] =
+  implicit def equal[T[_[_]]: OrderT: EqualT]: Equal[Provenance[T]] =
     Equal.equal {
       case (Nada(),        Nada())        => true
       case (Value(_),      Value(_))      => true
@@ -68,7 +69,7 @@ object Provenance {
   }
 }
 
-class ProvenanceT[T[_[_]]: CorecursiveT: EqualT] extends TTypes[T] {
+class ProvenanceT[T[_[_]]: CorecursiveT: OrderT: EqualT] extends TTypes[T] {
   type Provenance = quasar.qscript.provenance.Provenance[T]
 
   def genComparisons(lps: List[Provenance], rps: List[Provenance]): JoinFunc =

--- a/connector/src/main/scala/quasar/qscript/PruneArrays.scala
+++ b/connector/src/main/scala/quasar/qscript/PruneArrays.scala
@@ -18,6 +18,7 @@ package quasar.qscript
 
 import quasar.Predef.{ Map => ScalaMap, _ }
 import quasar.common.SortDir
+import quasar.contrib.matryoshka._
 import quasar.fp.ski._
 import quasar.qscript.MapFunc._
 import quasar.qscript.MapFuncs._
@@ -57,7 +58,7 @@ object PATypes {
   def remap[A](env: StateAcc, state: StateAcc, in: F[A]): Output[F, A]
 }
 
-class PAHelpers[T[_[_]]: BirecursiveT: EqualT] extends TTypes[T] {
+class PAHelpers[T[_[_]]: BirecursiveT: OrderT: EqualT] extends TTypes[T] {
   import PATypes._
 
   type Mapping = ScalaMap[BigInt, BigInt]
@@ -177,7 +178,7 @@ object PruneArrays {
   // TODO examine branches
   implicit def equiJoin[T[_[_]]]: PruneArrays[EquiJoin[T, ?]] = default
 
-  implicit def projectBucket[T[_[_]]: BirecursiveT: EqualT]
+  implicit def projectBucket[T[_[_]]: BirecursiveT: OrderT: EqualT]
       : PruneArrays[ProjectBucket[T, ?]] =
     new PruneArrays[ProjectBucket[T, ?]] {
 
@@ -208,7 +209,7 @@ object PruneArrays {
       }
     }
 
-  implicit def qscriptCore[T[_[_]]: BirecursiveT: EqualT]
+  implicit def qscriptCore[T[_[_]]: BirecursiveT: OrderT: EqualT]
       : PruneArrays[QScriptCore[T, ?]] =
     new PruneArrays[QScriptCore[T, ?]] {
 

--- a/connector/src/main/scala/quasar/qscript/QScriptCore.scala
+++ b/connector/src/main/scala/quasar/qscript/QScriptCore.scala
@@ -19,6 +19,7 @@ package quasar.qscript
 import quasar.Predef._
 import quasar.{NonTerminal, Terminal, RenderTree, RenderTreeT}, RenderTree.ops._
 import quasar.common.SortDir
+import quasar.contrib.matryoshka._
 import quasar.fp._
 
 import matryoshka._
@@ -149,7 +150,7 @@ object QScriptCore {
   def unapply[T[_[_]], F[_], A](fa: F[A])(implicit C: QScriptCore[T, ?] :<: F): Option[QScriptCore[T, A]] =
     C.prj(fa)
 
-  implicit def equal[T[_[_]]: EqualT]: Delay[Equal, QScriptCore[T, ?]] =
+  implicit def equal[T[_[_]]: OrderT: EqualT]: Delay[Equal, QScriptCore[T, ?]] =
     new Delay[Equal, QScriptCore[T, ?]] {
       def apply[A](eq: Equal[A]) =
         Equal.equal {
@@ -280,7 +281,7 @@ object QScriptCore {
         }
     }
 
-  implicit def mergeable[T[_[_]]: BirecursiveT: EqualT: ShowT]:
+  implicit def mergeable[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT]:
       Mergeable.Aux[T, QScriptCore[T, ?]] =
     new Mergeable[QScriptCore[T, ?]] {
       type IT[F[_]] = T[F]

--- a/connector/src/main/scala/quasar/qscript/Rewrite.scala
+++ b/connector/src/main/scala/quasar/qscript/Rewrite.scala
@@ -17,6 +17,7 @@
 package quasar.qscript
 
 import quasar.Predef._
+import quasar.contrib.matryoshka._
 import quasar.contrib.pathy.{ADir, AFile}
 import quasar.fp._
 import quasar.fs.MonadFsErr
@@ -32,7 +33,7 @@ import scalaz.{:+: => _, Divide => _, _},
   Leibniz._,
   Scalaz._
 
-class Rewrite[T[_[_]]: BirecursiveT: EqualT] extends TTypes[T] {
+class Rewrite[T[_[_]]: BirecursiveT: OrderT: EqualT] extends TTypes[T] {
   def flattenArray[A: Show](array: ConcatArrays[T, FreeMapA[A]]): List[FreeMapA[A]] = {
     def inner(jf: FreeMapA[A]): List[FreeMapA[A]] =
       jf.resume match {

--- a/connector/src/main/scala/quasar/qscript/ThetaJoin.scala
+++ b/connector/src/main/scala/quasar/qscript/ThetaJoin.scala
@@ -18,6 +18,7 @@ package quasar.qscript
 
 import quasar.Predef._
 import quasar.{RenderTree, NonTerminal, RenderTreeT}, RenderTree.ops._
+import quasar.contrib.matryoshka._
 import quasar.fp._
 
 import matryoshka._
@@ -45,7 +46,7 @@ import scalaz._, Scalaz._
   combine: JoinFunc[T])
 
 object ThetaJoin {
-  implicit def equal[T[_[_]]: EqualT]: Delay[Equal, ThetaJoin[T, ?]] =
+  implicit def equal[T[_[_]]: OrderT: EqualT]: Delay[Equal, ThetaJoin[T, ?]] =
     new Delay[Equal, ThetaJoin[T, ?]] {
       def apply[A](eq: Equal[A]) =
         Equal.equal {
@@ -91,7 +92,7 @@ object ThetaJoin {
         }
       }
 
-  implicit def mergeable[T[_[_]]: BirecursiveT: EqualT: ShowT]
+  implicit def mergeable[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT]
       : Mergeable.Aux[T, ThetaJoin[T, ?]] =
     new Mergeable[ThetaJoin[T, ?]] {
       type IT[F[_]] = T[F]

--- a/connector/src/main/scala/quasar/qscript/Transform.scala
+++ b/connector/src/main/scala/quasar/qscript/Transform.scala
@@ -18,6 +18,7 @@ package quasar.qscript
 
 import quasar.Predef.{ Eq => _, _ }
 import quasar._, Planner._
+import quasar.contrib.matryoshka._
 import quasar.ejson._
 import quasar.fp._
 import quasar.frontend.{logicalplan => lp}
@@ -44,7 +45,7 @@ import shapeless.{nat, Sized}
 // TODO: Could maybe require only Functor[F], once CoEnv exposes the proper
 //       instances
 class Transform
-  [T[_[_]]: BirecursiveT: EqualT: ShowT,
+  [T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT,
     F[_]: Traverse: Normalizable]
   (implicit
     C:  Coalesce.Aux[T, F, F],

--- a/connector/src/main/scala/quasar/qscript/package.scala
+++ b/connector/src/main/scala/quasar/qscript/package.scala
@@ -17,6 +17,7 @@
 package quasar
 
 import quasar.Predef._
+import quasar.contrib.matryoshka._
 import quasar.contrib.pathy.{ADir, AFile}
 import quasar.fp._
 import quasar.qscript.{provenance => prov}
@@ -116,7 +117,7 @@ package object qscript {
 
   def EmptyAnn[T[_[_]]]: Ann[T] = Ann[T](Nil, HoleF[T])
 
-  def concat[T[_[_]]: BirecursiveT: EqualT: ShowT, A: Equal: Show](
+  def concat[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT, A: Equal: Show](
     l: FreeMapA[T, A], r: FreeMapA[T, A]):
       (FreeMapA[T, A], FreeMap[T], FreeMap[T]) = {
     val norm = Normalizable.normalizable[T]
@@ -149,7 +150,7 @@ package object qscript {
 
   def rebase[M[_]: Bind, A](in: M[A], field: M[A]): M[A] = in >> field
 
-  def rebaseBranch[T[_[_]]: BirecursiveT: EqualT: ShowT]
+  def rebaseBranch[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT]
     (br: FreeQS[T], fm: FreeMap[T]): FreeQS[T] = {
     val rewrite = new Rewrite[T]
 
@@ -220,7 +221,7 @@ package qscript {
   @Lenses final case class Ann[T[_[_]]](provenance: List[prov.Provenance[T]], values: FreeMap[T])
 
   object Ann {
-    implicit def equal[T[_[_]]: EqualT]: Equal[Ann[T]] =
+    implicit def equal[T[_[_]]: OrderT: EqualT]: Equal[Ann[T]] =
       Equal.equal((a, b) => a.provenance ≟ b.provenance && a.values ≟ b.values)
 
     implicit def show[T[_[_]]: ShowT]: Show[Ann[T]] =
@@ -230,7 +231,7 @@ package qscript {
   @Lenses final case class Target[T[_[_]], F[_]](ann: Ann[T], value: T[F])
 
   object Target {
-    implicit def equal[T[_[_]]: EqualT, F[_]: Functor]
+    implicit def equal[T[_[_]]: OrderT: EqualT, F[_]: Functor]
       (implicit F: Delay[Equal, F])
         : Equal[Target[T, F]] =
       Equal.equal((a, b) => a.ann ≟ b.ann && a.value ≟ b.value)

--- a/couchbase/src/main/scala/quasar/physical/couchbase/fs/queryfile.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/fs/queryfile.scala
@@ -20,6 +20,7 @@ import quasar.Predef._
 import quasar.{Data, DataCodec, RenderTreeT}
 import quasar.common.{PhaseResults, PhaseResultT}
 import quasar.common.PhaseResult.{detail, tree}
+import quasar.contrib.matryoshka._
 import quasar.contrib.pathy._
 import quasar.contrib.scalaz.eitherT._
 import quasar.effect.{KeyValueStore, Read, MonotonicSeq}
@@ -85,7 +86,7 @@ object queryfile {
     case FileExists(file)     => fileExists(file)
   }
 
-  def executePlan[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT, S[_]](
+  def executePlan[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT: RenderTreeT, S[_]](
     lp: T[LogicalPlan], out: AFile
   )(implicit
     S0: Read[Context, ?] :<: S,
@@ -120,7 +121,7 @@ object queryfile {
                 ))).into.liftF
     } yield out).run.run
 
-  def evaluatePlan[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT, S[_]](
+  def evaluatePlan[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT: RenderTreeT, S[_]](
     lp: T[LogicalPlan]
   )(implicit
     S0: Read[Context, ?] :<: S,
@@ -154,7 +155,7 @@ object queryfile {
   ): Free[S, Unit] =
     results.delete(handle)
 
-  def explain[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT, S[_]](
+  def explain[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT: RenderTreeT, S[_]](
     lp: T[LogicalPlan]
   )(implicit
     S0: Read[Context, ?] :<: S,
@@ -211,7 +212,7 @@ object queryfile {
                  )).into.liftM[PhaseResultT])
     } yield r
 
-  def lpToN1ql[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT, S[_]](
+  def lpToN1ql[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT: RenderTreeT, S[_]](
     lp: T[LogicalPlan]
   )(implicit
     S0: Read[Context, ?] :<: S,
@@ -224,7 +225,7 @@ object queryfile {
     lpLcToN1ql[T, S](lp, lc)
   }
 
-  def lpLcToN1ql[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT, S[_]](
+  def lpLcToN1ql[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT: RenderTreeT, S[_]](
     lp: T[LogicalPlan],
     lc: DiscoverPath.ListContents[Plan[S, ?]]
   )(implicit

--- a/ejson/src/main/scala/quasar/ejson/EJson.scala
+++ b/ejson/src/main/scala/quasar/ejson/EJson.scala
@@ -16,23 +16,26 @@
 
 package quasar.ejson
 
-import quasar.Predef._
+import quasar.Predef.{Byte => SByte, Char => SChar, Map => SMap, _}
+import quasar.contrib.matryoshka._
 import quasar.fp._
 
 import matryoshka._
 import scalaz._, Scalaz._
 
-sealed trait Common[A]
+sealed abstract class Common[A]
 final case class Arr[A](value: List[A])    extends Common[A]
 final case class Null[A]()                 extends Common[A]
 final case class Bool[A](value: Boolean)   extends Common[A]
 final case class Str[A](value: String)     extends Common[A]
 final case class Dec[A](value: BigDecimal) extends Common[A]
 
-object Common {
+object Common extends CommonInstances {
   def unapply[F[_], A](fa: F[A])(implicit C: Common :<: F): Option[Common[A]] =
     C.prj(fa)
+}
 
+sealed abstract class CommonInstances extends CommonInstances0 {
   implicit val traverse: Traverse[Common] = new Traverse[Common] {
     def traverseImpl[G[_], A, B](
       fa: Common[A])(
@@ -48,20 +51,12 @@ object Common {
       }
   }
 
-  implicit val equal: Delay[Equal, Common] =
-    new Delay[Equal, Common] {
-      def apply[α](eq: Equal[α]) = Equal.equal((a, b) => (a, b) match {
-        case (Arr(l),       Arr(r))  => listEqual(eq).equal(l, r)
-        case (Arr(_),       _)       => false
-        case (Null(),       Null())  => true
-        case (Null(),       _)       => false
-        case (Bool(l),      Bool(r)) => l ≟ r
-        case (Bool(_),      _)       => false
-        case (Str(l),       Str(r))  => l ≟ r
-        case (Str(_),       _)       => false
-        case (Dec(l),       Dec(r))  => l ≟ r
-        case (Dec(_),       _)       => false
-      })
+  implicit val order: Delay[Order, Common] =
+    new Delay[Order, Common] {
+      def apply[α](ord: Order[α]) = {
+        implicit val ordA: Order[α] = ord
+        Order.orderBy(generic)
+      }
     }
 
   implicit val show: Delay[Show, Common] =
@@ -76,32 +71,68 @@ object Common {
     }
 }
 
+sealed abstract class CommonInstances0 {
+  implicit val equal: Delay[Equal, Common] =
+    new Delay[Equal, Common] {
+      def apply[α](eql: Equal[α]) = {
+        implicit val eqlA: Equal[α] = eql
+        Equal.equalBy(generic)
+      }
+    }
+
+  ////
+
+  private[ejson] def generic[A](c: Common[A]) = (
+    arr.getOption(c) ,
+    bool.getOption(c),
+    dec.getOption(c) ,
+    nul.isMatching(c),
+    str.getOption(c)
+  )
+}
+
 final case class Obj[A](value: ListMap[String, A])
 
-object Obj {
+object Obj extends ObjInstances {
   // TODO: This means we have the same names for the projection and the Obj
   //       pattern matcher. It could go away if this unapply were defined on
   //       `scalaz.Inject`. (scalaz/scalaz#1311)
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
   def unapply[F[_], A](fa: F[A])(implicit O: Obj :<: F): Option[Obj[A]] =
     O.prj(fa)
+}
 
+sealed abstract class ObjInstances extends ObjInstances0 {
   implicit val traverse: Traverse[Obj] = new Traverse[Obj] {
     def traverseImpl[G[_]: Applicative, A, B](fa: Obj[A])(f: A => G[B]):
         G[Obj[B]] =
       fa.value.traverse(f).map(Obj(_))
   }
 
-  implicit val equal: Delay[Equal, Obj] =
-    new Delay[Equal, Obj] {
-      def apply[α](eq: Equal[α]) = Equal.equal((a, b) =>
-        mapEqual(stringInstance, eq).equal(a.value, b.value))
+  implicit val order: Delay[Order, Obj] =
+    new Delay[Order, Obj] {
+      def apply[α](ord: Order[α]) = {
+        implicit val ordA: Order[α] = ord
+        Order.orderBy(_.value: SMap[String, α])
+      }
     }
 
   implicit val show: Delay[Show, Obj] =
     new Delay[Show, Obj] {
-      def apply[α](shw: Show[α]) = Show.show(a =>
-        mapShow(stringInstance, shw).show(a.value))
+      def apply[α](shw: Show[α]) = {
+        implicit val shwA: Show[α] = shw
+        Show.show(o => (o.value: SMap[String, α]).show)
+      }
+    }
+}
+
+sealed abstract class ObjInstances0 {
+  implicit val equal: Delay[Equal, Obj] =
+    new Delay[Equal, Obj] {
+      def apply[α](eql: Equal[α]) = {
+        implicit val eqlA: Equal[α] = eql
+        Equal.equalBy(_.value: SMap[String, α])
+      }
     }
 }
 
@@ -110,17 +141,22 @@ object Obj {
   * bytes, and distinct integers. It also adds metadata, which allows arbitrary
   * annotations on values.
   */
-sealed trait Extension[A]
+sealed abstract class Extension[A]
 final case class Meta[A](value: A, meta: A)  extends Extension[A]
 final case class Map[A](value: List[(A, A)]) extends Extension[A]
-final case class Byte[A](value: scala.Byte)  extends Extension[A]
-final case class Char[A](value: scala.Char)  extends Extension[A]
+final case class Byte[A](value: SByte)       extends Extension[A]
+final case class Char[A](value: SChar)       extends Extension[A]
 final case class Int[A](value: BigInt)       extends Extension[A]
 
-object Extension {
+object Extension extends ExtensionInstances {
   def unapply[F[_], A](fa: F[A])(implicit E: Extension :<: F): Option[Extension[A]] =
     E.prj(fa)
 
+  def fromObj[A](f: String => A): Obj[A] => Extension[A] =
+    obj => map(obj.value.toList.map(_.leftMap(f)))
+}
+
+sealed abstract class ExtensionInstances extends ExtensionInstances0 {
   implicit val traverse: Traverse[Extension] = new Traverse[Extension] {
     def traverseImpl[G[_], A, B](
       fa: Extension[A])(
@@ -136,23 +172,14 @@ object Extension {
       }
   }
 
-  // TODO need Equal[Char]
-  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
-  implicit val equal: Delay[Equal, Extension] =
-    new Delay[Equal, Extension] {
-      def apply[α](eq: Equal[α]) = Equal.equal((a, b) => (a, b) match {
-        case (Meta(l, _), Meta(r, _)) => eq.equal(l, r)
-        case (Meta(_, _), _)          => false
-        case (Map(l),     Map(r))     =>
-          listEqual(tuple2Equal(eq, eq)).equal(l, r)
-        case (Map(_),     _)          => false
-        case (Byte(l),    Byte(r))    => l ≟ r
-        case (Byte(_),    _)          => false
-        case (Char(l),    Char(r))    => l == r
-        case (Char(_),    _)          => false
-        case (Int(l),     Int(r))     => l ≟ r
-        case (Int(_),     _)          => false
-      })
+  implicit val order: Delay[Order, Extension] =
+    new Delay[Order, Extension] {
+      def apply[α](ord: Order[α]) = {
+        implicit val ordA: Order[α] = ord
+        // TODO: Not sure why this isn't found?
+        implicit val ordC: Order[SChar] = scalaz.std.anyVal.char
+        Order.orderBy(generic)
+      }
     }
 
   implicit val show: Delay[Show, Extension] =
@@ -165,7 +192,26 @@ object Extension {
         case Int(v)     => Cord(s"Int($v)")
       })
     }
+}
 
-  def fromObj[A](f: String => A): Obj[A] => Extension[A] =
-    obj => Map(obj.value.toList.map(_.leftMap(f)))
+sealed abstract class ExtensionInstances0 {
+  implicit val equal: Delay[Equal, Extension] =
+    new Delay[Equal, Extension] {
+      def apply[α](eql: Equal[α]) = {
+        implicit val eqlA: Equal[α] = eql
+        // TODO: Not sure why this isn't found?
+        implicit val eqlC: Equal[SChar] = scalaz.std.anyVal.char
+        Equal.equalBy(generic)
+      }
+    }
+
+  ////
+
+  private[ejson] def generic[A](e: Extension[A]) = (
+    byte.getOption(e) ,
+    char.getOption(e) ,
+    int.getOption(e)  ,
+    map.getOption(e)  ,
+    meta.getOption(e)
+  )
 }

--- a/ejson/src/main/scala/quasar/ejson/EJson.scala
+++ b/ejson/src/main/scala/quasar/ejson/EJson.scala
@@ -156,7 +156,7 @@ object Extension extends ExtensionInstances {
     obj => map(obj.value.toList.map(_.leftMap(f)))
 }
 
-sealed abstract class ExtensionInstances extends ExtensionInstances0 {
+sealed abstract class ExtensionInstances {
   implicit val traverse: Traverse[Extension] = new Traverse[Extension] {
     def traverseImpl[G[_], A, B](
       fa: Extension[A])(
@@ -178,7 +178,7 @@ sealed abstract class ExtensionInstances extends ExtensionInstances0 {
         implicit val ordA: Order[α] = ord
         // TODO: Not sure why this isn't found?
         implicit val ordC: Order[SChar] = scalaz.std.anyVal.char
-        Order.orderBy(generic)
+        Order.orderBy(generic[α])
       }
     }
 
@@ -192,26 +192,14 @@ sealed abstract class ExtensionInstances extends ExtensionInstances0 {
         case Int(v)     => Cord(s"Int($v)")
       })
     }
-}
-
-sealed abstract class ExtensionInstances0 {
-  implicit val equal: Delay[Equal, Extension] =
-    new Delay[Equal, Extension] {
-      def apply[α](eql: Equal[α]) = {
-        implicit val eqlA: Equal[α] = eql
-        // TODO: Not sure why this isn't found?
-        implicit val eqlC: Equal[SChar] = scalaz.std.anyVal.char
-        Equal.equalBy(generic)
-      }
-    }
 
   ////
 
-  private[ejson] def generic[A](e: Extension[A]) = (
-    byte.getOption(e) ,
-    char.getOption(e) ,
-    int.getOption(e)  ,
-    map.getOption(e)  ,
+  private[ejson] def generic[A: Order](e: Extension[A]) = (
+    byte.getOption(e)                          ,
+    char.getOption(e)                          ,
+    int.getOption(e)                           ,
+    map.getOption(e) map (IMap fromFoldable _) ,
     meta.getOption(e)
   )
 }

--- a/ejson/src/main/scala/quasar/ejson/jsonParser.scala
+++ b/ejson/src/main/scala/quasar/ejson/jsonParser.scala
@@ -32,12 +32,12 @@ object jsonParser {
         new SimpleFacade[T] {
           def jarray(arr: List[T])          = C(Arr(arr)).embed
           def jobject(obj: SMap[String, T]) = O(Obj(ListMap(obj.toList: _*))).embed
-          def jnull()                          = C(Null[T]()).embed
-          def jfalse()                         = C(Bool[T](false)).embed
-          def jtrue()                          = C(Bool[T](true)).embed
-          def jnum(n: String)                  = C(Dec[T](BigDecimal(n))).embed
-          def jint(n: String)                  = C(Dec[T](BigDecimal(n))).embed
-          def jstring(s: String)               = C(Str[T](s)).embed
+          def jnull()                       = C(Null[T]()).embed
+          def jfalse()                      = C(Bool[T](false)).embed
+          def jtrue()                       = C(Bool[T](true)).embed
+          def jnum(n: String)               = C(Dec[T](BigDecimal(n))).embed
+          def jint(n: String)               = C(Dec[T](BigDecimal(n))).embed
+          def jstring(s: String)            = C(Str[T](s)).embed
         }
     }
 }

--- a/ejson/src/main/scala/quasar/ejson/package.scala
+++ b/ejson/src/main/scala/quasar/ejson/package.scala
@@ -27,31 +27,40 @@ import scala.math.{BigDecimal, BigInt}
 
 import matryoshka._
 import matryoshka.implicits._
-import monocle.Prism
+import monocle.{Iso, Prism}
 import scalaz._
 
 package object ejson {
-  def nul[A] =
-    Prism.partial[Common[A], Unit] { case Null() => () } (κ(Null()))
-  def bool[A] =
-    Prism.partial[Common[A], Boolean] { case Bool(b) => b } (Bool(_))
-  def dec[A] =
-    Prism.partial[Common[A], BigDecimal] { case Dec(bd) => bd } (Dec(_))
-  def str[A] = Prism.partial[Common[A], String] { case Str(s) => s } (Str(_))
   def arr[A] =
     Prism.partial[Common[A], List[A]] { case Arr(a) => a } (Arr(_))
 
+  def bool[A] =
+    Prism.partial[Common[A], Boolean] { case Bool(b) => b } (Bool(_))
+
+  def dec[A] =
+    Prism.partial[Common[A], BigDecimal] { case Dec(bd) => bd } (Dec(_))
+
+  def nul[A] =
+    Prism.partial[Common[A], Unit] { case Null() => () } (κ(Null()))
+
+  def str[A] =
+    Prism.partial[Common[A], String] { case Str(s) => s } (Str(_))
+
   def obj[A] =
-    Prism.partial[Obj[A], ListMap[String, A]] { case Obj(o) => o } (Obj(_))
+    Iso[Obj[A], ListMap[String, A]](_.value)(Obj(_))
 
   def byte[A] =
     Prism.partial[Extension[A], scala.Byte] { case Byte(b) => b } (Byte(_))
+
   def char[A] =
     Prism.partial[Extension[A], scala.Char] { case Char(c) => c } (Char(_))
+
   def int[A] =
     Prism.partial[Extension[A], BigInt] { case Int(i) => i } (Int(_))
+
   def map[A] =
     Prism.partial[Extension[A], List[(A, A)]] { case Map(m) => m } (Map(_))
+
   def meta[A] =
     Prism.partial[Extension[A], (A, A)] {
       case Meta(v, m) => (v, m)
@@ -77,9 +86,6 @@ package object ejson {
       ExtEJson.inj(_).embed
 
     def isNull[T](ej: T)(implicit T: Recursive.Aux[T, EJson]): Boolean =
-      CommonEJson.prj(ej.project).fold(false) {
-        case ejson.Null() => true
-        case _ => false
-    }
+      CommonEJson.prj(ej.project) exists (nul.isMatching(_))
   }
 }

--- a/ejson/src/test/scala/quasar/ejson/EJsonArbitrary.scala
+++ b/ejson/src/test/scala/quasar/ejson/EJsonArbitrary.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.ejson
+
+import quasar.fp._
+import quasar.pkg.tests._
+
+// TODO[matryoshka]: Switch to Delay[Arbitrary, F] when we're able to upgrade
+trait EJsonArbitrary {
+  implicit val arbitraryCommon = new WrapArb[Common] {
+    def apply[α](arb: Arbitrary[α]) = Arbitrary(
+      Gen.oneOf(
+        arb.list ^^ Arr[α],
+        const(Null[α]()),
+        genBool ^^ Bool[α],
+        genString map Str[α],
+        genBigDecimal map Dec[α]
+      )
+    )
+  }
+
+  implicit val arbitraryObj = new WrapArb[Obj] {
+    def apply[α](arb: Arbitrary[α]) =
+      (genString, arb.gen).zip.list ^^ (l => Obj(l.toListMap))
+  }
+
+  implicit val arbitraryExtension = new WrapArb[Extension] {
+    def apply[α](arb: Arbitrary[α]) = Arbitrary(
+      Gen.oneOf(
+        (arb.gen, arb.gen).zip.list ^^ Map[α],
+        genByte ^^ Byte[α],
+        genChar ^^ Char[α],
+        genBigInt ^^ Int[α]
+      )
+    )
+  }
+}
+
+object EJsonArbitrary extends EJsonArbitrary

--- a/foundation/src/main/scala/quasar/contrib/matryoshka/package.scala
+++ b/foundation/src/main/scala/quasar/contrib/matryoshka/package.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.contrib
+
+import _root_.matryoshka._
+import _root_.scalaz._
+
+package object matryoshka {
+  implicit def delayOrder[F[_], A](implicit F: Delay[Order, F], A: Order[A]): Order[F[A]] =
+    F(A)
+
+  implicit def orderTOrder[T[_[_]], F[_]: Functor](implicit T: OrderT[T], F: Delay[Order, F]): Order[T[F]] =
+    T.orderT[F](F)
+
+  implicit def coproductOrder[F[_], G[_]](implicit F: Delay[Order, F], G: Delay[Order, G]): Delay[Order, Coproduct[F, G, ?]] =
+    new Delay[Order, Coproduct[F, G, ?]] {
+      def apply[A](ord: Order[A]): Order[Coproduct[F, G, A]] = {
+        implicit val ordA: Order[A] = ord
+        Order.orderBy((_: Coproduct[F, G, A]).run)
+      }
+    }
+}

--- a/foundation/src/test/scala/quasar/pkg/TestsPackage.scala
+++ b/foundation/src/test/scala/quasar/pkg/TestsPackage.scala
@@ -16,11 +16,14 @@
 
 package quasar.pkg
 
-import scala.Predef.$conforms
 import quasar.Predef._
+
+import scala.Predef.$conforms
 import scala.collection.mutable.Builder
 import scala.language.postfixOps
 import scala.{ Byte, Char }
+
+import scalaz.~>
 
 package object tests extends TestsPackage
 
@@ -56,6 +59,7 @@ trait ScalacheckSupport {
   type Pretty                  = org.scalacheck.util.Pretty
   type Prop                    = org.scalacheck.Prop
   type Shrink[A]               = org.scalacheck.Shrink[A]
+  type WrapArb[F[_]]           = Arbitrary ~> λ[α => Arbitrary[F[α]]]
 
   import Gen.{ listOfN, containerOfN, identifier, sized, oneOf, frequency, alphaNumChar }
 

--- a/marklogic/src/main/scala/quasar/physical/marklogic/fs/queryfile.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/fs/queryfile.scala
@@ -19,6 +19,7 @@ package quasar.physical.marklogic.fs
 import quasar.Predef._
 import quasar.{Planner => QPlanner, RenderTreeT}
 import quasar.common._
+import quasar.contrib.matryoshka._
 import quasar.contrib.pathy._
 import quasar.contrib.scalaz.{toMonadError_Ops => _, _}
 import quasar.effect.{Kvs, MonoSeq}
@@ -117,7 +118,7 @@ object queryfile {
 
   def lpToXQuery[
     F[_]   : Monad: MonadFsErr: PhaseResultTell: PrologL: Xcc,
-    T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT,
+    T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT: RenderTreeT,
     FMT: SearchOptions
   ](
     lp: T[LogicalPlan]

--- a/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -19,6 +19,7 @@ package quasar.physical.mongodb
 import quasar.Predef._
 import quasar._, Planner._, Type.{Const => _, Coproduct => _, _}
 import quasar.common.{PhaseResult, PhaseResults, SortDir}
+import quasar.contrib.matryoshka._
 import quasar.contrib.pathy.{ADir, AFile}
 import quasar.contrib.scalaz._, eitherT._
 import quasar.fp._
@@ -1206,7 +1207,7 @@ object MongoDbQScriptPlanner {
     ma.mproduct(a => mtell.tell(Vector(PhaseResult.tree(label, a)))) ∘ (_._1)
 
   def plan0
-    [T[_[_]]: BirecursiveT: EqualT: RenderTreeT: ShowT,
+    [T[_[_]]: BirecursiveT: OrderT: EqualT: RenderTreeT: ShowT,
       M[_]: Monad,
       WF[_]: Functor: Coalesce: Crush: Crystallize,
       EX[_]: Traverse]
@@ -1269,7 +1270,7 @@ object MongoDbQScriptPlanner {
     * can be used, but the resulting plan uses the largest, common type so that
     * callers don't need to worry about it.
     */
-  def plan[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT, M[_]: Monad]
+  def plan[T[_[_]]: BirecursiveT: OrderT: EqualT: ShowT: RenderTreeT, M[_]: Monad]
     (logical: T[LogicalPlan], queryContext: fs.QueryContext[M])
     (implicit
       merr: MonadError_[M, FileSystemError],


### PR DESCRIPTION
Adds `OrderT` and `Delay[Order, Common|Obj|Extension]` instances. Also extracts `EJson` arbitrary instances from the `EJson` tests so they can be used elsewhere.