### PR TITLE
Json codec for EJson

### DIFF
--- a/ejson/src/main/scala/quasar/ejson/JsonCodec.scala
+++ b/ejson/src/main/scala/quasar/ejson/JsonCodec.scala
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.ejson
+
+import slamdata.Predef.{Char => SChar, _}
+import quasar.contrib.matryoshka._
+import quasar.fp.ski.κ
+
+import matryoshka._
+import matryoshka.implicits._
+import matryoshka.patterns.CoEnv
+import monocle.Prism
+import scalaz._, Scalaz.{char => charz, _}
+
+object JsonCodec {
+  /** Encode an EJson value as Json.
+    *
+    * In order to remain compatible with JSON and achieve a compact encoding
+    * the following scheme is used:
+    *
+    * 1. All JSON compatible values are encoded verbatim.
+    *
+    * 2. Extended values are encoded as
+    *
+    *    Meta -> { ∃value: ..., ∃meta: ...}
+    *    Map  -> { ∃map: [{∃key: ..., ∃value: ...}, ...] }
+    *    Byte -> { ∃byte: 42 }
+    *    Char -> { ∃char: "x" }
+    *    Int  -> { ∃int: 2345 }
+    *
+    * 3. A Map where the keys are all strings will be encoded as a Json object
+    *    with encoded EJson values.
+    *
+    * 4. Any map keys in a source EJson value that begin with '∃' are prefixed with an
+    *    additional '∃'.
+    */
+  def encodeƒ[J](
+    implicit
+    JC: Corecursive.Aux[J, Json],
+    JR: Recursive.Aux[J, Json]
+  ): Algebra[EJson, J] = {
+    case CommonEJson(c) =>
+      CommonJson(c).embed
+
+    case ExtEJson(Meta(v, m)) =>
+      MetaObj(v, m).embed
+
+    case ExtEJson(Byte(b)) =>
+      SingletonObj(ByteK, CommonJson(dec[J](BigDecimal(b.toInt))).embed).embed
+
+    case ExtEJson(Char(c)) =>
+      SingletonObj(CharK, OneChar[J](c).embed).embed
+
+    case ExtEJson(Int(i)) =>
+      SingletonObj(IntK, CommonJson(dec[J](BigDecimal(i))).embed).embed
+
+    case ExtEJson(Map(entries)) =>
+      val sigildEntries =
+        entries.map(_.leftMap(_.mapR(sigildJs)))
+
+      val maybeObj =
+        sigildEntries.traverse({
+          case (Embed(CommonJson(Str(k))), v) => some(k -> v)
+          case _                              => none
+        }) map (kvs => ObjJson(Obj(ListMap(kvs: _*))).embed)
+
+      maybeObj getOrElse SingletonObj(MapK, MapArr(sigildEntries).embed).embed
+  }
+
+  /** Error describing why decoding the given value failed. */
+  final case class DecodingFailed[A](reason: String, value: A)
+
+  /** Attempt to decode an EJson value from Json. */
+  def decodeƒ[J](
+    implicit
+    JC: Corecursive.Aux[J, Json],
+    JR: Recursive.Aux[J, Json]
+  ): Coalgebra[CoEnv[DecodingFailed[J], EJson, ?], J] =
+    j => CoEnv(j.project match {
+      case MetaObj(v, m) =>
+        ExtEJson(Meta(v, m)).right
+
+      case SingletonObj(`ByteK`, v) =>
+        extractC(dec[J], v.project)
+          .filter(_.isValidByte)
+          .map(d => EE[J].composePrism(byte)(d.toByte))
+          .toRightDisjunction(DecodingFailed("expected a byte", v))
+
+      case SingletonObj(`CharK`, v) =>
+        some(v.project)
+          .collect { case OneChar(c) => EE[J].composePrism(char)(c) }
+          .toRightDisjunction(DecodingFailed("expected a single character", v))
+
+      case SingletonObj(`IntK`, v) =>
+        extractC(dec[J], v.project)
+          .flatMap(_.toBigIntExact.map(EE[J].composePrism(int)(_)))
+          .toRightDisjunction(DecodingFailed("expected an integer", v))
+
+      case SingletonObj(`MapK`, v) =>
+        MapArr.unapply(v.project)
+          .map(xs => ExtEJson(Map(xs)))
+          .toRightDisjunction(DecodingFailed("expected an array of map entries", v))
+
+      case ObjJson(Obj(m)) =>
+        ExtEJson(Map(m.toList.map(_.leftMap(s =>
+          CJ[J].composePrism(str)(unsigild(s)).embed
+        )))).right
+
+      case CommonJson(c) =>
+        CommonEJson(c).right
+    })
+
+  /** Constants used in the Json encoding. */
+  val Sigil   = '∃'
+  val ByteK   = sigild("byte")
+  val CharK   = sigild("char")
+  val IntK    = sigild("int")
+  val KeyK    = sigild("key")
+  val MetaK   = sigild("meta")
+  val MapK    = sigild("map")
+  val ValueK  = sigild("value")
+  val ExtKeys = ISet.fromList(List(ByteK, CharK, IntK, KeyK, MetaK, MapK, ValueK))
+
+  ////
+
+  private def CJ[A] = Prism[Json[A], Common[A]](CommonJson.prj)(CommonJson.inj)
+  private def EE[A] = Prism[EJson[A], Extension[A]](ExtEJson.prj)(ExtEJson.inj)
+
+  private def extractC[A, B](p: Prism[Common[A], B], j: Json[A]): Option[B] =
+    CJ[A].composePrism(p).getOption(j)
+
+  private def isSigild(s: String): Boolean =
+    s.headOption.exists(_ ≟ Sigil)
+
+  private def sigild(s: String): String =
+    Sigil.toString + s
+
+  private def unsigild(s: String): String =
+    (isSigild(s) && ExtKeys.notMember(s)) ? s.drop(1) | s
+
+  private def sigildJs[A]: Json[A] => Json[A] = totally {
+    case CommonJson(Str(s)) if isSigild(s) => CommonJson(str[A](sigild(s)))
+  }
+
+  private object OneChar {
+    def apply[A](c: SChar): Json[A] =
+      CommonJson(Str(c.toString))
+
+    def unapply[A](js: Json[A]): Option[SChar] =
+      CJ[A].composePrism(str)
+        .getOption(js)
+        .flatMap(s => s.headOption.filter(κ(s.length ≟ 1)))
+  }
+
+  private object SingletonObj {
+    def apply[A](k: String, v: A): Json[A] =
+      ObjJson(Obj(ListMap(k -> v)))
+
+    def unapply[A](js: Json[A]): Option[(String, A)] =
+      ObjJson.prj(js) flatMap {
+        case Obj(m) => m.headOption.filter(κ(m.size ≟ 1))
+      }
+  }
+
+  private object MetaObj {
+    def apply[A](v: A, m: A): Json[A] =
+      ObjJson(Obj(ListMap(ValueK -> v, MetaK -> m)))
+
+    def unapply[A](js: Json[A]): Option[(A, A)] =
+      ObjJson.prj(js) flatMap {
+        case Obj(m) => (m.get(ValueK) tuple m.get(MetaK)).filter(κ(m.size ≟ 2))
+      }
+  }
+
+  private object MapArr {
+    def apply[J](xs: List[(J, J)])(
+      implicit J: Corecursive.Aux[J, Json]
+    ): Json[J] =
+      CommonJson(Arr(xs map { case (k, v) => MapEntry(k, v).embed }))
+
+    def unapply[J](js: Json[J])(
+      implicit J: Recursive.Aux[J, Json]
+    ): Option[List[(J, J)]] =
+      CJ[J].composePrism(arr)
+        .getOption(js)
+        .flatMap(_.traverse(j => MapEntry.unapply(j.project)))
+  }
+
+  private object MapEntry {
+    def apply[A](k: A, v: A): Json[A] =
+      ObjJson(Obj(ListMap(KeyK -> k, ValueK -> v)))
+
+    def unapply[A](js: Json[A]): Option[(A, A)] =
+      ObjJson.prj(js) flatMap {
+        case Obj(m) => (m.get(KeyK) tuple m.get(ValueK)).filter(κ(m.size ≟ 2))
+      }
+  }
+}

--- a/ejson/src/main/scala/quasar/ejson/package.scala
+++ b/ejson/src/main/scala/quasar/ejson/package.scala
@@ -68,11 +68,12 @@ package object ejson {
 
   /** For _strict_ JSON, you want something like `Obj[Mu[Json]]`.
     */
-  type Json[A] = Coproduct[Obj, Common, A]
+  type Json[A]    = Coproduct[Obj, Common, A]
+  val ObjJson     = implicitly[Obj :<: Json]
+  val CommonJson  = implicitly[Common :<: Json]
 
-  type EJson[A] = Coproduct[Extension, Common, A]
-
-  val ExtEJson = implicitly[Extension :<: EJson]
+  type EJson[A]   = Coproduct[Extension, Common, A]
+  val ExtEJson    = implicitly[Extension :<: EJson]
   val CommonEJson = implicitly[Common :<: EJson]
 
   object EJson {

--- a/ejson/src/test/scala/quasar/ejson/EJson.scala
+++ b/ejson/src/test/scala/quasar/ejson/EJson.scala
@@ -18,6 +18,7 @@ package quasar.ejson
 
 import slamdata.Predef._
 import quasar.contrib.matryoshka._
+import quasar.contrib.matryoshka.arbitrary._
 import quasar.fp._, Helpers._
 
 import matryoshka._

--- a/ejson/src/test/scala/quasar/ejson/EJsonArbitrary.scala
+++ b/ejson/src/test/scala/quasar/ejson/EJsonArbitrary.scala
@@ -19,36 +19,40 @@ package quasar.ejson
 import quasar.fp._
 import quasar.pkg.tests._
 
-// TODO[matryoshka]: Switch to Delay[Arbitrary, F] when we're able to upgrade
+import matryoshka.Delay
+
 trait EJsonArbitrary {
-  implicit val arbitraryCommon = new WrapArb[Common] {
-    def apply[α](arb: Arbitrary[α]) = Arbitrary(
-      Gen.oneOf(
-        arb.list ^^ Arr[α],
-        const(Null[α]()),
-        genBool ^^ Bool[α],
-        genString map Str[α],
-        genBigDecimal map Dec[α]
+  implicit val arbitraryCommon: Delay[Arbitrary, Common] =
+    new Delay[Arbitrary, Common] {
+      def apply[α](arb: Arbitrary[α]) = Arbitrary(
+        Gen.oneOf(
+          arb.list      ^^ Arr[α],
+          const(           Null[α]()),
+          genBool       ^^ Bool[α],
+          genString     ^^ Str[α],
+          genBigDecimal ^^ Dec[α]
+        )
       )
-    )
-  }
+    }
 
-  implicit val arbitraryObj = new WrapArb[Obj] {
-    def apply[α](arb: Arbitrary[α]) =
-      (genString, arb.gen).zip.list ^^ (l => Obj(l.toListMap))
-  }
+  implicit val arbitraryObj: Delay[Arbitrary, Obj] =
+    new Delay[Arbitrary, Obj] {
+      def apply[α](arb: Arbitrary[α]) =
+        (genString, arb.gen).zip.list ^^ (l => Obj(l.toListMap))
+    }
 
-  implicit val arbitraryExtension = new WrapArb[Extension] {
-    def apply[α](arb: Arbitrary[α]) = Arbitrary(
-      Gen.oneOf(
-        (arb.gen, arb.gen).zip ^^ ((Meta[α] _).tupled),
-        (arb.gen, arb.gen).zip.list ^^ Map[α],
-        genByte ^^ Byte[α],
-        genChar ^^ Char[α],
-        genBigInt ^^ Int[α]
+  implicit val arbitraryExtension: Delay[Arbitrary, Extension] =
+    new Delay[Arbitrary, Extension] {
+      def apply[α](arb: Arbitrary[α]) = Arbitrary(
+        Gen.oneOf(
+          (arb.gen, arb.gen).zip      ^^ (Meta[α] _).tupled,
+          (arb.gen, arb.gen).zip.list ^^ Map[α],
+          genByte                     ^^ Byte[α],
+          genChar                     ^^ Char[α],
+          genBigInt                   ^^ Int[α]
+        )
       )
-    )
-  }
+    }
 }
 
 object EJsonArbitrary extends EJsonArbitrary

--- a/ejson/src/test/scala/quasar/ejson/JsonCodecSpec.scala
+++ b/ejson/src/test/scala/quasar/ejson/JsonCodecSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.ejson
+
+import slamdata.Predef._
+import quasar.Qspec
+import quasar.contrib.matryoshka._
+import quasar.contrib.matryoshka.arbitrary._
+import quasar.fp._
+
+import matryoshka.{equalTEqual => _, _}
+import matryoshka.data.Fix
+import matryoshka.implicits._
+import org.specs2.scalacheck._
+import scalaz._, Scalaz._
+
+final class JsonCodecSpec extends Qspec with EJsonArbitrary {
+  import JsonCodec.DecodingFailed
+
+  implicit val params = Parameters(maxSize = 10)
+
+  type E = Fix[EJson]
+  type J = Fix[Json]
+
+  val decodeMƒ: CoalgebraM[DecodingFailed[J] \/ ?, EJson, J] =
+    JsonCodec.decodeƒ[J] >>> (_.run)
+
+  val roundtrip: E => DecodingFailed[J] \/ E =
+    _.cata(JsonCodec.encodeƒ[J]).anaM[E](decodeMƒ)
+
+  val soloKeys = JsonCodec.ExtKeys \\ ISet.fromList(List(JsonCodec.KeyK, JsonCodec.ValueK, JsonCodec.MetaK))
+
+  "faithfully roundtrip EJson" >> prop { e: E =>
+    roundtrip(e).toEither must beRight(equal(e))
+  }
+
+  soloKeys.toList foreach { k =>
+    s"fail when singleton map with `$k` key maps to unexpected value" >> {
+      val n = CommonJson(nul[J]()).embed
+      val j = ObjJson(Obj(ListMap(k -> n))).embed
+      j.anaM[E](decodeMƒ) must beLike {
+        case -\/(DecodingFailed(_, v)) => v must_= n
+      }
+    }
+  }
+
+  "map keys beginning with the codec sigil are preserved" >> prop { (k10: String, k20: String, v1: E, v2: E) =>
+    val (k1, k2) = (JsonCodec.Sigil.toString + k10, JsonCodec.Sigil.toString + k20)
+    val m = ExtEJson(Map(List(
+      CommonEJson(str[E](k1)).embed -> v1,
+      CommonEJson(str[E](k2)).embed -> v2
+    ))).embed
+
+    roundtrip(m).toEither must beRight(equal(m))
+  }
+
+  "map keys equal to one of the codec keys are preserved" >> prop { v: E =>
+    val m = ExtEJson(Map(JsonCodec.ExtKeys.toList map { k =>
+      CommonEJson(str[E](k)).embed -> v
+    })).embed
+
+    roundtrip(m).toEither must beRight(equal(m))
+  }
+}

--- a/ejson/src/test/scala/quasar/ejson/JsonCodecSpec.scala
+++ b/ejson/src/test/scala/quasar/ejson/JsonCodecSpec.scala
@@ -75,4 +75,12 @@ final class JsonCodecSpec extends Qspec with EJsonArbitrary {
 
     roundtrip(m).toEither must beRight(equal(m))
   }
+
+  "map keys equal to one of the codec keys with additional sigil prefix are preserved" >> prop { v: E =>
+    val m = ExtEJson(Map(JsonCodec.ExtKeys.toList map { k =>
+      CommonEJson(str[E](JsonCodec.Sigil.toString + k)).embed -> v
+    })).embed
+
+    roundtrip(m).toEither must beRight(equal(m))
+  }
 }

--- a/foundation/src/main/scala/quasar/contrib/matryoshka/package.scala
+++ b/foundation/src/main/scala/quasar/contrib/matryoshka/package.scala
@@ -22,6 +22,10 @@ import _root_.matryoshka._
 import _root_.scalaz._, Scalaz._
 
 package object matryoshka {
+  /** Make a partial endomorphism total by returning the argument when undefined. */
+  def totally[A](pf: PartialFunction[A, A]): A => A =
+    orOriginal(pf.lift)
+
   implicit def delayOrder[F[_], A](implicit F: Delay[Order, F], A: Order[A]): Order[F[A]] =
     F(A)
 

--- a/foundation/src/test/scala/quasar/contrib/matryoshka/CorecursiveArbitrary.scala
+++ b/foundation/src/test/scala/quasar/contrib/matryoshka/CorecursiveArbitrary.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.contrib.matryoshka
+
+import _root_.matryoshka.{Corecursive, Delay}
+import _root_.matryoshka.data._
+import _root_.matryoshka.implicits._
+import org.scalacheck.{Arbitrary, Gen}
+import scalaz.Functor
+
+// TODO{matryoshka}: This exists as matryoshka depends on a shapshot version of
+//                   scalacheck at the moment.
+trait CorecursiveArbitrary {
+  def corecursiveArbitrary[T, F[_]: Functor]
+    (implicit T: Corecursive.Aux[T, F], fArb: Delay[Arbitrary, F])
+      : Arbitrary[T] =
+    Arbitrary(Gen.sized(size =>
+      fArb(Arbitrary(
+        if (size <= 0)
+          Gen.fail[T]
+        else
+          Gen.resize(size - 1, corecursiveArbitrary[T, F].arbitrary))).arbitrary map (_.embed)))
+
+  implicit def fixArbitrary[F[_]: Functor](implicit fArb: Delay[Arbitrary, F]): Arbitrary[Fix[F]] =
+    corecursiveArbitrary[Fix[F], F]
+
+  implicit def muArbitrary[F[_]: Functor](implicit fArb: Delay[Arbitrary, F]): Arbitrary[Mu[F]] =
+    corecursiveArbitrary[Mu[F], F]
+
+  implicit def nuArbitrary[F[_]: Functor](implicit fArb: Delay[Arbitrary, F]): Arbitrary[Nu[F]] =
+    corecursiveArbitrary[Nu[F], F]
+}
+
+object CorecursiveArbitrary extends CorecursiveArbitrary

--- a/foundation/src/test/scala/quasar/contrib/matryoshka/arbitrary.scala
+++ b/foundation/src/test/scala/quasar/contrib/matryoshka/arbitrary.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.contrib.matryoshka
+
+import _root_.matryoshka.Delay
+import org.scalacheck.{Arbitrary, Gen}
+import scalaz.Coproduct
+import scalaz.syntax.either._
+
+object arbitrary extends CorecursiveArbitrary {
+  implicit def delayArbitrary[F[_], A](
+    implicit
+    A: Arbitrary[A],
+    F: Delay[Arbitrary, F]
+  ): Arbitrary[F[A]] =
+    F(A)
+
+  implicit def coproductDelayArbitrary[F[_], G[_]](implicit F: Delay[Arbitrary, F], G: Delay[Arbitrary, G]): Delay[Arbitrary, Coproduct[F, G, ?]] =
+    new Delay[Arbitrary, Coproduct[F, G, ?]] {
+      def apply[A](arb: Arbitrary[A]): Arbitrary[Coproduct[F, G, A]] =
+        Arbitrary(Gen.oneOf(
+          F(arb).arbitrary map (_.left),
+          G(arb).arbitrary map (_.right)
+        ) map (Coproduct(_)))
+    }
+}

--- a/foundation/src/test/scala/quasar/pkg/TestsPackage.scala
+++ b/foundation/src/test/scala/quasar/pkg/TestsPackage.scala
@@ -24,8 +24,6 @@ import scala.collection.Traversable
 import scala.language.postfixOps
 import scala.{ Byte, Char }
 
-import scalaz.~>
-
 package object tests extends TestsPackage
 
 trait TestsPackage extends ScalacheckSupport with SpecsSupport
@@ -60,7 +58,6 @@ trait ScalacheckSupport {
   type Pretty                  = org.scalacheck.util.Pretty
   type Prop                    = org.scalacheck.Prop
   type Shrink[A]               = org.scalacheck.Shrink[A]
-  type WrapArb[F[_]]           = Arbitrary ~> λ[α => Arbitrary[F[α]]]
 
   import Gen.{ listOfN, containerOfN, identifier, sized, oneOf, frequency, alphaNumChar }
 


### PR DESCRIPTION
Implements the `Json` encoding for `EJson` described in #2066.

I had to pull in the `Arbitrary` machinery for corecursive types from `matryoshka` as it still depends on a snapshot version of `scalacheck`. Once we're able to upgrade to the latest `matryoshka`, we can get rid of it.

Closes #2066.