### PR TITLE
Basic join branch array pruning

### DIFF
--- a/connector/src/main/scala/quasar/qscript/PruneArrays.scala
+++ b/connector/src/main/scala/quasar/qscript/PruneArrays.scala
@@ -32,21 +32,47 @@ import simulacrum.typeclass
 object PATypes {
   type SeenIndices = Set[BigInt]
   type KnownIndices = Option[SeenIndices]
+  type Indices = ScalaMap[Hole \/ JoinSide, KnownIndices]
+
+  sealed abstract class RewriteState
+  final case object Ignore extends RewriteState
+  final case class Rewrite(indices: Indices) extends RewriteState
+
+  def liftHole(in: ScalaMap[Hole, KnownIndices]): RewriteState =
+    Rewrite(in.mapKeys(_.left))
+
+  def liftJoinSide(in: ScalaMap[JoinSide, KnownIndices]): RewriteState =
+    Rewrite(in.mapKeys(_.right))
 
   implicit final class KnownIndicesOps(val self: KnownIndices) extends AnyVal {
-    /** The standard Semigroup on Option chooses one value if both are `Some`.
-      * This appends them.
+    /** The standard Semigroup on Option appends a Some and a None to result in a Some.
+      * This appends a Some and a None to result in a None.
       */
     def |++|(other: KnownIndices): KnownIndices =
       Semigroup.liftSemigroup[Option, SeenIndices].append(self, other)
+  }
+
+  implicit final class IndicesOps[A](val self: ScalaMap[A, KnownIndices]) extends AnyVal {
+    def |++|(other: ScalaMap[A, KnownIndices]): ScalaMap[A, KnownIndices] =
+      self.unionWith(other)(_ |++| _)
+  }
+
+  implicit def RewriteStateMonoid: Monoid[RewriteState] = new Monoid[RewriteState] {
+    def zero: RewriteState = Rewrite(ScalaMap())
+    def append(f1: RewriteState, f2: => RewriteState): RewriteState =
+      (f1, f2) match {
+        case (Ignore, _) => Ignore
+        case (_, Ignore) => Ignore
+        case (Rewrite(a), Rewrite(b)) => Rewrite(a |++| b)
+      }
   }
 }
 
 @typeclass trait PruneArrays[F[_]] {
   import PATypes._
 
-  def find[M[_], A](in: F[A])(implicit M: MonadState[M, KnownIndices]): M[KnownIndices]
-  def remap[M[_], A](env: KnownIndices, in: F[A])(implicit M: MonadState[M, KnownIndices])
+  def find[M[_], A](in: F[A])(implicit M: MonadState[M, RewriteState]): M[RewriteState]
+  def remap[M[_], A](env: RewriteState, in: F[A])(implicit M: MonadState[M, RewriteState])
       : M[F[A]]
 }
 
@@ -54,13 +80,6 @@ class PAHelpers[T[_[_]]: BirecursiveT: OrderT: EqualT] extends TTypes[T] {
   import PATypes._
 
   type IndexMapping = ScalaMap[BigInt, BigInt]
-
-  def mergeMaps[A](a: ScalaMap[A, KnownIndices], b: ScalaMap[A, KnownIndices]) =
-    a.alignWith(b) {
-      case \&/.This(k)      => k
-      case \&/.That(k)      => k
-      case \&/.Both(k1, k2) => k1 |++| k2
-    }
 
   /** Returns `None` if a non-static non-integer index was found.
     * Else returns all indices of the form `ProjectIndex(SrcHole, IntLit(_))`.
@@ -71,16 +90,16 @@ class PAHelpers[T[_[_]]: BirecursiveT: OrderT: EqualT] extends TTypes[T] {
   def findIndicesInStruct[A](func: Free[MapFunc, A]): ScalaMap[A, KnownIndices] = {
     def accumulateIndices: GAlgebra[(Free[MapFunc, A], ?), MapFunc, ScalaMap[A, KnownIndices]] = {
       case ProjectIndex((src, acc1), (value, acc2)) =>
-        val newMap = mergeMaps(acc1, acc2)
-          (src.project.run, value.project.run) match {
+        val newMap = acc1 |++| acc2
+        (src.project.run, value.project.run) match {
           case (-\/(k), \/-(IntLitMapFunc(idx))) => newMap + (k -> newMap.get(k).fold(Set(idx).some)(_.map(_ + idx))) // static integer index
           case (-\/(k), _)                       => newMap + (k -> none) // non-static index
           case (_,      _)                       => newMap
         }
       // check if entire array is referenced
       case f => f.foldRight(ScalaMap.empty[A, KnownIndices])((elem, acc) => elem match {
-        case (Embed(CoEnv(-\/(k))), value) => mergeMaps(value, acc) + (k -> none)
-        case (_,                    value) => mergeMaps(value, acc)
+        case (Embed(CoEnv(-\/(k))), value) => (value |++| acc) + (k -> none)
+        case (_,                    value) => value |++| acc
       })
     }
 
@@ -90,7 +109,7 @@ class PAHelpers[T[_[_]]: BirecursiveT: OrderT: EqualT] extends TTypes[T] {
     func.para(findIndices)
   }
 
-  def remapResult[A](hole: FreeMapA[A], mapping: IndexMapping, idx: BigInt): CoEnv[A, MapFunc, FreeMapA[A]] =
+  private def remapResult[A](hole: FreeMapA[A], mapping: IndexMapping, idx: BigInt): CoEnv[A, MapFunc, FreeMapA[A]] =
     CoEnv[A, MapFunc, FreeMapA[A]](\/-(ProjectIndex(hole, IntLit(mapping.get(idx).getOrElse(idx)))))
 
   /** Remap all indices in `func` in structures like
@@ -114,7 +133,7 @@ class PAHelpers[T[_[_]]: BirecursiveT: OrderT: EqualT] extends TTypes[T] {
 
   /** Prune the provided `array` keeping only the indices in `indicesToKeep`. */
   def arrayRewrite(array: ConcatArrays[T, JoinFunc], indicesToKeep: Set[Int]): JoinFunc = {
-    val rewrite = new Rewrite[T]
+    val rewrite = new quasar.qscript.Rewrite[T]
 
     def removeUnusedIndices[A](array: List[A], indicesToKeep: Set[Int]): List[A] =
       indicesToKeep.toList.sorted map array
@@ -134,17 +153,25 @@ class PAHelpers[T[_[_]]: BirecursiveT: OrderT: EqualT] extends TTypes[T] {
 object PruneArrays {
   import PATypes._
 
-  private def haltRemap[M[_], A](out: A)(implicit M: MonadState[M, KnownIndices])
-      : M[A] =
-    M.put(none).as(out)
+  private def haltRemap[M[_], A](out: A)(implicit M: MonadState[M, RewriteState]): M[A] =
+    M.put(Ignore).as(out)
 
   private def default[IN[_]]
       : PruneArrays[IN] =
     new PruneArrays[IN] {
-      def find[M[_], A](in: IN[A])(implicit M: MonadState[M, KnownIndices]) =
-        M.put(none).as(none)
-      def remap[M[_], A](env: KnownIndices, in: IN[A])(implicit M: MonadState[M, KnownIndices]) =
+      def find[M[_], A](in: IN[A])(implicit M: MonadState[M, RewriteState]) =
+        M.put(Ignore).as(Ignore)
+      def remap[M[_], A](env: RewriteState, in: IN[A])(implicit M: MonadState[M, RewriteState]) =
         haltRemap(in)
+    }
+
+  private def getIndices(indices: Indices): KnownIndices =
+    indices.get(SrcHole.left).getOrElse(Set.empty[BigInt].some)
+
+  private def remapState[F[_], A](state: RewriteState, default: F[A], mapping: SeenIndices => F[A]): F[A] =
+    state match {
+      case Ignore => default
+      case Rewrite(indices) => getIndices(indices).fold(default)(mapping)
     }
 
   implicit def coproduct[I[_], J[_]]
@@ -152,10 +179,10 @@ object PruneArrays {
       : PruneArrays[Coproduct[I, J, ?]] =
     new PruneArrays[Coproduct[I, J, ?]] {
 
-      def find[M[_], A](in: Coproduct[I, J, A])(implicit M: MonadState[M, KnownIndices]) =
+      def find[M[_], A](in: Coproduct[I, J, A])(implicit M: MonadState[M, RewriteState]) =
         in.run.fold(I.find[M, A], J.find[M, A])
 
-      def remap[M[_], A](env: KnownIndices, in: Coproduct[I, J, A])(implicit M: MonadState[M, KnownIndices]) =
+      def remap[M[_], A](env: RewriteState, in: Coproduct[I, J, A])(implicit M: MonadState[M, RewriteState]) =
         in.run.fold(
           I.remap(env, _) ∘ Coproduct.leftc,
           J.remap(env, _) ∘ Coproduct.rightc)
@@ -180,23 +207,26 @@ object PruneArrays {
       val helpers = new PAHelpers[T]
       import helpers._
 
-      private def findInBucket[M[_]](fm1: FreeMap, fm2: FreeMap)(implicit M: MonadState[M, KnownIndices])
-          : M[KnownIndices] =
-        M.put(extractFromMap(findIndicesInFunc(fm1), SrcHole) |++| extractFromMap(findIndicesInFunc(fm2), SrcHole)).as(none)
+      private def findInBucket[M[_]](fm1: FreeMap, fm2: FreeMap)(implicit M: MonadState[M, RewriteState])
+          : M[RewriteState] =
+        M.put(liftHole(findIndicesInFunc[Hole](fm1)) |+| liftHole(findIndicesInFunc[Hole](fm2))).as(Ignore)
 
-      def find[M[_], A](in: ProjectBucket[A])(implicit M: MonadState[M, KnownIndices]) =
+      def find[M[_], A](in: ProjectBucket[A])(implicit M: MonadState[M, RewriteState]) =
         in match {
           case BucketField(_, value, name) => findInBucket(value, name)
           case BucketIndex(_, value, index) => findInBucket(value, index)
         }
 
-      def remap[M [_], A](env: KnownIndices, in: ProjectBucket[A])(implicit M: MonadState[M, KnownIndices]) =
-        M.get >>= (st => haltRemap(st.fold(in)(indexMapping >>> (repl => in match {
-          case BucketField(src, value, name) =>
-            BucketField(src, remapIndicesInFunc(value, repl), remapIndicesInFunc(name, repl))
-          case BucketIndex(src, value, index) =>
-            BucketIndex(src, remapIndicesInFunc(value, repl), remapIndicesInFunc(index, repl))
-        }))))
+      def remap[M[_], A](env: RewriteState, in: ProjectBucket[A])(implicit M: MonadState[M, RewriteState]) = {
+        val mapping: SeenIndices => ProjectBucket[A] =
+	  indexMapping >>> (repl => in match {
+            case BucketField(src, value, name) =>
+              BucketField(src, remapIndicesInFunc(value, repl), remapIndicesInFunc(name, repl))
+            case BucketIndex(src, value, index) =>
+              BucketIndex(src, remapIndicesInFunc(value, repl), remapIndicesInFunc(index, repl))
+          })
+        M.get >>= (st => haltRemap(remapState(st, in, mapping)))
+      }
     }
 
   implicit def qscriptCore[T[_[_]]: BirecursiveT: OrderT: EqualT]
@@ -206,44 +236,49 @@ object PruneArrays {
       val helpers = new PAHelpers[T]
       import helpers._
 
-      def find[M[_], A](in: QScriptCore[A])(implicit M: MonadState[M, KnownIndices]) =
+      def find[M[_], A](in: QScriptCore[A])(implicit M: MonadState[M, RewriteState]) =
         in match {
           case LeftShift(_, struct, _, repair) =>
-            val newState =
-              extractFromMap(findIndicesInFunc(repair), LeftSide) |++| extractFromMap(findIndicesInFunc(struct), SrcHole)
+            val state: RewriteState =
+              liftHole(findIndicesInFunc[JoinSide](repair).collect {
+                case (LeftSide, i) => (SrcHole, i)
+              }) |+| liftHole(findIndicesInFunc[Hole](struct))
 
-            M.get >>= (st => M.put(newState).as(repair.resume match {
-              case -\/(ConcatArrays(_, _)) => st // annotate state as environment
-              case _                       => none
+            M.get >>= (st => M.put(state).as(repair.resume match {
+              case -\/(ConcatArrays(_, _)) => st  // annotate state as environment
+              case _                       => Ignore
             }))
 
           case Reduce(src, bucket, reducers, _) =>
-            val bucketState: KnownIndices = extractFromMap(findIndicesInFunc(bucket), SrcHole)
-            val reducersState: KnownIndices = reducers.foldMap(_.foldMap[KnownIndices](r => extractFromMap(findIndicesInFunc(r), SrcHole)))
-            M.put(bucketState |++| reducersState).as(none)
+            val bucketIndices: RewriteState =
+	      liftHole(findIndicesInFunc[Hole](bucket))
+            val reducersIndices: RewriteState =
+              reducers.foldMap(_.foldMap[RewriteState](f => liftHole(findIndicesInFunc[Hole](f))))
+
+            M.put(bucketIndices |+| reducersIndices).as(Ignore)
 
           case Union(_, _, _)     => default.find(in) // TODO examine branches
           case Subset(_, _, _, _) => default.find(in) // TODO examine branches
 
-          case Map(_, func)    => M.put(extractFromMap(findIndicesInFunc(func), SrcHole)).as(none)
-          case Filter(_, func) => M.modify(extractFromMap(findIndicesInFunc(func), SrcHole) |++| _).as(none)
+          case Map(_, func)    => M.put(liftHole(findIndicesInFunc[Hole](func))).as(Ignore)
+          case Filter(_, func) => M.modify(liftHole(findIndicesInFunc[Hole](func)) |+| _).as(Ignore)
 
           case Sort(_, bucket, order) =>
-            val bucketState: KnownIndices = extractFromMap(findIndicesInFunc(bucket), SrcHole)
-            val orderState: KnownIndices = order.foldMap {
-              case (f, _) => extractFromMap(findIndicesInFunc(f), SrcHole)
+            val bucketState: RewriteState = liftHole(findIndicesInFunc[Hole](bucket))
+            val orderState: RewriteState = order.foldMap {
+              case (f, _) => liftHole(findIndicesInFunc(f))
             }
-            M.modify(bucketState |++| orderState |++| _).as(none)
+            M.modify(bucketState |+| orderState |+| _).as(Ignore)
 
           case Unreferenced() => default.find(in)
         }
 
-      def remap[M[_], A](env: KnownIndices, in: QScriptCore[A])(implicit M: MonadState[M, KnownIndices]) =
+      def remap[M[_], A](env: RewriteState, in: QScriptCore[A])(implicit M: MonadState[M, RewriteState]) =
         // ignore `env` everywhere except for `LeftShift`
         in match {
           case LeftShift(src, struct, id, repair) =>
-            def rewriteRepair(array: ConcatArrays[T, JoinFunc], acc: SeenIndices): JoinFunc  =
-              arrayRewrite(array, acc.map(_.toInt).toSet)
+            def rewriteRepair(array: ConcatArrays[T, JoinFunc], seen: SeenIndices): JoinFunc  =
+              arrayRewrite(array, seen.map(_.toInt).toSet)
 
             def replacementRemap(repl: IndexMapping): QScriptCore[A] =
               LeftShift(src,
@@ -251,23 +286,28 @@ object PruneArrays {
                 id,
                 remapIndicesInLeftShift(struct, repair, repl))
 
+            def notSeen: M[QScriptCore[A]] =
+              M.get >>= (st => haltRemap(remapState(st, in, indexMapping >>> replacementRemap)))
+
             repair.resume match {
               case -\/(array @ ConcatArrays(_, _)) =>
-                env.cata(
-                  acc => {
-                    def replacement(repl: IndexMapping): QScriptCore[A] =
-                      LeftShift(src,
-                        remapIndicesInFunc(struct, repl),
-                        id,
-                        remapIndicesInLeftShift(struct, rewriteRepair(array, acc), repl))
-                    M.put(env).as(
-                      env.fold[QScriptCore[A]](
-                        LeftShift(src, struct, id, rewriteRepair(array, acc)))(
-                        indexMapping >>> replacement))
-                  },
-                  M.get >>= (st => haltRemap(st.fold(in)(indexMapping >>> replacementRemap))))
-              case _ =>
-                M.get >>= (st => haltRemap(st.fold(in)(indexMapping >>> replacementRemap)))
+                env match {
+                  case Ignore => notSeen
+                  case Rewrite(indices) =>
+                    getIndices(indices).cata(
+                      seen => {
+                        def replacement(repl: IndexMapping): QScriptCore[A] =
+                          LeftShift(src,
+                            remapIndicesInFunc(struct, repl),
+                            id,
+                            remapIndicesInLeftShift(struct, rewriteRepair(array, seen), repl))
+                        M.put(env).as(
+                          getIndices(indices).fold[QScriptCore[A]](
+                            LeftShift(src, struct, id, rewriteRepair(array, seen)))(
+                            indexMapping >>> replacement))
+                      }, notSeen)
+                }
+              case _ => notSeen
             }
 
           case Reduce(src, bucket0, reducers0, repair) =>
@@ -277,7 +317,7 @@ object PruneArrays {
                 remapIndicesInFunc(bucket0, repl),
                 reducers0.map(_.map(remapIndicesInFunc(_, repl))),
                 repair)
-            M.get >>= (st => haltRemap(st.fold(in)(indexMapping >>> replacement)))
+            M.get >>= (st => haltRemap(remapState(st, in, indexMapping >>> replacement)))
 
           case Union(_, _, _)     => default.remap(env, in) // TODO examine branches
           case Subset(_, _, _, _) => default.remap(env, in) // TODO examine branches
@@ -285,12 +325,12 @@ object PruneArrays {
           case Map(src, func) =>
             def replacement(repl: IndexMapping): QScriptCore[A] =
               Map(src, remapIndicesInFunc(func, repl))
-            M.get >>= (st => haltRemap(st.fold(in)(indexMapping >>> replacement)))
+            M.get >>= (st => haltRemap(remapState(st, in, indexMapping >>> replacement)))
 
           case Filter(src, func) =>
             def replacement(repl: IndexMapping): QScriptCore[A] =
               Filter(src, remapIndicesInFunc(func, repl))
-            M.get ∘ (_.fold(in)(indexMapping >>> replacement))
+            M.get ∘ (remapState(_, in, indexMapping >>> replacement))
 
           case Sort(src, bucket0, order0) =>
             def replacement(repl: IndexMapping): QScriptCore[A] =
@@ -298,7 +338,7 @@ object PruneArrays {
                 src,
                 remapIndicesInFunc(bucket0, repl),
                 order0.map(_.leftMap(remapIndicesInFunc(_, repl))))
-            M.get ∘ (_.fold(in)(indexMapping >>> replacement))
+            M.get ∘ (remapState(_, in, indexMapping >>> replacement))
 
           case Unreferenced() => default.remap(env, in)
         }
@@ -308,7 +348,7 @@ object PruneArrays {
 class PAFindRemap[T[_[_]]: BirecursiveT, F[_]: Functor] {
   import PATypes._
 
-  type ArrayEnv[G[_], A] = EnvT[KnownIndices, G, A]
+  type ArrayEnv[G[_], A] = EnvT[RewriteState, G, A]
 
   /** Given an input, we accumulate state and annotate the focus.
     *
@@ -319,7 +359,7 @@ class PAFindRemap[T[_[_]]: BirecursiveT, F[_]: Functor] {
     * If the focus is an array that can be pruned, the annotatation is set to
     * the state. Else the annotation is set to `None`.
     */
-  def findIndices[M[_]](implicit M: MonadState[M, KnownIndices], P: PruneArrays[F])
+  def findIndices[M[_]](implicit M: MonadState[M, RewriteState], P: PruneArrays[F])
       : CoalgebraM[M, ArrayEnv[F, ?], T[F]] = tqs => {
     val gtg = tqs.project
     P.find(gtg) ∘ (newEnv => EnvT((newEnv, gtg)))
@@ -332,9 +372,9 @@ class PAFindRemap[T[_[_]]: BirecursiveT, F[_]: Functor] {
     * If an array has an associated environment, we update the state
     * to be the environment and prune the array.
     */
-  def remapIndices[M[_]](implicit M: MonadState[M, KnownIndices], P: PruneArrays[F])
+  def remapIndices[M[_]](implicit M: MonadState[M, RewriteState], P: PruneArrays[F])
       : AlgebraM[M, ArrayEnv[F, ?], T[F]] = arrenv => {
-    val (env, qs): (KnownIndices, F[T[F]]) = arrenv.run
+    val (env, qs): (RewriteState, F[T[F]]) = arrenv.run
 
     P.remap(env, qs) ∘ (_.embed)
   }

--- a/connector/src/main/scala/quasar/qscript/package.scala
+++ b/connector/src/main/scala/quasar/qscript/package.scala
@@ -222,7 +222,7 @@ package object qscript {
       (implicit PA: PruneArrays[F], T: BirecursiveT[T], TF: Traverse[F])
         : T[F] = {
       val pa = new PAFindRemap[T, F]
-      self.hyloM[State[PATypes.KnownIndices, ?], pa.ArrayEnv[F, ?], T[F]](pa.remapIndices, pa.findIndices).run(none)._2
+      self.hyloM[State[PATypes.RewriteState, ?], pa.ArrayEnv[F, ?], T[F]](pa.remapIndices, pa.findIndices).run(PATypes.Ignore)._2
     }
   }
 }

--- a/connector/src/test/scala/quasar/qscript/PruneArrays.scala
+++ b/connector/src/test/scala/quasar/qscript/PruneArrays.scala
@@ -653,6 +653,43 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
       initial.pruneArrays must equal(initial)
     }
 
+    // this can be rewritten - we just don't support that yet
+    "not rewrite theta join with filtered left shift as branch" in {
+      val initial: Fix[QST] =
+        TJT.inj(ThetaJoin(
+          UnreferencedRT.embed,
+	  Free.roll(QCT.inj(Filter(arrayBranch3, ProjectIndexR(HoleF, IntLit[Fix, Hole](1))))),
+          HoleQS,
+          EqR(
+	    ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](2)),
+	    StrLit[Fix, JoinSide]("foo")),
+          JoinType.Inner,
+          MakeMapR(
+	    StrLit[Fix, JoinSide]("bar"),
+	    ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](1))))).embed
+
+      initial.pruneArrays must equal(initial)
+    }
+
+    // this can be rewritten - we just don't support that yet
+    "not rewrite equi join with filtered left shift as branch" in {
+      val initial: Fix[QST] =
+        EJT.inj(EquiJoin(
+          UnreferencedRT.embed,
+	  Free.roll(QCT.inj(Filter(arrayBranch3, ProjectIndexR(HoleF, IntLit[Fix, Hole](1))))),
+          HoleQS,
+          EqR(
+	    ProjectIndexR(HoleF, IntLit[Fix, Hole](2)),
+	    StrLit[Fix, Hole]("foo")),
+	  HoleF,
+          JoinType.Inner,
+          MakeMapR(
+	    StrLit[Fix, JoinSide]("bar"),
+	    ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](1))))).embed
+
+      initial.pruneArrays must equal(initial)
+    }
+
     "rewrite theta join with unused array elements in both branches" in {
       val rBranch: FreeQS =
         Free.roll(QCT.inj(LeftShift(

--- a/connector/src/test/scala/quasar/qscript/PruneArrays.scala
+++ b/connector/src/test/scala/quasar/qscript/PruneArrays.scala
@@ -308,7 +308,7 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     "not rewrite leftshift with nonstatic array dereference" in {
       val initial: Fix[QST] =
         QCT.inj(Map(
-	  array3,
+          array3,
           AddR(
             ProjectIndexR(HoleF, IntLit(2)),
             ProjectIndexR(HoleF, AddR(IntLit(0), IntLit(1)))))).embed
@@ -486,7 +486,7 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     "rewrite bucket index with unused array elements" in {
       val initial: Fix[QST] =
         PBT.inj(BucketIndex(
-	  array3,
+          array3,
           ProjectIndexR(HoleF, IntLit(2)),
           ProjectIndexR(HoleF, IntLit(0)))).embed
 
@@ -573,14 +573,14 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
       val initial: Fix[QST] =
         EJT.inj(EquiJoin(
           UnreferencedRT.embed,
-	  arrayBranch3,
+          arrayBranch3,
           HoleQS,
-	  HoleF,  // reference entire left branch
+          HoleF,  // reference entire left branch
           HoleF,
           JoinType.Inner,
           MakeMapR(
-	    StrLit("xyz"),
-	    ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](2))))).embed
+            StrLit("xyz"),
+            ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](2))))).embed
 
       initial.pruneArrays must equal(initial)
     }
@@ -589,15 +589,15 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
       val initial: Fix[QST] =
         TJT.inj(ThetaJoin(
           UnreferencedRT.embed,
-	  arrayBranch3,
+          arrayBranch3,
           HoleQS,
-	  EqR(
-	    AddR(LeftSideF, IntLit[Fix, JoinSide](2)),  // reference entire left branch
-	    RightSideF),
+          EqR(
+            AddR(LeftSideF, IntLit[Fix, JoinSide](2)),  // reference entire left branch
+            RightSideF),
           JoinType.Inner,
           MakeMapR(
-	    StrLit("xyz"),
-	    ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](2))))).embed
+            StrLit("xyz"),
+            ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](2))))).embed
 
       initial.pruneArrays must equal(initial)
     }
@@ -606,14 +606,14 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
       val initial: Fix[QST] =
         EJT.inj(EquiJoin(
           UnreferencedRT.embed,
-	  arrayBranch3,
+          arrayBranch3,
           HoleQS,
           ProjectIndexR(HoleF, IntLit[Fix, Hole](2)),
           HoleF,
           JoinType.Inner,
           MakeMapR(
-	    StrLit("xyz"),
-	    LeftSideF))).embed  // reference entire left branch
+            StrLit("xyz"),
+            LeftSideF))).embed  // reference entire left branch
 
       initial.pruneArrays must equal(initial)
     }
@@ -622,13 +622,13 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
       val initial: Fix[QST] =
         TJT.inj(ThetaJoin(
           UnreferencedRT.embed,
-	  arrayBranch3,
+          arrayBranch3,
           HoleQS,
           ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](2)),
           JoinType.Inner,
           MakeMapR(
-	    StrLit("xyz"),
-	    LeftSideF))).embed  // reference entire left branch
+            StrLit("xyz"),
+            LeftSideF))).embed  // reference entire left branch
 
       initial.pruneArrays must equal(initial)
     }
@@ -640,15 +640,15 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
         QCT.inj(Map(
           EJT.inj(EquiJoin(
             UnreferencedRT.embed,
-	    arrayBranch3,
+            arrayBranch3,
             HoleQS,
             ProjectIndexR(HoleF, IntLit[Fix, Hole](2)),
             HoleF,
             JoinType.Inner,
             ConcatArraysR(MakeArrayR(LeftSideF), MakeArrayR(RightSideF)))).embed,
-	  ProjectIndexR(
-	    ProjectIndexR(HoleF, IntLit[Fix, Hole](0)),
-	    IntLit[Fix, Hole](2)))).embed
+          ProjectIndexR(
+            ProjectIndexR(HoleF, IntLit[Fix, Hole](0)),
+            IntLit[Fix, Hole](2)))).embed
 
       initial.pruneArrays must equal(initial)
     }
@@ -658,15 +658,15 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
       val initial: Fix[QST] =
         TJT.inj(ThetaJoin(
           UnreferencedRT.embed,
-	  Free.roll(QCT.inj(Filter(arrayBranch3, ProjectIndexR(HoleF, IntLit[Fix, Hole](1))))),
+          Free.roll(QCT.inj(Filter(arrayBranch3, ProjectIndexR(HoleF, IntLit[Fix, Hole](1))))),
           HoleQS,
           EqR(
-	    ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](2)),
-	    StrLit[Fix, JoinSide]("foo")),
+            ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](2)),
+            StrLit[Fix, JoinSide]("foo")),
           JoinType.Inner,
           MakeMapR(
-	    StrLit[Fix, JoinSide]("bar"),
-	    ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](1))))).embed
+            StrLit[Fix, JoinSide]("bar"),
+            ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](1))))).embed
 
       initial.pruneArrays must equal(initial)
     }
@@ -676,16 +676,16 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
       val initial: Fix[QST] =
         EJT.inj(EquiJoin(
           UnreferencedRT.embed,
-	  Free.roll(QCT.inj(Filter(arrayBranch3, ProjectIndexR(HoleF, IntLit[Fix, Hole](1))))),
+          Free.roll(QCT.inj(Filter(arrayBranch3, ProjectIndexR(HoleF, IntLit[Fix, Hole](1))))),
           HoleQS,
           EqR(
-	    ProjectIndexR(HoleF, IntLit[Fix, Hole](2)),
-	    StrLit[Fix, Hole]("foo")),
-	  HoleF,
+            ProjectIndexR(HoleF, IntLit[Fix, Hole](2)),
+            StrLit[Fix, Hole]("foo")),
+          HoleF,
           JoinType.Inner,
           MakeMapR(
-	    StrLit[Fix, JoinSide]("bar"),
-	    ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](1))))).embed
+            StrLit[Fix, JoinSide]("bar"),
+            ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](1))))).embed
 
       initial.pruneArrays must equal(initial)
     }
@@ -705,15 +705,15 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
       val initial: Fix[QST] =
         TJT.inj(ThetaJoin(
           UnreferencedRT.embed,
-	  arrayBranch3,
+          arrayBranch3,
           rBranch,
           EqR(
-	    ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](2)),
-	    ProjectIndexR(RightSideF, IntLit[Fix, JoinSide](0))),
+            ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](2)),
+            ProjectIndexR(RightSideF, IntLit[Fix, JoinSide](0))),
           JoinType.Inner,
           MakeMapR(
-	    ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](2)),
-	    ProjectIndexR(RightSideF, IntLit[Fix, JoinSide](2))))).embed
+            ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](2)),
+            ProjectIndexR(RightSideF, IntLit[Fix, JoinSide](2))))).embed
 
       val lBranchExpected: FreeQS =
         Free.roll(QCT.inj(LeftShift(
@@ -735,15 +735,15 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
       val expected: Fix[QST] =
         TJT.inj(ThetaJoin(
           UnreferencedRT.embed,
-	  lBranchExpected,
+          lBranchExpected,
           rBranchExpected,
           EqR(
-	    ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](0)),
-	    ProjectIndexR(RightSideF, IntLit[Fix, JoinSide](0))),
+            ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](0)),
+            ProjectIndexR(RightSideF, IntLit[Fix, JoinSide](0))),
           JoinType.Inner,
           MakeMapR(
-	    ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](0)),
-	    ProjectIndexR(RightSideF, IntLit[Fix, JoinSide](1))))).embed
+            ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](0)),
+            ProjectIndexR(RightSideF, IntLit[Fix, JoinSide](1))))).embed
 
       initial.pruneArrays must equal(expected)
     }
@@ -763,14 +763,14 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
       val initial: Fix[QST] =
         EJT.inj(EquiJoin(
           UnreferencedRT.embed,
-	  arrayBranch3,
+          arrayBranch3,
           rBranch,
           ProjectIndexR(HoleF, IntLit[Fix, Hole](2)),
           ProjectIndexR(HoleF, IntLit[Fix, Hole](0)),
           JoinType.Inner,
           MakeMapR(
-	    ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](2)),
-	    ProjectIndexR(RightSideF, IntLit[Fix, JoinSide](2))))).embed
+            ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](2)),
+            ProjectIndexR(RightSideF, IntLit[Fix, JoinSide](2))))).embed
 
       val lBranchExpected: FreeQS =
         Free.roll(QCT.inj(LeftShift(
@@ -792,14 +792,14 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
       val expected: Fix[QST] =
         EJT.inj(EquiJoin(
           UnreferencedRT.embed,
-	  lBranchExpected,
+          lBranchExpected,
           rBranchExpected,
           ProjectIndexR(HoleF, IntLit[Fix, Hole](0)),
           ProjectIndexR(HoleF, IntLit[Fix, Hole](0)),
           JoinType.Inner,
           MakeMapR(
-	    ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](0)),
-	    ProjectIndexR(RightSideF, IntLit[Fix, JoinSide](1))))).embed
+            ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](0)),
+            ProjectIndexR(RightSideF, IntLit[Fix, JoinSide](1))))).embed
 
       initial.pruneArrays must equal(expected)
     }

--- a/connector/src/test/scala/quasar/qscript/PruneArrays.scala
+++ b/connector/src/test/scala/quasar/qscript/PruneArrays.scala
@@ -28,6 +28,23 @@ import pathy.Path._
 import scalaz._, Scalaz._
 
 class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers {
+  private def makeLeftShift3[A](src: A): QST[A] =
+    QCT.inj(LeftShift(
+      src,
+      HoleF,
+      ExcludeId,
+      ConcatArraysR(
+        ConcatArraysR(
+          MakeArrayR(IntLit(6)),
+          MakeArrayR(IntLit(7))),
+        MakeArrayR(IntLit(8)))))
+
+  private val arrayBranch3: FreeQS =
+    Free.roll(makeLeftShift3[FreeQS](HoleQS))
+
+  private val array3: Fix[QST] =
+    makeLeftShift3[Fix[QST]](UnreferencedRT.embed).embed
+
   "prune arrays" should {
     "rewrite map-filter with unused array elements" in {
       def initial(src: QST[Fix[QST]]): Fix[QST] =
@@ -193,15 +210,7 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     "not rewrite map with entire array referenced" in {
       val initial: Fix[QST] =
         QCT.inj(Map(
-          QCT.inj(LeftShift(
-            UnreferencedRT.embed,
-            HoleF,
-            ExcludeId,
-            ConcatArraysR(
-              ConcatArraysR(
-                MakeArrayR(IntLit(6)),
-                MakeArrayR(IntLit(7))),
-              MakeArrayR(IntLit(8))))).embed,
+          array3,
           HoleF)).embed
 
       initial.pruneArrays must equal(initial)
@@ -210,15 +219,7 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     "not rewrite map with entire array and specific index referenced" in {
       val initial: Fix[QST] =
         QCT.inj(Map(
-          QCT.inj(LeftShift(
-            UnreferencedRT.embed,
-            HoleF,
-            ExcludeId,
-            ConcatArraysR(
-              ConcatArraysR(
-                MakeArrayR(IntLit(6)),
-                MakeArrayR(IntLit(7))),
-              MakeArrayR(IntLit(8))))).embed,
+          array3,
           ConcatArraysR(
             MakeArrayR(ProjectIndexR(HoleF, IntLit(0))),
             MakeArrayR(HoleF)))).embed
@@ -229,15 +230,7 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     "rewrite map with unused array elements 1,2" in {
       val initial: Fix[QST] =
         QCT.inj(Map(
-          QCT.inj(LeftShift(
-            UnreferencedRT.embed,
-            HoleF,
-            ExcludeId,
-            ConcatArraysR(
-              ConcatArraysR(
-                MakeArrayR(IntLit(6)),
-                MakeArrayR(IntLit(7))),
-              MakeArrayR(IntLit(8))))).embed,
+          array3,
           ProjectIndexR(HoleF, IntLit(0)))).embed
 
       val expected: Fix[QST] =
@@ -255,15 +248,7 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     "rewrite map with unused array elements 0,2" in {
       val initial: Fix[QST] =
         QCT.inj(Map(
-          QCT.inj(LeftShift(
-            UnreferencedRT.embed,
-            HoleF,
-            ExcludeId,
-            ConcatArraysR(
-              ConcatArraysR(
-                MakeArrayR(IntLit(6)),
-                MakeArrayR(IntLit(7))),
-              MakeArrayR(IntLit(8))))).embed,
+          array3,
           ProjectIndexR(HoleF, IntLit(1)))).embed
 
       val expected: Fix[QST] =
@@ -281,15 +266,7 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     "rewrite map with unused array elements 0,1" in {
       val initial: Fix[QST] =
         QCT.inj(Map(
-          QCT.inj(LeftShift(
-            UnreferencedRT.embed,
-            HoleF,
-            ExcludeId,
-            ConcatArraysR(
-              ConcatArraysR(
-                MakeArrayR(IntLit(6)),
-                MakeArrayR(IntLit(7))),
-              MakeArrayR(IntLit(8))))).embed,
+          array3,
           ProjectIndexR(HoleF, IntLit(2)))).embed
 
       val expected: Fix[QST] =
@@ -307,15 +284,7 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     "rewrite map with unused array elements in a binary map func" in {
       val initial: Fix[QST] =
         QCT.inj(Map(
-          QCT.inj(LeftShift(
-            UnreferencedRT.embed,
-            HoleF,
-            ExcludeId,
-            ConcatArraysR(
-              ConcatArraysR(
-                MakeArrayR(IntLit(6)),
-                MakeArrayR(IntLit(7))),
-              MakeArrayR(IntLit(8))))).embed,
+          array3,
           AddR(
             ProjectIndexR(HoleF, IntLit(2)),
             ProjectIndexR(HoleF, IntLit(0))))).embed
@@ -339,15 +308,7 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     "not rewrite leftshift with nonstatic array dereference" in {
       val initial: Fix[QST] =
         QCT.inj(Map(
-          QCT.inj(LeftShift(
-            UnreferencedRT.embed,
-            HoleF,
-            ExcludeId,
-            ConcatArraysR(
-              ConcatArraysR(
-                MakeArrayR(IntLit(6)),
-                MakeArrayR(IntLit(7))),
-              MakeArrayR(IntLit(8))))).embed,
+	  array3,
           AddR(
             ProjectIndexR(HoleF, IntLit(2)),
             ProjectIndexR(HoleF, AddR(IntLit(0), IntLit(1)))))).embed
@@ -525,15 +486,7 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     "rewrite bucket index with unused array elements" in {
       val initial: Fix[QST] =
         PBT.inj(BucketIndex(
-          QCT.inj(LeftShift(
-            UnreferencedRT.embed,
-            HoleF,
-            ExcludeId,
-            ConcatArraysR(
-              ConcatArraysR(
-                MakeArrayR(IntLit(6)),
-                MakeArrayR(IntLit(7))),
-              MakeArrayR(IntLit(8))))).embed,
+	  array3,
           ProjectIndexR(HoleF, IntLit(2)),
           ProjectIndexR(HoleF, IntLit(0)))).embed
 
@@ -554,20 +507,9 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
 
     // this can be rewritten - we just don't support that yet
     "not rewrite subset with unused array elements" in {
-      val src: Fix[QST] =
-        QCT.inj(LeftShift(
-          UnreferencedRT.embed,
-          HoleF,
-          ExcludeId,
-          ConcatArraysR(
-            ConcatArraysR(
-              MakeArrayR(IntLit(6)),
-              MakeArrayR(IntLit(7))),
-            MakeArrayR(IntLit(8))))).embed
-
       val initial: Fix[QST] =
         QCT.inj(Subset(
-          src,
+          array3,
           Free.roll(QCT.inj(Map(
             HoleQS,
             ProjectIndexR(HoleF, IntLit[Fix, Hole](2))))),
@@ -581,20 +523,9 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
 
     // this can be rewritten - we just don't support that yet
     "not rewrite union with unused array elements" in {
-      val src: Fix[QST] =
-        QCT.inj(LeftShift(
-          UnreferencedRT.embed,
-          HoleF,
-          ExcludeId,
-          ConcatArraysR(
-            ConcatArraysR(
-              MakeArrayR(IntLit(6)),
-              MakeArrayR(IntLit(7))),
-            MakeArrayR(IntLit(8))))).embed
-
       val initial: Fix[QST] =
         QCT.inj(Union(
-          src,
+          array3,
           Free.roll(QCT.inj(Map(
             HoleQS,
             ProjectIndexR(HoleF, IntLit[Fix, Hole](2))))),
@@ -607,20 +538,9 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
 
     // this can be rewritten - we just don't support that yet
     "not rewrite theta join with unused array elements in source" in {
-      val src: Fix[QST] =
-        QCT.inj(LeftShift(
-          UnreferencedRT.embed,
-          HoleF,
-          ExcludeId,
-          ConcatArraysR(
-            ConcatArraysR(
-              MakeArrayR(IntLit(6)),
-              MakeArrayR(IntLit(7))),
-            MakeArrayR(IntLit(8))))).embed
-
       val initial: Fix[QST] =
         TJT.inj(ThetaJoin(
-          src,
+          array3,
           Free.roll(QCT.inj(Map(
             HoleQS,
             ProjectIndexR(HoleF, IntLit[Fix, Hole](2))))),
@@ -634,20 +554,9 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
 
     // this can be rewritten - we just don't support that yet
     "not rewrite equi join with unused array elements in source" in {
-      val src: Fix[QST] =
-        QCT.inj(LeftShift(
-          UnreferencedRT.embed,
-          HoleF,
-          ExcludeId,
-          ConcatArraysR(
-            ConcatArraysR(
-              MakeArrayR(IntLit(6)),
-              MakeArrayR(IntLit(7))),
-            MakeArrayR(IntLit(8))))).embed
-
       val initial: Fix[QST] =
         EJT.inj(EquiJoin(
-          src,
+          array3,
           Free.roll(QCT.inj(Map(
             HoleQS,
             ProjectIndexR(HoleF, IntLit[Fix, Hole](2))))),
@@ -661,21 +570,10 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     }
 
     "not rewrite equi join with entire array branch referenced in key" in {
-      val lBranch: FreeQS =
-        Free.roll(QCT.inj(LeftShift(
-          HoleQS,
-          HoleF,
-          ExcludeId,
-          ConcatArraysR(
-            ConcatArraysR(
-              MakeArrayR(IntLit(6)),
-              MakeArrayR(IntLit(7))),
-            MakeArrayR(IntLit(8))))))
-
       val initial: Fix[QST] =
         EJT.inj(EquiJoin(
           UnreferencedRT.embed,
-	  lBranch,
+	  arrayBranch3,
           HoleQS,
 	  HoleF,  // reference entire left branch
           HoleF,
@@ -688,21 +586,10 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     }
 
     "not rewrite theta join with entire array branch referenced in condition" in {
-      val lBranch: FreeQS =
-        Free.roll(QCT.inj(LeftShift(
-          HoleQS,
-          HoleF,
-          ExcludeId,
-          ConcatArraysR(
-            ConcatArraysR(
-              MakeArrayR(IntLit(6)),
-              MakeArrayR(IntLit(7))),
-            MakeArrayR(IntLit(8))))))
-
       val initial: Fix[QST] =
         TJT.inj(ThetaJoin(
           UnreferencedRT.embed,
-	  lBranch,
+	  arrayBranch3,
           HoleQS,
 	  EqR(
 	    AddR(LeftSideF, IntLit[Fix, JoinSide](2)),  // reference entire left branch
@@ -716,21 +603,10 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     }
 
     "not rewrite equi join with entire array branch referenced in combine" in {
-      val lBranch: FreeQS =
-        Free.roll(QCT.inj(LeftShift(
-          HoleQS,
-          HoleF,
-          ExcludeId,
-          ConcatArraysR(
-            ConcatArraysR(
-              MakeArrayR(IntLit(6)),
-              MakeArrayR(IntLit(7))),
-            MakeArrayR(IntLit(8))))))
-
       val initial: Fix[QST] =
         EJT.inj(EquiJoin(
           UnreferencedRT.embed,
-	  lBranch,
+	  arrayBranch3,
           HoleQS,
           ProjectIndexR(HoleF, IntLit[Fix, Hole](2)),
           HoleF,
@@ -743,21 +619,10 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     }
 
     "not rewrite theta join with entire array branch referenced in combine" in {
-      val lBranch: FreeQS =
-        Free.roll(QCT.inj(LeftShift(
-          HoleQS,
-          HoleF,
-          ExcludeId,
-          ConcatArraysR(
-            ConcatArraysR(
-              MakeArrayR(IntLit(6)),
-              MakeArrayR(IntLit(7))),
-            MakeArrayR(IntLit(8))))))
-
       val initial: Fix[QST] =
         TJT.inj(ThetaJoin(
           UnreferencedRT.embed,
-	  lBranch,
+	  arrayBranch3,
           HoleQS,
           ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](2)),
           JoinType.Inner,
@@ -771,22 +636,11 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     // we'd like to be able to rewrite this
     // but it might require more work in addition to array pruning
     "not rewrite equi join with array branch referenced outside of join" in {
-      val lBranch: FreeQS =
-        Free.roll(QCT.inj(LeftShift(
-          HoleQS,
-          HoleF,
-          ExcludeId,
-          ConcatArraysR(
-            ConcatArraysR(
-              MakeArrayR(IntLit(6)),
-              MakeArrayR(IntLit(7))),
-            MakeArrayR(IntLit(8))))))
-
       val initial: Fix[QST] =
         QCT.inj(Map(
           EJT.inj(EquiJoin(
             UnreferencedRT.embed,
-	    lBranch,
+	    arrayBranch3,
             HoleQS,
             ProjectIndexR(HoleF, IntLit[Fix, Hole](2)),
             HoleF,
@@ -800,17 +654,6 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     }
 
     "rewrite theta join with unused array elements in both branches" in {
-      val lBranch: FreeQS =
-        Free.roll(QCT.inj(LeftShift(
-          HoleQS,
-          HoleF,
-          ExcludeId,
-          ConcatArraysR(
-            ConcatArraysR(
-              MakeArrayR(IntLit(6)),
-              MakeArrayR(IntLit(7))),
-            MakeArrayR(IntLit(8))))))
-
       val rBranch: FreeQS =
         Free.roll(QCT.inj(LeftShift(
           HoleQS,
@@ -825,7 +668,7 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
       val initial: Fix[QST] =
         TJT.inj(ThetaJoin(
           UnreferencedRT.embed,
-	  lBranch,
+	  arrayBranch3,
           rBranch,
           EqR(
 	    ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](2)),
@@ -869,17 +712,6 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     }
 
     "rewrite equi join with unused array elements in both branches" in {
-      val lBranch: FreeQS =
-        Free.roll(QCT.inj(LeftShift(
-          HoleQS,
-          HoleF,
-          ExcludeId,
-          ConcatArraysR(
-            ConcatArraysR(
-              MakeArrayR(IntLit(6)),
-              MakeArrayR(IntLit(7))),
-            MakeArrayR(IntLit(8))))))
-
       val rBranch: FreeQS =
         Free.roll(QCT.inj(LeftShift(
           HoleQS,
@@ -894,7 +726,7 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
       val initial: Fix[QST] =
         EJT.inj(EquiJoin(
           UnreferencedRT.embed,
-	  lBranch,
+	  arrayBranch3,
           rBranch,
           ProjectIndexR(HoleF, IntLit[Fix, Hole](2)),
           ProjectIndexR(HoleF, IntLit[Fix, Hole](0)),
@@ -936,20 +768,9 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     }
 
     "rewrite left shift with array referenced through struct" in {
-      val initialSrc: Fix[QST] =
-        QCT.inj(LeftShift(
-          UnreferencedRT.embed,
-          HoleF,
-          ExcludeId,
-          ConcatArraysR(
-            ConcatArraysR(
-              MakeArrayR(IntLit(6)),
-              MakeArrayR(IntLit(7))),
-            MakeArrayR(IntLit(8))))).embed
-
       val initial: Fix[QST] =
         QCT.inj(LeftShift(
-          initialSrc,
+          array3,
           ProjectIndexR(HoleF, IntLit[Fix, Hole](2)),
           ExcludeId,
           MakeMapR(StrLit("xyz"), RightSideF))).embed
@@ -972,20 +793,9 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     }
 
     "not rewrite left shift with entire array referenced through left side" in {
-      val initialSrc: Fix[QST] =
-        QCT.inj(LeftShift(
-          UnreferencedRT.embed,
-          HoleF,
-          ExcludeId,
-          ConcatArraysR(
-            ConcatArraysR(
-              MakeArrayR(IntLit(6)),
-              MakeArrayR(IntLit(7))),
-            MakeArrayR(IntLit(8))))).embed
-
       val initial: Fix[QST] =
         QCT.inj(LeftShift(
-          initialSrc,
+          array3,
           ProjectIndexR(HoleF, IntLit[Fix, Hole](2)),
           ExcludeId,
           MakeMapR(StrLit("xyz"), LeftSideF))).embed
@@ -994,20 +804,9 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     }
 
     "not rewrite left shift with array referenced non-statically through struct" in {
-      val initialSrc: Fix[QST] =
-        QCT.inj(LeftShift(
-          UnreferencedRT.embed,
-          HoleF,
-          ExcludeId,
-          ConcatArraysR(
-            ConcatArraysR(
-              MakeArrayR(IntLit(6)),
-              MakeArrayR(IntLit(7))),
-            MakeArrayR(IntLit(8))))).embed
-
       val initial: Fix[QST] =
         QCT.inj(LeftShift(
-          initialSrc,
+          array3,
           ProjectIndexR(HoleF, AddR(IntLit(0), IntLit(1))),
           ExcludeId,
           MakeMapR(StrLit("xyz"), LeftSideF))).embed
@@ -1016,20 +815,9 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     }
 
     "rewrite left shift with array referenced through left side and struct" in {
-      val initialSrc: Fix[QST] =
-        QCT.inj(LeftShift(
-          UnreferencedRT.embed,
-          HoleF,
-          ExcludeId,
-          ConcatArraysR(
-            ConcatArraysR(
-              MakeArrayR(IntLit(6)),
-              MakeArrayR(IntLit(7))),
-            MakeArrayR(IntLit(8))))).embed
-
       val initial: Fix[QST] =
         QCT.inj(LeftShift(
-          initialSrc,
+          array3,
           ProjectIndexR(HoleF, IntLit[Fix, Hole](2)),
           ExcludeId,
           ProjectIndexR(LeftSideF, IntLit[Fix, JoinSide](1)))).embed
@@ -1091,20 +879,9 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     }
 
     "rewrite left shift with entire array unreferenced" in {
-      val initialSrc: Fix[QST] =
-        QCT.inj(LeftShift(
-          UnreferencedRT.embed,
-          HoleF,
-          ExcludeId,
-          ConcatArraysR(
-            ConcatArraysR(
-              MakeArrayR(IntLit(6)),
-              MakeArrayR(IntLit(7))),
-            MakeArrayR(IntLit(8))))).embed
-
       val initial: Fix[QST] =
         QCT.inj(LeftShift(
-          initialSrc,
+          array3,
           IntLit(2),
           ExcludeId,
           AddR(IntLit[Fix, JoinSide](2), IntLit[Fix, JoinSide](3)))).embed
@@ -1127,20 +904,9 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     }
 
     "not rewrite left shift with entire array referenced by the right side" in {
-      val initialSrc: Fix[QST] =
-        QCT.inj(LeftShift(
-          UnreferencedRT.embed,
-          HoleF,
-          ExcludeId,
-          ConcatArraysR(
-            ConcatArraysR(
-              MakeArrayR(IntLit(6)),
-              MakeArrayR(IntLit(7))),
-            MakeArrayR(IntLit(8))))).embed
-
       val initial: Fix[QST] =
         QCT.inj(LeftShift(
-          initialSrc,
+          array3,
           HoleF,
           ExcludeId,
           RightSideF)).embed
@@ -1149,20 +915,9 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
     }
 
     "not rewrite left shift with entire array referenced by the left side" in {
-      val initialSrc: Fix[QST] =
-        QCT.inj(LeftShift(
-          UnreferencedRT.embed,
-          HoleF,
-          ExcludeId,
-          ConcatArraysR(
-            ConcatArraysR(
-              MakeArrayR(IntLit(6)),
-              MakeArrayR(IntLit(7))),
-            MakeArrayR(IntLit(8))))).embed
-
       val initial: Fix[QST] =
         QCT.inj(LeftShift(
-          initialSrc,
+          array3,
           HoleF,
           ExcludeId,
           LeftSideF)).embed

--- a/connector/src/test/scala/quasar/qscript/PruneArrays.scala
+++ b/connector/src/test/scala/quasar/qscript/PruneArrays.scala
@@ -505,7 +505,7 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
       initial.pruneArrays must equal(expected)
     }
 
-    // this can be rewritten - we just don't support that yet
+    // FIXME: this can be rewritten - we just don't support that yet
     "not rewrite subset with unused array elements" in {
       val initial: Fix[QST] =
         QCT.inj(Subset(
@@ -521,7 +521,7 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
       initial.pruneArrays must equal(initial)
     }
 
-    // this can be rewritten - we just don't support that yet
+    // FIXME: this can be rewritten - we just don't support that yet
     "not rewrite union with unused array elements" in {
       val initial: Fix[QST] =
         QCT.inj(Union(
@@ -536,7 +536,7 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
       initial.pruneArrays must equal(initial)
     }
 
-    // this can be rewritten - we just don't support that yet
+    // FIXME: this can be rewritten - we just don't support that yet
     "not rewrite theta join with unused array elements in source" in {
       val initial: Fix[QST] =
         TJT.inj(ThetaJoin(
@@ -552,7 +552,7 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
       initial.pruneArrays must equal(initial)
     }
 
-    // this can be rewritten - we just don't support that yet
+    // FIXME: this can be rewritten - we just don't support that yet
     "not rewrite equi join with unused array elements in source" in {
       val initial: Fix[QST] =
         EJT.inj(EquiJoin(
@@ -633,7 +633,7 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
       initial.pruneArrays must equal(initial)
     }
 
-    // we'd like to be able to rewrite this
+    // FIXME: we'd like to be able to rewrite this
     // but it might require more work in addition to array pruning
     "not rewrite equi join with array branch referenced outside of join" in {
       val initial: Fix[QST] =
@@ -653,7 +653,7 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
       initial.pruneArrays must equal(initial)
     }
 
-    // this can be rewritten - we just don't support that yet
+    // FIXME: this can be rewritten - we just don't support that yet
     "not rewrite theta join with filtered left shift as branch" in {
       val initial: Fix[QST] =
         TJT.inj(ThetaJoin(
@@ -671,7 +671,7 @@ class QScriptPruneArraysSpec extends quasar.Qspec with CompilerHelpers with QScr
       initial.pruneArrays must equal(initial)
     }
 
-    // this can be rewritten - we just don't support that yet
+    // FIXME: this can be rewritten - we just don't support that yet
     "not rewrite equi join with filtered left shift as branch" in {
       val initial: Fix[QST] =
         EJT.inj(EquiJoin(

--- a/connector/src/test/scala/quasar/qscript/QScript.scala
+++ b/connector/src/test/scala/quasar/qscript/QScript.scala
@@ -223,23 +223,19 @@ class QScriptSpec
               ProjectFieldR(HoleF, StrLit("foo"))))),
             HoleF,
             IncludeId,
-            Free.roll(ConcatArrays(
-              Free.roll(MakeArray(LeftSideF)),
-              Free.roll(MakeArray(RightSideF))))))),
+            Free.roll(MakeArray(RightSideF))))),
           Free.roll(QCT.inj(LeftShift(
             Free.roll(QCT.inj(Map(
               Free.point(SrcHole),
               ProjectFieldR(HoleF, StrLit("bar"))))),
             HoleF,
             IncludeId,
-            Free.roll(ConcatArrays(
-              Free.roll(MakeArray(LeftSideF)),
-              Free.roll(MakeArray(RightSideF))))))),
+            Free.roll(MakeArray(RightSideF))))),
           BoolLit(true),
           JoinType.Inner,
           Free.roll(Add(
-            ProjectIndexR(ProjectIndexR(LeftSideF, IntLit(1)), IntLit(1)),
-            ProjectIndexR(ProjectIndexR(RightSideF, IntLit(1)), IntLit(1)))))))))
+            ProjectIndexR(ProjectIndexR(LeftSideF, IntLit(0)), IntLit(1)),
+            ProjectIndexR(ProjectIndexR(RightSideF, IntLit(0)), IntLit(1)))))))))
     }
 
     "convert project object and make object" in {
@@ -494,21 +490,17 @@ class QScriptSpec
             Free.roll(RTF.inj(Const(Read(rootDir </> file("person"))))),
             HoleF,
             IncludeId,
-            Free.roll(ConcatArrays(
-              Free.roll(MakeArray(LeftSideF)),
-              Free.roll(MakeArray(RightSideF))))))),
+            Free.roll(MakeArray(RightSideF))))),
           Free.roll(QCT.inj(LeftShift(
             Free.roll(RTF.inj(Const(Read(rootDir </> file("car"))))),
             HoleF,
             IncludeId,
-            Free.roll(ConcatArrays(
-              Free.roll(MakeArray(LeftSideF)),
-              Free.roll(MakeArray(RightSideF))))))),
+            Free.roll(MakeArray(RightSideF))))),
           BoolLit(true),
           JoinType.Inner,
           Free.roll(ConcatMaps(
-            ProjectIndexR(ProjectIndexR(LeftSideF, IntLit(1)), IntLit(1)),
-            ProjectIndexR(ProjectIndexR(RightSideF, IntLit(1)), IntLit(1)))))))))
+            ProjectIndexR(ProjectIndexR(LeftSideF, IntLit(0)), IntLit(1)),
+            ProjectIndexR(ProjectIndexR(RightSideF, IntLit(0)), IntLit(1)))))))))
     }
 
     // TODO #1794 prune arrays

--- a/connector/src/test/scala/quasar/qscript/QScriptHelpers.scala
+++ b/connector/src/test/scala/quasar/qscript/QScriptHelpers.scala
@@ -24,7 +24,6 @@ import quasar.ejson, ejson.EJson
 import quasar.fp._
 import quasar.fs._
 import quasar.frontend.logicalplan.{LogicalPlan => LP}
-import quasar.qscript.MapFuncs._
 import quasar.sql.CompilerHelpers
 
 import scala.Predef.implicitly
@@ -83,31 +82,35 @@ trait QScriptHelpers extends CompilerHelpers with TTypes[Fix] {
 
   def ProjectFieldR[A](src: FreeMapA[A], field: FreeMapA[A]):
       FreeMapA[A] =
-    Free.roll(ProjectField(src, field))
+    Free.roll(MapFuncs.ProjectField(src, field))
 
   def ProjectIndexR[A](src: FreeMapA[A], field: FreeMapA[A]):
       FreeMapA[A] =
-    Free.roll(ProjectIndex(src, field))
+    Free.roll(MapFuncs.ProjectIndex(src, field))
 
   def MakeArrayR[A](src: FreeMapA[A]):
       FreeMapA[A] =
-    Free.roll(MakeArray(src))
+    Free.roll(MapFuncs.MakeArray(src))
 
   def MakeMapR[A](key: FreeMapA[A], src: FreeMapA[A]):
       FreeMapA[A] =
-    Free.roll(MakeMap(key, src))
+    Free.roll(MapFuncs.MakeMap(key, src))
 
   def ConcatArraysR[A](left: FreeMapA[A], right: FreeMapA[A]):
       FreeMapA[A] =
-    Free.roll(ConcatArrays(left, right))
+    Free.roll(MapFuncs.ConcatArrays(left, right))
 
   def ConcatMapsR[A](left: FreeMapA[A], right: FreeMapA[A]):
       FreeMapA[A] =
-    Free.roll(ConcatMaps(left, right))
+    Free.roll(MapFuncs.ConcatMaps(left, right))
 
   def AddR[A](left: FreeMapA[A], right: FreeMapA[A]):
       FreeMapA[A] =
-    Free.roll(Add(left, right))
+    Free.roll(MapFuncs.Add(left, right))
+
+  def EqR[A](left: FreeMapA[A], right: FreeMapA[A]):
+      FreeMapA[A] =
+    Free.roll(MapFuncs.Eq(left, right))
 
   def lpRead(path: String): Fix[LP] =
     lpf.read(sandboxAbs(posixCodec.parseAbsFile(path).get))


### PR DESCRIPTION
If the left and/or right branch of a qscript join is a `LeftShift` with a `combine` func that is an array, then in some cases we can rewrite the array produced by that `LeftShift`, namely when only some (but not all) elements of that array are used in the join condition and join combine.

Closes #1794 