### PR TITLE
Enable largestZips.test for couchbase.

### DIFF
--- a/it/src/main/resources/tests/largestZips.test
+++ b/it/src/main/resources/tests/largestZips.test
@@ -2,7 +2,6 @@
     "name": "largest zips",
     "backends": {
         "postgresql": "pending",
-        "couchbase":  "skip",
         "spark_local": "pending",
         "spark_hdfs": "pending"
     },


### PR DESCRIPTION
Enable `largestZips.test` for couchbase; it was already fixed, likely by #1694.