### PR TITLE
Upgrade to `http4s` version `0.15.9a`

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,12 +9,13 @@ import slamdata.CommonDependencies
 
 object Dependencies {
   private val disciplineVersion        = "0.5"
-  private val jawnVersion              = "0.8.4"
+  private val jawnVersion              = "0.10.4"
   private val jacksonVersion           = "2.4.4"
   private val matryoshkaVersion        = "0.18.3"
   private val pathyVersion             = "0.2.9"
   private val raptureVersion           = "2.0.0-M6"
   private val scodecBitsVersion        = "1.1.0"
+  private val http4sVersion            = "0.15.9a"
   // For unknown reason sbt-slamdata's specsVersion, 3.8.7,
   // leads to a ParquetRDDE failure under a full test run
   private val specsVersion             = "3.8.4"
@@ -56,7 +57,7 @@ object Dependencies {
     CommonDependencies.doobie.core,
     CommonDependencies.doobie.hikari,
     CommonDependencies.doobie.postgres,
-    CommonDependencies.http4s.core,
+    "org.http4s"           %% "http4s-core" % http4sVersion,
     CommonDependencies.monocle.`macro`,
     "com.github.tototoshi" %% "scala-csv"      % "1.3.4",
     "com.slamdata"         %% "pathy-argonaut" % pathyVersion,
@@ -103,7 +104,7 @@ object Dependencies {
       .exclude("org.scalatest", "scalatest_2.11"),
     "org.apache.parquet" % "parquet-format" % "2.3.1",
     "org.apache.parquet" % "parquet-hadoop" % "1.9.0",
-    CommonDependencies.http4s.core
+    "org.http4s"         %% "http4s-core" % http4sVersion
   )
 
   def marklogicValidation = Seq(
@@ -120,13 +121,15 @@ object Dependencies {
   val couchbase = Seq(
     "com.couchbase.client" %  "java-client" % "2.3.5",
     "io.reactivex"         %% "rxscala"     % "0.26.3",
-    CommonDependencies.http4s.core
+    "org.http4s"           %% "http4s-core" % http4sVersion
   )
   def web = Seq(
-    CommonDependencies.http4s.dsl,
-    CommonDependencies.http4s.argonaut62,
-    CommonDependencies.http4s.blazeClient,
-    CommonDependencies.http4s.blazeServer,
+    "org.http4s"     %% "http4s-dsl"          % http4sVersion,
+    "org.http4s"     %% "http4s-argonaut"     % http4sVersion,
+    "org.http4s"     %% "http4s-client"       % http4sVersion,
+    "org.http4s"     %% "http4s-server"       % http4sVersion,
+    "org.http4s"     %% "http4s-blaze-server" % http4sVersion,
+    "org.http4s"     %% "http4s-blaze-client" % http4sVersion,
     "org.scodec"     %% "scodec-scalaz"       % "1.3.0a",
     "org.scodec"     %% "scodec-bits"         % scodecBitsVersion,
     "com.propensive" %% "rapture-json"        % raptureVersion     % Test,

--- a/web/src/main/scala/quasar/api/package.scala
+++ b/web/src/main/scala/quasar/api/package.scala
@@ -176,7 +176,7 @@ package object api {
       Service.lift { req: Request =>
         _uri_path.modifyF(rewrite)(req) match {
           case Some(req1) => service(req1)
-          case None       => HttpService.notFound // note: This needs to change to `Response.fallthrough` when http4s is upgraded
+          case None       => Response.fallthrough
         }
       }
     }

--- a/web/src/test/scala/quasar/api/services/DataServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/DataServiceSpec.scala
@@ -34,6 +34,7 @@ import quasar.fs._
 import argonaut.{Json, EncodeJson}
 import argonaut.Argonaut._
 import org.http4s._
+import org.http4s.argonaut._
 import org.http4s.headers._
 import org.http4s.server.middleware.GZip
 import org.specs2.specification.core.Fragment

--- a/web/src/test/scala/quasar/api/services/Fixture.scala
+++ b/web/src/test/scala/quasar/api/services/Fixture.scala
@@ -17,9 +17,8 @@
 package quasar.api.services
 
 import slamdata.Predef._
-import argonaut.{JsonObject, JsonNumber, Json, Argonaut}
+import argonaut.{Json, Argonaut}
 import Argonaut._
-import jawn.{FContext, Facade}
 import org.http4s.{MediaType, Charset, EntityEncoder}
 import org.http4s.headers.`Content-Type`
 import org.scalacheck.Arbitrary
@@ -36,47 +35,6 @@ object Fixture {
   val jsonPreciseLine = JsonContentType(Precise,LineDelimited)
   val jsonReadableArray = JsonContentType(Readable,SingleArray)
   val jsonPreciseArray = JsonContentType(Precise,SingleArray)
-
-  // See: https://github.com/non/jawn/pull/43
-  implicit val bugFreeArgonautFacade: Facade[Json] =
-    new Facade[Json] {
-      def jnull() = Json.jNull
-      def jfalse() = Json.jFalse
-      def jtrue() = Json.jTrue
-      def jnum(s: String) = Json.jNumber(JsonNumber.unsafeDecimal(s))
-      def jint(s: String) = Json.jNumber(JsonNumber.unsafeDecimal(s))
-      def jstring(s: String) = Json.jString(s)
-
-      def singleContext() = new FContext[Json] {
-        var value: Json = null
-        def add(s: String) = { value = jstring(s) }
-        def add(v: Json) = { value = v }
-        def finish: Json = value
-        def isObj: Boolean = false
-      }
-
-      def arrayContext() = new FContext[Json] {
-        val vs = scala.collection.mutable.ListBuffer.empty[Json]
-        def add(s: String) = { vs += jstring(s); () }
-        def add(v: Json) = { vs += v; () }
-        def finish: Json = Json.jArray(vs.toList)
-        def isObj: Boolean = false
-      }
-
-      def objectContext() = new FContext[Json] {
-        var key: String = null
-        var vs = JsonObject.empty
-        def add(s: String): Unit =
-          if (key == null) { key = s } else { vs = vs + (key, jstring(s)); key = null }
-        def add(v: Json): Unit =
-        { vs = vs + (key, v); key = null }
-        def finish = Json.jObject(vs)
-        def isObj = true
-      }
-    }
-
-  // Remove once version 0.8.4 or higher of jawn is realeased.
-  implicit val normalJsonBugFreeDecoder = org.http4s.jawn.jawnDecoder(bugFreeArgonautFacade)
 
   sealed abstract class JsonType
 

--- a/web/src/test/scala/quasar/api/services/query/ExecuteServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/query/ExecuteServiceSpec.scala
@@ -37,6 +37,7 @@ import eu.timepit.refined.numeric.{NonNegative, Positive => RPositive}
 import eu.timepit.refined.scalacheck.numeric._
 import matryoshka.data.Fix
 import org.http4s._
+import org.http4s.argonaut._
 import org.scalacheck.Arbitrary
 import org.specs2.matcher.MatchResult
 import pathy.Path._


### PR DESCRIPTION
- Upgrade `jawn` to version `0.10.4`
- Decouple `quasar` from `sbt-slamdata`'s version of `http4s`
- Remove code that worked around a `jawn` bug