### PR TITLE
Unicoalescense

### DIFF
--- a/connector/src/main/scala/quasar/qscript/unicoalesce.scala
+++ b/connector/src/main/scala/quasar/qscript/unicoalesce.scala
@@ -18,12 +18,13 @@ package quasar.qscript
 
 import slamdata.Predef._
 import quasar.fp._
+import quasar.fp.ski._
 
 import matryoshka._
 import scalaz._
 
 sealed trait Unicoalesce[T[_[_]], C <: CoM] {
-  def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]): Option[C#M[T[C#M]] => Option[C#M[T[C#M]]]]
+  def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]): C#M[T[C#M]] => Option[C#M[T[C#M]]]
 }
 
 object Unicoalesce {
@@ -43,7 +44,7 @@ object Unicoalesce {
       SR(C),
       EJ(C),
       TJ(C),
-      Some(N.normalizeF(_: C#M[T[C#M]]))).map(_.toList).flatten(x => x)
+      N.normalizeF(_: C#M[T[C#M]]))
 
     cs match {
       case hd :: tl =>
@@ -59,7 +60,7 @@ sealed trait UnicoalesceQC[T[_[_]], C <: CoM] extends Unicoalesce[T, C]
 
 private[qscript] trait UnicoalesceQCLowPriorityImplicits {
   implicit def default[T[_[_]], C <: CoM]: UnicoalesceQC[T, C] = new UnicoalesceQC[T, C] {
-    def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]) = None
+    def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]) = κ(None)
   }
 }
 
@@ -70,7 +71,7 @@ object UnicoalesceQC extends UnicoalesceQCLowPriorityImplicits {
       QC: QScriptCore[T, ?] :<: C#M): UnicoalesceQC[T, C] = new UnicoalesceQC[T, C] {
 
     def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]) =
-      Some(C.coalesceQC[C#M](idPrism))
+      C.coalesceQC[C#M](idPrism)
   }
 }
 
@@ -78,7 +79,7 @@ sealed trait UnicoalesceSR[T[_[_]], C <: CoM] extends Unicoalesce[T, C]
 
 private[qscript] trait UnicoalesceSRLowPriorityImplicits {
   implicit def default[T[_[_]], C <: CoM]: UnicoalesceSR[T, C] = new UnicoalesceSR[T, C] {
-    def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]) = None
+    def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]) = κ(None)
   }
 }
 
@@ -91,7 +92,7 @@ object UnicoalesceSR extends UnicoalesceSRLowPriorityImplicits {
       SR: Const[ShiftedRead[A], ?] :<: C#M): UnicoalesceSR[T, C] = new UnicoalesceSR[T, C] {
 
     def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]) =
-      Some(C.coalesceSR[C#M, A](idPrism))
+      C.coalesceSR[C#M, A](idPrism)
   }
 }
 
@@ -99,7 +100,7 @@ sealed trait UnicoalesceEJ[T[_[_]], C <: CoM] extends Unicoalesce[T, C]
 
 private[qscript] trait UnicoalesceEJLowPriorityImplicits {
   implicit def default[T[_[_]], C <: CoM]: UnicoalesceEJ[T, C] = new UnicoalesceEJ[T, C] {
-    def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]) = None
+    def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]) = κ(None)
   }
 }
 
@@ -110,7 +111,7 @@ object UnicoalesceEJ extends UnicoalesceEJLowPriorityImplicits {
       QC: EquiJoin[T, ?] :<: C#M): UnicoalesceEJ[T, C] = new UnicoalesceEJ[T, C] {
 
     def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]) =
-      Some(C.coalesceEJ[C#M](idPrism.get))
+      C.coalesceEJ[C#M](idPrism.get)
   }
 }
 
@@ -118,7 +119,7 @@ sealed trait UnicoalesceTJ[T[_[_]], C <: CoM] extends Unicoalesce[T, C]
 
 private[qscript] trait UnicoalesceTJLowPriorityImplicits {
   implicit def default[T[_[_]], C <: CoM]: UnicoalesceTJ[T, C] = new UnicoalesceTJ[T, C] {
-    def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]) = None
+    def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]) = κ(None)
   }
 }
 
@@ -129,6 +130,6 @@ object UnicoalesceTJ extends UnicoalesceTJLowPriorityImplicits {
       QC: ThetaJoin[T, ?] :<: C#M): UnicoalesceTJ[T, C] = new UnicoalesceTJ[T, C] {
 
     def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]) =
-      Some(C.coalesceTJ[C#M](idPrism.get))
+      C.coalesceTJ[C#M](idPrism.get)
   }
 }

--- a/connector/src/main/scala/quasar/qscript/unicoalesce.scala
+++ b/connector/src/main/scala/quasar/qscript/unicoalesce.scala
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript
+
+import slamdata.Predef._
+import quasar.fp._
+
+import matryoshka._
+import scalaz._
+
+sealed trait Unicoalesce[T[_[_]], C <: CoM] {
+  def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]): Option[C#M[T[C#M]] => Option[C#M[T[C#M]]]]
+}
+
+object Unicoalesce {
+
+  def apply[T[_[_]], C <: CoM](
+    implicit
+      C: Coalesce.Aux[T, C#M, C#M],
+      F: Functor[C#M],
+      QC: UnicoalesceQC[T, C],
+      SR: UnicoalesceSR[T, C],
+      EJ: UnicoalesceEJ[T, C],
+      TJ: UnicoalesceTJ[T, C],
+      N: Normalizable[C#M]): C#M[T[C#M]] => C#M[T[C#M]] = {
+
+    val cs = List(
+      QC(C),
+      SR(C),
+      EJ(C),
+      TJ(C),
+      Some(N.normalizeF(_: C#M[T[C#M]]))).map(_.toList).flatten(x => x)
+
+    cs match {
+      case hd :: tl =>
+        repeatedly(
+          applyTransforms[T, C#M, C#M](hd, tl: _*))
+
+      case Nil => (x => x)
+    }
+  }
+}
+
+sealed trait UnicoalesceQC[T[_[_]], C <: CoM] extends Unicoalesce[T, C]
+
+private[qscript] trait UnicoalesceQCLowPriorityImplicits {
+  implicit def default[T[_[_]], C <: CoM]: UnicoalesceQC[T, C] = new UnicoalesceQC[T, C] {
+    def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]) = None
+  }
+}
+
+object UnicoalesceQC extends UnicoalesceQCLowPriorityImplicits {
+
+  implicit def member[T[_[_]], C <: CoM](
+    implicit
+      QC: QScriptCore[T, ?] :<: C#M): UnicoalesceQC[T, C] = new UnicoalesceQC[T, C] {
+
+    def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]) =
+      Some(C.coalesceQC[C#M](idPrism))
+  }
+}
+
+sealed trait UnicoalesceSR[T[_[_]], C <: CoM] extends Unicoalesce[T, C]
+
+private[qscript] trait UnicoalesceSRLowPriorityImplicits {
+  implicit def default[T[_[_]], C <: CoM]: UnicoalesceSR[T, C] = new UnicoalesceSR[T, C] {
+    def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]) = None
+  }
+}
+
+object UnicoalesceSR extends UnicoalesceSRLowPriorityImplicits {
+
+  // TODO the A might not infer here
+  implicit def member[T[_[_]], A, C <: CoM](
+    implicit
+      QC: QScriptCore[T, ?] :<: C#M,
+      SR: Const[ShiftedRead[A], ?] :<: C#M): UnicoalesceSR[T, C] = new UnicoalesceSR[T, C] {
+
+    def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]) =
+      Some(C.coalesceSR[C#M, A](idPrism))
+  }
+}
+
+sealed trait UnicoalesceEJ[T[_[_]], C <: CoM] extends Unicoalesce[T, C]
+
+private[qscript] trait UnicoalesceEJLowPriorityImplicits {
+  implicit def default[T[_[_]], C <: CoM]: UnicoalesceEJ[T, C] = new UnicoalesceEJ[T, C] {
+    def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]) = None
+  }
+}
+
+object UnicoalesceEJ extends UnicoalesceEJLowPriorityImplicits {
+
+  implicit def member[T[_[_]], C <: CoM](
+    implicit
+      QC: EquiJoin[T, ?] :<: C#M): UnicoalesceEJ[T, C] = new UnicoalesceEJ[T, C] {
+
+    def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]) =
+      Some(C.coalesceEJ[C#M](idPrism.get))
+  }
+}
+
+sealed trait UnicoalesceTJ[T[_[_]], C <: CoM] extends Unicoalesce[T, C]
+
+private[qscript] trait UnicoalesceTJLowPriorityImplicits {
+  implicit def default[T[_[_]], C <: CoM]: UnicoalesceTJ[T, C] = new UnicoalesceTJ[T, C] {
+    def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]) = None
+  }
+}
+
+object UnicoalesceTJ extends UnicoalesceTJLowPriorityImplicits {
+
+  implicit def member[T[_[_]], C <: CoM](
+    implicit
+      QC: ThetaJoin[T, ?] :<: C#M): UnicoalesceTJ[T, C] = new UnicoalesceTJ[T, C] {
+
+    def apply(C: Coalesce.Aux[T, C#M, C#M])(implicit F: Functor[C#M]) =
+      Some(C.coalesceTJ[C#M](idPrism.get))
+  }
+}

--- a/marklogic/src/main/scala/quasar/physical/marklogic/fs/queryfile.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/fs/queryfile.scala
@@ -47,12 +47,14 @@ object queryfile {
 
   type QKvs[F[_], G[_]] = Kvs[G, QueryFile.ResultHandle, impl.DataStream[F]]
 
-  type MLQScript[T[_[_]], A] = (
+  type MLQScriptCP[T[_[_]]] = (
     QScriptCore[T, ?]           :\:
     ThetaJoin[T, ?]             :\:
     Const[ShiftedRead[ADir], ?] :/:
     Const[Read[AFile], ?]
-  )#M[A]
+  )
+
+  type MLQScript[T[_[_]], A] = MLQScriptCP[T]#M[A]
 
   implicit def mlQScriptToQScriptTotal[T[_[_]]]: Injectable.Aux[MLQScript[T, ?], QScriptTotal[T, ?]] =
     ::\::[QScriptCore[T, ?]](::\::[ThetaJoin[T, ?]](::/::[T, Const[ShiftedRead[ADir], ?], Const[Read[AFile], ?]]))
@@ -128,8 +130,6 @@ object queryfile {
     type MLQ[A]  = MLQScript[T, A]
     type QSR[A]  = QScriptRead[T, A]
 
-    val C = Coalesce[T, MLQ, MLQ]
-    val N = Normalizable[MLQ]
     val R = new Rewrite[T]
 
     def logPhase(pr: PhaseResult): F[Unit] =
@@ -144,10 +144,7 @@ object queryfile {
       _         <- logPhase(PhaseResult.tree("QScript (ShiftRead)", shifted))
       optimized =  shifted.transHylo(
                      R.optimize(reflNT[MLQ]),
-                     repeatedly(applyTransforms(
-                       C.coalesceQCNormalize[MLQ](idPrism),
-                       C.coalesceTJNormalize[MLQ](idPrism.get),
-                       C.coalesceSRNormalize[MLQ, ADir](idPrism))))
+                     Unicoalesce[T, MLQScriptCP[T]])
       _         <- logPhase(PhaseResult.tree("QScript (Optimized)", optimized))
       main      <- plan(optimized)
       inputs    =  optimized.cata(ExtractPath[MLQ, APath].extractPath[DList])

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/queryfile.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/queryfile.scala
@@ -40,8 +40,8 @@ import scalaz.concurrent.Task
 
 object queryfile {
 
-  type SparkQScript[A] =
-     (QScriptCore[Fix, ?] :\: EquiJoin[Fix, ?] :/: Const[ShiftedRead[AFile], ?])#M[A]
+  type SparkQScriptCP = QScriptCore[Fix, ?] :\: EquiJoin[Fix, ?] :/: Const[ShiftedRead[AFile], ?]
+  type SparkQScript[A] = SparkQScriptCP#M[A]
 
   implicit val sparkQScriptToQSTotal: Injectable.Aux[SparkQScript, QScriptTotal[Fix, ?]] =
     ::\::[QScriptCore[Fix, ?]](::/::[Fix, EquiJoin[Fix, ?], Const[ShiftedRead[AFile], ?]])
@@ -76,7 +76,6 @@ object queryfile {
     def toQScript(lp: Fix[LogicalPlan]): FileSystemErrT[PhaseResultT[Free[S, ?], ?], Fix[SparkQScript]] = {
       val lc: DiscoverPath.ListContents[FileSystemErrT[PhaseResultT[Free[S, ?],?],?]] =
         (adir: ADir) => EitherT(listContents(input, adir).liftM[PhaseResultT])
-      val C = quasar.qscript.Coalesce[Fix, SparkQScript, SparkQScript]
       val rewrite = new Rewrite[Fix]
       for {
         qs    <- QueryFile.convertToQScriptRead[Fix, FileSystemErrT[PhaseResultT[Free[S, ?],?],?], QScriptRead[Fix, ?]](lc)(lp)
@@ -84,10 +83,7 @@ object queryfile {
                    .flatMap(_.transCataM(ExpandDirs[Fix, SparkQScript0, SparkQScript].expandDirs(idPrism.reverseGet, lc)))
         optQS =  qs.transHylo(
                    rewrite.optimize(reflNT[SparkQScript]),
-                   repeatedly(applyTransforms(
-                     C.coalesceQCNormalize[SparkQScript](idPrism),
-                     C.coalesceEJNormalize[SparkQScript](idPrism.get),
-                     C.coalesceSRNormalize[SparkQScript, AFile](idPrism))))
+                   Unicoalesce[Fix, SparkQScriptCP])
         _     <- EitherT(WriterT[Free[S, ?], PhaseResults, FileSystemError \/ Unit]((Vector(PhaseResult.tree("QScript (Spark)", optQS)), ().right[FileSystemError]).point[Free[S, ?]]))
       } yield optQS
     }


### PR DESCRIPTION
This is the first step towards a more general backend abstraction.  It enables inference of the coalesces used by backends based on the qscript they declare support for.

Fixes #1978