### PR TITLE
Constrain publish to Travis job 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,7 @@ script:
   - if [ $QUASAR_SPARK_LOCAL ]; then echo "spark_local=\"${HOME}/${QUASAR_SPARK_LOCAL}/\"" > $TEST_CONFIG_FILE; fi
   - psql -c 'CREATE DATABASE "quasar-test";' -U postgres
   - ./scripts/build $MONGO_RELEASE
-  - sbt transferPublishAndTagResources
-  - ./scripts/publishAndTag 'quasar-analytics/quasar'
+  - ./scripts/quasarPublishAndTag
 
 after_success: ./scripts/afterSuccess
 

--- a/scripts/quasarPublishAndTag
+++ b/scripts/quasarPublishAndTag
@@ -3,10 +3,12 @@
 set -euo pipefail # STRICT MODE
 IFS=$'\n\t'       # http://redsymbol.net/articles/unofficial-bash-strict-mode/
 
+source scripts/constants
+
 # Only publishAndTag on first Travis job
 if [[ "${TRAVIS_JOB_NUMBER##*.}" == "1" ]]; then
   "$SBT" transferPublishAndTagResources
-  ./scripts/publishAndTag 'quasar-analytics/quasar'
+  scripts/publishAndTag 'quasar-analytics/quasar'
 else
   echo "Travis not running on job 1, so skipping publishAndTag"
 fi

--- a/scripts/quasarPublishAndTag
+++ b/scripts/quasarPublishAndTag
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail # STRICT MODE
+IFS=$'\n\t'       # http://redsymbol.net/articles/unofficial-bash-strict-mode/
+
+# Only publishAndTag on first Travis job
+if [[ "${TRAVIS_JOB_NUMBER##*.}" == "1" ]]; then
+  "$SBT" transferPublishAndTagResources
+  ./scripts/publishAndTag 'quasar-analytics/quasar'
+else
+  echo "Travis not running on job 1, so skipping publishAndTag"
+fi


### PR DESCRIPTION
Ideally sbt-slamdata would offer dependents a way to specify a publish predicate in some fashion. This is a quick interim solution until we spend time on the matter within sbt-slamdata.