### PR TITLE
Fix ArithmeticException in Spark

### DIFF
--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/CoreMap.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/CoreMap.scala
@@ -372,7 +372,6 @@ object CoreMap extends Serializable {
 
   private def divide(d1: Data, d2: Data): Data = (d1, d2) match {
     case (Data.Dec(a), Data.Dec(b)) => Data.Dec(a(BigDecimal.defaultMathContext) / b)
-    case (Data.Dec(a), Data.Dec(b)) => Data.Dec(a / b)
     case (Data.Int(a), Data.Dec(b)) => Data.Dec(BigDecimal(a) / b)
     case (Data.Dec(a), Data.Int(b)) => Data.Dec(a(BigDecimal.defaultMathContext) / BigDecimal(b))
     case (Data.Int(a), Data.Int(b)) => Data.Dec(BigDecimal(a) / BigDecimal(b))

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/CoreMap.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/CoreMap.scala
@@ -371,9 +371,10 @@ object CoreMap extends Serializable {
   }
 
   private def divide(d1: Data, d2: Data): Data = (d1, d2) match {
+    case (Data.Dec(a), Data.Dec(b)) => Data.Dec(a(BigDecimal.defaultMathContext) / b)
     case (Data.Dec(a), Data.Dec(b)) => Data.Dec(a / b)
     case (Data.Int(a), Data.Dec(b)) => Data.Dec(BigDecimal(a) / b)
-    case (Data.Dec(a), Data.Int(b)) => Data.Dec(a / BigDecimal(b))
+    case (Data.Dec(a), Data.Int(b)) => Data.Dec(a(BigDecimal.defaultMathContext) / BigDecimal(b))
     case (Data.Int(a), Data.Int(b)) => Data.Dec(BigDecimal(a) / BigDecimal(b))
     case (Data.Interval(a), Data.Dec(b)) => Data.Interval(a.multipliedBy(b.toLong))
     case (Data.Interval(a), Data.Int(b)) => Data.Interval(a.multipliedBy(b.toLong))

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/Planner.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/Planner.scala
@@ -200,7 +200,7 @@ object Planner {
             case Max(a) => a
             case Avg(a) => a >>> {
               case Data.Int(v) => Data.Arr(List(Data.Dec(BigDecimal(v)), Data.Int(1)))
-              case Data.Dec(v) => Data.Arr(List(Data.Dec(v), Data.Int(1)))
+              case Data.Dec(v) => Data.Arr(List(Data.Dec(v.apply(BigDecimal.defaultMathContext)), Data.Int(1)))
               case _ => Data.NA
             }
             case Arbitrary(a) => a


### PR DESCRIPTION
`BigDecimal`s will come with `MathContext.UNLIMMITED` after being parsed from string. 
Details in #2150.

Fixes https://github.com/quasar-analytics/quasar/issues/2150