### PR TITLE
Unified rewrites

### DIFF
--- a/connector/src/main/scala/quasar/qscript/unirewrite.scala
+++ b/connector/src/main/scala/quasar/qscript/unirewrite.scala
@@ -35,13 +35,13 @@ private[qscript] trait UnirewriteLowPriorityImplicits {
   implicit def fileRead[T[_[_]]: BirecursiveT, C <: CoM](
     implicit
       FQR: Functor[QScriptRead[T, ?]],
-      TSSR: Traverse[C0[C, ?]],
+      TSSR: Traverse[QScriptShiftRead[T, ?]],
       FC: Functor[C#M],
-      QC: QScriptCore[T, ?] :<: C0[C, ?],
-      TJ: ThetaJoin[T, ?] :<: C0[C, ?],
-      SD: Const[ShiftedRead[ADir], ?] :<: C0[C, ?],
-      SF: Const[ShiftedRead[AFile], ?] :<: C0[C, ?],
-      GI: Injectable.Aux[C0[C, ?], QScriptTotal[T, ?]],
+      TC0: Traverse[C0[C, ?]],
+      QC: QScriptCore[T, ?] :<: QScriptShiftRead[T, ?],
+      TJ: ThetaJoin[T, ?] :<: QScriptShiftRead[T, ?],
+      SD: Const[ShiftedRead[ADir], ?] :<: QScriptShiftRead[T, ?],
+      SF: Const[ShiftedRead[AFile], ?] :<: QScriptShiftRead[T, ?],
       S: ShiftRead.Aux[T, QScriptRead[T, ?], QScriptShiftRead[T, ?]],
       J: SimplifyJoin.Aux[T, QScriptShiftRead[T, ?], C0[C, ?]],
       C: Coalesce.Aux[T, QScriptShiftRead[T, ?], QScriptShiftRead[T, ?]],
@@ -51,7 +51,7 @@ private[qscript] trait UnirewriteLowPriorityImplicits {
     def apply[F[_]: Monad: MonadFsErr](r: Rewrite[T], lc: DiscoverPath.ListContents[F]): T[QScriptRead[T, ?]] => F[T[C#M]] = { qs =>
       r.simplifyJoinOnShiftRead[QScriptRead[T, ?], QScriptShiftRead[T, ?], C0[C, ?]]
         .apply(qs)
-        .transCataM(E.expandDirs(idPrism.reverseGet, lc))
+        .transCataM(E.expandDirs(reflNT[C#M], lc))
     }
   }
 }

--- a/connector/src/main/scala/quasar/qscript/unirewrite.scala
+++ b/connector/src/main/scala/quasar/qscript/unirewrite.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript
+
+import quasar.contrib.pathy._
+import quasar.fp._
+import quasar.fs._
+
+import matryoshka._
+import matryoshka.implicits._
+import scalaz._
+import scalaz.syntax.all._
+
+sealed trait Unirewrite[T[_[_]], C <: CoM] {
+  def apply[F[_]: Monad: MonadFsErr](r: Rewrite[T], lc: DiscoverPath.ListContents[F]): T[QScriptRead[T, ?]] => F[T[C#M]]
+}
+
+private[qscript] trait UnirewriteLowPriorityImplicits {
+  private type C0[C <: CoM, A] = (Const[ShiftedRead[ADir], ?] :/: C#M)#M[A]
+
+  implicit def fileRead[T[_[_]]: BirecursiveT, C <: CoM](
+    implicit
+      FQR: Functor[QScriptRead[T, ?]],
+      TSSR: Traverse[C0[C, ?]],
+      FC: Functor[C#M],
+      QC: QScriptCore[T, ?] :<: C0[C, ?],
+      TJ: ThetaJoin[T, ?] :<: C0[C, ?],
+      SD: Const[ShiftedRead[ADir], ?] :<: C0[C, ?],
+      SF: Const[ShiftedRead[AFile], ?] :<: C0[C, ?],
+      GI: Injectable.Aux[C0[C, ?], QScriptTotal[T, ?]],
+      S: ShiftRead.Aux[T, QScriptRead[T, ?], QScriptShiftRead[T, ?]],
+      J: SimplifyJoin.Aux[T, QScriptShiftRead[T, ?], C0[C, ?]],
+      C: Coalesce.Aux[T, QScriptShiftRead[T, ?], QScriptShiftRead[T, ?]],
+      N: Normalizable[QScriptShiftRead[T, ?]],
+      E: ExpandDirs.Aux[T, C0[C, ?], C#M]): Unirewrite[T, C] = new Unirewrite[T, C] {
+
+    def apply[F[_]: Monad: MonadFsErr](r: Rewrite[T], lc: DiscoverPath.ListContents[F]): T[QScriptRead[T, ?]] => F[T[C#M]] = { qs =>
+      r.simplifyJoinOnShiftRead[QScriptRead[T, ?], QScriptShiftRead[T, ?], C0[C, ?]]
+        .apply(qs)
+        .transCataM(E.expandDirs(idPrism.reverseGet, lc))
+    }
+  }
+}
+
+object Unirewrite extends UnirewriteLowPriorityImplicits {
+
+  implicit def dirRead[T[_[_]], C <: CoM](
+    implicit
+      D: Const[ShiftedRead[ADir], ?] :<: C#M,
+      T: Traverse[C#M],
+      QC: QScriptCore[T, ?] :<: C#M,
+      TJ: ThetaJoin[T, ?] :<: C#M,
+      GI: Injectable.Aux[C#M, QScriptTotal[T, ?]],
+      S: ShiftReadDir.Aux[T, QScriptRead[T, ?], C#M],
+      C: Coalesce.Aux[T, C#M, C#M],
+      N: Normalizable[C#M]): Unirewrite[T, C] = new Unirewrite[T, C] {
+
+    def apply[F[_]: Monad: MonadFsErr](r: Rewrite[T], lc: DiscoverPath.ListContents[F]): T[QScriptRead[T, ?]] => F[T[C#M]] =
+      r.shiftReadDir[QScriptRead[T, ?], C#M] andThen (_.point[F])
+  }
+
+  def apply[T[_[_]], C <: CoM, F[_]: Monad: MonadFsErr](r: Rewrite[T], lc: DiscoverPath.ListContents[F])(implicit U: Unirewrite[T, C]) =
+    U(r, lc)
+}

--- a/connector/src/main/scala/quasar/qscript/unirewrite.scala
+++ b/connector/src/main/scala/quasar/qscript/unirewrite.scala
@@ -34,15 +34,8 @@ private[qscript] trait UnirewriteLowPriorityImplicits {
 
   implicit def fileRead[T[_[_]]: BirecursiveT, C <: CoM](
     implicit
-      FQR: Functor[QScriptRead[T, ?]],
-      TSSR: Traverse[QScriptShiftRead[T, ?]],
       FC: Functor[C#M],
       TC0: Traverse[C0[C, ?]],
-      QC: QScriptCore[T, ?] :<: QScriptShiftRead[T, ?],
-      TJ: ThetaJoin[T, ?] :<: QScriptShiftRead[T, ?],
-      SD: Const[ShiftedRead[ADir], ?] :<: QScriptShiftRead[T, ?],
-      SF: Const[ShiftedRead[AFile], ?] :<: QScriptShiftRead[T, ?],
-      S: ShiftRead.Aux[T, QScriptRead[T, ?], QScriptShiftRead[T, ?]],
       J: SimplifyJoin.Aux[T, QScriptShiftRead[T, ?], C0[C, ?]],
       C: Coalesce.Aux[T, QScriptShiftRead[T, ?], QScriptShiftRead[T, ?]],
       N: Normalizable[QScriptShiftRead[T, ?]],

--- a/couchbase/src/main/scala/quasar/physical/couchbase/fs/queryfile.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/fs/queryfile.scala
@@ -242,12 +242,12 @@ object queryfile {
     val tell = MonadTell[Plan[S, ?], PhaseResults].tell _
     val rewrite = new Rewrite[T]
 
+    def implicitly[A](implicit A: A) = A
+
     for {
       qs   <- convertToQScriptRead[T, Plan[S, ?], QScriptRead[T, ?]](lc)(lp)
       _    <- tell(Vector(tree("QScript (post convertToQScriptRead)", qs)))
-      shft <- rewrite.simplifyJoinOnShiftRead[QScriptRead[T, ?], QScriptShiftRead[T, ?], CBQS0]
-                .apply(qs)
-                .transCataM(ExpandDirs[T, CBQS0, CBQS].expandDirs(idPrism.reverseGet, lc))
+      shft <- Unirewrite[T, CBQSCP, Plan[S, ?]](rewrite, lc).apply(qs)
       _    <- tell(Vector(tree("QScript (post shiftRead)", shft)))
       opz  =  shft.transHylo(
                 rewrite.optimize(reflNT[CBQS]),

--- a/couchbase/src/main/scala/quasar/physical/couchbase/fs/queryfile.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/fs/queryfile.scala
@@ -242,8 +242,6 @@ object queryfile {
     val tell = MonadTell[Plan[S, ?], PhaseResults].tell _
     val rewrite = new Rewrite[T]
 
-    def implicitly[A](implicit A: A) = A
-
     for {
       qs   <- convertToQScriptRead[T, Plan[S, ?], QScriptRead[T, ?]](lc)(lp)
       _    <- tell(Vector(tree("QScript (post convertToQScriptRead)", qs)))

--- a/marklogic/src/main/scala/quasar/physical/marklogic/fs/queryfile.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/fs/queryfile.scala
@@ -140,7 +140,6 @@ object queryfile {
 
     for {
       qs        <- convertToQScriptRead[T, F, QSR](ops.directoryContents[F, FMT])(lp)
-      // shifted   =  R.shiftReadDir[QSR, MLQ].apply(qs)
       shifted   <- Unirewrite[T, MLQScriptCP[T], F](R, ops.directoryContents[F, FMT]).apply(qs)
       _         <- logPhase(PhaseResult.tree("QScript (ShiftRead)", shifted))
       optimized =  shifted.transHylo(

--- a/marklogic/src/main/scala/quasar/physical/marklogic/fs/queryfile.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/fs/queryfile.scala
@@ -140,7 +140,8 @@ object queryfile {
 
     for {
       qs        <- convertToQScriptRead[T, F, QSR](ops.directoryContents[F, FMT])(lp)
-      shifted   =  R.shiftReadDir[QSR, MLQ].apply(qs)
+      // shifted   =  R.shiftReadDir[QSR, MLQ].apply(qs)
+      shifted   <- Unirewrite[T, MLQScriptCP[T], F](R, ops.directoryContents[F, FMT]).apply(qs)
       _         <- logPhase(PhaseResult.tree("QScript (ShiftRead)", shifted))
       optimized =  shifted.transHylo(
                      R.optimize(reflNT[MLQ]),

--- a/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/plannerQScript.scala
@@ -1249,8 +1249,7 @@ object MongoDbQScriptPlanner {
       //     interleave phase building in the composed recursion scheme
       opt <- log(
         "QScript (Mongo-specific)",
-        rewrite.simplifyJoinOnShiftRead[QScriptRead[T, ?], QScriptShiftRead[T, ?], MongoQScript0].apply(qs)
-          .transCataM(ExpandDirs[T, MongoQScript0, MongoQScript].expandDirs(idPrism.reverseGet, listContents))
+        Unirewrite[T, MongoQScriptCP, M](rewrite, listContents).apply(qs)
           .map(_.transHylo(
             rewrite.optimize(reflNT[MongoQScript]),
             Unicoalesce[T, MongoQScriptCP]))


### PR DESCRIPTION
Last step on the way to a unified backend abstraction!  This does for rewrites what we already did for coalescence.  With this change, all of the connectors have a syntactically-unified way of getting a specifically-typed qscript, given a logical plan.