### PR TITLE
Update Quasar readme with integration testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Of particular interest are the following two scripts:
   2. `docker/scripts/assembleTestingConf`
 
 
-Quasar supports the following backends datastores:
+Quasar supports the following datastores:
 
 ```
 quasar_mongodb_2_6

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Running the full test suite can be done using docker containers for various back
 
 ##### Full Testing (prerequisite: docker and docker-compose)
 
-In order to run integration test for various backends the `docker/scripts` are provided to easily create dockerized backend data stores.
+In order to run integration tests for various backends the `docker/scripts` are provided to easily create dockerized backend data stores.
 
 Of particular interest are the following two scripts:
 
@@ -58,7 +58,7 @@ Of particular interest are the following two scripts:
   2. `docker/scripts/assembleTestingConf`
 
 
-Supported backends datastores are:
+Qusar supports the following backends datastores:
 
 ```
 quasar_mongodb_2_6
@@ -73,16 +73,17 @@ quasar_marklogic_json
 quasar_couchbase
 ```
 
-Knowing which backend datastores are supported you can create and configure docker containers using `setupContainers`. For example the command:
+Knowing which backend datastores are supported you can create and configure docker containers using `setupContainers`. For example 
+if you wanted to run integration tests with mongo, postgresql, marklogic, and couchbsase you would use:
 
 ```
 ./setupContainers -u quasar_mongodb_3_0,quasar_postgresql,quasar_marklogic_xml,quasar_couchbase
 ```
 
-will create or pull docker images, create containers running the specified backends, and configure them appropriately for Quasar testing.
+This command will pull docker images, create containers running the specified backends, and configure them appropriately for Quasar testing.
 
 Once backends are ready we need to configure the integrations tests in order to inform Quasar about where to find the backends to test. 
-This information is convayed to Quasar using the file `it/testing.conf`. Using the `assembleTestingConf` script you can generate a `testing.conf`
+This information is conveyed to Quasar using the file `it/testing.conf`. Using the `assembleTestingConf` script you can generate a `testing.conf`
 file based on the currently running containerizd backends using the following command:
 
 ```
@@ -99,7 +100,7 @@ postgresql="jdbc:postgresql://192.168.99.101:5433/quasar-test?user=postgres&pass
 mongodb_3_0="mongodb://192.168.99.101:27019"
 ```
 
-IP's will vary depending on your docker enviornment. In addition the scripts assume you have docker and docker-compose installed.
+IP's will vary depending on your docker environment. In addition the scripts assume you have docker and docker-compose installed.
 You can find information about installing docker [here](https://www.docker.com/products/docker-toolbox).
 
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ To run the JAR, execute the following command:
 java -jar [<path to jar>] [-c <config file>]
 ```
 
+As a command-line REPL user, to have a fully functioning REPL you will also need the metadata store and a mount point. See [here](#Testing) for instructions creating metadata store backend using docker and see [here](#Web) for how to configure the metadata store. To add a mount you can start the web server mentioned [below](#Web) and issue a `curl` command like:
+
+```bash
+curl -v -X PUT http://localhost:8080/mount/fs/cb/ -d '{ "couchbase": { "connectionUri":"couchbase://192.168.99.100?username=Administrator&password=password" } }' 
+```
+
+You can find examples of `connectionUri`s [here](#Database) and [here](#Testing).
+
 #### Web JAR
 
 To build a JAR containing a lightweight HTTP server that allows you to programmatically interact with Quasar, execute the following command:
@@ -139,9 +147,12 @@ To run the JAR, execute the following command:
 java -jar [<path to jar>] [-c <config file>]
 ```
 
+For web jar users, you also need the metadata store. See [here](#Testing) for getting up and running with one.
+
+
 ### Configure
 
-The various JARs can be configured by using a command-line argument to indicate the location of a JSON configuration file. If no config file is specified, it is assumed to be `quasar-config.json`, from a standard location in the user's home directory.
+The various REPL JARs can be configured by using a command-line argument to indicate the location of a JSON configuration file. If no config file is specified, it is assumed to be `quasar-config.json`, from a standard location in the user's home directory.
 
 The JSON configuration file must have the following format:
 
@@ -150,14 +161,19 @@ The JSON configuration file must have the following format:
   "server": {
     "port": 8080
   },
-
-  "metastore": <metastore_config>
+  "metastore": {
+    "database": {
+      <metastore_config>
+    }
+  }
 }
 ```
 
 #### Metadata Store
 
 Configuration for the metadata store consists of providing connection information for a supported database. Currently the [H2](http://www.h2database.com/) and [PostgreSQL](https://www.postgresql.org/) databases are supported.
+
+To easily get up and running with a PostgreSQL metastore backend using docker see [Full Testing](#Full) section.
 
 If no metastore configuration is specified, the default configuration will use an H2 database located in the default quasar configuration directory for your operating system.
 
@@ -179,7 +195,14 @@ A PostgreSQL configuration looks something like
   "parameters": <an optional JSON object of parameter key:value pairs>
 }
 ```
-The contents of the optional `parameters` object correspond to the various driver configuration parameters available for PostgreSQL.
+
+The contents of the optional `parameters` object correspond to the various driver configuration parameters available for PostgreSQL. One example for a value of the `parameters` object may be a `loglevel`:
+
+```json
+"parameters": {
+  "loglevel": 1
+}
+```
 
 #### Initializing and updating Schema
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Of particular interest are the following two scripts:
   2. `docker/scripts/assembleTestingConf`
 
 
-Qusar supports the following backends datastores:
+Quasar supports the following backends datastores:
 
 ```
 quasar_mongodb_2_6
@@ -77,8 +77,10 @@ Knowing which backend datastores are supported you can create and configure dock
 if you wanted to run integration tests with mongo, postgresql, marklogic, and couchbsase you would use:
 
 ```
-./setupContainers -u quasar_mongodb_3_0,quasar_postgresql,quasar_marklogic_xml,quasar_couchbase
+./setupContainers -u quasar_metastore,quasar_mongodb_3_0,quasar_postgresql,quasar_marklogic_xml,quasar_couchbase
 ```
+
+Note: `quasar_metastore` is always needed to run integration tests.
 
 This command will pull docker images, create containers running the specified backends, and configure them appropriately for Quasar testing.
 
@@ -94,6 +96,7 @@ After running this command your `testing.conf` file should look similar to this:
 
 ```
 > cat it/testing.conf
+postgresql_metastore="{\"host\":\"192.168.99.101\",\"port\":5432,\"database\":\"metastore\",\"userName\":\"postgres\",\"password\":\"\"}"
 couchbase="couchbase://192.168.99.101?username=Administrator&password=password&socketConnectTimeoutSeconds=15"
 marklogic_xml="xcc://marklogic:marklogic@192.168.99.101:8000/Documents?format=xml"
 postgresql="jdbc:postgresql://192.168.99.101:5433/quasar-test?user=postgres&password=postgres"

--- a/README.md
+++ b/README.md
@@ -123,13 +123,13 @@ To run the JAR, execute the following command:
 java -jar [<path to jar>] [-c <config file>]
 ```
 
-As a command-line REPL user, to have a fully functioning REPL you will also need the metadata store and a mount point. See [here](#Testing) for instructions creating metadata store backend using docker and see [here](#Web) for how to configure the metadata store. To add a mount you can start the web server mentioned [below](#Web) and issue a `curl` command like:
+As a command-line REPL user, to work with a fully functioning REPL you will need the metadata store and a mount point. See [here](#full-testing-prerequisite-docker-and-docker-compose) for instructions on creating the metadata store backend using docker. To add a mount you can start the web server mentioned [below](#web-jar) and issue a `curl` command like:
 
 ```bash
 curl -v -X PUT http://localhost:8080/mount/fs/cb/ -d '{ "couchbase": { "connectionUri":"couchbase://192.168.99.100?username=Administrator&password=password" } }' 
 ```
 
-You can find examples of `connectionUri`s [here](#Database) and [here](#Testing).
+You can find examples of `connectionUri` values [here](#database-mounts).
 
 #### Web JAR
 
@@ -147,7 +147,7 @@ To run the JAR, execute the following command:
 java -jar [<path to jar>] [-c <config file>]
 ```
 
-For web jar users, you also need the metadata store. See [here](#Testing) for getting up and running with one.
+Web jar users, will also need the metadata store. See [here](#full-testing-prerequisite-docker-and-docker-compose) for getting up and running with one using docker.
 
 
 ### Configure


### PR DESCRIPTION
Quasar README update with instructions on creating containerized backend datastores using the scripts located in docker/scripts.