### PR TITLE
Eliminate `sealed trait`.

### DIFF
--- a/common/src/main/scala/quasar/common/PhaseResult.scala
+++ b/common/src/main/scala/quasar/common/PhaseResult.scala
@@ -23,7 +23,7 @@ import argonaut._, Argonaut._
 import scalaz.Show
 import scalaz.syntax.show._
 
-sealed trait PhaseResult {
+sealed abstract class PhaseResult {
   def name: String
 }
 

--- a/common/src/main/scala/quasar/fs/PathError.scala
+++ b/common/src/main/scala/quasar/fs/PathError.scala
@@ -24,7 +24,7 @@ import monocle.{Lens, Prism}
 import pathy.Path._
 import scalaz._
 
-sealed trait PathError
+sealed abstract class PathError
 
 object PathError {
   final case class PathExists private (path: APath)

--- a/connector/src/main/scala/quasar/config/ConfigError.scala
+++ b/connector/src/main/scala/quasar/config/ConfigError.scala
@@ -20,7 +20,7 @@ import quasar.Predef._
 import monocle.Prism
 import scalaz.Show
 
-sealed trait ConfigError
+sealed abstract class ConfigError
 
 object ConfigError {
   final case class MalformedConfig private[config] (src: String, reason: String)

--- a/connector/src/main/scala/quasar/config/FsPath.scala
+++ b/connector/src/main/scala/quasar/config/FsPath.scala
@@ -24,7 +24,7 @@ import scalaz.concurrent.Task
 import Leibniz.===
 import pathy._, Path._
 
-sealed trait FsPath[T, S] {
+sealed abstract class FsPath[T, S] {
   type Base
 
   def fold[X](uni: Path[Base, T, S] => X, inv: (String, Path[Base, T, S], Base === Abs) => X): X

--- a/connector/src/main/scala/quasar/config/OS.scala
+++ b/connector/src/main/scala/quasar/config/OS.scala
@@ -21,7 +21,7 @@ import quasar.Predef._
 import scala.util.Properties._
 import scalaz.concurrent.Task
 
-sealed trait OS {
+sealed abstract class OS {
   import OS._
 
   def fold[X](win: => X, mac: => X, posix: => X): X =

--- a/connector/src/main/scala/quasar/connector/EnvironmentError.scala
+++ b/connector/src/main/scala/quasar/connector/EnvironmentError.scala
@@ -22,7 +22,7 @@ import argonaut._, Argonaut._
 import monocle._
 import scalaz._, Scalaz._
 
-sealed trait EnvironmentError
+sealed abstract class EnvironmentError
 
 object EnvironmentError {
   final case class ConnectionFailed(error: Throwable)

--- a/connector/src/main/scala/quasar/fs/ManageFile.scala
+++ b/connector/src/main/scala/quasar/fs/ManageFile.scala
@@ -27,10 +27,10 @@ import monocle.Prism
 import pathy.{Path => PPath}, PPath._
 import scalaz._, Scalaz._
 
-sealed trait ManageFile[A]
+sealed abstract class ManageFile[A]
 
 object ManageFile {
-  sealed trait MoveSemantics
+  sealed abstract class MoveSemantics
 
   /** NB: Certain write operations' consistency is affected by faithful support
     *     of these semantics, thus their consistency/atomicity is as good as the
@@ -72,7 +72,7 @@ object ManageFile {
     implicit val show: Show[MoveSemantics] = Show.showFromToString
   }
 
-  sealed trait MoveScenario {
+  sealed abstract class MoveScenario {
     import MoveScenario._
 
     def fold[X](

--- a/connector/src/main/scala/quasar/fs/QueryFile.scala
+++ b/connector/src/main/scala/quasar/fs/QueryFile.scala
@@ -37,7 +37,7 @@ import scalaz._, Scalaz.{ToIdOps => _, _}
 import scalaz.iteratee._
 import scalaz.stream.Process
 
-sealed trait QueryFile[A]
+sealed abstract class QueryFile[A]
 
 object QueryFile {
   final case class ResultHandle(run: Long) extends scala.AnyVal

--- a/connector/src/main/scala/quasar/fs/ReadFile.scala
+++ b/connector/src/main/scala/quasar/fs/ReadFile.scala
@@ -34,7 +34,7 @@ import scalaz.syntax.show._
 import scalaz.syntax.std.option._
 import scalaz.stream._
 
-sealed trait ReadFile[A]
+sealed abstract class ReadFile[A]
 
 object ReadFile {
   final case class ReadHandle(file: AFile, id: Long)

--- a/connector/src/main/scala/quasar/fs/WriteFile.scala
+++ b/connector/src/main/scala/quasar/fs/WriteFile.scala
@@ -26,7 +26,7 @@ import monocle.Iso
 import scalaz._, Scalaz._
 import scalaz.stream._
 
-sealed trait WriteFile[A]
+sealed abstract class WriteFile[A]
 
 object WriteFile {
   final case class WriteHandle(file: AFile, id: Long)

--- a/connector/src/main/scala/quasar/planner.scala
+++ b/connector/src/main/scala/quasar/planner.scala
@@ -30,7 +30,7 @@ import scalaz._, Scalaz._
 import shapeless.Nat
 
 object Planner {
-  sealed trait PlannerError {
+  sealed abstract class PlannerError {
     def message: String
   }
 
@@ -96,7 +96,7 @@ object Planner {
   implicit val plannerErrorShow: Show[PlannerError] =
     Show.show(_.message)
 
-  sealed trait CompilationError {
+  sealed abstract class CompilationError {
     def message: String
   }
   object CompilationError {

--- a/connector/src/main/scala/quasar/qscript/JoinSide.scala
+++ b/connector/src/main/scala/quasar/qscript/JoinSide.scala
@@ -20,7 +20,7 @@ import quasar.RenderTree
 
 import scalaz._
 
-sealed trait JoinSide
+sealed abstract class JoinSide
 final case object LeftSide extends JoinSide
 final case object RightSide extends JoinSide
 

--- a/connector/src/main/scala/quasar/qscript/ReduceFunc.scala
+++ b/connector/src/main/scala/quasar/qscript/ReduceFunc.scala
@@ -23,7 +23,7 @@ import quasar.std.StdLib._
 import matryoshka._
 import scalaz._, Scalaz._
 
-sealed trait ReduceFunc[A]
+sealed abstract class ReduceFunc[A]
 
 object ReduceFunc {
   import ReduceFuncs._

--- a/core/src/main/scala/quasar/fs/mount/MountConfig.scala
+++ b/core/src/main/scala/quasar/fs/mount/MountConfig.scala
@@ -27,7 +27,7 @@ import monocle.Prism
 import scalaz._, Scalaz._
 
 /** Configuration for a mount, currently either a view or a filesystem. */
-sealed trait MountConfig
+sealed abstract class MountConfig
 
 object MountConfig {
   final case class ViewConfig private[mount] (query: Fix[Sql], vars: Variables)

--- a/core/src/main/scala/quasar/fs/mount/MountRequest.scala
+++ b/core/src/main/scala/quasar/fs/mount/MountRequest.scala
@@ -25,7 +25,7 @@ import quasar.sql.Sql
 import matryoshka.data.Fix
 import monocle.Prism
 
-sealed trait MountRequest {
+sealed abstract class MountRequest {
   import MountRequest._
 
   def path: APath =

--- a/core/src/main/scala/quasar/fs/mount/Mounting.scala
+++ b/core/src/main/scala/quasar/fs/mount/Mounting.scala
@@ -30,7 +30,7 @@ import monocle.std.{disjunction => D}
 import pathy._, Path._
 import scalaz._, Scalaz._
 
-sealed trait Mounting[A]
+sealed abstract class Mounting[A]
 
 object Mounting {
 

--- a/core/src/main/scala/quasar/fs/mount/MountingError.scala
+++ b/core/src/main/scala/quasar/fs/mount/MountingError.scala
@@ -24,7 +24,7 @@ import monocle.Prism
 import scalaz.NonEmptyList
 import scalaz._, Scalaz._
 
-sealed trait MountingError
+sealed abstract class MountingError
 
 object MountingError {
   final case class PError private (err: PathError)

--- a/effect/src/main/scala/quasar/effect/AtomicRef.scala
+++ b/effect/src/main/scala/quasar/effect/AtomicRef.scala
@@ -29,7 +29,7 @@ import scalaz.concurrent.Task
   *
   * @tparam V the type of value referenced
   */
-sealed trait AtomicRef[V, A]
+sealed abstract class AtomicRef[V, A]
 
 object AtomicRef {
   /** NB: Attempted to define this as `Get[V]() extends AtomicRef[V, V]` but

--- a/effect/src/main/scala/quasar/effect/Failure.scala
+++ b/effect/src/main/scala/quasar/effect/Failure.scala
@@ -28,7 +28,7 @@ import scalaz.syntax.std.option._
   *
   * @tparam E the reason/error describing why the computation failed
   */
-sealed trait Failure[E, A]
+sealed abstract class Failure[E, A]
 
 object Failure {
   final case class Fail[E, A](e: E) extends Failure[E, A]

--- a/effect/src/main/scala/quasar/effect/KeyValueStore.scala
+++ b/effect/src/main/scala/quasar/effect/KeyValueStore.scala
@@ -29,7 +29,7 @@ import scalaz.concurrent.Task
   * @tparam K the type of keys used to index values
   * @tparam V the type of values in the store
   */
-sealed trait KeyValueStore[K, V, A]
+sealed abstract class KeyValueStore[K, V, A]
 
 object KeyValueStore {
   // NB: Switch to cursor style terms for Keys once backing stores exist where all keys won't fit into memory.

--- a/effect/src/main/scala/quasar/effect/MonotonicSeq.scala
+++ b/effect/src/main/scala/quasar/effect/MonotonicSeq.scala
@@ -36,7 +36,7 @@ import scalaz.syntax.applicative._
   *
   * must always be true.
   */
-sealed trait MonotonicSeq[A]
+sealed abstract class MonotonicSeq[A]
 
 object MonotonicSeq {
   case object Next extends MonotonicSeq[Long]

--- a/effect/src/main/scala/quasar/effect/Timing.scala
+++ b/effect/src/main/scala/quasar/effect/Timing.scala
@@ -22,7 +22,7 @@ import java.time.{Duration, Instant}
 import scalaz._
 import scalaz.concurrent.Task
 
-sealed trait Timing[A]
+sealed abstract class Timing[A]
 object Timing {
   final case object Timestamp extends Timing[Instant]
   final case object Nanos extends Timing[Long]

--- a/ejson/src/main/scala/quasar/ejson/EJson.scala
+++ b/ejson/src/main/scala/quasar/ejson/EJson.scala
@@ -22,7 +22,7 @@ import quasar.fp._
 import matryoshka._
 import scalaz._, Scalaz._
 
-sealed trait Common[A]
+sealed abstract class Common[A]
 final case class Arr[A](value: List[A])    extends Common[A]
 final case class Null[A]()                 extends Common[A]
 final case class Bool[A](value: Boolean)   extends Common[A]
@@ -110,7 +110,7 @@ object Obj {
   * bytes, and distinct integers. It also adds metadata, which allows arbitrary
   * annotations on values.
   */
-sealed trait Extension[A]
+sealed abstract class Extension[A]
 final case class Meta[A](value: A, meta: A)  extends Extension[A]
 final case class Map[A](value: List[(A, A)]) extends Extension[A]
 final case class Byte[A](value: scala.Byte)  extends Extension[A]

--- a/foundation/src/main/scala/quasar/fp/coproduct.scala
+++ b/foundation/src/main/scala/quasar/fp/coproduct.scala
@@ -30,6 +30,6 @@ package quasar.fp
  *    )#M[A]
  */
 
-sealed trait CoM                             { type M[A]                               }
-sealed trait :/:[F[_], G[_]]     extends CoM { type M[A] = scalaz.Coproduct[F, G, A]   }
-sealed trait :\:[F[_], T <: CoM] extends CoM { type M[A] = scalaz.Coproduct[F, T#M, A] }
+sealed abstract class CoM                             { type M[A]                               }
+sealed abstract class :/:[F[_], G[_]]     extends CoM { type M[A] = scalaz.Coproduct[F, G, A]   }
+sealed abstract class :\:[F[_], T <: CoM] extends CoM { type M[A] = scalaz.Coproduct[F, T#M, A] }

--- a/foundation/src/main/scala/quasar/fp/package.scala
+++ b/foundation/src/main/scala/quasar/fp/package.scala
@@ -27,7 +27,7 @@ import scalaz.iteratee.EnumeratorT
 import scalaz.stream._
 import shapeless.{Fin, Nat, Sized, Succ}
 
-sealed trait ListMapInstances {
+sealed abstract class ListMapInstances {
   implicit def seqW[A](xs: Seq[A]): SeqW[A] = new SeqW(xs)
   class SeqW[A](xs: Seq[A]) {
     def toListMap[B, C](implicit ev: A <~< (B, C)): ListMap[B, C] = {

--- a/frontend/src/main/scala/quasar/SemanticError.scala
+++ b/frontend/src/main/scala/quasar/SemanticError.scala
@@ -26,7 +26,7 @@ import pathy.Path, Path._
 import scalaz._, Scalaz._
 import shapeless.{Prism => _, _}
 
-sealed trait SemanticError {
+sealed abstract class SemanticError {
   def message: String
 }
 

--- a/frontend/src/main/scala/quasar/data.scala
+++ b/frontend/src/main/scala/quasar/data.scala
@@ -32,7 +32,7 @@ import java.time.{Duration, Instant, LocalDate, LocalDateTime, LocalTime, ZoneOf
 import scalaz._, Scalaz._
 import scodec.bits.ByteVector
 
-sealed trait Data extends Product with Serializable {
+sealed abstract class Data extends Product with Serializable {
   def dataType: Type
   def toJs: Option[jscore.JsCore]
 }
@@ -60,7 +60,7 @@ object Data {
   val _bool =
     Prism.partial[Data, Boolean] { case Data.Bool(b) => b } (Data.Bool(_))
 
-  sealed trait Number extends Data {
+  sealed abstract class Number extends Data {
     override def equals(other: Any) = (this, other) match {
       case (Int(v1), Number(v2)) => BigDecimal(v1) ≟ v2
       case (Dec(v1), Number(v2)) => v1 ≟ v2

--- a/frontend/src/main/scala/quasar/functions.scala
+++ b/frontend/src/main/scala/quasar/functions.scala
@@ -28,7 +28,7 @@ import shapeless._
 import shapeless.syntax.sized._
 import shapeless.ops.nat.ToInt
 
-sealed trait DimensionalEffect
+sealed abstract class DimensionalEffect
 /** Describes a function that reduces a set of values to a single value. */
 final case object Reduction extends DimensionalEffect
 /** Describes a function that expands a compound value into a set of values for

--- a/frontend/src/main/scala/quasar/sql/IsDistinct.scala
+++ b/frontend/src/main/scala/quasar/sql/IsDistinct.scala
@@ -20,7 +20,7 @@ import quasar.Predef._
 
 import scalaz._
 
-sealed trait IsDistinct extends Product with Serializable
+sealed abstract class IsDistinct extends Product with Serializable
 
 final case object SelectDistinct extends IsDistinct
 final case object SelectAll extends IsDistinct

--- a/frontend/src/main/scala/quasar/sql/OrderType.scala
+++ b/frontend/src/main/scala/quasar/sql/OrderType.scala
@@ -20,7 +20,7 @@ import quasar.Predef._
 
 import scalaz._
 
-sealed trait OrderType extends Product with Serializable
+sealed abstract class OrderType extends Product with Serializable
 
 final case object ASC extends OrderType
 final case object DESC extends OrderType

--- a/frontend/src/main/scala/quasar/sql/ParsingError.scala
+++ b/frontend/src/main/scala/quasar/sql/ParsingError.scala
@@ -23,7 +23,7 @@ import quasar.fs._
 import matryoshka._
 import scalaz._, Scalaz._
 
-sealed trait ParsingError { def message: String}
+sealed abstract class ParsingError { def message: String}
 final case class GenericParsingError(message: String) extends ParsingError
 final case class ParsingPathError(error: PathError) extends ParsingError {
   def message = error.shows

--- a/frontend/src/main/scala/quasar/sql/SqlRelation.scala
+++ b/frontend/src/main/scala/quasar/sql/SqlRelation.scala
@@ -25,7 +25,7 @@ import monocle.macros.Lenses
 import pathy.Path._
 import scalaz._, Scalaz._
 
-sealed trait SqlRelation[A] extends Product with Serializable {
+sealed abstract class SqlRelation[A] extends Product with Serializable {
   def namedRelations: Map[String, List[NamedRelation[A]]] = {
     def collect(n: SqlRelation[A]): List[(String, NamedRelation[A])] =
       n match {
@@ -55,7 +55,7 @@ sealed trait SqlRelation[A] extends Product with Serializable {
   }
 }
 
-sealed trait NamedRelation[A] extends SqlRelation[A] {
+sealed abstract class NamedRelation[A] extends SqlRelation[A] {
   def aliasName: String
 }
 

--- a/frontend/src/main/scala/quasar/sql/Statement.scala
+++ b/frontend/src/main/scala/quasar/sql/Statement.scala
@@ -22,7 +22,7 @@ import quasar._, RenderTree.ops._
 import monocle.macros.Lenses
 import scalaz._, Scalaz._
 
-sealed trait Statement[BODY] {
+sealed abstract class Statement[BODY] {
   def pprint(implicit show: Show[BODY]): String
 
   implicit val functor: Functor[Statement] = new Functor[Statement] {

--- a/frontend/src/main/scala/quasar/sql/ast.scala
+++ b/frontend/src/main/scala/quasar/sql/ast.scala
@@ -24,7 +24,7 @@ import matryoshka._
 import monocle.macros.Lenses
 import scalaz._, Scalaz._
 
-sealed trait Sql[A]
+sealed abstract class Sql[A]
 object Sql {
 
   implicit val equal: Delay[Equal, Sql] =

--- a/frontend/src/main/scala/quasar/sql/parser.scala
+++ b/frontend/src/main/scala/quasar/sql/parser.scala
@@ -29,7 +29,7 @@ import matryoshka._
 import matryoshka.implicits._
 import scalaz._, Scalaz._
 
-sealed trait DerefType[T[_[_]]] extends Product with Serializable
+sealed abstract class DerefType[T[_[_]]] extends Product with Serializable
 final case class ObjectDeref[T[_[_]]](expr: T[Sql])      extends DerefType[T]
 final case class ArrayDeref[T[_[_]]](expr: T[Sql])       extends DerefType[T]
 final case class DimChange[T[_[_]]](unop: UnaryOperator) extends DerefType[T]

--- a/frontend/src/main/scala/quasar/types.scala
+++ b/frontend/src/main/scala/quasar/types.scala
@@ -27,7 +27,7 @@ import scala.Any
 import argonaut._, Argonaut._, ArgonautScalaz._
 import scalaz._, Scalaz._, NonEmptyList.nels, Validation.{success, failureNel}
 
-sealed trait Type extends Product with Serializable { self =>
+sealed abstract class Type extends Product with Serializable { self =>
   import Type._
 
   final def toPrimaryType: Option[PrimaryType] =

--- a/interface/src/main/scala/quasar/main/prettify.scala
+++ b/interface/src/main/scala/quasar/main/prettify.scala
@@ -27,7 +27,7 @@ import eu.timepit.refined.auto._
 import scalaz._, Scalaz._
 
 object Prettify {
-  sealed trait Segment extends Product with Serializable
+  sealed abstract class Segment extends Product with Serializable
   final case class FieldSeg(name: String) extends Segment
   final case class IndexSeg(index: Int) extends Segment
 
@@ -121,7 +121,7 @@ object Prettify {
     values.foldLeft[Data](init) { case (v, (p, str)) => append(v, p, str) }
   }
 
-  sealed trait Aligned[A] {
+  sealed abstract class Aligned[A] {
     def value: A
   }
   object Aligned {

--- a/it/src/test/scala/quasar/TaskResource.scala
+++ b/it/src/test/scala/quasar/TaskResource.scala
@@ -44,7 +44,7 @@ object TaskResource {
     val counter = new AtomicLong(0)
     def nextId: Task[Long] = Task.delay(counter.getAndIncrement)
 
-    sealed trait RsrcState
+    sealed abstract class RsrcState
     case object Start extends RsrcState
     case class Acquiring(id: Long) extends RsrcState
     case class Acquired(a: A) extends RsrcState

--- a/it/src/test/scala/quasar/regression/BackendIgnoreFieldOrder.scala
+++ b/it/src/test/scala/quasar/regression/BackendIgnoreFieldOrder.scala
@@ -19,7 +19,7 @@ package quasar.regression
 import quasar.Predef._
 import quasar.BackendName
 
-sealed trait IgnoreFieldOrderBackend
+sealed abstract class IgnoreFieldOrderBackend
 
 final case object IgnoreFieldOrderAllBackends                           extends IgnoreFieldOrderBackend
 final case class  IgnoreFieldOrderBackends(backends: List[BackendName]) extends IgnoreFieldOrderBackend

--- a/it/src/test/scala/quasar/regression/FieldOrder.scala
+++ b/it/src/test/scala/quasar/regression/FieldOrder.scala
@@ -16,7 +16,7 @@
 
 package quasar.regression
 
-sealed trait FieldOrder
+sealed abstract class FieldOrder
 
 final case object FieldOrderPreserved extends FieldOrder
 

--- a/it/src/test/scala/quasar/regression/Predicate.scala
+++ b/it/src/test/scala/quasar/regression/Predicate.scala
@@ -29,7 +29,7 @@ import org.specs2.matcher._
 import scalaz.{Failure => _, _}, Scalaz._
 import scalaz.stream._
 
-sealed trait Predicate {
+sealed abstract class Predicate {
   def apply[F[_]: Catchable: Monad](
     expected: Vector[Json],
     actual: Process[F, Json],

--- a/it/src/test/scala/quasar/regression/SkipDirective.scala
+++ b/it/src/test/scala/quasar/regression/SkipDirective.scala
@@ -20,7 +20,7 @@ import quasar.Predef._
 
 import argonaut._, Argonaut._
 
-sealed trait SkipDirective
+sealed abstract class SkipDirective
 
 object SkipDirective {
   final case object Skip    extends SkipDirective

--- a/js/src/main/scala/quasar/javascript/javascript.scala
+++ b/js/src/main/scala/quasar/javascript/javascript.scala
@@ -45,14 +45,14 @@ import scalaz._, Scalaz._
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-sealed trait Js extends Product with Serializable {
+sealed abstract class Js extends Product with Serializable {
   def pprint(indent: Int): String = JavascriptPrinter.print(this, indent)
 }
 
 object Js {
-  sealed trait Stmt extends Js
-  sealed trait Expr extends Stmt
-  sealed trait Lit extends Expr
+  sealed abstract class Stmt extends Js
+  sealed abstract class Expr extends Stmt
+  sealed abstract class Lit extends Expr
 
   final case class Bool(value: Boolean) extends Lit
   final case class Str(value: String) extends Lit
@@ -82,7 +82,7 @@ object Js {
   final case class While(cond: Expr, body: Stmt) extends Stmt
   final case class For(init: List[Stmt], check: Expr, update: List[Stmt], body: Stmt) extends Stmt
   final case class ForIn(ident: Ident, coll: Expr, body: Stmt) extends Stmt
-  sealed trait Switchable extends Stmt
+  sealed abstract class Switchable extends Stmt
   final case class Case(const: List[Expr], body: Stmt) extends Switchable
   final case class Default(body: Stmt) extends Switchable
   final case class Switch(expr: Expr, cases: List[Case], default: Option[Default]) extends Stmt

--- a/js/src/main/scala/quasar/jscore/jscore.scala
+++ b/js/src/main/scala/quasar/jscore/jscore.scala
@@ -65,7 +65,7 @@ object Name {
   implicit val equal: Equal[Name] = Equal.equalA
 }
 
-sealed trait JsCoreF[A]
+sealed abstract class JsCoreF[A]
 object JsCoreF {
   final case class LiteralF[A](value: Js.Lit) extends JsCoreF[A]
   final case class IdentF[A](name: Name) extends JsCoreF[A]

--- a/mongodb/src/main/scala/quasar/physical/mongodb/MongoQueryModel.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/MongoQueryModel.scala
@@ -18,7 +18,7 @@ package quasar.physical.mongodb
 
 import scalaz.Scalaz._
 
-sealed trait MongoQueryModel
+sealed abstract class MongoQueryModel
 
 object MongoQueryModel {
   /** The oldest supported version. */

--- a/mongodb/src/main/scala/quasar/physical/mongodb/RenameSemantics.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/RenameSemantics.scala
@@ -16,7 +16,7 @@
 
 package quasar.physical.mongodb
 
-sealed trait RenameSemantics
+sealed abstract class RenameSemantics
 
 object RenameSemantics {
   case object Overwrite extends RenameSemantics

--- a/mongodb/src/main/scala/quasar/physical/mongodb/WorkflowExecutionError.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/WorkflowExecutionError.scala
@@ -27,7 +27,7 @@ import scalaz._
 import scalaz.syntax.show._
 
 /** Error conditions possible during `Workflow` execution. */
-sealed trait WorkflowExecutionError
+sealed abstract class WorkflowExecutionError
 
 object WorkflowExecutionError {
   final case class InvalidTask private (task: WorkflowTask, reason: String)

--- a/mongodb/src/main/scala/quasar/physical/mongodb/accumulator/accumop.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/accumulator/accumop.scala
@@ -25,7 +25,7 @@ import matryoshka._
 import matryoshka.data.Fix
 import scalaz._, Scalaz._
 
-sealed trait AccumOp[A]
+sealed abstract class AccumOp[A]
 
 object AccumOp {
   final case class $addToSet[A](value: A) extends AccumOp[A]

--- a/mongodb/src/main/scala/quasar/physical/mongodb/bson.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/bson.scala
@@ -34,7 +34,7 @@ import scalaz._, Scalaz._
  * A type-safe ADT for Mongo's native data format. Note that this representation
  * is not suitable for efficiently storing large quantities of data.
  */
-sealed trait Bson extends Product with Serializable {
+sealed abstract class Bson extends Product with Serializable {
   // TODO: Once Bson is fixpoint, this should be an algebra:
   //       BsonF[BsonValue] => BsonValue
   def repr: BsonValue
@@ -249,7 +249,7 @@ object BsonType {
   final case object MaxKey extends BsonType(127)
 }
 
-sealed trait BsonField {
+sealed abstract class BsonField {
   def asText  : String
   def asField : String = "$" + asText
   def asVar   : String = "$$" + asText
@@ -310,7 +310,7 @@ sealed trait BsonField {
 }
 
 object BsonField {
-  sealed trait Root
+  sealed abstract class Root
   final case object Root extends Root
 
   def apply(v: NonEmptyList[BsonField.Name]): BsonField = v match {

--- a/mongodb/src/main/scala/quasar/physical/mongodb/mapreduce.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/mapreduce.scala
@@ -84,7 +84,7 @@ final case class MapReduce(
 object MapReduce {
   type Scope = ListMap[String, Bson]
 
-  sealed trait Action {
+  sealed abstract class Action {
     def nonAtomic: Option[Boolean]
   }
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/selector.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/selector.scala
@@ -25,7 +25,7 @@ import scala.Any
 
 import scalaz._, Scalaz._
 
-sealed trait Selector {
+sealed abstract class Selector {
   def bson: Bson.Doc
 
   import Selector._
@@ -93,7 +93,7 @@ object Selector {
       }
     }
 
-  sealed trait Condition {
+  sealed abstract class Condition {
     def bson: Bson
   }
 
@@ -185,7 +185,7 @@ object Selector {
     protected def rhs = Bson.Int32(size)
   }
 
-  sealed trait SelectorExpr {
+  sealed abstract class SelectorExpr {
     def bson: Bson
   }
 
@@ -219,7 +219,7 @@ object Selector {
       Doc(ListMap(pairs.map(t => t._1 -> Expr(t._2)): _*))
   }
 
-  sealed trait CompoundSelector extends Selector {
+  sealed abstract class CompoundSelector extends Selector {
     protected def op: String
     def left: Selector
     def right: Selector

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflow/CardinalExpr.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflow/CardinalExpr.scala
@@ -18,7 +18,7 @@ package quasar.physical.mongodb.workflow
 
 import scalaz._, Scalaz._
 
-sealed trait CardinalExpr[A]
+sealed abstract class CardinalExpr[A]
 
 final case class MapExpr[A](fn: A)  extends CardinalExpr[A]
 final case class FlatExpr[A](fn: A) extends CardinalExpr[A]

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflow/IdHandling.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflow/IdHandling.scala
@@ -18,7 +18,7 @@ package quasar.physical.mongodb.workflow
 
 import scalaz._
 
-sealed trait IdHandling
+sealed abstract class IdHandling
 final case object ExcludeId extends IdHandling
 final case object IncludeId extends IdHandling
 final case object IgnoreId extends IdHandling

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflow/Refs.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflow/Refs.scala
@@ -23,7 +23,7 @@ import quasar.physical.mongodb.expression.DocVar
 import scalaz._
 import simulacrum.typeclass
 
-@typeclass sealed trait Refs[F[_]] {
+@typeclass trait Refs[F[_]] {
   def refs[A](op: F[A]): List[DocVar]
 }
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflow/WorkflowOpCore.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflow/WorkflowOpCore.scala
@@ -434,7 +434,7 @@ object $geoNear {
     }
 }
 
-sealed trait MapReduceF[A] extends WorkflowOpCoreF[A] {
+sealed abstract class MapReduceF[A] extends WorkflowOpCoreF[A] {
   def singleSource: SingleSourceF[WorkflowOpCoreF, A]
 
   def newMR[F[_]](

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
@@ -35,7 +35,7 @@ import matryoshka.data.Fix
 import matryoshka.implicits._
 import scalaz._, Scalaz._
 
-sealed trait WorkflowBuilderF[F[_], +A] extends Product with Serializable
+sealed abstract class WorkflowBuilderF[F[_], +A] extends Product with Serializable
 
 object WorkflowBuilderF {
   import WorkflowBuilder._
@@ -273,8 +273,8 @@ object WorkflowBuilder {
       Fix[WorkflowBuilderF[F, ?]](new ArrayBuilderF(src, shape))
   }
 
-  sealed trait Contents[+A] extends Product with Serializable
-  sealed trait DocContents[+A] extends Contents[A]
+  sealed abstract class Contents[+A] extends Product with Serializable
+  sealed abstract class DocContents[+A] extends Contents[A]
   sealed trait ArrayContents[+A] extends Contents[A]
   object Contents {
     final case class Expr[A](contents: A) extends DocContents[A] with ArrayContents[A]
@@ -315,7 +315,7 @@ object WorkflowBuilder {
       Fix[WorkflowBuilderF[F, ?]](new GroupBuilderF(src, keys, contents))
   }
 
-  sealed trait StructureType[A] {
+  sealed abstract class StructureType[A] {
     val field: A
   }
   object StructureType {
@@ -875,7 +875,7 @@ object WorkflowBuilder {
     * structures that we need to be able to extract later. This tells us how to
     * extract them.
     */
-  sealed trait Base {
+  sealed abstract class Base {
     def \ (that: Base): Base = (this, that) match {
       case (Root(),      _)            => that
       case (_,           Root())       => this

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflowtask/ast.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflowtask/ast.scala
@@ -27,7 +27,7 @@ import matryoshka.Delay
 import scalaz._, Scalaz._
 
 /** A WorkflowTask approximately represents one request to MongoDB. */
-sealed trait WorkflowTaskF[A]
+sealed abstract class WorkflowTaskF[A]
 object WorkflowTaskF {
   /** A task that returns a necessarily small amount of raw data. */
   final case class PureTaskF[A](value: Bson) extends WorkflowTaskF[A]

--- a/repl/src/main/scala/quasar/repl/Command.scala
+++ b/repl/src/main/scala/quasar/repl/Command.scala
@@ -23,7 +23,7 @@ import quasar.sql.{Query}
 import pathy.Path, Path._
 import scalaz._, Scalaz._
 
-sealed trait Command
+sealed abstract class Command
 object Command {
   private val ExitPattern         = "(?i)(?:exit)|(?:quit)".r
   private val HelpPattern         = "(?i)(?:help)|(?:commands)|\\?".r

--- a/repl/src/main/scala/quasar/repl/ConsoleIO.scala
+++ b/repl/src/main/scala/quasar/repl/ConsoleIO.scala
@@ -22,7 +22,7 @@ import quasar.effect.LiftedOps
 
 import scalaz._
 
-sealed trait ConsoleIO[A]
+sealed abstract class ConsoleIO[A]
 object ConsoleIO {
   final case class PrintLn(message: String) extends ConsoleIO[Unit]
 

--- a/repl/src/main/scala/quasar/repl/DebugLevel.scala
+++ b/repl/src/main/scala/quasar/repl/DebugLevel.scala
@@ -18,7 +18,7 @@ package quasar.repl
 
 import quasar.Predef._
 
-sealed trait DebugLevel
+sealed abstract class DebugLevel
 object DebugLevel {
   final case object Silent extends DebugLevel
   final case object Normal extends DebugLevel

--- a/repl/src/main/scala/quasar/repl/OutputFormat.scala
+++ b/repl/src/main/scala/quasar/repl/OutputFormat.scala
@@ -20,7 +20,7 @@ import quasar.Predef._
 
 import scalaz._, Scalaz._
 
-sealed trait OutputFormat
+sealed abstract class OutputFormat
 object OutputFormat {
   case object Table extends OutputFormat
   case object Precise extends OutputFormat

--- a/sql/src/main/scala/quasar/sql/semantics.scala
+++ b/sql/src/main/scala/quasar/sql/semantics.scala
@@ -34,7 +34,7 @@ object SemanticAnalysis {
 
   private def fail[A](e: SemanticError) = Validation.failure[Failure, A](NonEmptyList(e))
 
-  sealed trait Synthetic
+  sealed abstract class Synthetic
   object Synthetic {
     final case object SortKey extends Synthetic
 
@@ -177,7 +177,7 @@ object SemanticAnalysis {
     }
   }
 
-  sealed trait Provenance {
+  sealed abstract class Provenance {
     import Provenance._
 
     def & (that: Provenance): Provenance = Both(this, that)

--- a/web/src/main/scala/quasar/api/MessageFormat.scala
+++ b/web/src/main/scala/quasar/api/MessageFormat.scala
@@ -34,7 +34,7 @@ import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 import scalaz.stream.Process
 
-sealed trait JsonPrecision extends Product with Serializable {
+sealed abstract class JsonPrecision extends Product with Serializable {
   def codec: DataCodec
   def name: String
 }
@@ -48,7 +48,7 @@ object JsonPrecision {
     val name = "precise"
   }
 }
-sealed trait JsonFormat extends Product with Serializable {
+sealed abstract class JsonFormat extends Product with Serializable {
   def mediaType: MediaType
 }
 object JsonFormat {
@@ -78,7 +78,7 @@ trait Decoder {
   }
 }
 
-sealed trait MessageFormat extends Decoder {
+sealed abstract class MessageFormat extends Decoder {
   def disposition: Option[`Content-Disposition`]
   def encode[F[_]](data: Process[F, Data]): Process[F, String]
   protected def dispositionExtension: Map[String, String] =

--- a/web/src/main/scala/quasar/api/zip.scala
+++ b/web/src/main/scala/quasar/api/zip.scala
@@ -32,7 +32,7 @@ import scodec.interop.scalaz._
 object Zip {
   // First construct a single Process of Ops which can be performed in
   // sequence to produce the entire archive.
-  private sealed trait Op extends Product with Serializable
+  private sealed abstract class Op extends Product with Serializable
   private object Op {
     final case object Start                           extends Op
     final case class StartEntry(entry: jzip.ZipEntry) extends Op

--- a/web/src/test/scala/quasar/api/services/Fixture.scala
+++ b/web/src/test/scala/quasar/api/services/Fixture.scala
@@ -78,7 +78,7 @@ object Fixture {
   // Remove once version 0.8.4 or higher of jawn is realeased.
   implicit val normalJsonBugFreeDecoder = org.http4s.jawn.jawnDecoder(bugFreeArgonautFacade)
 
-  sealed trait JsonType
+  sealed abstract class JsonType
 
   case class PreciseJson(value: Json) extends JsonType
   object PreciseJson {


### PR DESCRIPTION
Most have been converted to `sealed abstract class`. One was actually a type class, so I just unsealed it.

There are still a few remaining in Mongo (I feel like I write this comment in every PR), which are actually used with multiple inheritance, so not eliminable yet.