### PR TITLE
Remove temporal coercion from MarkLogic relation operators

### DIFF
--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/DataPlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/DataPlanner.scala
@@ -21,6 +21,9 @@ import quasar.physical.marklogic.optics._
 import quasar.physical.marklogic.xquery._
 import quasar.physical.marklogic.xquery.syntax._
 
+import java.time.format.DateTimeFormatter.{ISO_DATE, ISO_TIME}
+import java.time.ZoneOffset.UTC
+
 import matryoshka._
 import scalaz._, Scalaz._
 
@@ -31,7 +34,7 @@ private[qscript] final class DataPlanner[M[_]: Monad, FMT](
   val plan: AlgebraM[M, Const[Data, ?], XQuery] = _.getConst match {
     case Data.Binary(bytes) => xs.base64Binary(base64Bytes(bytes).xs).point[M]
     case Data.Bool(b)       => b.fold(fn.True, fn.False).point[M]
-    case Data.Date(d)       => xs.date(isoLocalDate(d).xs).point[M]
+    case Data.Date(d)       => xs.date(ISO_DATE.format(d atStartOfDay UTC).xs).point[M]
     case Data.Dec(d)        => xs.double(d.toString.xqy).point[M]
     case Data.Id(id)        => id.xs.point[M]
     case Data.Int(i)        => xs.integer(i.toString.xqy).point[M]
@@ -39,7 +42,7 @@ private[qscript] final class DataPlanner[M[_]: Monad, FMT](
     case Data.NA            => expr.emptySeq.point[M]
     case Data.Null          => SP.null_
     case Data.Str(s)        => s.xs.point[M]
-    case Data.Time(t)       => xs.time(isoLocalTime(t).xs).point[M]
+    case Data.Time(t)       => xs.time(ISO_TIME.format(t atOffset UTC).xs).point[M]
     case Data.Timestamp(ts) => xs.dateTime(isoInstant(ts).xs).point[M]
 
     case Data.Arr(elements) =>

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/StructuralPlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/StructuralPlanner.scala
@@ -191,13 +191,15 @@ trait StructuralPlanner[F[_], FMT] { self =>
           .then_(emptySeq)
           .else_(if_(~t eq "null".xs)
           .then_("null".xs)
+          .else_(if_(tpe eq "date".xs)
+          .then_(fn.formatDate(castItem, lib.dateFmt.xs))
           .else_(if_(tpe eq "time".xs)
-          .then_(fn.formatTime(castItem, lib.timeFmt))
+          .then_(fn.formatTime(castItem, lib.timeFmt.xs))
           .else_(if_(tpe eq "timestamp".xs)
-          .then_(fn.formatDateTime(castItem, lib.dateTimeFmt))
+          .then_(fn.formatDateTime(castItem, lib.dateTimeFmt.xs))
           .else_(typeswitch(item)(
             n as ST("node()") return_ κ(nstr)
-          ) default fn.string(item)))))
+          ) default fn.string(item))))))
         })
     })
 

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/lib.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/lib.scala
@@ -25,7 +25,6 @@ import quasar.physical.marklogic.xquery._
 import java.lang.SuppressWarnings
 
 import eu.timepit.refined.auto._
-import eu.timepit.refined.api.Refined
 import scalaz.{Bind, Functor, Monad}
 import scalaz.syntax.monad._
 
@@ -128,30 +127,6 @@ object lib {
       }
     })
 
-  // qscript:comp-eq($x as item()*, $y as item()*) as xs:boolean?
-  def compEq[F[_]: Bind: PrologW]: F[FunctionDecl2] =
-    mkComparisonFunction[F]("eq", _ eq _, fn.False)
-
-  // qscript:comp-ne($x as item()*, $y as item()*) as xs:boolean?
-  def compNe[F[_]: Bind: PrologW]: F[FunctionDecl2] =
-    mkComparisonFunction[F]("ne", _ ne _, fn.True)
-
-  // qscript:comp-lt($x as item()*, $y as item()*) as xs:boolean?
-  def compLt[F[_]: Bind: PrologW]: F[FunctionDecl2] =
-    mkComparisonFunction[F]("lt", _ lt _, emptySeq)
-
-  // qscript:comp-le($x as item()*, $y as item()*) as xs:boolean?
-  def compLe[F[_]: Bind: PrologW]: F[FunctionDecl2] =
-    mkComparisonFunction[F]("le", _ le _, emptySeq)
-
-  // qscript:comp-gt($x as item()*, $y as item()*) as xs:boolean?
-  def compGt[F[_]: Bind: PrologW]: F[FunctionDecl2] =
-    mkComparisonFunction[F]("gt", _ gt _, emptySeq)
-
-  // qscript:comp-ge($x as item()*, $y as item()*) as xs:boolean?
-  def compGe[F[_]: Bind: PrologW]: F[FunctionDecl2] =
-    mkComparisonFunction[F]("ge", _ ge _, emptySeq)
-
   // qscript:concat($x as item()?, $y as item()?) as item()?
   def concat[F[_]: Bind: PrologW, T](implicit SP: StructuralPlanner[F, T]): F[FunctionDecl2] =
     qs.declare("concat") flatMap (_(
@@ -198,14 +173,6 @@ object lib {
             .return_(~n))
         }
       }, src)
-    })
-
-  // qscript:element-left-shift($elt as element()) as item()*
-  def elementLeftShift[F[_]: Functor: PrologW]: F[FunctionDecl1] =
-    qs.declare("element-left-shift") map (_(
-      $("elt") as ST("element()?")
-    ).as(ST("item()*")) { elt =>
-      elt `/` child.element()
     })
 
   // qscript:isoyear-from-dateTime($dt as xs:dateTime?) as xs:integer
@@ -288,16 +255,6 @@ object lib {
     ).as(ST("node()?")) { item: XQuery =>
       val nodeClause = $("n") as ST("node()") return_ (SP.nodeMetadata(_))
       nodeClause map (ec => typeswitch(item)(ec) default emptySeq)
-    })
-
-  // qscript:project-field($src as element()?, $field as xs:QName?) as item()*
-  def projectField[F[_]: Functor: PrologW]: F[FunctionDecl2] =
-    qs.declare("project-field") map (_(
-      $("src")   as ST("element()?"),
-      $("field") as ST("xs:QName?")
-    ).as(ST.Top) { (src: XQuery, field: XQuery) =>
-      val n = $("n")
-      fn.filter(func(n.render)(fn.nodeName(~n) eq field), src `/` child.element())
     })
 
   // qscript:reduce-with(
@@ -516,26 +473,4 @@ object lib {
         }
       }
     })
-
-  ////
-
-  private def mkComparisonFunction[F[_]: Bind: PrologW](opName: String, op: (XQuery, XQuery) => XQuery, recover: XQuery): F[FunctionDecl2] =
-    asDateTime[F].fn flatMap { asDT =>
-      qs.declare(Refined.unsafeApply(s"comp-$opName")) map (_(
-        $("x") as ST.Top,
-        $("y") as ST.Top
-      ).as(ST("xs:boolean?")) { (x: XQuery, y: XQuery) =>
-        try_ {
-          if_(
-            isCastable(x, ST("xs:date"))     or
-            isCastable(y, ST("xs:date"))     or
-            isCastable(x, ST("xs:dateTime")) or
-            isCastable(y, ST("xs:dateTime")))
-          .then_ { op(asDT(x), asDT(y)) }
-          .else_ { op(x, y) }
-        } .catch_($("_")) { _ =>
-          recover
-        }
-      })
-    }
 }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/lib.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/lib.scala
@@ -36,9 +36,9 @@ object lib {
 
   val qs = NamespaceDecl(qscriptNs)
 
-  val dateFmt     = "[Y0001]-[M01]-[D01]".xs
-  val dateTimeFmt = "[Y0001]-[M01]-[D01]T[H01]:[m01]:[s01].[f001]Z".xs
-  val timeFmt     = "[H01]:[m01]:[s01].[f001]".xs
+  val dateFmt     = "[Y0001]-[M01]-[D01]"
+  val timeFmt     = "[H01]:[m01]:[s01].[f001]"
+  val dateTimeFmt = s"${dateFmt}T${timeFmt}Z"
 
   private val epoch    = xs.dateTime("1970-01-01T00:00:00Z".xs)
   private val timeZero = xs.time("00:00:00-00:00".xs)
@@ -368,7 +368,7 @@ object lib {
           xdmp.formatNumber(sec, "01".xs), ".".xs,
           xdmp.formatNumber(ms, "001".xs), "Z".xs)
 
-      def fmtDateTime(x: XQuery): XQuery = fn.formatDateTime(x, dateTimeFmt)
+      def fmtDateTime(x: XQuery): XQuery = fn.formatDateTime(x, dateTimeFmt.xs)
 
       val (dateTime, wrap) = ($("dateTime"), $("wrap"))
       let_(
@@ -381,9 +381,9 @@ object lib {
           $("dateTime") as ST("xs:dateTime") return_ (κ(
             xdmp.function(xs.QName("xs:dateTime".xs)))),
           $("date")     as ST("xs:date") return_ (κ(
-            func("$s")(xs.date(xdmp.parseDateTime(dateFmt, "$s".xqy))))),
+            func("$s")(xs.date(xdmp.parseDateTime(dateFmt.xs, "$s".xqy))))),
           $("time")     as ST("xs:time") return_ (κ(
-            func("$s")(xs.time(xdmp.parseDateTime(dateTimeFmt, "$s".xqy)))))
+            func("$s")(xs.time(xdmp.parseDateTime(dateTimeFmt.xs, "$s".xqy)))))
         ) default emptySeq
       ) return_ {
 

--- a/marklogic/src/main/scala/quasar/physical/marklogic/xquery/fn.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/xquery/fn.scala
@@ -91,6 +91,9 @@ object fn {
   def floor(n: XQuery): XQuery =
     XQuery(s"fn:floor($n)")
 
+  def formatDate(value: XQuery, picture: XQuery): XQuery =
+    XQuery(s"fn:format-date($value, $picture)")
+
   def formatDateTime(value: XQuery, picture: XQuery): XQuery =
     XQuery(s"fn:format-dateTime($value, $picture)")
 


### PR DESCRIPTION
Previously we were handling temporal coercion in relation operators due to some tests that were comparing dates and timestamps. They turned out to be incorrect and were corrected in #1843 and thus the behavior is no longer needed in MarkLogic.