### PR TITLE
Path card sign change

### DIFF
--- a/connector/src/main/scala/quasar/qscript/MapFunc.scala
+++ b/connector/src/main/scala/quasar/qscript/MapFunc.scala
@@ -222,7 +222,7 @@ object MapFunc {
 
   def normalize[T[_[_]]: BirecursiveT: OrderT: ShowT, A: Show]
       : CoEnv[A, MapFunc[T, ?], FreeMapA[T, A]] => CoEnv[A, MapFunc[T, ?], FreeMapA[T, A]] =
-    repeatedly(rewrite[T, A]) ⋘
+    (repeatedly(rewrite[T, A]) _) ⋘
       orOriginal(foldConstant[T, A].apply(_) ∘ (const => rollMF[T, A](Constant(const))))
 
   // TODO: This could be split up as it is in LP, with each function containing

--- a/connector/src/main/scala/quasar/qscript/Rewrite.scala
+++ b/connector/src/main/scala/quasar/qscript/Rewrite.scala
@@ -350,7 +350,7 @@ class Rewrite[T[_[_]]: BirecursiveT: OrderT: EqualT] extends TTypes[T] {
              TJ: ThetaJoin :<: F,
              FI: Injectable.Aux[F, QScriptTotal]):
       F[T[G]] => G[T[G]] =
-    repeatedly(Normalizable[F].normalizeF(_: F[T[G]])) ⋙
+    (repeatedly(Normalizable[F].normalizeF(_: F[T[G]])) _) ⋙
       liftFG(injectRepeatedly(elideNopJoin[F, T[G]](rebase))) ⋙
       liftFF(repeatedly(compactQC(_: QScriptCore[T[G]]))) ⋙
       liftFF(repeatedly(uniqueBuckets(_: QScriptCore[T[G]]))) ⋙

--- a/connector/src/main/scala/quasar/qscript/analysis/package.scala
+++ b/connector/src/main/scala/quasar/qscript/analysis/package.scala
@@ -38,47 +38,48 @@ package object analysis {
 
   @typeclass
   trait Cardinality[F[_]] {
-    def calculate(pathCard: APath => Int): Algebra[F, Int]
+    def calculate[M[_] : Monad](pathCard: APath => M[Int]): AlgebraM[M, F, Int]
   }
 
   @typeclass
   trait Cost[F[_]] {
-    def evaluate(pathCard: APath => Int): GAlgebra[(Int, ?), F, Int]
+    def evaluate[M[_] : Monad](pathCard: APath => M[Int]): GAlgebraM[(Int, ?), M, F, Int]
   }
 
-  def analyze[F[_], T](t: T)(pathCard: APath => Int)(implicit
+  def analyze[F[_] : Traverse, M[_] : Monad,  T](t: T)(pathCard: APath => M[Int])(implicit
     rec: Recursive.Aux[T, F],
-    func: Functor[F],
     cardinalty: Cardinality[F],
     cost: Cost[F]
-  ): Int = rec.zygo(t)(cardinalty.calculate(pathCard), cost.evaluate(pathCard))
+  ): M[Int] = rec.zygoM(t)(cardinalty.calculate(pathCard), cost.evaluate(pathCard))
 
   object Cardinality {
 
     implicit def read[A]: Cardinality[Const[Read[A], ?]] =
       new Cardinality[Const[Read[A], ?]] {
-        def calculate(pathCard: APath => Int): Algebra[ Const[Read[A], ?], Int] =
-          (qs: Const[Read[A], Int]) => 1
+        def calculate[M[_] : Monad](pathCard: APath => M[Int]): AlgebraM[M, Const[Read[A], ?], Int] =
+          (qs: Const[Read[A], Int]) => 1.point[M]
       }
+
     implicit def shiftedRead[A <: APath]: Cardinality[Const[ShiftedRead[A], ?]] =
       new Cardinality[Const[ShiftedRead[A], ?]] {
-        def calculate(pathCard: APath => Int): Algebra[ Const[ShiftedRead[A], ?], Int] =
+        def calculate[M[_] : Monad](pathCard: APath => M[Int]): AlgebraM[M, Const[ShiftedRead[A], ?], Int] =
           (qs: Const[ShiftedRead[A], Int]) => pathCard(qs.getConst.path)
       }
+
     implicit def qscriptCore[T[_[_]]: RecursiveT: ShowT]: Cardinality[QScriptCore[T, ?]] =
       new Cardinality[QScriptCore[T, ?]] {
 
         val I = Inject[QScriptCore[T, ?], QScriptTotal[T, ?]]
 
-        def calculate(pathCard: APath => Int): Algebra[QScriptCore[T, ?], Int] = {
-          case Map(card, f) => card
+        def calculate[M[_] : Monad](pathCard: APath => M[Int]): AlgebraM[M, QScriptCore[T, ?], Int] = {
+          case Map(card, f) => card.point[M]
           case Reduce(card, bucket, reducers, repair) =>
             bucket.fold(κ(card / 2), {
               case MapFuncs.Constant(v) => 1
               case _ => card / 2
-            })
-          case Sort(card, bucket, orders) => card
-          case Filter(card, f) => card / 2
+            }).point[M]
+          case Sort(card, bucket, orders) => card.point[M]
+          case Filter(card, f) => (card / 2).point[M]
           case Subset(card, from, sel, count) => {
             val compile = Cardinality[QScriptTotal[T, ?]].calculate(pathCard)
             def c = count.fold(κ(card / 2), {
@@ -89,51 +90,51 @@ package object analysis {
               case Drop => card - c
               case _ => c
             }
-          }
-          case LeftShift(card, struct, id, repair) => card * 10
+          }.point[M]
+          case LeftShift(card, struct, id, repair) => (card * 10).point[M]
           case Union(card, lBranch, rBranch) => {
             val compile = Cardinality[QScriptTotal[T, ?]].calculate(pathCard)
-            lBranch.cata(interpret(κ(card), compile)) + rBranch.cata(interpret(κ(card), compile))
+            (lBranch.cataM(interpretM(κ(card.point[M]), compile)) |@| rBranch.cataM(interpretM(κ(card.point[M]), compile))) { _ + _}
           }
-          case Unreferenced() => 1
+          case Unreferenced() => 1.point[M]
         }
       }
     implicit def projectBucket[T[_[_]] : RecursiveT: ShowT]: Cardinality[ProjectBucket[T, ?]] =
       new Cardinality[ProjectBucket[T, ?]] {
-        def calculate(pathCard: APath => Int): Algebra[ProjectBucket[T, ?], Int] = {
-          case BucketField(card, _, _) => card
-          case BucketIndex(card, _, _) => card
+        def calculate[M[_] : Monad](pathCard: APath => M[Int]): AlgebraM[M, ProjectBucket[T, ?], Int] = {
+          case BucketField(card, _, _) => card.point[M]
+          case BucketIndex(card, _, _) => card.point[M]
         }
       }
 
     implicit def equiJoin[T[_[_]]: RecursiveT: ShowT]: Cardinality[EquiJoin[T, ?]] =
       new Cardinality[EquiJoin[T, ?]] {
-        def calculate(pathCard: APath => Int): Algebra[ EquiJoin[T, ?], Int] = {
+        def calculate[M[_] : Monad](pathCard: APath => M[Int]): AlgebraM[M, EquiJoin[T, ?], Int] = {
           case EquiJoin(card, lBranch, rBranch, _, _, _, _) =>
             val compile = Cardinality[QScriptTotal[T, ?]].calculate(pathCard)
-            lBranch.cata(interpret(κ(card), compile)) * rBranch.cata(interpret(κ(card), compile))
+            (lBranch.cataM(interpretM(κ(card.point[M]), compile)) |@| rBranch.cataM(interpretM(κ(card.point[M]), compile))) { _ * _}
         }
       }
 
     implicit def thetaJoin[T[_[_]] : RecursiveT : ShowT]: Cardinality[ThetaJoin[T, ?]] =
       new Cardinality[ThetaJoin[T, ?]] {
-        def calculate(pathCard: APath => Int): Algebra[ThetaJoin[T, ?], Int] = {
+        def calculate[M[_] : Monad](pathCard: APath => M[Int]): AlgebraM[M, ThetaJoin[T, ?], Int] = {
           case ThetaJoin(card, lBranch, rBranch, _, _, _) =>
             val compile = Cardinality[QScriptTotal[T, ?]].calculate(pathCard)
-            lBranch.cata(interpret(κ(card), compile)) * rBranch.cata(interpret(κ(card), compile))
+            (lBranch.cataM(interpretM(κ(card.point[M]), compile)) |@| rBranch.cataM(interpretM(κ(card.point[M]), compile))) { _ * _}
         }
       }
 
     implicit def deadEnd: Cardinality[Const[DeadEnd, ?]] =
       new Cardinality[Const[DeadEnd, ?]] {
-        def calculate(pathCard: APath => Int): Algebra[Const[DeadEnd, ?], Int] = κ(1)
+        def calculate[M[_] : Monad](pathCard: APath => M[Int]): AlgebraM[M, Const[DeadEnd, ?], Int] = κ(1.point[M])
       }
 
     implicit def coproduct[F[_], G[_]](
       implicit F: Cardinality[F], G: Cardinality[G]):
         Cardinality[Coproduct[F, G, ?]] =
       new Cardinality[Coproduct[F, G, ?]] {
-        def calculate(pathCard: APath => Int): Algebra[Coproduct[F, G, ?], Int] =
+        def calculate[M[_] : Monad](pathCard: APath => M[Int]): AlgebraM[M, Coproduct[F, G, ?], Int] =
           _.run.fold(F.calculate(pathCard), G.calculate(pathCard))
       }
   }
@@ -145,70 +146,67 @@ package object analysis {
     */
   object Cost {
     implicit def deadEnd: Cost[Const[DeadEnd, ?]] = new Cost[Const[DeadEnd, ?]] {
-        def evaluate(pathCard: APath => Int): GAlgebra[(Int, ?), Const[DeadEnd, ?], Int] =
-          (qs: Const[DeadEnd, (Int, Int)]) => 1
+        def evaluate[M[_] : Monad](pathCard: APath => M[Int]): GAlgebraM[(Int, ?), M, Const[DeadEnd, ?], Int] =
+          (qs: Const[DeadEnd, (Int, Int)]) => 1.point[M]
       }
 
     implicit def read[A]: Cost[Const[Read[A], ?]] =
       new Cost[Const[Read[A], ?]] {
-        def evaluate(pathCard: APath => Int): GAlgebra[(Int, ?), Const[Read[A], ?], Int] =
-          (qs: Const[Read[A], (Int, Int)]) => 1
+        def evaluate[M[_] : Monad](pathCard: APath => M[Int]): GAlgebraM[(Int, ?), M, Const[Read[A], ?], Int] =
+          (qs: Const[Read[A], (Int, Int)]) => 1.point[M]
       }
     implicit def shiftedRead[A]: Cost[Const[ShiftedRead[A], ?]] =
       new Cost[Const[ShiftedRead[A], ?]] {
-        def evaluate(pathCard: APath => Int): GAlgebra[(Int, ?), Const[ShiftedRead[A], ?], Int] =
-          (qs: Const[ShiftedRead[A], (Int, Int)]) => 1
+        def evaluate[M[_] : Monad](pathCard: APath => M[Int]): GAlgebraM[(Int, ?), M, Const[ShiftedRead[A], ?], Int] =
+          (qs: Const[ShiftedRead[A], (Int, Int)]) => 1.point[M]
       }
+
     implicit def qscriptCore[T[_[_]]: RecursiveT: ShowT]: Cost[QScriptCore[T, ?]] =
       new Cost[QScriptCore[T, ?]] {
-        def evaluate(pathCard: APath => Int): GAlgebra[(Int, ?), QScriptCore[T, ?], Int] = {
-          case Map((card, cost), f) => card + cost
-          case Reduce((card, cost), bucket, reducers, repair) => card + cost
-          case Sort((card, cost), bucket, orders) => card + cost
-          case Filter((card, cost), f) => card + cost
-          case Subset((card, cost), from, sel, count) => card + cost
-          case LeftShift((card, cost), struct, id, repair) => card + cost
+        def evaluate[M[_] : Monad](pathCard: APath => M[Int]): GAlgebraM[(Int, ?), M, QScriptCore[T, ?], Int] = {
+          case Map((card, cost), f) => (card + cost).point[M]
+          case Reduce((card, cost), bucket, reducers, repair) => (card + cost).point[M]
+          case Sort((card, cost), bucket, orders) => (card + cost).point[M]
+          case Filter((card, cost), f) => (card + cost).point[M]
+          case Subset((card, cost), from, sel, count) => (card + cost).point[M]
+          case LeftShift((card, cost), struct, id, repair) => (card + cost).point[M]
           case Union((card, cost), lBranch, rBranch) => {
             val compileCardinality = Cardinality[QScriptTotal[T, ?]].calculate(pathCard)
             val compileCost = Cost[QScriptTotal[T, ?]].evaluate(pathCard)
-            val left = lBranch.zygo(interpret(κ(card), compileCardinality), ginterpret(κ(cost), compileCost))
-            val right = rBranch.zygo(interpret(κ(card), compileCardinality), ginterpret(κ(cost), compileCost))
-            (left + right) / 2
+            val left = lBranch.zygoM(interpretM(κ(card.point[M]), compileCardinality), ginterpretM(κ(cost.point[M]), compileCost))
+            val right = lBranch.zygoM(interpretM(κ(card.point[M]), compileCardinality), ginterpretM(κ(cost.point[M]), compileCost))
+            (left |@| right)( (l, r) => (l + r) / 2)
           }
-          case Unreferenced() => 0
+          case Unreferenced() => 0.point[M]
         }
       }
 
     implicit def projectBucket[T[_[_]]]: Cost[ProjectBucket[T, ?]] =
       new Cost[ProjectBucket[T, ?]] {
-        def evaluate(pathCard: APath => Int): GAlgebra[(Int, ?), ProjectBucket[T, ?], Int] = {
-          case BucketField((card, cost), _, _) => card + cost
-          case BucketIndex((card, cost), _, _) => card + cost
+        def evaluate[M[_] : Monad](pathCard: APath => M[Int]): GAlgebraM[(Int, ?), M, ProjectBucket[T, ?], Int] = {
+          case BucketField((card, cost), _, _) => (card + cost).point[M]
+          case BucketIndex((card, cost), _, _) => (card + cost).point[M]
         }
       }
 
-    // TODO contribute to matryoshka
-    private def ginterpret[W[_], F[_], A, B](f: A => Id[B], φ: GAlgebra[W, F, B]): GAlgebra[W, CoEnv[A, F, ?], B] =
-      ginterpretM[W, Id, F, A, B](f, φ)
-
     implicit def equiJoin[T[_[_]]: RecursiveT: ShowT]: Cost[EquiJoin[T, ?]] =
       new Cost[EquiJoin[T, ?]] {
-        def evaluate(pathCard: APath => Int): GAlgebra[(Int, ?), EquiJoin[T, ?], Int] = {
+        def evaluate[M[_] : Monad](pathCard: APath => M[Int]): GAlgebraM[(Int, ?), M, EquiJoin[T, ?], Int] = {
           case EquiJoin((card, cost), lBranch, rBranch, lKey, rKey, jt, combine) =>
             val compileCardinality = Cardinality[QScriptTotal[T, ?]].calculate(pathCard)
             val compileCost = Cost[QScriptTotal[T, ?]].evaluate(pathCard)
-            lBranch.zygo(interpret(κ(card), compileCardinality), ginterpret(κ(cost), compileCost)) +
-            rBranch.zygo(interpret(κ(card), compileCardinality), ginterpret(κ(cost), compileCost))
+            (lBranch.zygoM(interpretM(κ(card.point[M]), compileCardinality), ginterpretM(κ(cost.point[M]), compileCost)) |@|
+            rBranch.zygoM(interpretM(κ(card.point[M]), compileCardinality), ginterpretM(κ(cost.point[M]), compileCost))) { _ + _ }
         }
       }
     implicit def thetaJoin[T[_[_]] : RecursiveT : ShowT]: Cost[ThetaJoin[T, ?]] =
       new Cost[ThetaJoin[T, ?]] {
-        def evaluate(pathCard: APath => Int): GAlgebra[(Int, ?), ThetaJoin[T, ?], Int] = {
+        def evaluate[M[_] : Monad](pathCard: APath => M[Int]): GAlgebraM[(Int, ?), M, ThetaJoin[T, ?], Int] = {
           case ThetaJoin((card, cost), lBranch, rBranch, _, _, _) => {
             val compileCardinality = Cardinality[QScriptTotal[T, ?]].calculate(pathCard)
             val compileCost = Cost[QScriptTotal[T, ?]].evaluate(pathCard)
-            lBranch.zygo(interpret(κ(card), compileCardinality), ginterpret(κ(cost), compileCost)) +
-            rBranch.zygo(interpret(κ(card), compileCardinality), ginterpret(κ(cost), compileCost))
+            (lBranch.zygoM(interpretM(κ(card.point[M]), compileCardinality), ginterpretM(κ(cost.point[M]), compileCost)) |@|
+            rBranch.zygoM(interpretM(κ(card.point[M]), compileCardinality), ginterpretM(κ(cost.point[M]), compileCost))) { _ + _ }
           }
         }
       }
@@ -216,9 +214,10 @@ package object analysis {
     implicit def coproduct[F[_], G[_]](implicit F: Cost[F], G: Cost[G]):
         Cost[Coproduct[F, G, ?]] =
       new Cost[Coproduct[F, G, ?]] {
-        def evaluate(pathCard: APath => Int): GAlgebra[(Int, ?), Coproduct[F, G, ?], Int] =
+        def evaluate[M[_] : Monad](pathCard: APath => M[Int]): GAlgebraM[(Int, ?), M, Coproduct[F, G, ?], Int] =
           _.run.fold(F.evaluate(pathCard), G.evaluate(pathCard))
       }
+
   }
 
 }

--- a/connector/src/test/scala/quasar/qscript/analysis/CardinalitySpec.scala
+++ b/connector/src/test/scala/quasar/qscript/analysis/CardinalitySpec.scala
@@ -33,7 +33,7 @@ class CardinalitySpec extends quasar.Qspec with QScriptHelpers with DisjunctionM
 
   sequential
 
-  val empty: APath => Int = κ(0)
+  val empty: APath => Id[Int] = κ(0)
 
   "Cardinality" should {
 
@@ -55,7 +55,7 @@ class CardinalitySpec extends quasar.Qspec with QScriptHelpers with DisjunctionM
       "returns what 'pathCard' is returning for given file" in {
         val fileCardinality = 50
         val pathCard = κ(fileCardinality)
-        val compile = Cardinality.shiftedRead[AFile].calculate(pathCard)
+        val compile = Cardinality.shiftedRead[AFile].calculate[Id](pathCard)
         val afile = rootDir </> dir("path") </> dir("to") </> file("file")
         compile(Const[ShiftedRead[AFile], Int](ShiftedRead(afile, ExcludeId))) must_== fileCardinality
       }
@@ -63,7 +63,7 @@ class CardinalitySpec extends quasar.Qspec with QScriptHelpers with DisjunctionM
       "returns what 'pathCard' is returning for given dir" in {
         val dirCardinality = 55
         val pathCard = κ(dirCardinality)
-        val compile = Cardinality.shiftedRead[ADir].calculate(pathCard)
+        val compile = Cardinality.shiftedRead[ADir].calculate[Id](pathCard)
         val adir = rootDir </> dir("path") </> dir("to") </> dir("dir")
         compile(Const[ShiftedRead[ADir], Int](ShiftedRead(adir, ExcludeId))) must_== dirCardinality
       }
@@ -242,11 +242,11 @@ class CardinalitySpec extends quasar.Qspec with QScriptHelpers with DisjunctionM
         val compile = Cardinality.deadEnd.calculate(empty)
         compile(Const(Root)) must_== 1
       }
-    }
+     }
 
   }
 
   private def constFreeQS(v: Int): FreeQS =
     Free.roll(QCT.inj(quasar.qscript.Map(Free.roll(QCT.inj(Unreferenced())), IntLit(v))))
-
+     
 }

--- a/connector/src/test/scala/quasar/qscript/analysis/CardinalitySpec.scala
+++ b/connector/src/test/scala/quasar/qscript/analysis/CardinalitySpec.scala
@@ -242,11 +242,9 @@ class CardinalitySpec extends quasar.Qspec with QScriptHelpers with DisjunctionM
         val compile = Cardinality.deadEnd.calculate(empty)
         compile(Const(Root)) must_== 1
       }
-     }
-
+    }
   }
 
   private def constFreeQS(v: Int): FreeQS =
     Free.roll(QCT.inj(quasar.qscript.Map(Free.roll(QCT.inj(Unreferenced())), IntLit(v))))
-     
 }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
@@ -492,7 +492,7 @@ object WorkflowBuilder {
   }
 
   def normalize[F[_]: Coalesce](implicit ev0: WorkflowOpCoreF :<: F, exprOps: ExprOpOps.Uni[ExprOp]) =
-    repeatedly(normalizeƒ[F])
+    repeatedly(normalizeƒ[F]) _
 
   private def rewriteObjRefs
     (obj: ListMap[BsonField.Name, GroupValue[Fix[ExprOp]]])

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   private val disciplineVersion = "0.5"
   private val jawnVersion       = "0.8.4"
   private val jacksonVersion    = "2.4.4"
-  private val matryoshkaVersion = "0.16.4"
+  private val matryoshkaVersion = "0.18.3"
   private val pathyVersion      = "0.2.9"
   private val raptureVersion    = "2.0.0-M6"
   private val scodecBitsVersion = "1.1.0"


### PR DESCRIPTION
Part of https://github.com/quasar-analytics/quasar/issues/1716

It changes the signature of `pathCard` to close values over some `M`.
For `zygoM` matryoshka was upgraded to `0.18.3`

Commit `cf56d33` will be reverted once https://github.com/slamdata/matryoshka/pull/78 is merged to matryoshka
