### PR TITLE
Schema discovery service

### DIFF
--- a/connector/src/main/scala/quasar/fs/QueryFile.scala
+++ b/connector/src/main/scala/quasar/fs/QueryFile.scala
@@ -411,6 +411,9 @@ object QueryFile {
 
     val toCompExec: F ~> CompExecM =
       execToCompExec compose toExec
+
+    val dropPhases: ExecM ~> FileSystemErrT[F, ?] =
+      Hoist[FileSystemErrT].hoist(λ[PhaseResultT[F, ?] ~> F](_.value))
   }
 
   object Transforms {

--- a/ejson/src/main/scala/quasar/ejson/EncodeEJson.scala
+++ b/ejson/src/main/scala/quasar/ejson/EncodeEJson.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.ejson
+
+import slamdata.Predef.{Int => SInt, Char => SChar, Byte => SByte, _}
+import quasar.contrib.argonaut._
+
+import argonaut.EncodeJson
+import matryoshka._
+import matryoshka.implicits._
+import scalaz._
+import simulacrum.typeclass
+
+/** Typeclass for types that can be encoded as EJson. */
+@typeclass
+trait EncodeEJson[A] {
+  def encode[J](a: A)(implicit J: Corecursive.Aux[J, EJson]): J
+
+  def contramap[B](f: B => A): EncodeEJson[B] = {
+    val orig = this
+    new EncodeEJson[B] {
+      def encode[J](b: B)(implicit J: Corecursive.Aux[J, EJson]): J =
+        orig.encode[J](f(b))
+    }
+  }
+}
+
+object EncodeEJson extends EncodeEJsonInstances {
+  def encodeEJsonR[T, F[_]: Functor](
+    implicit T: Recursive.Aux[T, F], F: EncodeEJsonK[F]
+  ): EncodeEJson[T] =
+    new EncodeEJson[T] {
+      def encode[J](t: T)(implicit J: Corecursive.Aux[J, EJson]): J =
+        t.cata[J](F.encodeK[J])
+    }
+}
+
+sealed abstract class EncodeEJsonInstances extends EncodeEJsonInstances0 {
+  implicit val bigIntEncodeEJson: EncodeEJson[BigInt] =
+    new EncodeEJson[BigInt] {
+      def encode[J](i: BigInt)(implicit J: Corecursive.Aux[J, EJson]): J =
+        ExtEJson(int[J](i)).embed
+    }
+
+  implicit val intEncodeEJson: EncodeEJson[SInt] =
+    bigIntEncodeEJson.contramap(BigInt(_))
+
+  implicit val longEncodeEJson: EncodeEJson[Long] =
+    bigIntEncodeEJson.contramap(BigInt(_))
+
+  implicit val shortEncodeEJson: EncodeEJson[Short] =
+    intEncodeEJson.contramap(_.toInt)
+
+  implicit val byteEncodeEJson: EncodeEJson[SByte] =
+    new EncodeEJson[SByte] {
+      def encode[J](b: SByte)(implicit J: Corecursive.Aux[J, EJson]): J =
+        ExtEJson(byte[J](b)).embed
+    }
+
+  implicit val charEncodeEJson: EncodeEJson[SChar] =
+    new EncodeEJson[SChar] {
+      def encode[J](c: SChar)(implicit J: Corecursive.Aux[J, EJson]): J =
+        ExtEJson(char[J](c)).embed
+    }
+
+  implicit def optionEncodeEJson[A](implicit A: EncodeEJson[A]): EncodeEJson[Option[A]] =
+    new EncodeEJson[Option[A]] {
+      def encode[J](oa: Option[A])(implicit J: Corecursive.Aux[J, EJson]): J =
+        oa.fold(CommonEJson(nul[J]()).embed)(A.encode[J](_))
+    }
+
+
+  implicit def encodeJsonT[T[_[_]]: RecursiveT, F[_]: Functor: EncodeEJsonK]: EncodeEJson[T[F]] =
+    EncodeEJson.encodeEJsonR[T[F], F]
+}
+
+sealed abstract class EncodeEJsonInstances0 {
+  implicit def encodeJsonEJson[A: EncodeJson]: EncodeEJson[A] =
+    new EncodeEJson[A] {
+      def encode[J](a: A)(implicit J: Corecursive.Aux[J, EJson]): J = {
+        val mkKey: String => J = s => CommonEJson(str[J](s)).embed
+        EncodeJson.of[A].encode(a).transCata[J](EJson.fromJson(mkKey))
+      }
+    }
+}

--- a/ejson/src/main/scala/quasar/ejson/EncodeEJsonK.scala
+++ b/ejson/src/main/scala/quasar/ejson/EncodeEJsonK.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.ejson
+
+import slamdata.Predef._
+import quasar.ejson.implicits._
+
+import matryoshka._
+import matryoshka.implicits._
+import matryoshka.patterns.EnvT
+import scalaz._
+import simulacrum.typeclass
+
+/** Typeclass for higher-kinded types that can be encoded as EJson. */
+@typeclass
+trait EncodeEJsonK[F[_]] {
+  def encodeK[J](implicit J: Corecursive.Aux[J, EJson]): Algebra[F, J]
+
+  def contramapK[G[_]](f: G ~> F): EncodeEJsonK[G] = {
+    val orig = this
+    new EncodeEJsonK[G] {
+      def encodeK[J](implicit J: Corecursive.Aux[J, EJson]): Algebra[G, J] =
+        gj => orig.encodeK[J].apply(f(gj))
+    }
+  }
+}
+
+object EncodeEJsonK extends EncodeEJsonKInstances {
+  def envT[E: EncodeEJson, F[_]: EncodeEJsonK](
+    askLabel: String,
+    lowerLabel: String
+  ): EncodeEJsonK[EnvT[E, F, ?]] =
+    new EncodeEJsonK[EnvT[E, F, ?]] {
+      def encodeK[J](implicit J: Corecursive.Aux[J, EJson]): Algebra[EnvT[E, F, ?], J] = {
+        case EnvT((ask, lower)) =>
+          val fAlg = EncodeEJsonK[F].encodeK[J]
+          ExtEJson(map[J](List(
+            CommonEJson(str[J](askLabel)).embed   -> ask.asEJson[J],
+            CommonEJson(str[J](lowerLabel)).embed -> fAlg(lower)
+          ))).embed
+      }
+    }
+}
+
+sealed abstract class EncodeEJsonKInstances {
+  implicit val ejsonEncodeEJsonK: EncodeEJsonK[EJson] =
+    new EncodeEJsonK[EJson] {
+      def encodeK[J](implicit J: Corecursive.Aux[J, EJson]): Algebra[EJson, J] =
+        _.embed
+    }
+}

--- a/ejson/src/main/scala/quasar/ejson/implicits.scala
+++ b/ejson/src/main/scala/quasar/ejson/implicits.scala
@@ -36,4 +36,9 @@ object implicits {
         x.transCata[T](EJson.elideMetadata[T]),
         y.transCata[T](EJson.elideMetadata[T]))
     }
+
+  implicit final class EncodeEJsonOps[A](val self: A) extends scala.AnyVal {
+    def asEJson[J](implicit A: EncodeEJson[A], J: Corecursive.Aux[J, EJson]): J =
+      A.encode[J](self)
+  }
 }

--- a/foundation/src/main/scala/quasar/contrib/algebra/package.scala
+++ b/foundation/src/main/scala/quasar/contrib/algebra/package.scala
@@ -16,10 +16,21 @@
 
 package quasar.contrib
 
-import _root_.algebra.Eq
-import _root_.scalaz.Equal
+import _root_.algebra.{Eq, Semigroup => ASemigroup, Monoid => AMonoid, Order => AOrder}
+import _root_.scalaz.{Equal, Semigroup, Monoid, Order, Ordering}
 
-package object algebra {
-  implicit def eqIsEqual[A](implicit A: Eq[A]): Equal[A] =
+package object algebra extends AlgebraInstancesLowPriority {
+  implicit def algebraOrder[A](implicit A: AOrder[A]): Order[A] =
+    Order.order((x, y) => Ordering.fromInt(A.compare(x, y)))
+
+  implicit def algebraMonoid[A](implicit A: AMonoid[A]): Monoid[A] =
+    Monoid.instance((x, y) => A.combine(x, y), A.empty)
+}
+
+sealed abstract class AlgebraInstancesLowPriority {
+  implicit def algebraEqual[A](implicit A: Eq[A]): Equal[A] =
     Equal.equal(A.eqv)
+
+  implicit def algebraSemigroup[A](implicit A: ASemigroup[A]): Semigroup[A] =
+    Semigroup.instance((x, y) => A.combine(x, y))
 }

--- a/foundation/src/main/scala/quasar/contrib/matryoshka/package.scala
+++ b/foundation/src/main/scala/quasar/contrib/matryoshka/package.scala
@@ -18,7 +18,7 @@ package quasar.contrib
 
 import slamdata.Predef._
 
-import _root_.monocle.Getter
+import _root_.monocle.{Getter, Iso}
 import _root_.matryoshka._
 import _root_.matryoshka.patterns.EnvT
 import _root_.scalaz._, Scalaz._
@@ -35,6 +35,9 @@ package object matryoshka {
 
   def envT[E, W[_], A](e: E, wa: W[A]): EnvT[E, W, A] =
     EnvT((e, wa))
+
+  def envTIso[E, W[_], A]: Iso[EnvT[E, W, A], (E, W[A])] =
+    Iso((_: EnvT[E, W, A]).runEnvT)(EnvT(_))
 
   def project[T, F[_]: Functor](implicit T: Recursive.Aux[T, F]): Getter[T, F[T]] =
     Getter(T.project(_))

--- a/foundation/src/main/scala/quasar/contrib/matryoshka/package.scala
+++ b/foundation/src/main/scala/quasar/contrib/matryoshka/package.scala
@@ -18,17 +18,48 @@ package quasar.contrib
 
 import slamdata.Predef._
 
-import monocle.Getter
+import _root_.monocle.Getter
 import _root_.matryoshka._
+import _root_.matryoshka.patterns.EnvT
 import _root_.scalaz._, Scalaz._
 
 package object matryoshka {
+  /** Chains multiple transformations together, each of which can fail to change
+    * anything.
+    */
+  def applyTransforms[A](first: A => Option[A], rest: (A => Option[A])*)
+      : A => Option[A] =
+    rest.foldLeft(
+      first)(
+      (prev, next) => x => prev(x).fold(next(x))(orOriginal(next)(_).some))
+
+  def envT[E, W[_], A](e: E, wa: W[A]): EnvT[E, W, A] =
+    EnvT((e, wa))
+
   def project[T, F[_]: Functor](implicit T: Recursive.Aux[T, F]): Getter[T, F[T]] =
     Getter(T.project(_))
 
   /** Make a partial endomorphism total by returning the argument when undefined. */
   def totally[A](pf: PartialFunction[A, A]): A => A =
     orOriginal(pf.lift)
+
+  /** Derive a recursive instance over the functor transformed by EnvT by forgetting the annotation. */
+  def forgetRecursive[T, E, F[_]](implicit T: Recursive.Aux[T, EnvT[E, F, ?]]): Recursive.Aux[T, F] =
+    new Recursive[T] {
+      type Base[B] = F[B]
+
+      def project(t: T)(implicit BF: Functor[Base]) =
+        T.project(t).lower
+    }
+
+  /** Derive a corecursive instance over the functor transformed by EnvT using the zero of the annotation monoid. */
+  def rememberCorecursive[T, E: Monoid, F[_]](implicit T: Corecursive.Aux[T, EnvT[E, F, ?]]): Corecursive.Aux[T, F] =
+    new Corecursive[T] {
+      type Base[B] = F[B]
+
+      def embed(ft: Base[T])(implicit BF: Functor[Base]) =
+        T.embed(envT(∅[E], ft))
+    }
 
   implicit def delayOrder[F[_], A](implicit F: Delay[Order, F], A: Order[A]): Order[F[A]] =
     F(A)
@@ -40,13 +71,4 @@ package object matryoshka {
         Order.orderBy((_: Coproduct[F, G, A]).run)
       }
     }
-
-  /** Chains multiple transformations together, each of which can fail to change
-    * anything.
-    */
-  def applyTransforms[A](first: A => Option[A], rest: (A => Option[A])*)
-      : A => Option[A] =
-    rest.foldLeft(
-      first)(
-      (prev, next) => x => prev(x).fold(next(x))(orOriginal(next)(_).some))
 }

--- a/foundation/src/main/scala/quasar/fp/numeric/SampleStats.scala
+++ b/foundation/src/main/scala/quasar/fp/numeric/SampleStats.scala
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.fp.numeric
+
+import slamdata.Predef._
+
+import scalaz._
+import scalaz.std.string._
+import scalaz.std.tuple._
+import scalaz.syntax.equal._
+import scalaz.syntax.foldable._
+import scalaz.syntax.show._
+import scalaz.syntax.std.boolean._
+import scalaz.syntax.std.option._
+import spire.algebra.{AdditiveMonoid, Field, NRoot, Rig}
+import spire.implicits._
+
+/** Statistics based on a sample from a population. */
+final class SampleStats[A] private (
+  val size: A,
+  // Sums of powers (1-4) of differences from the mean.
+  val m1: A,
+  val m2: A,
+  val m3: A,
+  val m4: A
+) {
+
+  // Sample Statistics
+
+  def mean: A = m1
+
+  def variance(implicit E: Equal[A], F: Field[A]): Option[A] =
+    (size ≠ F.zero).option(m2 / size)
+
+  def stddev(implicit E: Equal[A], F: Field[A], R: NRoot[A]): Option[A] =
+    variance map (R.sqrt)
+
+  def skewness(implicit E: Equal[A], F: Field[A], R: NRoot[A]): Option[A] =
+    (m2 ≠ F.zero).option((R.sqrt(size) * m3) / R.fpow(m2, ℝ(1.5)))
+
+  def kurtosis(implicit E: Equal[A], F: Field[A]): Option[A] =
+    (m2 ≠ F.zero).option((size * m4) / (m2 * m2))
+
+  def excessKurtosis(implicit E: Equal[A], F: Field[A]): Option[A] =
+    kurtosis map (_ - ℤ(3))
+
+
+  // Population Estimates
+
+  /** Unbiased estimated variance of the population sampled. */
+  def populationVariance(implicit E: Equal[A], F: Field[A]): Option[A] =
+    (size ≠ F.one).option(m2 / (size - F.one))
+
+  /** Estimated standard deviation of the population sampled. */
+  def populationStddev(implicit E: Equal[A], F: Field[A], R: NRoot[A]): Option[A] =
+    populationVariance map (R.sqrt)
+
+  /** Estimated skewness of the population sampled. */
+  def populationSkewness(implicit E: Equal[A], F: Field[A], R: NRoot[A]): Option[A] =
+    ((m2 ≠ F.zero) && (size ≠ ℤ(2)))
+      .option((size * R.sqrt(size - F.one) * m3) / ((size - ℤ(2)) * R.fpow(m2, ℝ(1.5))))
+
+  /** Estimated kurtosis of the population sampled. */
+  def populationKurtosis(implicit E: Equal[A], F: Field[A]): Option[A] = {
+    val denom = (size - ℤ(2)) * (size - ℤ(3)) * m2 * m2
+    (denom ≠ F.zero).option((size * (size + F.one) * (size - F.one) * m4) / denom)
+  }
+
+  /** Estimated excess kurtosis of the population sampled. */
+  def populationExcessKurtosis(implicit E: Equal[A], F: Field[A]): Option[A] =
+    populationKurtosis map (_ - ℤ(3))
+
+
+  // Operations
+
+  /** Returns new stats that include the given observation.
+    *
+    * NB: This is equivalent to `merge`, simplified for the case when one of
+    *     the stats has exactly one observation.
+    */
+  def observe(x: A)(implicit F: Field[A]): SampleStats[A] = {
+    val n       = size + F.one
+    val δ       = x - m1
+    val `δ/n`   = δ / n
+    val `δ²/n²` = `δ/n` * `δ/n`
+    val t1      = δ * `δ/n` * size
+
+    new SampleStats(
+      n,
+
+      m1 + `δ/n`,
+
+      m2 + t1,
+
+      m3 + (t1 * `δ/n` * (n - ℤ(2))) -
+           (ℤ(3) * `δ/n` * m2),
+
+      m4 + (t1 * `δ²/n²` * ((n * n) - (ℤ(3) * n) + ℤ(3))) +
+           (ℤ(6) * `δ²/n²` * m2) -
+           (ℤ(4) * `δ/n` * m3)
+    )
+  }
+
+  /** Combine with another `SampleStats` to produce stats about the union of
+    * their observations.
+    *
+    * Implementation via Chan et al.
+    * https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Parallel_algorithm
+    */
+  def merge(b: SampleStats[A])(implicit E: Equal[A], F: Field[A]): SampleStats[A] = {
+    def doMerge: SampleStats[A] = {
+      val `n₁`  = size
+      val `n₁²` = `n₁` * `n₁`
+
+      val `n₂`  = b.size
+      val `n₂²` = `n₂` * `n₂`
+
+      val `n₁₂` = `n₁` * `n₂`
+
+      val  n    = `n₁` + `n₂`
+      val `n²`  =  n   * n
+      val `n³`  = `n²` * n
+
+      val  δ    = b.m1 - m1
+      val `δ²`  =  δ   *  δ
+      val `δ³`  = `δ²` *  δ
+      val `δ⁴`  = `δ²` * `δ²`
+
+      new SampleStats(
+        n,
+
+        ((`n₁` * m1) + (`n₂` * b.m1)) / n,
+
+        m2 + b.m2 + ((`δ²` * `n₁₂`) / n),
+
+        m3 + b.m3 + ((`δ³` * `n₁₂` * (`n₁` - `n₂`)) / `n²`) +
+                    ((ℤ(3) * δ * ((`n₁` * b.m2) - (`n₂` * m2))) / n),
+
+        m4 + b.m4 + ((`δ⁴` * `n₁₂` * (`n₁²` - `n₁₂` + `n₂²`)) / `n³`) +
+                    ((ℤ(6) * `δ²` * ((`n₁²` * b.m2) + (`n₂²` * m2))) / `n²`) +
+                    ((ℤ(4) * δ * ((`n₁` * b.m3) - (`n₂` * m3))) / n)
+      )
+    }
+
+         if (b.size ≟ F.zero) this
+    else if (size   ≟ F.zero) b
+    else if (b.size ≟  F.one) observe(b.mean)
+    else if (size   ≟  F.one) b.observe(mean)
+    else    doMerge
+  }
+
+  /** Alias for `merge`. */
+  def + (b: SampleStats[A])(implicit E: Equal[A], F: Field[A]): SampleStats[A] =
+    merge(b)
+
+  ////
+
+  private def ℝ (d: Double)(implicit F: Field[A]): A =
+    F.fromDouble(d)
+
+  private def ℤ (i: Int)(implicit F: Field[A]): A =
+    F.fromInt(i)
+}
+
+object SampleStats extends SampleStatsInstances {
+  /** Stats over zero observations. */
+  def empty[A](implicit A: AdditiveMonoid[A]): SampleStats[A] =
+    freq(A.zero, A.zero)
+
+  /** Stats over the frequency of an observation. */
+  def freq[A](count: A, a: A)(implicit A: AdditiveMonoid[A]): SampleStats[A] =
+    new SampleStats[A](count, a, A.zero, A.zero, A.zero)
+
+  /** Stats over a `Foldable` of samples. */
+  def fromFoldable[F[_]: Foldable, A: Field](fa: F[A]): SampleStats[A] =
+    fa.foldLeft(empty[A])(_ observe _)
+
+  /** Stats over a single observation. */
+  def one[A](a: A)(implicit R: Rig[A]): SampleStats[A] =
+    freq(R.one, a)
+}
+
+sealed abstract class SampleStatsInstances {
+  implicit def equal[A: Equal]: Equal[SampleStats[A]] =
+    Equal.equalBy(ss => (ss.size, ss.m1, ss.m2, ss.m3, ss.m4))
+
+  // TODO{cats}: CommutativeMonoid
+  implicit def monoid[A: Equal: Field]: Monoid[SampleStats[A]] =
+    Monoid.instance((a, b) => a + b, SampleStats.empty[A])
+
+  implicit def show[A: Show: Equal: Field: NRoot]: Show[SampleStats[A]] =
+    Show.shows(ss => "SampleStats" + IList(
+        s"n = ${ss.size.shows}"
+      , s"μ = ${ss.mean.shows}"
+      , s"σ² = ${ss.populationVariance.map(_.shows) | "?"}"
+      , s"σ = ${ss.populationStddev.map(_.shows) | "?"}"
+    ).shows)
+}

--- a/foundation/src/test/scala/quasar/fp/numeric/SampleStatsArbitrary.scala
+++ b/foundation/src/test/scala/quasar/fp/numeric/SampleStatsArbitrary.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.fp.numeric
+
+import quasar.pkg.tests._
+
+import org.scalacheck.Gen
+import scalaz.Equal
+import scalaz.std.list._
+import spire.algebra.Field
+
+trait SampleStatsArbitrary {
+  implicit def arbitrarySampleStats[A: Arbitrary: Equal: Field]: Arbitrary[SampleStats[A]] =
+    Arbitrary(for {
+      n  <- Gen.choose(0, 20)
+      ds <- Gen.listOfN(n, Gen.choose(-1000000.0, 1000000.0))
+    } yield SampleStats.fromFoldable(ds.map(Field[A].fromDouble)))
+}
+
+object SampleStatsArbitrary extends SampleStatsArbitrary

--- a/foundation/src/test/scala/quasar/fp/numeric/SampleStatsSpec.scala
+++ b/foundation/src/test/scala/quasar/fp/numeric/SampleStatsSpec.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.fp.numeric
+
+import slamdata.Predef._
+import quasar.contrib.algebra._
+
+import org.scalacheck.{Arbitrary, Gen}, Arbitrary.arbitrary
+import org.specs2.scalaz._
+import scalaz.scalacheck.{ScalazProperties => propz}
+import scalaz.{NonEmptyList, Show}
+import scalaz.std.option._
+import scalaz.syntax.foldable1._
+import scalaz.syntax.equal._
+import scalaz.syntax.std.boolean._
+import spire.laws.arb._
+import spire.math.Real
+
+final class SampleStatsSpec extends Spec with ScalazMatchers with SampleStatsArbitrary {
+  implicit val showReal: Show[Real] =
+    Show.showFromToString
+
+  /** A list of moderately sized reals, to ensure they don't grow so big that
+    * computation gets prohibitively slow.
+    */
+  case class ModerateReals(rs: NonEmptyList[Real])
+
+  object ModerateReals {
+    implicit val arbitraryModerateReals: Arbitrary[ModerateReals] =
+      Arbitrary(for {
+        h <- arbitrary[Double]
+        t <- Gen.listOf(Gen.choose(-100000000.0, 100000000.0))
+      } yield ModerateReals(NonEmptyList(Real(h), t.map(Real(_)): _*)))
+  }
+
+  def μ(xs: NonEmptyList[Real]): Real =
+    xs.foldLeft1(_ + _) / Real(xs.length)
+
+  // The k-th moment about the mean.
+  def `mₖ`(k: Int, xs: NonEmptyList[Real]): Real = {
+    val  n   = Real(xs.length)
+    val `m₁` = μ(xs)
+    xs.map(x => (x - `m₁`) ** k).foldLeft1(_ + _) / n
+  }
+
+  checkAll(propz.equal.laws[SampleStats[Real]])
+  checkAll(propz.monoid.laws[SampleStats[Real]])
+
+  "commutative monoid" >> {
+    "merge is commutative" >> prop { (x: SampleStats[Real], y: SampleStats[Real]) =>
+      (x + y) must equal(y + x)
+    }
+  }
+
+  "correctness" >> {
+    "mean" >> prop { mr: ModerateReals =>
+      val xs = mr.rs
+      val ss = SampleStats.fromFoldable(xs)
+
+      ss.mean must equal(μ(xs))
+    }
+
+    // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Na.C3.AFve_algorithm
+    "variance" >> prop { mr: ModerateReals =>
+      val xs   = mr.rs
+      val ss   = SampleStats.fromFoldable(xs)
+      val n    = Real(xs.length)
+      val ssq  = xs.map(x => x * x).foldLeft1(_ + _)
+      val sum  = xs.foldLeft1(_ + _)
+      val `σ²` = (ssq - ((sum * sum) / n)) / n
+
+      ss.variance must beSome(equal(`σ²`))
+    }
+
+    // https://en.wikipedia.org/wiki/Skewness#Pearson.27s_moment_coefficient_of_skewness
+    "skewness" >> prop { mr: ModerateReals =>
+      val xs   = mr.rs
+      val ss   = SampleStats.fromFoldable(xs)
+      val `m₂` = `mₖ`(2, xs)
+      val `m₃` = `mₖ`(3, xs)
+      val  sk  = (`m₂` ≠ Real(0)).option(`m₃` /  `m₂`.fpow(1.5))
+
+      ss.skewness must equal(sk)
+    }
+
+    // https://en.wikipedia.org/wiki/Kurtosis#Sample_kurtosis
+    "kurtosis" >> prop { mr: ModerateReals =>
+      val  xs  = mr.rs
+      val  ss  = SampleStats.fromFoldable(xs)
+      val `m₂` = `mₖ`(2, xs)
+      val `m₄` = `mₖ`(4, xs)
+      val  k   = (`m₂` ≠ Real(0)).option(`m₄` /  (`m₂` ** 2))
+
+      ss.kurtosis must equal(k)
+    }
+  }
+}

--- a/frontend/src/main/scala/quasar/sst/StructuralType.scala
+++ b/frontend/src/main/scala/quasar/sst/StructuralType.scala
@@ -18,7 +18,7 @@ package quasar.sst
 
 import slamdata.Predef._
 import quasar.contrib.matryoshka._
-import quasar.ejson.EJson
+import quasar.ejson.{EJson, EncodeEJson, EncodeEJsonK}
 import quasar.fp.ski.κ
 import quasar.tpe._
 
@@ -183,6 +183,11 @@ object StructuralType extends StructuralTypeInstances {
 }
 
 sealed abstract class StructuralTypeInstances extends StructuralTypeInstances0 {
+  implicit def encodeEJson[L: EncodeEJson, V: EncodeEJson]: EncodeEJson[StructuralType[L, V]] = {
+    implicit val encodeEnvT = EncodeEJsonK.envT[V, TypeF[L, ?]]("measure", "structure")
+    EncodeEJson.encodeEJsonR[StructuralType[L, V], EnvT[V, TypeF[L, ?], ?]]
+  }
+
   implicit def corecursive[L, V]: Corecursive.Aux[StructuralType[L, V], EnvT[V, TypeF[L, ?], ?]] =
     new Corecursive[StructuralType[L, V]] {
       type Base[B] = EnvT[V, TypeF[L, ?], B]

--- a/frontend/src/main/scala/quasar/sst/StructuralType.scala
+++ b/frontend/src/main/scala/quasar/sst/StructuralType.scala
@@ -137,7 +137,7 @@ object StructuralType extends StructuralTypeInstances {
         case (          None,           None) => none
       }
 
-    def mergable(x: T, y: T): Boolean =
+    def mergeable(x: T, y: T): Boolean =
       (x, y).umap(_.project.lower) match {
         case (    Top(),     Top()) => true
         case (Simple(a), Simple(b)) => a ≟ b
@@ -150,7 +150,7 @@ object StructuralType extends StructuralTypeInstances {
     def mergeUnions(v: V, xs: NonEmptyList[T], ys: NonEmptyList[T]): T \/ EnvT[V, TypeF[L, ?], TT] =
       xs.foldLeft(ys.toZipper map (_.right[TT]))((z, x) =>
         // Pair with merge candidate if found, otherwise add to the union.
-        z.findZ(_ exists (mergable(x, _))).cata(
+        z.findZ(_ exists (mergeable(x, _))).cata(
           _.modify(_ >>= ((x, _).left[T])),
           z.insert((x, ⊥).left[T])))
         .map(_.swap valueOr ((⊥, _)))

--- a/frontend/src/main/scala/quasar/sst/StructuralType.scala
+++ b/frontend/src/main/scala/quasar/sst/StructuralType.scala
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.sst
+
+import slamdata.Predef._
+import quasar.contrib.matryoshka._
+import quasar.ejson.EJson
+import quasar.fp.ski.κ
+import quasar.tpe._
+
+import matryoshka._
+import matryoshka.data._
+import matryoshka.implicits._
+import matryoshka.patterns.EnvT
+import scalaz._, Scalaz._
+
+/** A measure annotated Type focused on structure over semantics.
+  *
+  * @tparam L the type of literals
+  * @tparam V the measure the type is annotated with
+  */
+final case class StructuralType[L, V](toCofree: Cofree[TypeF[L, ?], V]) extends scala.AnyVal {
+  def cobind[W](f: StructuralType[L, V] => W): StructuralType[L, W] =
+    StructuralType(toCofree.cobind(c => f(StructuralType(c))))
+
+  def cojoin: StructuralType[L, StructuralType[L, V]] =
+    StructuralType(toCofree.duplicate map (StructuralType(_)))
+
+  def copoint: V =
+    toCofree.head
+
+  def map[W](f: V => W): StructuralType[L, W] =
+    StructuralType(toCofree map f)
+
+  /** Convert to a type, forgetting annotations. */
+  def toType[T](implicit T: Corecursive.Aux[T, TypeF[L, ?]]): T =
+    forgetAnnotation[Cofree[TypeF[L, ?], V], T, TypeF[L, ?], V](toCofree)
+}
+
+object StructuralType extends StructuralTypeInstances {
+  /** The structural type representing the given EJson value, annotated with
+    * the result of `measure`.
+    */
+  object fromEJson {
+    def apply[J] = new PartiallyApplied[J]
+    final class PartiallyApplied[J] {
+      def apply[V](measure: Algebra[TypeF[J, ?], V], ejson: J)(
+        implicit
+        J : Order[J],
+        JC: Corecursive.Aux[J, EJson],
+        JR: Recursive.Aux[J, EJson]
+      ): StructuralType[J, V] = {
+        type T = Fix[TypeF[J, ?]]
+
+        val attrV =
+          attributeAlgebra[TypeF[J, ?], V](measure)
+
+        val normAndAttr =
+          ((_: T).cata[Cofree[TypeF[J, ?], V]](attrV)) <<<
+          ((_: TypeF[J, T]).embed)                     <<<
+          normalization.lowerConst[J, T]
+
+        StructuralType(normAndAttr(TypeF.const[J, T](ejson)))
+      }
+    }
+  }
+
+  /** The structural type representing the given EJson value annotated with
+    * the given measure.
+    */
+  object fromEJsonK {
+    def apply[J] = new PartiallyApplied[J]
+    final class PartiallyApplied[J] {
+      def apply[V](measure: V, ejson: J)(
+        implicit
+        J : Order[J],
+        JC: Corecursive.Aux[J, EJson],
+        JR: Recursive.Aux[J, EJson]
+      ): StructuralType[J, V] =
+        fromEJson[J](κ(measure), ejson)
+    }
+  }
+
+  /** Unfold a pair of structural types into their deep structural merge. */
+  def mergeƒ[L: Order, V: Monoid, T](
+    implicit
+    TR: Recursive.Aux[T, EnvT[V, TypeF[L, ?], ?]],
+    TC: Corecursive.Aux[T, EnvT[V, TypeF[L, ?], ?]]
+  ): ElgotCoalgebra[T \/ ?, EnvT[V, TypeF[L, ?], ?], (T, T)] = {
+    import TypeF._
+    type TT = (T, T)
+    val ⊥ = envT(∅[V], bottom[L, T]()).embed
+
+    def mergeThese[F[_]: Align](xs: F[T], ys: F[T]): F[TT] =
+      xs.alignWith(ys)(_.fold((_, ⊥), (_, ⊥), (_, _)))
+
+    def mergeArr(l: (V, IList[T] \/ T), r: (V, IList[T] \/ T)): TypeF[L, T] \/ TypeF[L, TT] =
+      (l, r) match {
+        case ((_, -\/(              xs)), (_, -\/(              ys))) => arr[L, TT](mergeThese(xs, ys).left).right
+        case ((_, \/-(               x)), (_, \/-(               y))) => arr[L, TT]((x, y).right).right
+        case ((_, -\/(          INil())), (_, y @ \/-(           _))) => arr[L,  T](y).left
+        case ((_, x @ \/-(           _)), (_, -\/(          INil()))) => arr[L,  T](x).left
+        case ((_, -\/(ICons(x, INil()))), (_, \/-(               y))) => arr[L, TT]((x, y).right).right
+        case ((_, \/-(               x)), (_, -\/(ICons(y, INil())))) => arr[L, TT]((x, y).right).right
+
+        case ((v, -\/(ICons(a, ICons(b, cs)))), (_, \/-(y))) =>
+          arr[L, TT]((envT(v, union[L, T](a, b, cs)).embed, y).right).right
+
+        case ((_, \/-(x)), (v, -\/(ICons(a, ICons(b, cs))))) =>
+          arr[L, TT]((x, envT(v, union[L, T](a, b, cs)).embed).right).right
+      }
+
+    def mergeUnk(xu: Option[TT], yu: Option[TT]): Option[(TT, TT)] =
+      (xu, yu) match {
+        case (Some((xk, xv)), Some((yk, yv))) => some(((xk, yk), (xv, yv)))
+        case (Some((xk, xv)),           None) => some(((xk,  ⊥), (xv,  ⊥)))
+        case (          None, Some((yk, yv))) => some(((⊥ , yk), (⊥ , yv)))
+        case (          None,           None) => none
+      }
+
+    def mergable(x: T, y: T): Boolean =
+      (x, y).umap(_.project.lower) match {
+        case (    Top(),     Top()) => true
+        case (Simple(a), Simple(b)) => a ≟ b
+        case ( Const(a),  Const(b)) => a ≟ b
+        case (   Arr(_),    Arr(_)) => true
+        case (Map(_, _), Map(_, _)) => true
+        case _                      => false
+      }
+
+    def mergeUnions(v: V, xs: NonEmptyList[T], ys: NonEmptyList[T]): T \/ EnvT[V, TypeF[L, ?], TT] =
+      xs.foldLeft(ys.toZipper map (_.right[TT]))((z, x) =>
+        // Pair with merge candidate if found, otherwise add to the union.
+        z.findZ(_ exists (mergable(x, _))).cata(
+          _.modify(_ >>= ((x, _).left[T])),
+          z.insert((x, ⊥).left[T])))
+        .map(_.swap valueOr ((⊥, _)))
+        .toNel match {
+          case NonEmptyList(a, ICons(b, cs)) => envT(v, union[L, TT](a, b, cs)).right
+          case NonEmptyList(a,       INil()) => envT(v, coproduct[L, T](a)).embed.left
+        }
+
+    _.umap(_.project) match {
+      case (                     x, EnvT((_,    Bottom())))            => x.embed.left
+      case (EnvT((_,    Bottom())),                      y)            => y.embed.left
+      case (EnvT((v,       Top())), EnvT((w,       Top())))            => envT(v |+| w, top[L, T]()).embed.left
+      case (EnvT((v,   Simple(x))), EnvT((w,   Simple(y)))) if (x ≟ y) => envT(v |+| w, simple[L, T](x)).embed.left
+      case (EnvT((v,    Const(x))), EnvT((w,    Const(y)))) if (x ≟ y) => envT(v |+| w, const[L, T](x)).embed.left
+      case (EnvT((v, Unioned(xs))), EnvT((w, Unioned(ys))))            => mergeUnions(v |+| w, xs, ys)
+      case (x @ EnvT((v,       _)), EnvT((w, Unioned(ys))))            => mergeUnions(v |+| w, x.embed.wrapNel, ys)
+      case (EnvT((v, Unioned(xs))), y @ EnvT((w,       _)))            => mergeUnions(v |+| w, xs, y.embed.wrapNel)
+
+      case (EnvT((v, Arr(x))), EnvT((w, Arr(y)))) =>
+        val sum = v |+| w
+        mergeArr((v, x), (w, y)).bimap(envT(sum, _).embed, envT(sum, _))
+
+      case (EnvT((v, Map(xs, xunk))), EnvT((w, Map(ys, yunk)))) =>
+        envT(v |+| w, map[L, TT](mergeThese(xs, ys), mergeUnk(xunk, yunk))).right
+
+      case (x @ EnvT((v, _)), y @ EnvT((w, _))) =>
+        envT(v |+| w, coproduct[L, T](x.embed, y.embed)).embed.left
+    }
+  }
+}
+
+sealed abstract class StructuralTypeInstances extends StructuralTypeInstances0 {
+  implicit def corecursive[L, V]: Corecursive.Aux[StructuralType[L, V], EnvT[V, TypeF[L, ?], ?]] =
+    new Corecursive[StructuralType[L, V]] {
+      type Base[B] = EnvT[V, TypeF[L, ?], B]
+
+      def embed(st: EnvT[V, TypeF[L, ?], StructuralType[L, V]])(implicit BF: Functor[EnvT[V, TypeF[L, ?], ?]]) =
+        StructuralType(st.map(_.toCofree).embed)
+    }
+
+  implicit def recursive[L, V]: Recursive.Aux[StructuralType[L, V], EnvT[V, TypeF[L, ?], ?]] =
+    new Recursive[StructuralType[L, V]] {
+      type Base[B] = EnvT[V, TypeF[L, ?], B]
+
+      def project(st: StructuralType[L, V])(implicit BF: Functor[EnvT[V, TypeF[L, ?], ?]]) =
+        st.toCofree.project map (StructuralType(_))
+    }
+
+  implicit def monoid[L: Order, V: Monoid]: Monoid[StructuralType[L, V]] =
+    new Monoid[StructuralType[L, V]] {
+      type T = Cofree[TypeF[L, ?], V]
+      val zero = StructuralType(Cofree(∅[V], TypeF.bottom[L, T]()))
+      def append(x: StructuralType[L, V], y: => StructuralType[L, V]) =
+        StructuralType((x.toCofree, y.toCofree).elgotApo[T](StructuralType.mergeƒ[L, V, T]))
+    }
+
+  implicit def comonad[L]: Comonad[StructuralType[L, ?]] =
+    new Comonad[StructuralType[L, ?]] {
+      def copoint[A](st: StructuralType[L, A]) =
+        st.toCofree.head
+
+      override def cojoin[A](st: StructuralType[L, A]) =
+        StructuralType(st.toCofree.duplicate map (StructuralType(_)))
+
+      override final def map[A, B](st: StructuralType[L, A])(f: A => B) =
+        StructuralType(st.toCofree map f)
+
+      def cobind[A, B](st: StructuralType[L, A])(f: StructuralType[L, A] => B) =
+        StructuralType(st.toCofree.cobind(c => f(StructuralType(c))))
+    }
+
+  implicit def equal[L: Equal, V: Equal]: Equal[StructuralType[L, V]] = {
+    implicit val eqlTypeF = TypeF.structuralEqual[L]
+    Equal.equalBy(_.toCofree)
+  }
+
+  implicit def show[L: Show, V: Show]: Show[StructuralType[L, V]] =
+    Show.show(st => Cord("StructuralType") ++ st.toCofree.show)
+}
+
+sealed abstract class StructuralTypeInstances0 {
+  implicit def traverse1[L]: Traverse1[StructuralType[L, ?]] =
+    new Traverse1[StructuralType[L, ?]] {
+      override def map[A, B](st: StructuralType[L, A])(f: A => B): StructuralType[L, B] =
+        StructuralType(st.toCofree map f)
+
+      override final def foldMap[A, B: Monoid](st: StructuralType[L, A])(f: A => B): B =
+        st.toCofree.foldMap(f)
+
+      override final def foldRight[A, B](st: StructuralType[L, A], z: => B)(f: (A, => B) => B): B =
+        st.toCofree.foldRight(z)(f)
+
+      override final def foldLeft[A, B](st: StructuralType[L, A], z: B)(f: (B, A) => B): B =
+        st.toCofree.foldLeft(z)(f)
+
+      override final def foldMapLeft1[A, B](st: StructuralType[L, A])(z: A => B)(f: (B, A) => B): B =
+        st.toCofree.foldMapLeft1(z)(f)
+
+      override def foldMapRight1[A, B](st: StructuralType[L, A])(z: A => B)(f: (A, => B) => B): B =
+        st.toCofree.foldMapRight1(z)(f)
+
+      override def foldMap1[A, B](st: StructuralType[L, A])(f: A => B)(implicit S: Semigroup[B]): B =
+        st.toCofree.foldMap1(f)
+
+      override def traverseImpl[G[_]: Applicative, A, B](st: StructuralType[L, A])(f: A => G[B]): G[StructuralType[L, B]] =
+        st.toCofree.traverse(f) map (StructuralType(_))
+
+      def traverse1Impl[G[_]: Apply, A, B](st: StructuralType[L, A])(f: A => G[B]): G[StructuralType[L, B]] =
+        st.toCofree.traverse1(f) map (StructuralType(_))
+    }
+}

--- a/frontend/src/main/scala/quasar/sst/TypeStat.scala
+++ b/frontend/src/main/scala/quasar/sst/TypeStat.scala
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.sst
+
+import slamdata.Predef.{Byte => SByte, Char => SChar, _}
+import quasar.{ejson => ejs}, ejs.{CommonEJson => C, EJson, ExtEJson => E}
+import quasar.fp.numeric.SampleStats
+import quasar.tpe.TypeF
+
+import matryoshka._
+import monocle.Prism
+import scalaz._, Scalaz._, NonEmptyList.nel, Tags.Max
+import scalaz.std.anyVal.{char => charInst}
+import spire.algebra.{AdditiveMonoid, AdditiveSemigroup, Field, NRoot}
+import spire.math.ConvertableTo
+import spire.syntax.field._
+
+sealed abstract class TypeStat[A] {
+  import TypeStat._
+
+  /** The number of observations. */
+  def size(implicit A: AdditiveSemigroup[A]): A = this match {
+    case  Bool(t, f   )       => A.plus(t, f)
+    case  Byte(c, _, _)       => c
+    case  Char(c, _, _)       => c
+    case   Str(c, _, _, _, _) => c
+    case   Int(s, _, _)       => s.size
+    case   Dec(s, _, _)       => s.size
+    case  Coll(c, _, _)       => c
+    case Count(c      )       => c
+  }
+
+  /** Combine with `other` accumulating type specific information when possible
+    * and summing counts otherwise.
+    */
+  def + (other: TypeStat[A])(implicit O: Order[A], F: Field[A]): TypeStat[A] =
+    (this, other) match {
+      case (Bool(t1, f1        ), Bool(t2, f2        )) => bool(t1 + t2, f1 + f2)
+      case (Byte(c1, min1, max1), Byte(c2, min2, max2)) => byte(c1 + c2, mn(min1, min2), mx(max1, max2))
+      case (Char(c1, min1, max1), Char(c2, min2, max2)) => char(c1 + c2, mn(min1, min2), mx(max1, max2))
+      case ( Int(s1, min1, max1),  Int(s2, min2, max2)) =>  int(s1 + s2, mn(min1, min2), mx(max1, max2))
+      case ( Dec(s1, min1, max1),  Dec(s2, min2, max2)) =>  dec(s1 + s2, mn(min1, min2), mx(max1, max2))
+      case (Coll(c1, min1, max1), Coll(c2, min2, max2)) => coll(c1 + c2, mn(min1, min2), mx(max1, max2))
+
+      case (Str(c1, minl1, maxl1, min1, max1), Str(c2, minl2, maxl2, min2, max2)) =>
+        str(c1 + c2, mn(minl1, minl2), mx(maxl1, maxl2), mn(min1, min2), mx(max1, max2))
+
+      case (Coll(c1, min1, max1),  Str(c2, minl2, maxl2, _, _)) =>
+        coll(c1 + c2, mn(min1, some(minl2)), mx(max1, some(maxl2)))
+
+      case (Str(c1, minl1, maxl1, _, _), Coll(c2, min2, max2)) =>
+        coll(c1 + c2, mn(some(minl1), min2), mx(some(maxl1), max2))
+
+      case (                   x,                    y) => count(x.size + y.size)
+    }
+
+  // NB: Avoids conflicts between min/max and implicit widening for byte
+  private def mn[A: Order](x: A, y: A): A = Order[A].min(x, y)
+  private def mx[A: Order](x: A, y: A): A = Order[A].max(x, y)
+}
+
+object TypeStat extends TypeStatInstances {
+  final case class  Bool[A](trues: A, falses: A)                                     extends TypeStat[A]
+  final case class  Byte[A](cnt: A, min: SByte, max: SByte)                          extends TypeStat[A]
+  final case class  Char[A](cnt: A, min: SChar, max: SChar)                          extends TypeStat[A]
+  final case class   Str[A](cnt: A, minLen: A, maxLen: A, min: String, max: String)  extends TypeStat[A]
+  final case class   Int[A](stats: SampleStats[A], min: BigInt, max: BigInt)         extends TypeStat[A]
+  final case class   Dec[A](stats: SampleStats[A], min: BigDecimal, max: BigDecimal) extends TypeStat[A]
+  final case class  Coll[A](cnt: A, minSize: Option[A], maxSize: Option[A])          extends TypeStat[A]
+  final case class Count[A](cnt: A)                                                  extends TypeStat[A]
+
+  def bool[A] = Prism.partial[TypeStat[A], (A, A)] {
+    case Bool(t, f) => (t, f)
+  } ((Bool[A](_, _)).tupled)
+
+  def byte[A] = Prism.partial[TypeStat[A], (A, SByte, SByte)] {
+    case Byte(n, min, max) => (n, min, max)
+  } ((Byte[A](_, _, _)).tupled)
+
+  def char[A] = Prism.partial[TypeStat[A], (A, SChar, SChar)] {
+    case Char(n, min, max) => (n, min, max)
+  } ((Char[A](_, _, _)).tupled)
+
+  def str[A] = Prism.partial[TypeStat[A], (A, A, A, String, String)] {
+    case Str(n, minLen, maxLen, min, max) => (n, minLen, maxLen, min, max)
+  } ((Str[A](_, _, _, _, _)).tupled)
+
+  def int[A] = Prism.partial[TypeStat[A], (SampleStats[A], BigInt, BigInt)] {
+    case Int(ss, min, max) => (ss, min, max)
+  } ((Int[A](_, _, _)).tupled)
+
+  def dec[A] = Prism.partial[TypeStat[A], (SampleStats[A], BigDecimal, BigDecimal)] {
+    case Dec(ss, min, max) => (ss, min, max)
+  } ((Dec[A](_, _, _)).tupled)
+
+  def coll[A] = Prism.partial[TypeStat[A], (A, Option[A], Option[A])] {
+    case Coll(c, min, max) => (c, min, max)
+  } ((Coll[A](_, _, _)).tupled)
+
+  def count[A] = Prism.partial[TypeStat[A], A] {
+    case Count(n) => n
+  } (Count(_))
+
+  def fromEJson[A](cnt: A, ejson: EJson[_])(implicit M: AdditiveMonoid[A], A: ConvertableTo[A]): TypeStat[A] =
+    ejson match {
+      case C(   ejs.Null())  => count(cnt)
+      case C(   ejs.Bool(b)) => bool(b.fold(cnt, M.zero), b.fold(M.zero, cnt))
+      case E(   ejs.Byte(b)) => byte(cnt, b, b)
+      case E(   ejs.Char(c)) => char(cnt, c, c)
+      case C(    ejs.Str(s)) => str(cnt, A fromInt s.length, A fromInt s.length, s, s)
+      case E(    ejs.Int(i)) => int(SampleStats.freq(cnt, A fromBigInt     i), i, i)
+      case C(    ejs.Dec(d)) => dec(SampleStats.freq(cnt, A fromBigDecimal d), d, d)
+      case C(   ejs.Arr(xs)) => fromFoldable(cnt, xs)
+      case E(   ejs.Map(xs)) => fromFoldable(cnt, xs)
+      case E(ejs.Meta(_, _)) => count(cnt)
+    }
+
+  def fromFoldable[F[_]: Foldable, A](cnt: A, fa: F[_])(implicit A: ConvertableTo[A]): TypeStat[A] =
+    (coll(cnt, _: Option[A], _: Option[A])).tupled(some(A fromInt fa.length).squared)
+
+  def fromTypeFƒ[J, A: Order: ConvertableTo](cnt: A)(
+    implicit
+    J: Recursive.Aux[J, EJson],
+    F: Field[A]
+  ): Algebra[TypeF[J, ?], Option[TypeStat[A]]] = {
+    case TypeF.Bottom()              => none
+    case TypeF.Top()                 => some(count(cnt))
+    case TypeF.Simple(_)             => some(count(cnt))
+    case TypeF.Const(j)              => some(fromEJson(cnt, J.project(j)))
+    case TypeF.Arr(-\/(xs))          => some(fromFoldable(maxOr(cnt, xs), xs))
+    case TypeF.Arr(\/-(x))           => some(coll(x.cata(_.size, cnt), none, none))
+    case TypeF.Map(xs, None)         => some(fromFoldable(maxOr(cnt, xs), xs))
+
+    case TypeF.Map(xs, Some((a, b))) =>
+      val ys = xs.toIList
+      some(coll(maxOr(cnt, a :: b :: ys), some(F fromInt xs.size), none))
+
+    case TypeF.Union(a, b, cs)       => nel(a, b :: cs).suml1
+  }
+
+  ////
+
+  private def maxOr[F[_]: Foldable, A: Order: AdditiveSemigroup](a: A, fa: F[Option[TypeStat[A]]]): A =
+    Tag.unwrap(fa.foldMap(s => Max(s map (_.size)))) | a
+}
+
+sealed abstract class TypeStatInstances {
+  import TypeStat._
+
+  implicit def semigroup[A: Order: Field]: Semigroup[TypeStat[A]] =
+    Semigroup.instance(_ + _)
+
+  implicit def equal[A: Equal]: Equal[TypeStat[A]] =
+    Equal.equal((a, b) => (a, b) match {
+      case ( Bool(x1, x2    ),  Bool(y1, y2    )) => x1 ≟ y1 && x2 ≟ y2
+      case ( Byte(x1, x2, x3),  Byte(y1, y2, y3)) => x1 ≟ y1 && x2 ≟ y2 && x3 ≟ y3
+      case ( Char(x1, x2, x3),  Char(y1, y2, y3)) => x1 ≟ y1 && x2 ≟ y2 && x3 ≟ y3
+      case (  Int(x1, x2, x3),   Int(y1, y2, y3)) => x1 ≟ y1 && x2 ≟ y2 && x3 ≟ y3
+      case (  Dec(x1, x2, x3),   Dec(y1, y2, y3)) => x1 ≟ y1 && x2 ≟ y2 && x3 ≟ y3
+      case ( Coll(x1, x2, x3),  Coll(y1, y2, y3)) => x1 ≟ y1 && x2 ≟ y2 && x3 ≟ y3
+      case (Count(x1        ), Count(y1        )) => x1 ≟ y1
+
+      case (Str(x1, x2, x3, x4, x5), Str(y1, y2, y3, y4, y5)) =>
+        x1 ≟ y1 && x2 ≟ y2 && x3 ≟ y3 && x4 ≟ y4 && x5 ≟ y5
+
+      case _ => false
+    })
+
+  implicit def show[A: Show: Equal: Field: NRoot]: Show[TypeStat[A]] =
+    Show.shows {
+      case  Bool(t, f       )             => s"Bool(${t.shows}, ${f.shows})"
+      case  Byte(c, min, max)             => s"Byte(${c.shows}, ${min.shows}, ${max.shows})"
+      case  Char(c, min, max)             => s"Char(${c.shows}, ${min.shows}, ${max.shows})"
+      case   Str(c, minl, maxl, min, max) => s"Str(${c.shows}, ${minl.shows}, ${maxl.shows}, ${min.shows}, ${max.shows})"
+      case   Int(s, min, max)             => s"Int(${s.shows}, ${min.shows}, ${max.shows})"
+      case   Dec(s, min, max)             => s"Dec(${s.shows}, ${min.shows}, ${max.shows})"
+      case  Coll(c, min, max)             => s"Coll(${c.shows}, ${min.shows}, ${max.shows})"
+      case Count(c          )             => s"Count(${c.shows})"
+    }
+}

--- a/frontend/src/main/scala/quasar/sst/compression.scala
+++ b/frontend/src/main/scala/quasar/sst/compression.scala
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.sst
+
+import slamdata.Predef._
+import quasar.contrib.matryoshka._
+import quasar.ejson.{EJson, CommonEJson => C, Str}
+import quasar.fp.numeric._
+import quasar.fp.ski.ι
+import quasar.tpe._
+
+import matryoshka._
+import matryoshka.data.Fix
+import matryoshka.patterns.EnvT
+import matryoshka.implicits._
+import scalaz._, Scalaz._
+import spire.algebra.{Field, Ring}
+import spire.math.ConvertableTo
+import spire.syntax.field._
+
+object compression {
+  import TypeF._
+  private val TS = TypeStat
+
+  /** Compress a map by moving the largest group of keys having the same primary
+    * type to the unknown key field and their values to the unknown value field.
+    *
+    * Only maps having at least `minObs` observations and where the ratio
+    * of the size of the map to the number of
+    * observations >= `distinctRatio` are considered.
+    */
+  def coalesceKeys[J: Order, A: Order: Field: ConvertableTo](
+    minObs: Positive,
+    keyRatio: Double
+  )(implicit
+    JC: Corecursive.Aux[J, EJson],
+    JR: Recursive.Aux[J, EJson]
+  ): SSTF[J, A, SST[J, A]] => SSTF[J, A, SST[J, A]] = {
+    type T = Fix[TypeF[J, ?]]
+    type M = PrimaryType ==>> (J ==>> Unit)
+
+    totally {
+      case sstf @ EnvT((ts, Map(kn, unk))) if sufficientlyDiverse(minObs, keyRatio, ts, kn) =>
+        val grouped = kn.foldlWithKey(IMap.empty: M) { (m, j, _) =>
+          primaryTypeOf(j.project).fold(m) { pt =>
+            m.alter(pt, _ map (_ insert (j, ())) orElse some(IMap.singleton(j, ())))
+          }
+        }
+
+        val (kn1, unk1) = grouped.maximumBy(_.size).fold((kn, unk)) { m =>
+          val toCompress = kn intersection m
+
+          val compressed = toCompress.toList foldMap { case (j, sst) =>
+            (primarySST(size1(sst.copoint), j), sst)
+          }
+
+          (kn \\ toCompress, some(compressed) |+| unk)
+        }
+
+        envT(ts, map[J, SST[J, A]](kn1, unk1))
+    }
+  }
+
+  /** Compress the largest group of values in a union having the same
+    * primary type to that type.
+    *
+    * Only unions having at least `minObs` observations and where the ratio
+    * of the size of the union to the number of
+    * observations >= `distinctRatio` are considered.
+    */
+  def coalescePrimary[J: Order, A: Order: Field: ConvertableTo](
+    minObs: Positive,
+    distinctRatio: Double
+  )(implicit
+    JC: Corecursive.Aux[J, EJson],
+    JR: Recursive.Aux[J, EJson]
+  ): SSTF[J, A, SST[J, A]] => SSTF[J, A, SST[J, A]] = {
+    type T = Fix[TypeF[J, ?]]
+    type M = PrimaryType ==>> NonEmptyList[SST[J, A]]
+
+    totally {
+      case sstf @ EnvT((ts, Unioned(xs))) if sufficientlyDiverse(minObs, distinctRatio, ts, xs) =>
+        val grouped   = xs.list.groupBy(sst => TypeF.primary[J](sst.project.lower))
+        val primaries = grouped.toList.map(_.bitraverse(ι, some)).unite
+
+        val compressed = primaries.maximumBy(_._2.length).fold(grouped) {
+          case (pt, ssts) =>
+            val reduced = ssts.foldMap(sst => sst.project match {
+              case EnvT((x, Const(j))) => sstMeasure[J, A].set(x)(primarySST(size1(x), j))
+              case _                   => sst
+            })
+            grouped.insert(some(pt), reduced.wrapNel)
+        }
+
+        compressed.foldMap(_.list) match {
+          case ICons(x, ICons(y, zs)) => envT(ts, union[J, SST[J, A]](x, y, zs))
+          case ICons(x, INil())       => envT(ts, x.project.lower)
+          case INil()                 => sstf
+        }
+    }
+  }
+
+  /** Replace arrays of known size longer than the given limit with an array of unknown size. */
+  def limitArrays[J: Order, A: Order](maxLength: Positive)(
+    implicit
+    A : Field[A],
+    JR: Recursive.Aux[J, EJson]
+  ): SSTF[J, A, SST[J, A]] => SSTF[J, A, SST[J, A]] = totally {
+    case EnvT((ts, Arr(-\/(elts)))) if elts.length > maxLength.value =>
+      val (cnt, len) = (size1(ts), A fromInt elts.length)
+      envT(some(TS.coll(cnt, some(len), some(len))), arr(\/-(elts.suml)))
+  }
+
+  /** Replace literal string types longer than the given limit with `char[]`. */
+  def limitStrings[J, A](maxLength: Positive)(
+    implicit
+    A : Ring[A],
+    JR: Recursive.Aux[J, EJson]
+  ): SSTF[J, A, SST[J, A]] => SSTF[J, A, SST[J, A]] = totally {
+    case EnvT((ts, Const(Embed(C(Str(s)))))) if s.length > maxLength.value =>
+      val (cnt, len) = (size1(ts), A fromInt s.length)
+      envT(some(TS.coll(cnt, some(len), some(len))), charArr(cnt))
+  }
+
+  /** Replace encoded binary strings with `byte[]`. */
+  def z85EncodedBinary[J, A](
+    implicit
+    A : Field[A],
+    JR: Recursive.Aux[J, EJson]
+  ): SSTF[J, A, SST[J, A]] => SSTF[J, A, SST[J, A]] = totally {
+    case EnvT((ts, Const(Embed(EncodedBinary(size))))) =>
+      // NB: Z85 uses 5 chars for every 4 bytes.
+      val (cnt, len) = (size1(ts), A.fromBigInt(size) * A.fromInt(4) / A.fromInt(5))
+      envT(some(TS.coll(cnt, some(len), some(len))), byteArr(cnt))
+  }
+
+  ////
+
+  private def sstMeasure[J, A] = StructuralType.measure[J, Option[TypeStat[A]]]
+
+  private def byteArr[J, A](cnt: A): TypeF[J, SST[J, A]] =
+    simpleArr(cnt, SimpleType.Byte)
+
+  private def charArr[J, A](cnt: A): TypeF[J, SST[J, A]] =
+    simpleArr(cnt, SimpleType.Char)
+
+  private def simpleArr[J, A](cnt: A, st: SimpleType): TypeF[J, SST[J, A]] =
+    arr[J, SST[J, A]](envT(some(TS.count(cnt)), simple[J, SST[J, A]](st)).embed.right)
+
+  /** Returns the SST of the primary type of the given EJson value.
+    *
+    * ∀ a j. Const(j).embed <: primarySST(a, j).toType[T]
+    */
+  private def primarySST[J: Order, A: ConvertableTo: Field: Order](cnt: A, j: J)(
+    implicit
+    JC: Corecursive.Aux[J, EJson],
+    JR: Recursive.Aux[J, EJson]
+  ): SST[J, A] = j.project match {
+    case ej @ SimpleEJson(s) => envT(some(TS.fromEJson(cnt, ej)), simple[J, SST[J, A]](s)).embed
+    case ej @ C(Str(_))      => envT(some(TS.fromEJson(cnt, ej)), charArr[J, A](cnt)).embed
+    case _                   => SST.fromEJson(cnt, j)
+  }
+
+  private def size1[A](ots: Option[TypeStat[A]])(implicit R: Ring[A]): A =
+    ots.cata(_.size, R.one)
+
+  /** Returns whether the given foldable is "sufficiently diverse" based on the
+    * provided parameters. Diversity is defined as the ratio of the size of F
+    * to the number of observations.
+    */
+  private def sufficientlyDiverse[F[_]: Foldable, A: Order, B](
+    minObs: Positive,
+    ratio: Double,
+    ts: Option[TypeStat[A]],
+    fb: F[B]
+  )(implicit A: Field[A]): Boolean = {
+    val (cnt, len) = (size1(ts), fb.length)
+    val alen       = A fromInt len
+    len >= minObs.value && (alen / cnt) >= A.fromDouble(ratio)
+  }
+}

--- a/frontend/src/main/scala/quasar/sst/compression.scala
+++ b/frontend/src/main/scala/quasar/sst/compression.scala
@@ -189,7 +189,8 @@ object compression {
     fb: F[B]
   )(implicit A: Field[A]): Boolean = {
     val (cnt, len) = (size1(ts), fb.length)
+    val thold      = A fromBigInt BigInt(minObs.value)
     val alen       = A fromInt len
-    len >= minObs.value && (alen / cnt) >= A.fromDouble(ratio)
+    cnt >= thold && (alen / cnt) >= A.fromDouble(ratio)
   }
 }

--- a/frontend/src/main/scala/quasar/sst/compression.scala
+++ b/frontend/src/main/scala/quasar/sst/compression.scala
@@ -31,7 +31,6 @@ import monocle.syntax.fields._
 import scalaz._, Scalaz._
 import spire.algebra.{Field, Ring}
 import spire.math.ConvertableTo
-import spire.syntax.field._
 
 object compression {
   import TypeF._
@@ -149,8 +148,8 @@ object compression {
   ): SSTF[J, A, SST[J, A]] => SSTF[J, A, SST[J, A]] = totally {
     case EnvT((ts, Const(Embed(EncodedBinary(size))))) =>
       // NB: Z85 uses 5 chars for every 4 bytes.
-      val (cnt, len) = (size1(ts), A.fromBigInt(size) * A.fromInt(4) / A.fromInt(5))
-      envT(some(TS.coll(cnt, some(len), some(len))), byteArr(cnt))
+      val (cnt, len) = (size1(ts), some(A.fromBigInt(size)))
+      envT(some(TS.coll(cnt, len, len)), byteArr(cnt))
   }
 
   ////

--- a/frontend/src/main/scala/quasar/sst/package.scala
+++ b/frontend/src/main/scala/quasar/sst/package.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar
+
+import slamdata.Predef._
+
+package object sst {
+  /** Statistical Structural Type */
+  type SST[J, A] = StructuralType[J, Option[TypeStat[A]]]
+}

--- a/frontend/src/main/scala/quasar/sst/package.scala
+++ b/frontend/src/main/scala/quasar/sst/package.scala
@@ -72,7 +72,7 @@ package object sst {
   object EncodedBinary {
     def unapply[J](ejs: EJson[J])(implicit J: Recursive.Aux[J, EJson]): Option[BigInt] =
       ejs match {
-        case E(Meta(Embed(SizedTypeTag(BinaryTag, size)), Embed(C(Str(_))))) => some(size)
+        case E(Meta(Embed(C(Str(_))), Embed(SizedTypeTag(BinaryTag, size)))) => some(size)
         case _                                                               => none
       }
   }

--- a/frontend/src/main/scala/quasar/sst/package.scala
+++ b/frontend/src/main/scala/quasar/sst/package.scala
@@ -17,8 +17,63 @@
 package quasar
 
 import slamdata.Predef._
+import quasar.contrib.matryoshka._
+import quasar.ejson.{BinaryTag, EJson, CommonEJson => C, ExtEJson => E, Meta, Null, SizedTypeTag, Str}
+import quasar.fp.ski.κ
+import quasar.tpe._
+
+import matryoshka._
+import matryoshka.implicits._
+import matryoshka.patterns._
+import scalaz._, Scalaz._
+import spire.algebra.Field
+import spire.math.ConvertableTo
 
 package object sst {
   /** Statistical Structural Type */
-  type SST[J, A] = StructuralType[J, Option[TypeStat[A]]]
+  type SSTF[J, A, B] = EnvT[Option[TypeStat[A]], TypeF[J, ?], B]
+  type SST[J, A]     = StructuralType[J, Option[TypeStat[A]]]
+
+  object SST {
+    def fromData[J: Order, A: ConvertableTo: Field: Order](
+      count: A,
+      data: Data
+    )(implicit
+      JC: Corecursive.Aux[J, EJson],
+      JR: Recursive.Aux[J, EJson]
+    ): SST[J, A] = {
+      val ejs = data.hylo[CoEnv[Data, EJson, ?], J](
+        interpret(κ(C(Null[J]()).embed), elideNonBinaryMetadata[J] >>> (_.embed)),
+        Data.toEJson[EJson])
+      StructuralType.fromEJson[J](TypeStat.fromTypeFƒ(count), ejs)
+    }
+
+    def fromEJson[J: Order, A: ConvertableTo: Field: Order](
+      count: A,
+      ejson: J
+    )(implicit
+      JC: Corecursive.Aux[J, EJson],
+      JR: Recursive.Aux[J, EJson]
+    ): SST[J, A] =
+      StructuralType.fromEJson[J](
+        TypeStat.fromTypeFƒ(count),
+        ejson.transCata[J](elideNonBinaryMetadata[J]))
+
+    ////
+
+    private def elideNonBinaryMetadata[J](
+      implicit J: Recursive.Aux[J, EJson]
+    ): EJson[J] => EJson[J] = {
+      case ejs @ EncodedBinary(_) => ejs
+      case other                  => EJson.elideMetadata[J] apply other
+    }
+  }
+
+  object EncodedBinary {
+    def unapply[J](ejs: EJson[J])(implicit J: Recursive.Aux[J, EJson]): Option[BigInt] =
+      ejs match {
+        case E(Meta(Embed(SizedTypeTag(BinaryTag, size)), Embed(C(Str(_))))) => some(size)
+        case _                                                               => none
+      }
+  }
 }

--- a/frontend/src/main/scala/quasar/tpe/TypeF.scala
+++ b/frontend/src/main/scala/quasar/tpe/TypeF.scala
@@ -18,7 +18,8 @@ package quasar.tpe
 
 import slamdata.Predef._
 import quasar.contrib.matryoshka._
-import quasar.ejson.EJson
+import quasar.ejson
+import quasar.ejson.{CommonEJson => C, ExtEJson => E, EJson, EncodeEJson, EncodeEJsonK}
 import quasar.fp.ski.κ
 
 import scala.Tuple2
@@ -355,6 +356,50 @@ private[quasar] sealed abstract class TypeFInstances {
          union[J, A].getOption(tf),
            top[J, A].getOption(tf)
       )
+    }
+
+  implicit def encodeEJsonK[A](implicit A: EncodeEJson[A]): EncodeEJsonK[TypeF[A, ?]] =
+    new EncodeEJsonK[TypeF[A, ?]] {
+      def encodeK[J](implicit J: Corecursive.Aux[J, EJson]): Algebra[TypeF[A, ?], J] = {
+        case Bottom()        => tlabel("bottom")
+        case Top()           => tlabel("top")
+        case Simple(s)       => tlabel(SimpleType.name(s))
+        case Const(a)        => tof("const", A.encode[J](a))
+        case Union(x, y, zs) => tof("sum", C(ejson.arr((x :: y :: zs).toList)).embed)
+
+        case Arr(a) =>
+          tof("array", a.leftMap(js => C(ejson.arr(js.toList)).embed).merge)
+
+        case Map(kvs, unk) =>
+          val jjs   = kvs.toList.map(_.leftMap(A.encode[J](_)))
+          val other = unk map { case (k, v) => (
+            C(ejson.str[J]("other")).embed,
+            map1(
+              C(ejson.str[J]("keys")).embed   -> k,
+              C(ejson.str[J]("values")).embed -> v)
+          )}
+          tof("map", E(ejson.map(jjs)).embed, other.toList: _*)
+      }
+
+      private def map1[J](assoc: (J, J), assocs: (J, J)*)(
+        implicit J: Corecursive.Aux[J, EJson]
+      ): J =
+        E(ejson.map(assoc :: assocs.toList)).embed
+
+      private def tmap[J](v: J, assocs: (J, J)*)(
+        implicit J: Corecursive.Aux[J, EJson]
+      ): J =
+        map1(C(ejson.str[J]("type")).embed -> v, assocs: _*)
+
+      private def tlabel[J](label: String, assocs: (J, J)*)(
+        implicit J: Corecursive.Aux[J, EJson]
+      ): J =
+        tmap(C(ejson.str[J](label)).embed, assocs: _*)
+
+      private def tof[J](label: String, of: J, assocs: (J, J)*)(
+        implicit J: Corecursive.Aux[J, EJson]
+      ): J =
+        tlabel(label, ((C(ejson.str[J]("of")).embed -> of) :: assocs.toList): _*)
     }
 
   implicit def traverse[J]: Traverse[TypeF[J, ?]] =

--- a/frontend/src/main/scala/quasar/tpe/package.scala
+++ b/frontend/src/main/scala/quasar/tpe/package.scala
@@ -38,6 +38,11 @@ package object tpe {
         _.fold(SimpleType.name(_), CompositeType.name(_)))
   }
 
+  object SimpleEJson {
+    def unapply(ejs: EJson[_]): Option[SimpleType] =
+      simpleTypeOf(ejs)
+  }
+
   /** Returns the `CompositeType` of the given EJson value, if exists. */
   val compositeTypeOf: EJson[_] => Option[CompositeType] = {
     case C(ejs.Arr(_)) => some(CompositeType.Arr)

--- a/frontend/src/test/scala/quasar/sst/CompressionSpec.scala
+++ b/frontend/src/test/scala/quasar/sst/CompressionSpec.scala
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.sst
+
+import slamdata.Predef._
+import quasar.contrib.algebra._
+import quasar.contrib.matryoshka._
+import quasar.contrib.matryoshka.arbitrary._
+import quasar.ejson, ejson.{CommonEJson => C, EJson, EJsonArbitrary, ExtEJson => E, z85}
+import quasar.ejson.implicits._
+import quasar.fp._
+import quasar.fp.numeric.Positive
+import quasar.tpe._
+
+import scala.Predef.$conforms
+
+import eu.timepit.refined.auto._
+import matryoshka.{project => _, _}
+import matryoshka.data._
+import matryoshka.implicits._
+import monocle.syntax.fields._
+import org.scalacheck._, Arbitrary.arbitrary
+import org.specs2.scalacheck._
+import scalaz._, Scalaz._
+import scalaz.scalacheck.ScalazArbitrary._
+import scodec.bits.ByteVector
+import spire.math.Real
+
+final class CompressionSpec extends quasar.Qspec
+  with StructuralTypeArbitrary
+  with TypeStatArbitrary
+  with EJsonArbitrary
+  with SimpleTypeArbitrary {
+
+  implicit val params = Parameters(maxSize = 10)
+
+  type J = Fix[EJson]
+  type S = SST[J, Real]
+
+  case class LeafEjs(ejs: J) {
+    def toSST: S = SST.fromEJson(Real(1), ejs)
+  }
+
+  implicit val arbitraryLeafEjs: Arbitrary[LeafEjs] =
+    Arbitrary(Gen.oneOf(
+      Gen.const(C(ejson.nul[J]()).embed),
+      arbitrary[Boolean] map (b => C(ejson.bool[J](b)).embed),
+      arbitrary[String] map (s => C(ejson.str[J](s)).embed),
+      arbitrary[BigDecimal] map (d => C(ejson.dec[J](d)).embed),
+      arbitrary[Byte] map (b => E(ejson.byte[J](b)).embed),
+      arbitrary[Char] map (c => E(ejson.char[J](c)).embed),
+      arbitrary[BigInt] map (i => E(ejson.int[J](i)).embed)
+    ) map (LeafEjs(_)))
+
+  implicit val orderLeafEjs: Order[LeafEjs] =
+    Order.orderBy(_.ejs)
+
+  implicit val realShow: Show[Real] = Show.showFromToString
+
+  val cnt1 = TypeStat.count(Real(1)).some
+  val envTType = envTIso[Option[TypeStat[Real]], TypeF[J, ?], S] composeLens _2
+  val sstConst = project[S, SSTF[J, Real, ?]] composeLens envTType composePrism TypeF.const
+
+  "coalesceKeys" >> {
+    "compresses largest group of keys having same primary type" >> prop {
+      (cs: ISet[Char], n: BigInt, b: Byte, unk0: Option[(LeafEjs, LeafEjs)]) => (cs.size > 1) ==> {
+
+      val chars = cs.toIList.map(c => E(ejson.char[J](c)).embed)
+      val int = E(ejson.int[J](n)).embed
+      val byte = E(ejson.byte[J](b)).embed
+      val nul = SST.fromEJson(Real(1), C(ejson.nul[J]()).embed)
+      val m0 = IMap.fromFoldable((int :: byte :: chars) strengthR nul)
+
+      val unk  = unk0.map(_.umap(_.toSST))
+      val msst = envT(cnt1, TypeF.map[J, S](m0, unk)).embed
+      val uval = SST.fromEJson(Real(cs.size), C(ejson.nul[J]()).embed)
+      val ust  = chars.foldMap(c => TypeStat.fromEJson(Real(1), c).some)
+      val ukey = envT(ust, TypeF.simple[J, S](SimpleType.Char)).embed
+      val m1   = IMap.fromFoldable(IList(byte, int) strengthR nul)
+      val unk1 = (ukey, uval).some |+| unk
+      val exp  = envT(cnt1, TypeF.map[J, S](m1, unk1)).embed
+
+      msst.transCata[S](compression.coalesceKeys[J, Real](2L)) must_= exp
+    }}
+
+    "ignores map where size of keys does not exceed maxSize" >> prop {
+      (xs: IList[(LeafEjs, LeafEjs)], unk0: Option[(LeafEjs, LeafEjs)]) =>
+
+      val m   = IMap.fromFoldable(xs.map(_.bimap(_.ejs, _.toSST)))
+      val unk = unk0.map(_.umap(l => SST.fromEJson(Real(1), l.ejs)))
+      val sst = envT(cnt1, TypeF.map[J, S](m, unk)).embed
+
+      Positive(m.size.toLong).cata(
+        l => sst.transCata[S](compression.coalesceKeys[J, Real](l)),
+        sst
+      ) must_= sst
+    }
+  }
+
+  "coalescePrimary" >> {
+    "combines consts with their primary type in unions" >> prop { (st0: SimpleType, sjs: ISet[LeafEjs]) =>
+      val st = sjs.findMax.flatMap(x => simpleTypeOf(x.ejs)) | st0
+      val simpleSst = envT(cnt1, TypeF.simple[J, S](st)).embed
+      val ssts = sjs.toIList.map(_.toSST)
+      val (matching, nonmatching) = ssts.partition(sstConst.exist(j => simpleTypeOf(j) exists (_ ≟ st)))
+      val simplified = matching.map(x => envTType.set(TypeF.simple(st))(x.project).embed)
+      val coalesced = (simpleSst :: simplified).suml
+
+      val compressed = (simpleSst :: ssts).suml.transCata[S](compression.coalescePrimary[J, Real])
+
+      compressed must_= (coalesced :: nonmatching).suml
+    }
+
+    "combines multiple instances of a primary type in unions" >> prop {
+      (sts: NonEmptyList[SimpleType], a1: NonEmptyList[J], a2: NonEmptyList[J]) =>
+      val as1 = SST.fromEJson(Real(1), C(ejson.arr[J](a1.toList)).embed)
+      val as2 = SST.fromEJson(Real(1), C(ejson.arr[J](a2.toList)).embed)
+      val xs  = sts.list.map(st => envT(cnt1, TypeF.simple[J, S](st)).embed)
+      val cnt = TypeStat.count(Real(xs.length + 2)).some
+
+      val union = envT(cnt, TypeF.union[J, S](as1, as2, xs)).embed
+      val sum   = (as1 :: as2 :: xs).suml
+
+      union.transCata[S](compression.coalescePrimary[J, Real]) must_= sum
+    }
+
+    "no effect when a const's primary type not in the union" >> prop { ljs: IList[LeafEjs] =>
+      val sum = ljs.foldMap(_.toSST)
+      sum.transCata[S](compression.coalescePrimary[J, Real]) must_= sum
+    }
+  }
+
+  "limitArrays" >> {
+    "compresses arrays longer than maxLen to the union of the members" >> prop {
+      xs: List[BigInt] => (xs.length > 1) ==> {
+
+      val alen: Positive = Positive(xs.length.toLong) getOrElse 1L
+      val lt: Positive = Positive((xs.length - 1).toLong) getOrElse 1L
+      val rlen = Real(xs.length).some
+      val ints = xs.map(i => E(ejson.int[J](i)).embed)
+      val xsst = SST.fromEJson(Real(1), C(ejson.arr[J](ints)).embed)
+
+      val sum = ints.foldMap(x => SST.fromEJson(Real(1), x))
+      val coll = TypeStat.coll(Real(1), rlen, rlen).some
+      val lubarr = envT(coll, TypeF.arr[J, S](sum.right)).embed
+
+      val req = xsst.transCata[S](compression.limitArrays[J, Real](alen))
+      val rlt = xsst.transCata[S](compression.limitArrays[J, Real](lt))
+
+      (req must_= xsst) and (rlt must_= lubarr)
+    }}
+  }
+
+  "limitStrings" >> {
+    "compresses strings longer than maxLen" >> prop { s: String => (s.length > 1) ==> {
+      val plen: Positive = Positive(s.length.toLong) getOrElse 1L
+      val lt: Positive = Positive((s.length - 1).toLong) getOrElse 1L
+      val rlen = Real(s.length).some
+      val str  = SST.fromEJson(Real(1), C(ejson.str[J](s)).embed)
+
+      val char = envT(cnt1, TypeF.simple[J, S](SimpleType.Char)).embed
+      val coll = TypeStat.coll(Real(1), rlen, rlen).some
+      val arr  = envT(coll, TypeF.arr[J, S](char.right)).embed
+
+      val req = str.transCata[S](compression.limitStrings[J, Real](plen))
+      val rlt = str.transCata[S](compression.limitStrings[J, Real](lt))
+
+      (req must_= str) and (rlt must_= arr)
+    }}
+  }
+
+  "narrowUnion" >> {
+    "reduces the largest group of values having the same primary type" >> prop {
+      (bs: ISet[Byte], c1: Char, c2: Char, c3: Char, d1: BigDecimal) =>
+      ((bs.size > 3) && (ISet.fromFoldable(IList(c1, c2, c3)).size ≟ 3)) ==> {
+
+      val bytes = bs.toIList.map(b => SST.fromEJson(Real(1), E(ejson.byte[J](b)).embed))
+      val chars = IList(c1, c2, c3).map(c => SST.fromEJson(Real(1), E(ejson.char[J](c)).embed))
+      val dec = SST.fromEJson(Real(1), C(ejson.dec[J](d1)).embed)
+
+      val compByte = envT(
+        bytes.foldMap(_.copoint),
+        TypeF.simple[J, S](SimpleType.Byte)
+      ).embed
+
+      val union0 = (dec :: chars ::: bytes).suml
+      val union1 = envT(union0.copoint, TypeF.union[J, S](compByte, dec, chars)).embed
+
+      union0.transCata[S](compression.narrowUnion(3L)) must_= union1
+    }}
+
+    "no effect on unions smaller or equal to maxSize" >> prop {
+      (x: LeafEjs, y: LeafEjs, xs: IList[LeafEjs]) =>
+
+      val union = envT(cnt1, TypeF.union[J, S](x.toSST, y.toSST, xs map (_.toSST))).embed
+
+      Positive((xs.length + 2).toLong).cata(
+        l => union.transCata[S](compression.narrowUnion(l)),
+        union
+      ) must_= union
+    }
+  }
+
+  "z85EncodedBinary" >> {
+    "compresses all encoded binary strings" >> prop { bs: Vector[Byte] =>
+      val bytes   = ByteVector(bs)
+      val encoded = z85.encode(bytes)
+      val ejs     = E(ejson.meta[J](
+                      C(ejson.str[J](encoded)).embed,
+                      ejson.SizedTypeTag[J](ejson.BinaryTag, BigInt(bytes.size))
+                    )).embed
+      val sst     = SST.fromEJson(Real(1), ejs)
+
+      val byte    = envT(cnt1, TypeF.simple[J, S](SimpleType.Byte)).embed
+      val rsize   = Real(bytes.size).some
+      val coll    = TypeStat.coll(Real(1), rsize, rsize).some
+      val barr    = envT(coll, TypeF.arr[J, S](byte.right)).embed
+
+      sst.transCata[S](compression.z85EncodedBinary[J, Real]) must_= barr
+    }
+  }
+}

--- a/frontend/src/test/scala/quasar/sst/StructuralTypeArbitrary.scala
+++ b/frontend/src/test/scala/quasar/sst/StructuralTypeArbitrary.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.sst
+
+import quasar.ejson.EJson
+import quasar.fp.ski.κ
+import quasar.pkg.tests._
+
+import matryoshka._
+import scalaz._
+import scalaz.std.anyVal._
+import scalaz.syntax.traverse1._
+import scalaz.scalacheck.ScalaCheckBinding._
+import scalaz.scalacheck.ScalazArbitrary._
+
+trait StructuralTypeArbitrary {
+  implicit def structuralTypeArbitrary[J: Arbitrary: Order, V: Arbitrary](
+    implicit
+    JC: Corecursive.Aux[J, EJson],
+    JR: Recursive.Aux[J, EJson]
+  ): Arbitrary[StructuralType[J, V]] =
+    Arbitrary(arbitrary[NonEmptyList[J]] flatMap { js =>
+      js.foldMap1(StructuralType.fromEJsonK[J]((), _)).traverse1(κ(arbitrary[V]))
+    })
+}
+
+object StructuralTypeArbitrary extends StructuralTypeArbitrary

--- a/frontend/src/test/scala/quasar/sst/StructuralTypeSpec.scala
+++ b/frontend/src/test/scala/quasar/sst/StructuralTypeSpec.scala
@@ -63,7 +63,7 @@ final class StructuralTypeSpec extends Spec
     }
 
     "unmergable values accumulate via union" >> prop { (x: J, y: J) =>
-      ((compositeTypeOf(x.project) ≠ compositeTypeOf(y.project)) && (x ≠ y)) ==> {
+      ((compositeTypeOf(x) ≠ compositeTypeOf(y)) && (x ≠ y)) ==> {
       val (xst, yst) = (mkST(x), mkST(y))
       val exp = envT(2, TypeF.coproduct[J, S](xst, yst)).embed
       (xst |+| yst) must equal(exp)

--- a/frontend/src/test/scala/quasar/sst/StructuralTypeSpec.scala
+++ b/frontend/src/test/scala/quasar/sst/StructuralTypeSpec.scala
@@ -62,7 +62,7 @@ final class StructuralTypeSpec extends Spec
       st.multiply(k) must equal(st as k)
     }
 
-    "unmergable values accumulate via union" >> prop { (x: J, y: J) =>
+    "unmergeable values accumulate via union" >> prop { (x: J, y: J) =>
       ((compositeTypeOf(x) ≠ compositeTypeOf(y)) && (x ≠ y)) ==> {
       val (xst, yst) = (mkST(x), mkST(y))
       val exp = envT(2, TypeF.coproduct[J, S](xst, yst)).embed
@@ -100,7 +100,7 @@ final class StructuralTypeSpec extends Spec
       } getOrElse ok
     }
 
-    "unions merge by accumulating mergable values" >> prop { (xs: IList[S], ys: IList[S], i: BigInt, s: String, st: SimpleType) =>
+    "unions merge by accumulating mergeable values" >> prop { (xs: IList[S], ys: IList[S], i: BigInt, s: String, st: SimpleType) =>
       val xst = envT(1, TypeF.arr[J, S](xs.left)).embed
       val yst = envT(1, TypeF.arr[J, S](ys.left)).embed
       val ist = mkST(E(ejs.int[J](i)).embed)

--- a/frontend/src/test/scala/quasar/sst/StructuralTypeSpec.scala
+++ b/frontend/src/test/scala/quasar/sst/StructuralTypeSpec.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.sst
+
+import slamdata.Predef._
+import quasar.contrib.matryoshka._
+import quasar.contrib.matryoshka.arbitrary._
+import quasar.{ejson => ejs}
+import quasar.ejson.{CommonEJson => C, EJson, EJsonArbitrary, ExtEJson => E}
+import quasar.ejson.implicits._
+import quasar.fp._
+import quasar.tpe._
+
+import scala.Predef.$conforms
+
+import matryoshka._
+import matryoshka.data._
+import matryoshka.implicits._
+import org.specs2.scalacheck._
+import org.specs2.scalaz._
+import scalaz._, Scalaz._
+import scalaz.scalacheck.{ScalazProperties => propz}
+import scalaz.scalacheck.ScalazArbitrary._
+
+final class StructuralTypeSpec extends Spec
+  with ScalazMatchers
+  with StructuralTypeArbitrary
+  with EJsonArbitrary
+  with SimpleTypeArbitrary {
+
+  implicit val params = Parameters(maxSize = 5)
+
+  type J = Fix[EJson]
+  type S = StructuralType[J, Int]
+
+  def mkST(j: J): S = StructuralType.fromEJsonK[J](1, j)
+
+  checkAll(propz.equal.laws[S])
+  checkAll(propz.monoid.laws[S])
+  checkAll(propz.traverse1.laws[StructuralType[J, ?]])
+  // FIXME: Need Cogen
+  //checkAll(propz.comonad.laws[StructuralType[J, ?]])
+
+  "structural monoid" >> {
+    "accumulates measure for identical structure" >> prop { (ejs: J, k0: Int) =>
+      val k = scala.math.abs(k0 % 100) + 1
+      val st = mkST(ejs)
+      st.multiply(k) must equal(st as k)
+    }
+
+    "unmergable values accumulate via union" >> prop { (x: J, y: J) =>
+      ((compositeTypeOf(x.project) ≠ compositeTypeOf(y.project)) && (x ≠ y)) ==> {
+      val (xst, yst) = (mkST(x), mkST(y))
+      val exp = envT(2, TypeF.coproduct[J, S](xst, yst)).embed
+      (xst |+| yst) must equal(exp)
+    }}
+
+    "known and unknown arrays merge union of known with lub" >> prop { (xs: List[J], y: SimpleType) =>
+      val arr = mkST(C(ejs.Arr(xs)).embed)
+      val ySimple = envT(1, TypeF.simple[J, S](y)).embed
+      val lubArr = envT(1, TypeF.arr[J, S](ySimple.right)).embed
+      val consts = xs.toIList.map(mkST)
+
+      val exp = envT(2, TypeF.arr[J, S](\/-(consts match {
+        case INil()                 => ySimple
+        case ICons(a, INil())       => envT(2, TypeF.coproduct[J, S](ySimple, a)).embed
+        case ICons(a, ICons(b, cs)) => envT(2, TypeF.union[J, S](ySimple, a, b :: cs)).embed
+      }))).embed
+
+      (lubArr |+| arr) must equal(exp)
+    }
+
+    "merging known map with unknown results in a map with both" >> prop { (kn: IMap[J, S], unk: (S, S)) =>
+      val m1 = envT(1, TypeF.map[J, S](kn, None)).embed
+      val m2 = envT(1, TypeF.map[J, S](IMap.empty[J, S], Some(unk))).embed
+      val me = envT(2, TypeF.map[J, S](kn, Some(unk))).embed
+      (m1 |+| m2) must equal(me)
+    }
+
+    "merging known maps where some keys differ results in combination of keys" >> prop { m0: IMap[J, S] =>
+      m0.minViewWithKey map { case ((k, v), m) =>
+        val m1 = envT(1, TypeF.map[J, S](IMap.singleton(k, v), None)).embed
+        val m2 = envT(1, TypeF.map[J, S](m, None)).embed
+        val m3 = envT(2, TypeF.map[J, S](m0, None)).embed
+        (m1 |+| m2) must equal(m3)
+      } getOrElse ok
+    }
+
+    "unions merge by accumulating mergable values" >> prop { (xs: IList[S], ys: IList[S], i: BigInt, s: String, st: SimpleType) =>
+      val xst = envT(1, TypeF.arr[J, S](xs.left)).embed
+      val yst = envT(1, TypeF.arr[J, S](ys.left)).embed
+      val ist = mkST(E(ejs.int[J](i)).embed)
+      val sst = mkST(C(ejs.str[J](s)).embed)
+      val pst = envT(1, TypeF.simple[J, S](st)).embed
+      val a   = envT(1, TypeF.union[J, S](xst, ist, IList(pst))).embed
+      val b   = envT(1, TypeF.union[J, S](yst, sst, IList(pst))).embed
+      val c   = envT(2, TypeF.union[J, S](xst |+| yst, ist, IList(sst, pst |+| pst))).embed
+      (a |+| b) must equal(c)
+    }
+  }
+}

--- a/frontend/src/test/scala/quasar/sst/TypeStatArbitrary.scala
+++ b/frontend/src/test/scala/quasar/sst/TypeStatArbitrary.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.sst
+
+import slamdata.Predef.{Byte => SByte, Char => SChar, _}
+import quasar.fp.numeric.{SampleStats, SampleStatsArbitrary}
+import quasar.pkg.tests._
+
+import scalaz._
+import scalaz.std.anyVal._
+import scalaz.std.math.bigInt._
+import scalaz.std.math.bigDecimal._
+import scalaz.std.option._
+import scalaz.std.string._
+import scalaz.syntax.apply._
+import scalaz.syntax.order._
+import scalaz.scalacheck.ScalaCheckBinding._
+import spire.algebra.Field
+
+trait TypeStatArbitrary {
+  import TypeStat._
+  import SampleStatsArbitrary._
+
+  // NB: This instance isn't found otherwise.
+  private implicit val charOrder: Order[SChar] = scalaz.std.anyVal.char
+
+  implicit def typeStatArbitrary[A: Arbitrary: Order: Field]: Arbitrary[TypeStat[A]] =
+    Gen.oneOf(
+      genBool[A],
+      genColl[A],
+      arbitrary[A] map (count[A](_)),
+      (arbitrary[A] |@| genRange[SByte])((a, r) => byte(a, r._1, r._2)),
+      (arbitrary[A] |@| genRange[SChar])((a, r) => char(a, r._1, r._2)),
+      (arbitrary[A] |@| genRange[A] |@| genRange[String])((c, r, s) => str[A](c, r._1, r._2, s._1, s._2)),
+      (arbitrary[SampleStats[A]] |@| genRange[BigInt])((s, r) => int[A](s, r._1, r._2)),
+      (arbitrary[SampleStats[A]] |@| genRange[BigDecimal])((s, r) => dec[A](s, r._1, r._2)))
+
+  ////
+
+  private def genBool[A: Arbitrary]: Gen[TypeStat[A]] =
+    (arbitrary[A] |@| arbitrary[A])(bool[A](_, _))
+
+  private def genRange[A: Arbitrary: Order]: Gen[(A, A)] =
+    (arbitrary[A] |@| arbitrary[A])((b1, b2) => (b1 min b2, b1 max b2))
+
+  private def genColl[A: Arbitrary: Order]: Gen[TypeStat[A]] =
+    (arbitrary[A] |@| arbitrary[Option[A]] |@| arbitrary[Option[A]]) { (a, o1, o2) =>
+      val (mn, mx) =
+        if (o1.isEmpty || o2.isEmpty) (o1, o2)
+        else (o1 min o2, o1 max o2)
+
+      coll[A](a, mn, mx)
+    }
+}
+
+object TypeStatArbitrary extends TypeStatArbitrary

--- a/frontend/src/test/scala/quasar/sst/TypeStatSpec.scala
+++ b/frontend/src/test/scala/quasar/sst/TypeStatSpec.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.sst
+
+import slamdata.Predef._
+import quasar.contrib.algebra._
+
+import org.specs2.scalaz._
+import scalaz.Show
+import scalaz.scalacheck.{ScalazProperties => propz}
+import spire.laws.arb._
+import spire.math.Real
+
+final class TypeStatSpec extends Spec with ScalazMatchers with TypeStatArbitrary {
+  import TypeStat._
+
+  implicit val realShow: Show[Real] = Show.showFromToString
+
+  checkAll(propz.equal.laws[TypeStat[Real]])
+  checkAll(propz.semigroup.laws[TypeStat[Real]])
+
+  "combining preserves shape" >> prop { ts: TypeStat[Real] =>
+    count[Real].isEmpty(ts + ts) must_== count[Real].isEmpty(ts)
+  }
+
+  "combining sums counts" >> prop { (x: TypeStat[Real], y: TypeStat[Real]) =>
+    (x + y).size must equal(x.size + y.size)
+  }
+
+  "combining string and coll treats string as collection" >> {
+    val strStat  = str[Real](Real(3), Real(3), Real(4), "foo", "quux")
+    val collStat = coll[Real](Real(2), Some(Real(2)), None)
+    val expStat  = coll[Real](Real(5), Some(Real(2)), Some(Real(4)))
+
+    (strStat + collStat) must equal(expStat)
+  }
+}

--- a/frontend/src/test/scala/quasar/tpe/TypeFSpec.scala
+++ b/frontend/src/test/scala/quasar/tpe/TypeFSpec.scala
@@ -78,7 +78,7 @@ final class TypeFSpec extends Spec with TypeFArbitrary with EJsonArbitrary {
     }
 
     "<ejs> <: SimpleType" >> prop { j: J =>
-      simpleTypeOf(j.project) all { st =>
+      simpleTypeOf(j) all { st =>
         isSubtypeOf[J](const[J, T](j).embed, simple[J, T](st).embed)
       }
     }

--- a/interface/src/main/scala/quasar/main/analysis.scala
+++ b/interface/src/main/scala/quasar/main/analysis.scala
@@ -16,7 +16,6 @@
 
 package quasar.main
 
-import slamdata.Predef._
 import quasar.Data
 import quasar.contrib.matryoshka._
 import quasar.contrib.pathy._

--- a/interface/src/main/scala/quasar/main/analysis.scala
+++ b/interface/src/main/scala/quasar/main/analysis.scala
@@ -38,23 +38,27 @@ import spire.math.ConvertableTo
 object analysis {
   /** Knobs controlling various aspects of SST compression.
     *
+    * @param arrayMaxSize    arrays larger than this will be compressed
     * @param mapMaxSize      maps larger than this will be compressed
     * @param stringMaxLength all strings longer than this are compressed to char[]
     * @param unionMaxSize    unions larger than this will be compressed
     */
   final case class CompressionSettings(
+    arrayMaxLength:  Positive,
     mapMaxSize:      Positive,
     stringMaxLength: Positive,
     unionMaxSize:    Positive
   )
 
   object CompressionSettings {
-    val DefaultMapMaxSize:      Positive = 50L
+    val DefaultArrayMaxLength:  Positive = 64L
+    val DefaultMapMaxSize:      Positive = 64L
     val DefaultStringMaxLength: Positive = 64L
     val DefaultUnionMaxSize:    Positive =  1L
 
     val Default: CompressionSettings =
       CompressionSettings(
+        arrayMaxLength  = DefaultArrayMaxLength,
         mapMaxSize      = DefaultMapMaxSize,
         stringMaxLength = DefaultStringMaxLength,
         unionMaxSize    = DefaultUnionMaxSize)
@@ -71,6 +75,7 @@ object analysis {
       compression.coalesceKeys[J, A](settings.mapMaxSize)      >>>
       compression.z85EncodedBinary[J, A]                       >>>
       compression.limitStrings[J, A](settings.stringMaxLength) >>>
+      compression.limitArrays[J, A](settings.arrayMaxLength)   >>>
       compression.coalescePrimary[J, A]                        >>>
       compression.narrowUnion[J, A](settings.unionMaxSize)
 

--- a/interface/src/main/scala/quasar/main/analysis.scala
+++ b/interface/src/main/scala/quasar/main/analysis.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.main
+
+import quasar.Data
+import quasar.contrib.matryoshka._
+import quasar.ejson.EJson
+import quasar.fp.numeric.Positive
+import quasar.sst._
+
+import eu.timepit.refined.auto._
+import matryoshka._
+import matryoshka.implicits._
+import scalaz._, Scalaz._
+import scalaz.stream._
+import spire.algebra.Field
+import spire.math.ConvertableTo
+
+object analysis {
+  /** Reduces the input to an `SST` describing the `Data` seen so far. */
+  def extractSchema[J: Order, A: ConvertableTo: Field: Order](
+    implicit
+    JC: Corecursive.Aux[J, EJson],
+    JR: Recursive.Aux[J, EJson]
+  ): Process1[Data, SST[J, A]] = {
+    // TODO: CompressionSettings
+    val stringLimit: Positive = 128L
+    val minimumObs : Positive =   1L
+    val distRatio             = 0.80
+
+    val preprocess =
+      compression.z85EncodedBinary[J, A] >>> compression.limitStrings[J, A](stringLimit)
+
+    val compressTrans =
+      compression.coalesceKeys[J, A](minimumObs, distRatio)   >>>
+      preprocess                                              >>>
+      compression.coalescePrimary[J, A](minimumObs, distRatio)
+
+    val compress = (sst: SST[J, A]) => {
+      val compSST = sst.transCata[SST[J, A]](compressTrans)
+      (sst ≠ compSST) option compSST
+    }
+
+    process1.lift(SST.fromData[J, A](Field[A].one, _: Data))
+      .map(_ transCata[SST[J, A]] preprocess)
+      .reduceMonoid
+      .map(repeatedly(compress))
+  }
+}

--- a/interface/src/main/scala/quasar/main/analysis.scala
+++ b/interface/src/main/scala/quasar/main/analysis.scala
@@ -72,6 +72,7 @@ object analysis {
     JR: Recursive.Aux[J, EJson]
   ): Process1[Data, SST[J, A]] = {
     val structuralTrans =
+      compression.coalesceWithUnknown[J, A]                    >>>
       compression.coalesceKeys[J, A](settings.mapMaxSize)      >>>
       compression.z85EncodedBinary[J, A]                       >>>
       compression.limitStrings[J, A](settings.stringMaxLength) >>>

--- a/interface/src/test/scala/quasar/main/ExtractSchemaSpec.scala
+++ b/interface/src/test/scala/quasar/main/ExtractSchemaSpec.scala
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.main
+
+import slamdata.Predef.{Int => SInt, _}
+import quasar.Data
+import quasar.contrib.matryoshka._
+import quasar.{ejson => e}
+import quasar.ejson.{CommonEJson => C, EJson, ExtEJson => E}
+import quasar.ejson.implicits._
+import quasar.fp._
+import quasar.fp.numeric.SampleStats
+import quasar.sst._
+import quasar.tpe._
+
+import eu.timepit.refined.auto._
+import matryoshka.data.Fix
+import matryoshka.implicits._
+import scalaz._, Scalaz._
+import scalaz.stream.Process
+import spire.std.double._
+
+final class ExtractSchemaSpec extends quasar.Qspec {
+  import Data._
+
+  type J = Fix[EJson]
+  type S = SST[J, Double]
+
+  val settings = analysis.CompressionSettings(1000L, 1000L, 1000L, 1000L)
+
+  def verify(cs: analysis.CompressionSettings, input: List[Data], expected: S) =
+    Process.emitAll(input)
+      .pipe(analysis.extractSchema[J, Double](cs))
+      .toVector.headOption must beSome(equal(expected))
+
+  def ints(ns: SInt*): IList[S] =
+    IList(ns: _*) map (n =>
+      envT(
+        TypeStat.int(SampleStats.one(n.toDouble), BigInt(n), BigInt(n)).some,
+        TypeF.const[J, S](E(e.int[J](BigInt(n))).embed)).embed)
+
+  "compress arrays" >> {
+    val input = List(
+      _obj(ListMap("foo" -> _arr(List(_int(1), _int(2))))),
+      _obj(ListMap("bar" -> _arr(List(_int(1), _int(2), _int(3)))))
+    )
+
+    val expected = envT(
+      TypeStat.coll(2.0, 1.0.some, 1.0.some).some,
+      TypeF.map[J, S](IMap(
+        C(e.str[J]("foo")).embed -> envT(
+          TypeStat.coll(1.0, 2.0.some, 2.0.some).some,
+          TypeF.arr[J, S](ints(1, 2).left)).embed,
+
+        C(e.str[J]("bar")).embed -> envT(
+          TypeStat.coll(1.0, 3.0.some, 3.0.some).some,
+          TypeF.arr[J, S](ints(1, 2, 3).suml.right)).embed
+      ), None)).embed
+
+    verify(settings.copy(arrayMaxLength = 2L), input, expected)
+  }
+
+  "compress long strings" >> {
+    val input = List(
+      _obj(ListMap("foo" -> _str("abcdef"))),
+      _obj(ListMap("bar" -> _str("abcde")))
+    )
+
+    val expected = envT(
+      TypeStat.coll(2.0, 1.0.some, 1.0.some).some,
+      TypeF.map[J, S](IMap(
+        C(e.str[J]("foo")).embed -> envT(
+          TypeStat.coll(1.0, 6.0.some, 6.0.some).some,
+          TypeF.arr[J, S](envT(
+            TypeStat.count(1.0).some,
+            TypeF.simple[J, S](SimpleType.Char)
+          ).embed.right)).embed,
+
+        C(e.str[J]("bar")).embed -> envT(
+          TypeStat.str(1.0, 5.0, 5.0, "abcde", "abcde").some,
+          TypeF.const[J, S](C(e.str[J]("abcde")).embed)
+        ).embed
+      ), None)).embed
+
+    verify(settings.copy(stringMaxLength = 5L), input, expected)
+  }
+
+  "compress encoded binary strings" >> {
+    val b1 = ImmutableArray.fromArray("".getBytes)
+    val l1 = b1.length.toDouble
+    val b2 = ImmutableArray.fromArray("abcdef".getBytes)
+    val l2 = b2.length.toDouble
+
+    val input = List(
+      _obj(ListMap("foo" -> _binary(b1))),
+      _obj(ListMap("bar" -> _binary(b2)))
+    )
+
+    val expected = envT(
+      TypeStat.coll(2.0, 1.0.some, 1.0.some).some,
+      TypeF.map[J, S](IMap(
+        C(e.str[J]("foo")).embed -> envT(
+          TypeStat.coll(1.0, l1.some, l1.some).some,
+          TypeF.arr[J, S](envT(
+            TypeStat.count(1.0).some,
+            TypeF.simple[J, S](SimpleType.Byte)
+          ).embed.right)).embed,
+
+        C(e.str[J]("bar")).embed -> envT(
+          TypeStat.coll(1.0, l2.some, l2.some).some,
+          TypeF.arr[J, S](envT(
+            TypeStat.count(1.0).some,
+            TypeF.simple[J, S](SimpleType.Byte)
+          ).embed.right)).embed
+      ), None)).embed
+
+    verify(settings, input, expected)
+  }
+
+  "coalesce map keys until <= max size" >> {
+    val input = List(
+      _obj(ListMap("foo" -> _int(1))),
+      _obj(ListMap("bar" -> _int(1))),
+      _obj(ListMap("baz" -> _int(1))),
+      _obj(ListMap("quux" -> _int(1)))
+    )
+
+    val expected = envT(
+      TypeStat.coll(4.0, 1.0.some, 1.0.some).some,
+      TypeF.map[J, S](IMap.empty[J, S], Some((
+        envT(
+          TypeStat.str(4.0, 3.0, 4.0, "bar", "quux").some,
+          TypeF.arr[J, S](envT(
+            TypeStat.count(4.0).some,
+            TypeF.simple[J, S](SimpleType.Char)
+          ).embed.right)).embed,
+        envT(
+          TypeStat.int(SampleStats.freq(4.0, 1.0), BigInt(1), BigInt(1)).some,
+          TypeF.const[J, S](E(e.int[J](1)).embed)
+        ).embed
+      )))).embed
+
+    verify(settings.copy(mapMaxSize = 3L), input, expected)
+  }
+
+  "narrow unions until <= max size" >> {
+    val input = List(
+      _obj(ListMap("foo" -> _int(1))),
+      _obj(ListMap("foo" -> _int(2))),
+      _obj(ListMap("foo" -> _bool(true))),
+      _obj(ListMap("foo" -> _bool(false)))
+    )
+
+    val expected = envT(
+      TypeStat.coll(4.0, 1.0.some, 1.0.some).some,
+      TypeF.map[J, S](IMap(
+        C(e.str[J]("foo")).embed -> envT(
+          TypeStat.count(4.0).some,
+          TypeF.coproduct[J, S](
+            envT(
+              TypeStat.int(
+                SampleStats.fromFoldable(IList(1.0, 2.0)),
+                BigInt(1),
+                BigInt(2)).some,
+              TypeF.simple[J, S](SimpleType.Int)).embed,
+            envT(
+              TypeStat.bool(1.0, 1.0).some,
+              TypeF.simple[J, S](SimpleType.Bool)).embed)
+        ).embed
+      ), None)).embed
+
+    verify(settings.copy(unionMaxSize = 2L), input, expected)
+  }
+
+  "coalesce consts with primary types in unions" >> {
+    val input = List(
+      _obj(ListMap("foo" -> _int(1))),
+      _obj(ListMap("foo" -> _int(2))),
+      _obj(ListMap("foo" -> _bool(true))),
+      _obj(ListMap("foo" -> _int(3)))
+    )
+
+    val expected = envT(
+      TypeStat.coll(4.0, 1.0.some, 1.0.some).some,
+      TypeF.map[J, S](IMap(
+        C(e.str[J]("foo")).embed -> envT(
+          TypeStat.count(4.0).some,
+          TypeF.coproduct[J, S](
+            envT(
+              TypeStat.int(
+                SampleStats.fromFoldable(IList(1.0, 2.0, 3.0)),
+                BigInt(1),
+                BigInt(3)).some,
+              TypeF.simple[J, S](SimpleType.Int)).embed,
+            envT(
+              TypeStat.bool(1.0, 0.0).some,
+              TypeF.const[J, S](C(e.bool[J](true)).embed)).embed)
+        ).embed
+      ), None)).embed
+
+    verify(settings.copy(unionMaxSize = 2L), input, expected)
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,13 +20,15 @@ object Dependencies {
   // For unknown reason sbt-slamdata's specsVersion, 3.8.7,
   // leads to a ParquetRDDE failure under a full test run
   private val specsVersion             = "3.8.4"
+  private val spireVersion             = "0.14.1"
 
   def foundation = Seq(
     CommonDependencies.scalaz.core,
     CommonDependencies.scalaz.concurrent,
     CommonDependencies.scalazStream.scalazStream,
     CommonDependencies.monocle.core,
-    "org.typelevel" %% "algebra"         % algebraVersion,
+    "org.typelevel" %% "algebra"     % algebraVersion,
+    "org.typelevel" %% "spire"       % spireVersion,
     CommonDependencies.argonaut.argonaut,
     CommonDependencies.argonaut.scalaz,
     "com.slamdata"  %% "matryoshka-core" % matryoshkaVersion,
@@ -36,7 +38,9 @@ object Dependencies {
     CommonDependencies.shapeless.shapeless,
     CommonDependencies.scalacheck.scalacheck                  % Test,
     CommonDependencies.simulacrum.simulacrum                  % Test,
+    "org.typelevel" %% "algebra-laws"    % algebraVersion     % Test,
     "org.typelevel" %% "discipline"      % disciplineVersion  % Test,
+    "org.typelevel" %% "spire-laws"      % spireVersion       % Test,
     "org.specs2"    %% "specs2-core"     % specsVersion       % Test,
     CommonDependencies.scalaz.scalacheckBinding               % Test,
     CommonDependencies.typelevel.shapelessScalacheck          % Test,

--- a/repl/src/main/scala/quasar/repl/Command.scala
+++ b/repl/src/main/scala/quasar/repl/Command.scala
@@ -30,6 +30,7 @@ object Command {
   private val CdPattern           = "(?i)cd(?: +(.+))?".r
   private val NamedExprPattern    = "(?i)([^ :]+) *<- *(.+)".r
   private val ExplainPattern      = "(?i)explain +(.+)".r
+  private val SchemaPattern       = "(?i)schema(?: +(.+))?".r
   private val LsPattern           = "(?i)ls(?: +(.+))?".r
   private val SavePattern         = "(?i)save +([\\S]+) (.+)".r
   private val AppendPattern       = "(?i)append +([\\S]+) (.+)".r
@@ -47,6 +48,7 @@ object Command {
   final case class Cd(dir: XDir) extends Command
   final case class Select(name: Option[String], query: Query) extends Command
   final case class Explain(query: Query) extends Command
+  final case class Schema(path: XFile) extends Command
   final case class Ls(dir: Option[XDir]) extends Command
   final case class Save(path: XFile, value: String) extends Command
   final case class Append(path: XFile, value: String) extends Command
@@ -65,6 +67,7 @@ object Command {
       case CdPattern(_)                  => Cd(rootDir.right)
       case NamedExprPattern(name, query) => Select(Some(name), Query(query))
       case ExplainPattern(query)         => Explain(Query(query))
+      case SchemaPattern(XFile(f))       => Schema(f)
       case LsPattern(XDir(d))            => Ls(d.some)
       case LsPattern(_)                  => Ls(none)
       case SavePattern(XFile(f), value)  => Save(f, value)

--- a/repl/src/main/scala/quasar/repl/Repl.scala
+++ b/repl/src/main/scala/quasar/repl/Repl.scala
@@ -234,10 +234,9 @@ object Repl {
           file  =  state targetFile f
           proc  <- analysis.sampleResults(file, 1000L).run
           cfg   =  analysis.CompressionSettings(
-                     stringMaxLength  =  64L,
-                     observationThold = 100L,
-                     mapSizeRatio     = 0.03,
-                     unionSizeRatio   = 0.03)
+                     mapMaxSize      = 50L,
+                     stringMaxLength = 64L,
+                     unionMaxSize    = 20L)
           p1    =  analysis.extractSchema[Fix[EJson], Double](cfg)
           sst   =  proc.map(_.pipe(p1).toVector.headOption)
           _     <- sst.fold(err => DF.fail(err.shows), s => P.println(s.shows))

--- a/repl/src/main/scala/quasar/repl/Repl.scala
+++ b/repl/src/main/scala/quasar/repl/Repl.scala
@@ -236,11 +236,8 @@ object Repl {
           state <- RS.get
           file  =  state targetFile f
           proc  <- analysis.sampleResults(file, 1000L).run
-          cfg   =  analysis.CompressionSettings(
-                     mapMaxSize      = 50L,
-                     stringMaxLength = 64L,
-                     unionMaxSize    = 20L)
-          p1    =  analysis.extractSchema[Fix[EJson], Double](cfg)
+          p1    =  analysis.extractSchema[Fix[EJson], Double](
+                     analysis.CompressionSettings.Default)
           sst   =  proc.map(_.pipe(p1).toVector.headOption)
           sstJs =  sst.map(_.map(_.asEJson[Fix[EJson]].cata(JsonCodec.encodeƒ[Json])))
           _     <- sstJs.fold(

--- a/repl/src/main/scala/quasar/repl/Repl.scala
+++ b/repl/src/main/scala/quasar/repl/Repl.scala
@@ -20,12 +20,11 @@ import slamdata.Predef._
 
 import quasar.{Data, DataCodec, Variables}
 import quasar.common.PhaseResults
-import quasar.contrib.argonaut._
 import quasar.contrib.matryoshka._
 import quasar.contrib.pathy._
 import quasar.csv.CsvWriter
 import quasar.effect._
-import quasar.ejson.{EJson, JsonCodec}
+import quasar.ejson.EJson
 import quasar.ejson.implicits._
 import quasar.fp._, ski._, numeric._
 import quasar.fs._
@@ -238,11 +237,11 @@ object Repl {
           proc  <- analysis.sampleResults(file, 1000L).run
           p1    =  analysis.extractSchema[Fix[EJson], Double](
                      analysis.CompressionSettings.Default)
-          sst   =  proc.map(_.pipe(p1).toVector.headOption)
-          sstJs =  sst.map(_.map(_.asEJson[Fix[EJson]].cata(JsonCodec.encodeƒ[Json])))
-          _     <- sstJs.fold(
+          sst   =  proc.map(_.pipe(p1).map(_.asEJson[Fix[EJson]].cata(Data.fromEJson)))
+          js    =  sst.map(_.toVector.headOption.flatMap(DataCodec.Precise.encode))
+          _     <- js.fold(
                      err => DF.fail(err.shows),
-                     s   => P.println(s.fold("{}")(_.spaces2)))
+                     j   => P.println(j.fold("{}")(_.spaces2)))
         } yield ()
 
 

--- a/repl/src/main/scala/quasar/repl/Repl.scala
+++ b/repl/src/main/scala/quasar/repl/Repl.scala
@@ -20,19 +20,24 @@ import slamdata.Predef._
 
 import quasar.{Data, DataCodec, Variables}
 import quasar.common.PhaseResults
+import quasar.contrib.matryoshka._
 import quasar.contrib.pathy._
 import quasar.csv.CsvWriter
 import quasar.effect._
+import quasar.ejson.EJson
+import quasar.ejson.implicits._
 import quasar.fp._, ski._, numeric._
 import quasar.fs._
 import quasar.fs.mount._
-import quasar.main.{FilesystemQueries, Prettify}
+import quasar.main.{analysis, FilesystemQueries, Prettify}
 import quasar.sql
 
 import eu.timepit.refined.auto._
+import matryoshka.data.Fix
 import pathy.Path, Path._
 import scalaz.{Failure => _, _}, Scalaz._
 import scalaz.concurrent.Task
+import spire.std.double._
 
 object Repl {
   import Command.{XDir, XFile}
@@ -50,6 +55,7 @@ object Repl {
       |  [query]
       |  [id] <- [query]
       |  explain [query]
+      |  schema [path]
       |  ls [path]
       |  save [path] [value]
       |  append [path] [value]
@@ -221,6 +227,22 @@ object Repl {
                       perr => DF.fail(perr.shows),
                       κ(().point[Free[S, ?]])))
         } yield ()
+
+      case Schema(f) =>
+        for {
+          state <- RS.get
+          file  =  state targetFile f
+          proc  <- analysis.sampleResults(file, 1000L).run
+          cfg   =  analysis.CompressionSettings(
+                     stringMaxLength  =  64L,
+                     observationThold = 100L,
+                     mapSizeRatio     = 0.03,
+                     unionSizeRatio   = 0.03)
+          p1    =  analysis.extractSchema[Fix[EJson], Double](cfg)
+          sst   =  proc.map(_.pipe(p1).toVector.headOption)
+          _     <- sst.fold(err => DF.fail(err.shows), s => P.println(s.shows))
+        } yield ()
+
 
       case Save(f, v) =>
         write(W.saveThese(_, _), f, v)

--- a/web/src/main/scala/quasar/api/package.scala
+++ b/web/src/main/scala/quasar/api/package.scala
@@ -213,6 +213,14 @@ package object api {
         "path" := path))
     }
 
+  def decodedFile(encodedPath: String): ApiError \/ AFile =
+    decodedPath(encodedPath) flatMap { path =>
+      refineType(path).leftAs(ApiError.fromMsg(
+        BadRequest withReason "File path expected.",
+        s"Expected '${posixCodec.printPath(path)}' to be a file.",
+        "path" := path))
+    }
+
   def decodedPath(encodedPath: String): ApiError \/ APath =
     AsPath.unapply(HPath(encodedPath)) \/> ApiError.fromMsg(
       BadRequest withReason "Malformed path.",

--- a/web/src/main/scala/quasar/api/services/RestApi.scala
+++ b/web/src/main/scala/quasar/api/services/RestApi.scala
@@ -57,7 +57,8 @@ object RestApi {
       "/metadata/fs" -> metadata.service[S],
       "/mount/fs"    -> mount.service[S],
       "/query/fs"    -> query.execute.service[S],
-      "/invoke/fs"   -> invoke.service[S]
+      "/invoke/fs"   -> invoke.service[S],
+      "/schema/fs"   -> analyze.schema.service[S]
     )
 
   val additionalServices: Map[String, HttpService] =

--- a/web/src/main/scala/quasar/api/services/analyze/schema.scala
+++ b/web/src/main/scala/quasar/api/services/analyze/schema.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api.services.analyze
+
+import slamdata.Predef.{-> => _, _}
+import quasar.api._
+import quasar.api.services._
+import quasar.ejson.EJson
+import quasar.ejson.implicits._
+import quasar.fp.numeric._
+import quasar.fs._
+import quasar.main.analysis
+
+import eu.timepit.refined.auto._
+import matryoshka.data.Fix
+import org.http4s.dsl._
+import scalaz._, Scalaz._
+import scalaz.concurrent.Task
+import spire.std.double._
+
+object schema {
+  type J = Fix[EJson]
+
+  val DefaultSampleSize: Positive = 1000L
+
+  object MapMaxSize extends OptionalValidatingQueryParamDecoderMatcher[Positive]("mapMaxSize")
+  object StringMaxLength extends OptionalValidatingQueryParamDecoderMatcher[Positive]("stringMaxLength")
+  object UnionMaxSize extends OptionalValidatingQueryParamDecoderMatcher[Positive]("unionMaxSize")
+
+  def service[S[_]](
+    implicit
+    Q : QueryFile.Ops[S],
+    S0: Task :<: S,
+    S1: FileSystemFailure :<: S
+  ): QHttpService[S] =
+    QHttpService {
+      case req @ GET -> _        :?
+        MapMaxSize(mapMax0)      +&
+        StringMaxLength(strMax0) +&
+        UnionMaxSize(unionMax0)  =>
+
+        val mapMax =
+          valueOrInvalid("mapMaxSize", mapMax0)
+            .map(_ | analysis.CompressionSettings.DefaultMapMaxSize)
+
+        val strMax =
+          valueOrInvalid("stringMaxLength", strMax0)
+            .map(_ | analysis.CompressionSettings.DefaultStringMaxLength)
+
+        val unionMax =
+          valueOrInvalid("unionMaxSize", unionMax0)
+            .map(_ | analysis.CompressionSettings.DefaultUnionMaxSize)
+
+        respond_((decodedFile(req.uri.path) |@| mapMax |@| strMax |@| unionMax) { (file, mmax, smax, umax) =>
+          val compressionSettings = analysis.CompressionSettings(
+            mapMaxSize      = mmax,
+            stringMaxLength = smax,
+            unionMaxSize    = umax)
+
+          firstEJsonResponse(
+            analysis.sample[S](file, DefaultSampleSize)
+              .pipe(analysis.extractSchema[J, Double](compressionSettings))
+              .map(_.asEJson[J]))
+        })
+    }
+}

--- a/web/src/test/scala/quasar/api/services/analyze/SchemaServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/analyze/SchemaServiceSpec.scala
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api.services.analyze
+
+import slamdata.Predef._
+import quasar.{Data, DataArbitrary}
+import quasar.api._, ApiErrorEntityDecoder._, PathUtils._
+import quasar.api.matchers._
+import quasar.contrib.argonaut._
+import quasar.contrib.matryoshka.arbitrary._
+import quasar.contrib.pathy._
+import quasar.ejson.{EJson, JsonCodec}
+import quasar.ejson.implicits._
+import quasar.fp._
+import quasar.fp.free._
+import quasar.fp.numeric._
+import quasar.fs._, InMemory.InMemState
+import quasar.main.analysis
+
+import argonaut._, Argonaut._, JsonScalaz._
+import eu.timepit.refined.auto._
+import matryoshka._
+import matryoshka.data.Fix
+import matryoshka.implicits._
+import org.http4s._
+import org.http4s.argonaut._
+import org.http4s.dsl._
+import org.scalacheck._
+import org.specs2.specification.core.Fragments
+import pathy.argonaut.PosixCodecJson._
+import pathy.scalacheck.PathyArbitrary._
+import scalaz._, Scalaz._
+import scalaz.concurrent.Task
+import scalaz.stream.Process
+import spire.std.double._
+
+final class SchemaServiceSpec extends quasar.Qspec with FileSystemFixture with Http4s {
+  import SchemaServiceSpec._
+  import DataArbitrary._
+
+  type J = Fix[EJson]
+
+  def stateForFile(file: AFile, contents: Vector[Data]) =
+    InMemState.empty.copy(queryResps = Map(
+      analysis.sampleQuery(file, schema.DefaultSampleSize) -> contents
+    ))
+
+  def nonPos(i: Int): Int =
+    if (i > 0) -i else i
+
+  def sstResponse(dataset: Vector[Data], cfg: analysis.CompressionSettings): Json =
+    Process.emitAll(dataset)
+      .pipe(analysis.extractSchema[J, Double](cfg))
+      .map(_.asEJson[J].cata[Json](JsonCodec.encodeƒ))
+      .toVector.headOption.getOrElse(Json.jNull)
+
+  case class SmallPositive(p: Positive)
+
+  implicit val smallPositiveArbitrary: Arbitrary[SmallPositive] =
+    Arbitrary(Gen.choose(1L, 10L) flatMap (l =>
+      Positive(l).cata(p => Gen.const(SmallPositive(p)), Gen.fail)))
+
+  "respond with bad request when" >> {
+    "no path given" >> {
+      service(InMemState.empty)(Request())
+        .flatMap(_.as[ApiError])
+        .map(_ must beApiErrorWithMessage(
+          BadRequest withReason "File path expected.",
+          "path" := "/"))
+        .unsafePerformSync
+    }
+
+    "directory path given" >> prop { dir: ADir =>
+      service(InMemState.empty)(Request(uri = pathUri(dir)))
+        .flatMap(_.as[ApiError])
+        .map(_ must beApiErrorWithMessage(
+          BadRequest withReason "File path expected.",
+          "path" := dir))
+        .unsafePerformSync
+    }
+
+    addFragments(Fragments(List("mapMaxSize", "stringMaxLength", "unionMaxSize") map { param =>
+      s"non-positive $param given" >> prop { (file: AFile, i: Int) =>
+        val ruri = pathUri(file) +? (param, nonPos(i).toString)
+
+        service(InMemState.empty)(Request(uri = ruri))
+          .flatMap(_.as[ApiError])
+          .map(_ must beApiErrorWithMessage(
+            BadRequest withReason "Invalid query parameter."))
+          .unsafePerformSync
+      }
+    } : _*))
+  }
+
+  "successful response" >> {
+    def shouldSucceed(file: AFile, x: Data, y: Data, cfg: analysis.CompressionSettings, req: Request) = {
+      val dataset = Vector.fill(5)(x) ++ Vector.fill(5)(y)
+
+      service(stateForFile(file, dataset))(req)
+        .flatMap(_.as[Json])
+        .map(_ must_= sstResponse(dataset, cfg))
+        .unsafePerformSync
+    }
+
+    "includes the sst for the dataset as JSON-encoded EJson" >> prop { (file: AFile, x: Data, y: Data) =>
+      shouldSucceed(file, x, y,
+        analysis.CompressionSettings.Default,
+        Request(uri = pathUri(file)))
+    }
+
+    "applies mapMaxSize when specified" >> prop { (file: AFile, x: Data, y: Data, size: SmallPositive) =>
+      val cfg = analysis.CompressionSettings.Default.copy(mapMaxSize = size.p)
+      val req = Request(uri = pathUri(file) +? ("mapMaxSize", size.p.shows))
+      shouldSucceed(file, x, y, cfg, req)
+    }
+
+    "applies stringMaxLength when specified" >> prop { (file: AFile, x: Data, y: Data, len: SmallPositive) =>
+      val cfg = analysis.CompressionSettings.Default.copy(stringMaxLength = len.p)
+      val req = Request(uri = pathUri(file) +? ("stringMaxLength", len.p.shows))
+      shouldSucceed(file, x, y, cfg, req)
+    }
+
+    "applies unionMaxSize when specified" >> prop { (file: AFile, x: Data, y: Data, size: SmallPositive) =>
+      val cfg = analysis.CompressionSettings.Default.copy(unionMaxSize = size.p)
+      val req = Request(uri = pathUri(file) +? ("unionMaxSize", size.p.shows))
+      shouldSucceed(file, x, y, cfg, req)
+    }
+
+    "has an empty body when file exists but is empty" >> prop { file: AFile =>
+      service(stateForFile(file, Vector()))(Request(uri = pathUri(file)))
+        .flatMap(_.as[String])
+        .map(_ must beEmpty)
+        .unsafePerformSync
+    }
+  }
+}
+
+object SchemaServiceSpec {
+  type SchemaEff[A] = (QueryFile :\: FileSystemFailure :/: Task)#M[A]
+
+  def runQueryFile(mem: InMemState): Task[QueryFile ~> ResponseOr] =
+    InMemory.runStatefully(mem) map { eval =>
+      liftMT[Task, ResponseT] compose eval compose InMemory.queryFile
+    }
+
+  def service(mem: InMemState): HttpService =
+    Kleisli(req => runQueryFile(mem) flatMap { runQF =>
+      schema.service[SchemaEff].toHttpService(
+        runQF                              :+:
+        failureResponseOr[FileSystemError] :+:
+        liftMT[Task, ResponseT]
+      )(req)
+    })
+}

--- a/web/src/test/scala/quasar/api/services/analyze/SchemaServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/analyze/SchemaServiceSpec.scala
@@ -93,7 +93,7 @@ final class SchemaServiceSpec extends quasar.Qspec with FileSystemFixture with H
         .unsafePerformSync
     }
 
-    addFragments(Fragments(List("mapMaxSize", "stringMaxLength", "unionMaxSize") map { param =>
+    addFragments(Fragments(List("arrayMaxLength", "mapMaxSize", "stringMaxLength", "unionMaxSize") map { param =>
       s"non-positive $param given" >> prop { (file: AFile, i: Int) =>
         val ruri = pathUri(file) +? (param, nonPos(i).toString)
 
@@ -120,6 +120,12 @@ final class SchemaServiceSpec extends quasar.Qspec with FileSystemFixture with H
       shouldSucceed(file, x, y,
         analysis.CompressionSettings.Default,
         Request(uri = pathUri(file)))
+    }
+
+    "applies arrayMaxLength when specified" >> prop { (file: AFile, x: Data, y: Data, len: SmallPositive) =>
+      val cfg = analysis.CompressionSettings.Default.copy(arrayMaxLength = len.p)
+      val req = Request(uri = pathUri(file) +? ("arrayMaxLength", len.p.shows))
+      shouldSucceed(file, x, y, cfg, req)
     }
 
     "applies mapMaxSize when specified" >> prop { (file: AFile, x: Data, y: Data, size: SmallPositive) =>


### PR DESCRIPTION
Implements a schema discovery service, allowing users to obtain a statistical structural type (SST) for a dataset that summarizes the structure of the data, annotated with frequency, bounds and distribution information where applicable.

Both an HTTP endpoint, `/schema/fs`, and a `schema` repl command are provided and the HTTP endpoint allows for some control over the amount of information preserved in the resulting SST.

Closes #1715.
Closes #2022.