### PR TITLE
Improve QScript performance

### DIFF
--- a/connector/src/main/scala/quasar/qscript/Rewrite.scala
+++ b/connector/src/main/scala/quasar/qscript/Rewrite.scala
@@ -85,8 +85,8 @@ class Rewrite[T[_[_]]: BirecursiveT: OrderT: EqualT] extends TTypes[T] {
       : T[F] => T[G] = {
     _.codyna(
       normalize[G]                                              >>>
-      liftFG(injectRepeatedly(C.coalesceSR[G, ADir](idPrism)))  >>>
-      liftFG(injectRepeatedly(C.coalesceSR[G, AFile](idPrism))) >>>
+      liftFG(injectRepeatedly(C.coalesceSRNormalize[G, ADir](idPrism)))  >>>
+      liftFG(injectRepeatedly(C.coalesceSRNormalize[G, AFile](idPrism))) >>>
       (_.embed),
       ((_: T[F]).project) >>> (S.shiftRead(idPrism.reverseGet)(_)))
   }
@@ -103,7 +103,7 @@ class Rewrite[T[_[_]]: BirecursiveT: OrderT: EqualT] extends TTypes[T] {
   ): T[F] => T[G] =
     _.codyna(
       normalize[G]                                             >>>
-      liftFG(injectRepeatedly(C.coalesceSR[G, ADir](idPrism))) >>>
+      liftFG(injectRepeatedly(C.coalesceSRNormalize[G, ADir](idPrism))) >>>
       (_.embed),
       ((_: T[F]).project) >>> (S.shiftReadDir(idPrism.reverseGet)(_)))
 
@@ -330,17 +330,6 @@ class Rewrite[T[_[_]]: BirecursiveT: OrderT: EqualT] extends TTypes[T] {
     case _ => None
   }
 
-  /** Chains multiple transformations together, each of which can fail to change
-    * anything.
-    */
-  def applyTransforms[F[_]]
-    (transform: F[T[F]] => Option[F[T[F]]],
-      transforms: (F[T[F]] => Option[F[T[F]]])*)
-      : F[T[F]] => Option[F[T[F]]] =
-    transforms.foldLeft(
-      transform)(
-      (prev, next) => x => prev(x).fold(next(x))(y => next(y).orElse(y.some)))
-
   // TODO: add reordering
   // - Filter can be moved ahead of Sort
   // - Subset can have a normalized order _if_ their counts are constant
@@ -364,8 +353,8 @@ class Rewrite[T[_[_]]: BirecursiveT: OrderT: EqualT] extends TTypes[T] {
       liftFG(injectRepeatedly(elideNopJoin[F, T[G]](rebase))) ⋙
       liftFF(repeatedly(compactQC(_: QScriptCore[T[G]]))) ⋙
       liftFF(repeatedly(uniqueBuckets(_: QScriptCore[T[G]]))) ⋙
-      repeatedly(C.coalesceQC[G](prism)) ⋙
-      liftFG(injectRepeatedly(C.coalesceTJ[G](prism.get))) ⋙
+      repeatedly(C.coalesceQCNormalize[G](prism)) ⋙
+      liftFG(injectRepeatedly(C.coalesceTJNormalize[G](prism.get))) ⋙
       (fa => QC.prj(fa).fold(prism.reverseGet(fa))(elideNopQC[F, G](prism.reverseGet)))
 
   def normalizeCoEnv[F[_]: Traverse: Normalizable](

--- a/connector/src/main/scala/quasar/qscript/package.scala
+++ b/connector/src/main/scala/quasar/qscript/package.scala
@@ -184,6 +184,18 @@ package object qscript {
       : F[A] => G[A] =
     fa => op(fa).fold(F.inj(fa))(ga => F.prj(ga).fold(ga)(injectRepeatedly(op)))
 
+  /** Chains multiple transformations together, each of which can fail to change
+    * anything.
+    */
+  def applyTransforms[T[_[_]], F[_], G[_]]
+    (transform: F[T[G]] => Option[F[T[G]]],
+      transforms: (F[T[G]] => Option[F[T[G]]])*)
+      : F[T[G]] => Option[F[T[G]]] =
+    transforms.foldLeft(
+      transform)(
+      (prev, next) => x => prev(x).fold(next(x))(y => next(y).orElse(y.some)))
+
+
   // Helpers for creating `Injectable` instances
 
   object ::\:: {

--- a/couchbase/src/main/scala/quasar/physical/couchbase/fs/queryfile.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/fs/queryfile.scala
@@ -251,11 +251,10 @@ object queryfile {
       _    <- tell(Vector(tree("QScript (post shiftRead)", shft)))
       opz  =  shft.transHylo(
                 rewrite.optimize(reflNT[CBQS]),
-                repeatedly(rewrite.applyTransforms(
-                  C.coalesceQC[CBQS](idPrism),
-                  C.coalesceEJ[CBQS](idPrism.get),
-                  C.coalesceSR[CBQS, AFile](idPrism),
-                  Normalizable[CBQS].normalizeF(_: CBQS[T[CBQS]]))))
+                repeatedly(applyTransforms(
+                  C.coalesceQCNormalize[CBQS](idPrism),
+                  C.coalesceEJNormalize[CBQS](idPrism.get),
+                  C.coalesceSRNormalize[CBQS, AFile](idPrism))))
       _    <- tell(Vector(tree("QScript (optimized)", opz)))
       n1ql <- opz.cataM(
                 Planner[T, Free[S, ?], CBQS].plan

--- a/it/src/main/resources/tests/couchbase/leftKeyJoinMultipleSelect.test
+++ b/it/src/main/resources/tests/couchbase/leftKeyJoinMultipleSelect.test
@@ -1,0 +1,42 @@
+{
+    "name": "left key join with multiple fields selected (Couchbase)",
+    "backends": {
+        "marklogic_json":    "skip",
+        "marklogic_xml":     "skip",
+        "mongodb_2_6":       "skip",
+        "mongodb_3_0":       "skip",
+        "mongodb_read_only": "skip",
+        "mongodb_3_2":       "skip",
+        "mongodb_q_3_2":     "skip",
+        "postgresql":        "skip",
+        "spark_local":       "skip",
+        "spark_hdfs":        "skip"
+    },
+    "data": [],
+    "query": "SELECT META(brewery).id AS brewery_meta_id,
+                     brewery.name AS brewery_name,
+                     beer.name AS beer_name,
+                     beer.brewery_id AS beer_brewery_id,
+                     beer.category AS beer_category
+              FROM `/beer-sample/brewery` AS brewery JOIN `/beer-sample/beer` AS beer
+              ON META(brewery).id = beer.brewery_id
+              WHERE beer.category = \"North American Ale\"",
+    "ignoreFieldOrder": [ "couchbase" ],
+    "predicate": "containsAtLeast",
+    "expected": [
+        {
+            "brewery_meta_id": "21st_amendment_brewery_cafe",
+            "brewery_name": "21st Amendment Brewery Cafe",
+            "beer_brewery_id": "21st_amendment_brewery_cafe",
+            "beer_name": "21A IPA",
+            "beer_category": "North American Ale"
+        },
+        {
+            "brewery_meta_id": "21st_amendment_brewery_cafe",
+            "brewery_name": "21st Amendment Brewery Cafe",
+            "beer_brewery_id": "21st_amendment_brewery_cafe",
+            "beer_name": "563 Stout",
+            "beer_category": "North American Ale"
+        }
+    ]
+}

--- a/it/src/main/resources/tests/joins/multipleSelectJoin.test
+++ b/it/src/main/resources/tests/joins/multipleSelectJoin.test
@@ -1,0 +1,29 @@
+{
+    "name": "join with multiple fields selected",
+
+    "backends": {
+        "couchbase": "pending",
+        "marklogic_json": "pending",
+        "mongodb_read_only": "pending",
+        "mongodb_q_3_2": "pending",
+        "postgresql":        "pending",
+        "spark_local": "skip",
+        "spark_hdfs": "skip"
+    },
+
+    "data": ["../smallZips.data", "../extraSmallZips.data"],
+
+    "query": "SELECT smallZips.city AS CitySmall,
+                     smallZips.state AS StateSmall,
+                     extraSmallZips.city AS City,
+                     extraSmallZips.state AS State,
+                     extraSmallZips.pop AS Pop
+              FROM `../smallZips` JOIN `../extraSmallZips`
+              ON smallZips.pop = extraSmallZips.pop
+              WHERE extraSmallZips.state = \"MA\"",
+
+    "predicate": "containsAtLeast",
+
+    "expected": [{ "CitySmall": "AGAWAM", "StateSmall": "MA", "City": "AGAWAM", "State": "MA", "Pop": 15338 },
+                 { "CitySmall": "WARE",   "StateSmall": "MA", "City": "WARE",   "State": "MA", "Pop": 9808  }]
+}

--- a/marklogic/src/main/scala/quasar/physical/marklogic/fs/queryfile.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/fs/queryfile.scala
@@ -144,11 +144,10 @@ object queryfile {
       _         <- logPhase(PhaseResult.tree("QScript (ShiftRead)", shifted))
       optimized =  shifted.transHylo(
                      R.optimize(reflNT[MLQ]),
-                     repeatedly(R.applyTransforms(
-                       C.coalesceQC[MLQ](idPrism),
-                       C.coalesceTJ[MLQ](idPrism.get),
-                       C.coalesceSR[MLQ, ADir](idPrism),
-                       N.normalizeF(_: MLQ[T[MLQ]]))))
+                     repeatedly(applyTransforms(
+                       C.coalesceQCNormalize[MLQ](idPrism),
+                       C.coalesceTJNormalize[MLQ](idPrism.get),
+                       C.coalesceSRNormalize[MLQ, ADir](idPrism))))
       _         <- logPhase(PhaseResult.tree("QScript (Optimized)", optimized))
       main      <- plan(optimized)
       inputs    =  optimized.cata(ExtractPath[MLQ, APath].extractPath[DList])

--- a/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -1247,11 +1247,10 @@ object MongoDbQScriptPlanner {
           .transCataM(ExpandDirs[T, MongoQScript0, MongoQScript].expandDirs(idPrism.reverseGet, listContents))
           .map(_.transHylo(
             rewrite.optimize(reflNT[MongoQScript]),
-            repeatedly(rewrite.applyTransforms(
-              C.coalesceQC[MongoQScript](idPrism),
-              C.coalesceEJ[MongoQScript](idPrism.get),
-              C.coalesceSR[MongoQScript, AFile](idPrism),
-              Normalizable[MongoQScript].normalizeF(_: MongoQScript[T[MongoQScript]])))))
+            repeatedly(applyTransforms(
+              C.coalesceQCNormalize[MongoQScript](idPrism),
+              C.coalesceEJNormalize[MongoQScript](idPrism.get),
+              C.coalesceSRNormalize[MongoQScript, AFile](idPrism)))))
           .flatMap(_.transCataM(liftFGM(assumeReadType[M, T, MongoQScript](Type.AnyObject))))).liftM[GenT]
       wb  <- log(
         "Workflow Builder",

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/queryfile.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/queryfile.scala
@@ -84,11 +84,10 @@ object queryfile {
                    .flatMap(_.transCataM(ExpandDirs[Fix, SparkQScript0, SparkQScript].expandDirs(idPrism.reverseGet, lc)))
         optQS =  qs.transHylo(
                    rewrite.optimize(reflNT[SparkQScript]),
-                   repeatedly(rewrite.applyTransforms(
-                     C.coalesceQC[SparkQScript](idPrism),
-                     C.coalesceEJ[SparkQScript](idPrism.get),
-                     C.coalesceSR[SparkQScript, AFile](idPrism),
-                     Normalizable[SparkQScript].normalizeF(_: SparkQScript[Fix[SparkQScript]]))))
+                   repeatedly(applyTransforms(
+                     C.coalesceQCNormalize[SparkQScript](idPrism),
+                     C.coalesceEJNormalize[SparkQScript](idPrism.get),
+                     C.coalesceSRNormalize[SparkQScript, AFile](idPrism))))
         _     <- EitherT(WriterT[Free[S, ?], PhaseResults, FileSystemError \/ Unit]((Vector(PhaseResult.tree("QScript (Spark)", optQS)), ().right[FileSystemError]).point[Free[S, ?]]))
       } yield optQS
     }


### PR DESCRIPTION
Improves `QScript` generation performance by consistently calling `normalizeF` after each coalescing.

Fixes #1950 