### PR TITLE
Fixes sql ident parser to comply with SQL92 rules.

### DIFF
--- a/frontend/src/main/scala/quasar/sql/package.scala
+++ b/frontend/src/main/scala/quasar/sql/package.scala
@@ -145,7 +145,7 @@ package object sql {
 
   def pprint[T](sql: T)(implicit T: Recursive.Aux[T, Sql]) = sql.para(pprintƒ)
 
-  private val SimpleNamePattern = "[_a-zA-Z][_a-zA-Z0-9]*".r
+  private val SimpleNamePattern = "[a-zA-Z][_a-zA-Z0-9]*".r
 
   private def _q(s: String): String = "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
 

--- a/frontend/src/main/scala/quasar/sql/parser.scala
+++ b/frontend/src/main/scala/quasar/sql/parser.scala
@@ -63,7 +63,7 @@ private[sql] class SQLParser[T[_[_]]: BirecursiveT]
       delim
 
     def identifierString: Parser[String] =
-      ((letter | elem('_')) ~ rep(digit | letter | elem('_'))) ^^ {
+      letter ~ rep(digit | letter | elem('_')) ^^ {
         case x ~ xs => (x :: xs).mkString
       }
 
@@ -101,7 +101,6 @@ private[sql] class SQLParser[T[_[_]]: BirecursiveT]
       "org.wartremover.warts.Serializable"))
     def identParser: Parser[Token] =
       quotedIdentParser | identifierString ^^ processIdent
-
 
     override def whitespace: Parser[scala.Any] = rep(
       whitespaceChar |

--- a/frontend/src/test/scala/quasar/sql/ExprArbitrary.scala
+++ b/frontend/src/test/scala/quasar/sql/ExprArbitrary.scala
@@ -19,7 +19,6 @@ package quasar.sql
 import slamdata.Predef._
 import quasar.common.JoinType._
 import quasar.contrib.pathy._, PathArbitrary._
-import quasar.contrib.scalacheck.gen
 import quasar.sql.fixpoint._
 
 import matryoshka.data.Fix
@@ -172,8 +171,10 @@ trait ExprArbitrary {
     genIdentString map (Vari(_))
 
   private def genIdentString: Gen[String] =
-    Gen.listOf(gen.printableAsciiChar) map (_.filter(_ ≠ '`').mkString)
-
+    for {
+      c <- Gen.alphaChar
+      cs <- Gen.listOf(Gen.frequency((1, '_'), (62, Gen.alphaNumChar)))
+    } yield (c :: cs).mkString
 }
 
 object ExprArbitrary extends ExprArbitrary

--- a/frontend/src/test/scala/quasar/sql/SqlSpec.scala
+++ b/frontend/src/test/scala/quasar/sql/SqlSpec.scala
@@ -30,14 +30,14 @@ class SQLSpec extends quasar.Qspec {
   "namedProjections" should {
     "create unique names" >> {
       "when two fields have the same name" in {
-        val query = "SELECT owner.name, car.name from owners as owner join cars as car on car._id = owner.carId"
+        val query = "SELECT owner.name, car.name from owners as owner join cars as car on car.`_id` = owner.carId"
         val projections = fixParser.parseExpr(query).toOption.get.project.asInstanceOf[Select[Fix[Sql]]].projections
         projectionNames(projections, None) must beLike { case \/-(list) =>
           list.map(_._1) must contain(allOf("name", "name0"))
         }
       }
       "when a field and an alias have the same name" in {
-        val query = "SELECT owner.name, car.model as name from owners as owner join cars as car on car._id = owner.carId"
+        val query = "SELECT owner.name, car.model as name from owners as owner join cars as car on car.`_id` = owner.carId"
         val projections = fixParser.parseExpr(query).toOption.get.project.asInstanceOf[Select[Fix[Sql]]].projections
         projectionNames(projections, None) must beLike { case \/-(list) =>
           list.map(_._1) must contain(allOf("name0", "name"))

--- a/it/src/main/resources/tests/convertFromString.test
+++ b/it/src/main/resources/tests/convertFromString.test
@@ -5,7 +5,7 @@
         "postgresql":        "pending"
     },
     "data": "smallZips.data",
-    "query": "select integer(_id) as intId, decimal(_id) as decId from smallZips",
+    "query": "select integer(`_id`) as intId, decimal(`_id`) as decId from smallZips",
     "predicate": "containsAtLeast",
     "ignoreFieldOrder": [ "couchbase", "marklogic_json" ],
     "expected": [

--- a/it/src/main/resources/tests/convertToFromString.test
+++ b/it/src/main/resources/tests/convertToFromString.test
@@ -5,7 +5,7 @@
         "postgresql":        "pending"
     },
     "data": "zips.data",
-    "query": "select integer(_id) as intId, decimal(_id) as decId, to_string(pop) as popStr, to_string(loc[0]) as locStr, to_string(length(city) < 9) as boolStr from zips",
+    "query": "select integer(`_id`) as intId, decimal(`_id`) as decId, to_string(pop) as popStr, to_string(loc[0]) as locStr, to_string(length(city) < 9) as boolStr from zips",
     "predicate": "containsAtLeast",
     "ignoreFieldOrder": ["couchbase", "marklogic_json"],
     "expected": [

--- a/it/src/main/resources/tests/filterOnFieldComparison.test
+++ b/it/src/main/resources/tests/filterOnFieldComparison.test
@@ -5,7 +5,7 @@
         "postgresql":        "pending"
     },
     "data": "zips.data",
-    "query": "select * from zips where pop < loc[1] order by _id limit 10",
+    "query": "select * from zips where pop < loc[1] order by `_id` limit 10",
     "predicate": "equalsExactly",
     "ignoreFieldOrder": ["marklogic_json"],
     "expected": [

--- a/it/src/main/resources/tests/filterOnOid.test
+++ b/it/src/main/resources/tests/filterOnOid.test
@@ -5,7 +5,7 @@
         "postgresql": "pending"
     },
     "data": "days.data",
-    "query": "select day from days where _id = oid(\"54b6f430d4c654959e963a62\")",
+    "query": "select day from days where `_id` = oid(\"54b6f430d4c654959e963a62\")",
     "predicate": "containsExactly",
     "expected": ["Sunday"]
 }

--- a/it/src/main/resources/tests/filterWithComplexNot.test
+++ b/it/src/main/resources/tests/filterWithComplexNot.test
@@ -11,7 +11,7 @@
 
     "data": "largeZips.data",
 
-    "query": "select _id as zip from largeZips
+    "query": "select `_id` as zip from largeZips
               where not (city not like \"BOULD%\" or state != \"CO\" or (pop between 20000 and 40000 and loc[1] != 40.017235))",
 
     "predicate": "containsExactly",

--- a/it/src/main/resources/tests/flattenArrayLeftWithUnflattened.test
+++ b/it/src/main/resources/tests/flattenArrayLeftWithUnflattened.test
@@ -6,7 +6,7 @@
         "postgresql": "pending"
     },
     "data": "zips.data",
-    "query": "SELECT loc[*] as coord, _id as zip FROM zips",
+    "query": "SELECT loc[*] as coord, `_id` as zip FROM zips",
     "predicate": "containsAtLeast",
     "ignoreFieldOrder": ["marklogic_json"],
     "expected": [

--- a/it/src/main/resources/tests/flattenArrayWithUnflattened.test
+++ b/it/src/main/resources/tests/flattenArrayWithUnflattened.test
@@ -6,7 +6,7 @@
         "postgresql": "pending"
     },
     "data": "zips.data",
-    "query": "SELECT _id as zip, loc as loc, loc[*] as coord FROM zips",
+    "query": "SELECT `_id` as zip, loc as loc, loc[*] as coord FROM zips",
     "predicate": "containsAtLeast",
     "ignoreFieldOrder": ["marklogic_json"],
     "expected": [

--- a/it/src/main/resources/tests/groupAndWildcard.test
+++ b/it/src/main/resources/tests/groupAndWildcard.test
@@ -7,7 +7,7 @@
 
   "data": "zips.data",
 
-  "query": "select * from zips where _id like \"8030%\" group by city",
+  "query": "select * from zips where `_id` like \"8030%\" group by city",
 
   "predicate": "containsExactly",
 

--- a/it/src/main/resources/tests/idAliased.test
+++ b/it/src/main/resources/tests/idAliased.test
@@ -7,7 +7,7 @@
 
   "data": "zips.data",
 
-  "query": "select _id as zip from zips where city = \"BOULDER\" and state = \"CO\"",
+  "query": "select `_id` as zip from zips where city = \"BOULDER\" and state = \"CO\"",
 
   "predicate": "containsExactly",
 

--- a/it/src/main/resources/tests/joins/3WayJoin.test
+++ b/it/src/main/resources/tests/joins/3WayJoin.test
@@ -11,8 +11,8 @@
     "data": ["../extraSmallZips.data", "../smallZips.data", "../zips.data"],
     "query": "select z1.city, z2.state
               from `../extraSmallZips` as z1
-              join `../smallZips` as z2 on z1._id = z2._id
-              join `../zips` as z3 on z2._id = z3._id",
+              join `../smallZips` as z2 on z1.`_id` = z2.`_id`
+              join `../zips` as z3 on z2.`_id` = z3.`_id`",
     "predicate": "containsAtLeast",
     "expected": [{ "city": "AGAWAM",        "state": "MA" },
                  { "city": "CUSHMAN",       "state": "MA" },

--- a/it/src/main/resources/tests/joins/constantOnLeft.test
+++ b/it/src/main/resources/tests/joins/constantOnLeft.test
@@ -12,8 +12,8 @@
 
     "data": ["../smallZips.data", "../zips.data"],
 
-    "query": "select smallZips.city, zips.state from `../smallZips`, `../zips` where smallZips._id = zips._id
-            and \"MA\" = zips.state",
+    "query": "select smallZips.city, zips.state from `../smallZips`, `../zips`
+              where smallZips.`_id` = zips.`_id` and \"MA\" = zips.state",
 
     "predicate": "containsAtLeast",
 

--- a/it/src/main/resources/tests/joins/crossJoin.test
+++ b/it/src/main/resources/tests/joins/crossJoin.test
@@ -12,7 +12,7 @@
 
     "data": ["../smallZips.data", "../zips.data"],
 
-    "query": "select smallZips.city, zips.state from `../smallZips`, `../zips` where smallZips._id = zips._id",
+    "query": "select smallZips.city, zips.state from `../smallZips`, `../zips` where smallZips.`_id` = zips.`_id`",
 
     "predicate": "containsAtLeast",
 

--- a/it/src/main/resources/tests/joins/crossJoinWithOneSidedConditions.test
+++ b/it/src/main/resources/tests/joins/crossJoinWithOneSidedConditions.test
@@ -12,7 +12,7 @@
 
     "query": "select a.city as a, b.city as b, b.pop - a.pop as diff
             from `../zips` as a, `../largeZips` as b
-            where a._id like \"80301\" and b._id like \"95928\"",
+            where a.`_id` like \"80301\" and b.`_id` like \"95928\"",
 
     "predicate": "equalsExactly",
 

--- a/it/src/main/resources/tests/joins/innerEquiJoin.test
+++ b/it/src/main/resources/tests/joins/innerEquiJoin.test
@@ -9,7 +9,7 @@
         "couchbase":         "skip"
     },
     "data": ["../smallZips.data", "../zips.data"],
-    "query": "select smallZips.city, zips.state from `../smallZips` join `../zips` on smallZips._id = zips._id",
+    "query": "select smallZips.city, zips.state from `../smallZips` join `../zips` on smallZips.`_id` = zips.`_id`",
     "predicate": "containsAtLeast",
     "expected": [{"city": "AGAWAM",       "state": "MA"},
                  {"city": "CUSHMAN",      "state": "MA"},

--- a/it/src/main/resources/tests/joins/innerEquiJoinWithWildcard.test
+++ b/it/src/main/resources/tests/joins/innerEquiJoinWithWildcard.test
@@ -9,7 +9,7 @@
         "couchbase":         "skip"
     },
     "data": ["../smallZips.data", "../zips.data"],
-    "query": "select * from `../smallZips` join `../zips` on smallZips._id = zips._id",
+    "query": "select * from `../smallZips` join `../zips` on smallZips.`_id` = zips.`_id`",
     "predicate": "containsAtLeast",
     "expected": [
         {"_id":"01001", "city":"AGAWAM",       "loc":[-72.622739,42.070206], "pop":15338, "state":"MA"},

--- a/it/src/main/resources/tests/joins/orderJoinByAlias.test
+++ b/it/src/main/resources/tests/joins/orderJoinByAlias.test
@@ -9,7 +9,7 @@
         "couchbase":         "skip"
     },
     "data": ["../smallZips.data", "../zips.data"],
-    "query": "select z1._id as zip, z2.pop / 1000 as popK from `../smallZips` as z1 inner join `../zips` as z2 on z1._id = z2._id order by popK desc",
+    "query": "select z1.`_id` as zip, z2.pop / 1000 as popK from `../smallZips` as z1 inner join `../zips` as z2 on z1.`_id` = z2.`_id` order by popK desc",
     "predicate": "equalsInitial",
     "expected": [{ "zip": "01201", "popK": 50.655 },
                  { "zip": "01040", "popK": 43.704 },

--- a/it/src/main/resources/tests/joins/sameFieldName.test
+++ b/it/src/main/resources/tests/joins/sameFieldName.test
@@ -7,7 +7,7 @@
         "postgresql":        "pending"
     },
     "data": ["../owners.data", "../cars.data"],
-    "query": "SELECT owner.name, car.name from `../owners` as owner join `../cars` as car on car._id = owner.carId",
+    "query": "SELECT owner.name, car.name from `../owners` as owner join `../cars` as car on car.`_id` = owner.carId",
     "predicate": "containsExactly",
     "ignoreFieldOrder": ["marklogic_json"],
     "expected": [{ "name": "emma",  "name0": "RangeRover-Evoque" },

--- a/it/src/main/resources/tests/joins/sameFieldNameComplex.test
+++ b/it/src/main/resources/tests/joins/sameFieldNameComplex.test
@@ -8,7 +8,7 @@
         "postgresql":        "pending"
     },
     "data": ["../owners.data", "../cars.data"],
-    "query": "SELECT owner.name, car.name from `../owners` as owner join `../cars` as car on car._id = owner.carId and owner.year = car.year[0]",
+    "query": "SELECT owner.name, car.name from `../owners` as owner join `../cars` as car on car.`_id` = owner.carId and owner.year = car.year[0]",
     "predicate": "containsExactly",
     "ignoreFieldOrder": ["marklogic_json"],
     "expected": [{ "name": "emma",  "name0": "RangeRover-Evoque" },

--- a/it/src/main/resources/tests/joins/selfjoinConstantOnLeft.test
+++ b/it/src/main/resources/tests/joins/selfjoinConstantOnLeft.test
@@ -16,8 +16,8 @@
 
     "data": "../largeZips.data",
 
-    "query": "select a.city, b.state from `../largeZips` as a, `../largeZips` as b where a._id = b._id
-            and \"CA\" = b.state",
+    "query": "select a.city, b.state from `../largeZips` as a, `../largeZips` as b
+              where a.`_id` = b.`_id` and \"CA\" = b.state",
 
     "predicate": "containsAtLeast",
     "expected": [{ "city": "REDONDO BEACH", "state": "CA" }]

--- a/it/src/main/resources/tests/manySimpleProjections.test
+++ b/it/src/main/resources/tests/manySimpleProjections.test
@@ -7,7 +7,7 @@
 
   "data": "zips.data",
 
-  "query": "select city as a, city as b, city as c, city as d, city as e, city as f from zips where _id = \"80301\"",
+  "query": "select city as a, city as b, city as c, city as d, city as e, city as f from zips where `_id` = \"80301\"",
 
   "predicate": "containsExactly",
 

--- a/it/src/main/resources/tests/simpleProjectWithOneRenamed.test
+++ b/it/src/main/resources/tests/simpleProjectWithOneRenamed.test
@@ -11,7 +11,7 @@
 
     "data": "zips.data",
 
-    "query": "select _id as zip, city from zips where pop = 18174",
+    "query": "select `_id` as zip, city from zips where pop = 18174",
 
     "predicate": "containsExactly",
     "ignoreFieldOrder": ["couchbase"],

--- a/it/src/main/resources/tests/unifyFlattenedFieldsWithMultipleUses.test
+++ b/it/src/main/resources/tests/unifyFlattenedFieldsWithMultipleUses.test
@@ -10,7 +10,7 @@
         "spark_hdfs": "pending"
     },
     "data": "zips.data",
-    "query": "select _id as zip, loc[*] from zips where loc[*] > 68 order by loc[*]",
+    "query": "select `_id` as zip, loc[*] from zips where loc[*] > 68 order by loc[*]",
     "predicate": "equalsExactly",
     "expected": [{ "zip": "99722", "loc": 68.077395},
                  { "zip": "99721", "loc": 68.11878},

--- a/it/src/main/resources/tests/unifyFlattenedFieldsWithUnflattened.test
+++ b/it/src/main/resources/tests/unifyFlattenedFieldsWithUnflattened.test
@@ -10,7 +10,7 @@
         "spark_hdfs": "pending"
     },
     "data": "zips.data",
-    "query": "select _id as zip, loc[*] from zips order by loc[*] limit 10",
+    "query": "select `_id` as zip, loc[*] from zips order by loc[*] limit 10",
     "predicate": "equalsExactly",
     "expected": [{ "zip": "99742", "loc": -171.701685},
                  { "zip": "99769", "loc": -170.470908},

--- a/it/src/main/resources/tests/union.test
+++ b/it/src/main/resources/tests/union.test
@@ -7,7 +7,7 @@
         "couchbase":         "skip"
     },
     "data": "zips.data",
-    "query": "select _id as zip from zips union select city, state from zips",
+    "query": "select `_id` as zip from zips union select city, state from zips",
     "predicate": "containsAtLeast",
     "expected": [
         { "zip": "01001" },

--- a/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -1971,7 +1971,7 @@ class PlannerSpec extends
     }
 
     "plan array flatten with unflattened field" in {
-      plan("SELECT _id as zip, loc as loc, loc[*] as coord FROM zips") must
+      plan("SELECT `_id` as zip, loc as loc, loc[*] as coord FROM zips") must
         beWorkflow {
           chain[Workflow](
             $read(collection("db", "zips")),
@@ -2052,7 +2052,7 @@ class PlannerSpec extends
     }
 
     "unify flattened fields with unflattened field" in {
-      plan("select _id as zip, loc[*] from zips order by loc[*]") must
+      plan("select `_id` as zip, loc[*] from zips order by loc[*]") must
       beWorkflow(chain[Workflow](
         $read(collection("db", "zips")),
         $project(
@@ -2623,7 +2623,7 @@ class PlannerSpec extends
     "plan js and filter with id" in {
       Bson.ObjectId.fromString("0123456789abcdef01234567").fold[Result](
         failure("Couldn’t create ObjectId."))(
-        oid => plan("""select length(city), foo = oid("0123456789abcdef01234567") from days where _id = oid("0123456789abcdef01234567")""") must
+        oid => plan("""select length(city), foo = oid("0123456789abcdef01234567") from days where `_id` = oid("0123456789abcdef01234567")""") must
           beWorkflow(chain[Workflow](
             $read(collection("db", "days")),
             $match(Selector.Doc(
@@ -2760,7 +2760,7 @@ class PlannerSpec extends
       Crystallize[WorkflowF].crystallize(joinStructure0(left, leftName, leftBase, right, leftKey, rightKey, fin, swapped))
 
     "plan simple join (map-reduce)" in {
-      plan2_6("select zips2.city from zips join zips2 on zips._id = zips2._id") must
+      plan2_6("select zips2.city from zips join zips2 on zips.`_id` = zips2.`_id`") must
         beWorkflow(
           joinStructure(
             $read(collection("db", "zips")), "__tmp0", $$ROOT,
@@ -2786,7 +2786,7 @@ class PlannerSpec extends
     }
 
     "plan simple join ($lookup)" in {
-      plan("select zips2.city from zips join zips2 on zips._id = zips2._id") must
+      plan("select zips2.city from zips join zips2 on zips.`_id` = zips2.`_id`") must
         beWorkflow(chain[Workflow](
           $read(collection("db", "zips")),
           $match(Selector.Doc(
@@ -2811,7 +2811,7 @@ class PlannerSpec extends
 
     "plan simple join with sharded inputs" in {
       // NB: cannot use $lookup, so fall back to the old approach
-      val query = "select zips2.city from zips join zips2 on zips._id = zips2._id"
+      val query = "select zips2.city from zips join zips2 on zips.`_id` = zips2.`_id`"
       plan3_2(query,
         c => Map(
           collection("db", "zips") -> CollectionStatistics(10, 100, true),
@@ -2822,7 +2822,7 @@ class PlannerSpec extends
 
     "plan simple join with sources in different DBs" in {
       // NB: cannot use $lookup, so fall back to the old approach
-      val query = "select zips2.city from `/db1/zips` join `/db2/zips2` on zips._id = zips2._id"
+      val query = "select zips2.city from `/db1/zips` join `/db2/zips2` on zips.`_id` = zips2.`_id`"
       plan(query) must_== plan2_6(query)
     }
 
@@ -2833,7 +2833,7 @@ class PlannerSpec extends
     }
 
     "plan non-equi join" in {
-      plan("select zips2.city from zips join zips2 on zips._id < zips2._id") must
+      plan("select zips2.city from zips join zips2 on zips.`_id` < zips2.`_id`") must
       beWorkflow(
         joinStructure(
           $read(collection("db", "zips")), "__tmp0", $$ROOT,
@@ -3313,7 +3313,7 @@ class PlannerSpec extends
 
     "plan count of $lookup" in {
       plan3_2(
-        "select tp._id, count(*) from `zips` as tp join `largeZips` as ti on tp._id = ti.TestProgramId group by tp._id",
+        "select tp.`_id`, count(*) from `zips` as tp join `largeZips` as ti on tp.`_id` = ti.TestProgramId group by tp.`_id`",
         defaultStats,
         indexes()) must
       beWorkflow(chain[Workflow](

--- a/mongodb/src/test/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -2002,7 +2002,7 @@ class PlannerQScriptSpec extends
     }.pendingUntilFixed(notOnPar)
 
     "plan array flatten with unflattened field" in {
-      plan("SELECT _id as zip, loc as loc, loc[*] as coord FROM zips") must
+      plan("SELECT `_id` as zip, loc as loc, loc[*] as coord FROM zips") must
         beWorkflow {
           chain[Workflow](
             $read(collection("db", "zips")),
@@ -2083,7 +2083,7 @@ class PlannerQScriptSpec extends
     }.pendingUntilFixed(notOnPar)
 
     "unify flattened fields with unflattened field" in {
-      plan("select _id as zip, loc[*] from zips order by loc[*]") must
+      plan("select `_id` as zip, loc[*] from zips order by loc[*]") must
       beWorkflow(chain[Workflow](
         $read(collection("db", "zips")),
         $project(
@@ -2653,7 +2653,7 @@ class PlannerQScriptSpec extends
     "plan js and filter with id" in {
       Bson.ObjectId.fromString("0123456789abcdef01234567").fold[Result](
         failure("Couldn’t create ObjectId."))(
-        oid => plan("""select length(city), foo = oid("0123456789abcdef01234567") from days where _id = oid("0123456789abcdef01234567")""") must
+        oid => plan("""select length(city), foo = oid("0123456789abcdef01234567") from days where `_id` = oid("0123456789abcdef01234567")""") must
           beWorkflow(chain[Workflow](
             $read(collection("db", "days")),
             $match(Selector.Doc(
@@ -2790,7 +2790,7 @@ class PlannerQScriptSpec extends
       Crystallize[WorkflowF].crystallize(joinStructure0(left, leftName, leftBase, right, leftKey, rightKey, fin, swapped))
 
     "plan simple join (map-reduce)" in {
-      plan2_6("select zips2.city from zips join zips2 on zips._id = zips2._id") must
+      plan2_6("select zips2.city from zips join zips2 on zips.`_id` = zips2.`_id`") must
         beWorkflow(
           joinStructure(
             $read(collection("db", "zips")), "__tmp0", $$ROOT,
@@ -2816,7 +2816,7 @@ class PlannerQScriptSpec extends
     }.pendingUntilFixed("#1560")
 
     "plan simple join ($lookup)" in {
-      plan("select zips2.city from zips join zips2 on zips._id = zips2._id") must
+      plan("select zips2.city from zips join zips2 on zips.`_id` = zips2.`_id`") must
         beWorkflow(chain[Workflow](
           $read(collection("db", "zips")),
           $match(Selector.Doc(
@@ -2841,7 +2841,7 @@ class PlannerQScriptSpec extends
 
     "plan simple join with sharded inputs" in {
       // NB: cannot use $lookup, so fall back to the old approach
-      val query = "select zips2.city from zips join zips2 on zips._id = zips2._id"
+      val query = "select zips2.city from zips join zips2 on zips.`_id` = zips2.`_id`"
       plan3_2(query,
         c => Map(
           collection("db", "zips") -> CollectionStatistics(10, 100, true),
@@ -2852,7 +2852,7 @@ class PlannerQScriptSpec extends
 
     "plan simple join with sources in different DBs" in {
       // NB: cannot use $lookup, so fall back to the old approach
-      val query = "select zips2.city from `/db1/zips` join `/db2/zips2` on zips._id = zips2._id"
+      val query = "select zips2.city from `/db1/zips` join `/db2/zips2` on zips.`_id` = zips2.`_id`"
       plan(query) must_== plan2_6(query)
     }
 
@@ -2863,7 +2863,7 @@ class PlannerQScriptSpec extends
     }
 
     "plan non-equi join" in {
-      plan("select zips2.city from zips join zips2 on zips._id < zips2._id") must
+      plan("select zips2.city from zips join zips2 on zips.`_id` < zips2.`_id`") must
       beWorkflow(
         joinStructure(
           $read(collection("db", "zips")), "__tmp0", $$ROOT,

--- a/sql/src/test/scala/quasar/sql/compiler.scala
+++ b/sql/src/test/scala/quasar/sql/compiler.scala
@@ -1656,7 +1656,7 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
     }
 
     "fail with duplicate alias" in {
-      compile("select car.name as name, owner.name as name from owners as owner join cars as car on car._id = owner.carId") must
+      compile("select car.name as name, owner.name as name from owners as owner join cars as car on car.`_id` = owner.carId") must
         beLeftDisjunction("DuplicateAlias(name)")
     }
 

--- a/web/src/test/scala/quasar/api/services/query/CompileServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/query/CompileServiceSpec.scala
@@ -64,7 +64,7 @@ class CompileServiceSpec extends quasar.Qspec with FileSystemFixture {
     "return all inputs of a query" >> {
       get[AJson](compileService)(
         path = rootDir </> dir("foo"),
-        query = Some(Query("""SELECT c1.user, c2.type FROM `/users` as c1 JOIN `events` as c2 ON c1._id = c2.userId""")),
+        query = Some(Query("""SELECT c1.user, c2.type FROM `/users` as c1 JOIN `events` as c2 ON c1.`_id` = c2.userId""")),
         state = InMemState.empty,
         status = Status.Ok,
         response = json => Json.parse(json.nospaces) must beLike {


### PR DESCRIPTION
Namely, the identifier must begin with a letter and contain only letters, digits, and '_' characters.

Fixes #2006