### PR TITLE
CB: bucket per mount mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ After running this command your `testing.conf` file should look similar to this:
 ```
 > cat it/testing.conf
 postgresql_metastore="{\"host\":\"192.168.99.101\",\"port\":5432,\"database\":\"metastore\",\"userName\":\"postgres\",\"password\":\"\"}"
-couchbase="couchbase://192.168.99.101/quasar-test?password=password&docTypeKey=type&socketConnectTimeoutSeconds=15"
+couchbase="couchbase://192.168.99.101/beer-sample?password=&docTypeKey=type&socketConnectTimeoutSeconds=15"
 marklogic_xml="xcc://marklogic:marklogic@192.168.99.101:8000/Documents?format=xml"
 postgresql="jdbc:postgresql://192.168.99.101:5433/quasar-test?user=postgres&password=postgres"
 mongodb_3_0="mongodb://192.168.99.101:27019"
@@ -126,7 +126,7 @@ java -jar [<path to jar>] [-c <config file>]
 As a command-line REPL user, to work with a fully functioning REPL you will need the metadata store and a mount point. See [here](#full-testing-prerequisite-docker-and-docker-compose) for instructions on creating the metadata store backend using docker. To add a mount you can start the web server mentioned [below](#web-jar) and issue a `curl` command like:
 
 ```bash
-curl -v -X PUT http://localhost:8080/mount/fs/cb/ -d '{ "couchbase": { "connectionUri":"couchbase://192.168.99.100/data-bucket?password=password&docTypeKey=type" } }'
+curl -v -X PUT http://localhost:8080/mount/fs/cb/ -d '{ "couchbase": { "connectionUri":"couchbase://192.168.99.100/beer-sample?password=&docTypeKey=type" } }'
 ```
 
 You can find examples of `connectionUri` values [here](#database-mounts).
@@ -237,9 +237,9 @@ To connect to Couchbase use the following `connectionUri` format:
 Prerequisites
 - Couchbase Server 4.5.1 or greater
 - A "default" bucket with anonymous access
-- Documents must have a "type" field to be listed
+- Documents must have a `docTypeKey` field to be listed
 - Primary index on queried buckets
-- Secondary index on "type" field for queried buckets
+- Secondary index on `docTypeKey` field for queried buckets
 - Additional indices and tuning as recommended by Couchbase for proper N1QL performance
 
 Known Limitations

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ quasar_couchbase
 ```
 
 Knowing which backend datastores are supported you can create and configure docker containers using `setupContainers`. For example
-if you wanted to run integration tests with mongo, postgresql, marklogic, and couchbsase you would use:
+if you wanted to run integration tests with mongo, postgresql, marklogic, and couchbase you would use:
 
 ```
 ./setupContainers -u quasar_metastore,quasar_mongodb_3_0,quasar_postgresql,quasar_marklogic_xml,quasar_couchbase
@@ -97,7 +97,7 @@ After running this command your `testing.conf` file should look similar to this:
 ```
 > cat it/testing.conf
 postgresql_metastore="{\"host\":\"192.168.99.101\",\"port\":5432,\"database\":\"metastore\",\"userName\":\"postgres\",\"password\":\"\"}"
-couchbase="couchbase://192.168.99.101?username=Administrator&password=password&socketConnectTimeoutSeconds=15"
+couchbase="couchbase://192.168.99.101/quasar-test?password=password&docTypeKey=type&socketConnectTimeoutSeconds=15"
 marklogic_xml="xcc://marklogic:marklogic@192.168.99.101:8000/Documents?format=xml"
 postgresql="jdbc:postgresql://192.168.99.101:5433/quasar-test?user=postgres&password=postgres"
 mongodb_3_0="mongodb://192.168.99.101:27019"
@@ -126,7 +126,7 @@ java -jar [<path to jar>] [-c <config file>]
 As a command-line REPL user, to work with a fully functioning REPL you will need the metadata store and a mount point. See [here](#full-testing-prerequisite-docker-and-docker-compose) for instructions on creating the metadata store backend using docker. To add a mount you can start the web server mentioned [below](#web-jar) and issue a `curl` command like:
 
 ```bash
-curl -v -X PUT http://localhost:8080/mount/fs/cb/ -d '{ "couchbase": { "connectionUri":"couchbase://192.168.99.100?username=Administrator&password=password" } }'
+curl -v -X PUT http://localhost:8080/mount/fs/cb/ -d '{ "couchbase": { "connectionUri":"couchbase://192.168.99.100/data-bucket?password=password&docTypeKey=type" } }'
 ```
 
 You can find examples of `connectionUri` values [here](#database-mounts).
@@ -232,7 +232,7 @@ To connect to MongoDB using TLS/SSL, specify `?ssl=true` in the connection strin
 
 To connect to Couchbase use the following `connectionUri` format:
 
-`couchbase://<host>[:<port>]?username=<username>&password=<password>[&queryTimeoutSeconds=<seconds>]`
+`couchbase://<host>[:<port>]/<bucket-name>?password=<password>&docTypeKey=<type>[&queryTimeoutSeconds=<seconds>]`
 
 Prerequisites
 - Couchbase Server 4.5.1 or greater

--- a/couchbase/src/main/scala/quasar/physical/couchbase/common.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/common.scala
@@ -86,9 +86,6 @@ object common {
       case h :: _   => DirName(h).left
     }.toSet
 
-  //def pathSegmentsFromBucketCollections(bktCols: List[String]): Set[PathSegment] =
-  //  pathSegments(bktCols.map(bc => bc.bucket :: bc.collection.split("/").toList))
-
   def pathSegmentsFromPrefixTypes(prefix: String, types: List[DocType]): Set[PathSegment] =
     pathSegments(types.map(_.v.stripPrefix(prefix).stripPrefix("/").split("/").toList))
 

--- a/couchbase/src/main/scala/quasar/physical/couchbase/common.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/common.scala
@@ -43,7 +43,6 @@ object common {
 
   final case class Context(bucket: BucketName, docTypeKey: DocTypeKey)
 
-
   final case class BucketName(v: String)
 
   // type field in Couchbase documents
@@ -61,7 +60,7 @@ object common {
     ctx: ClientContext,
     prefix: String
   ): Task[FileSystemError \/ Unit] = {
-    val qStr = s"""DELETE FROM `${ctx.bucket.name}` WHERE "${ctx.docTypeKey.v}" LIKE "${prefix}%""""
+    val qStr = s"""DELETE FROM `${ctx.bucket.name}` WHERE `${ctx.docTypeKey.v}` LIKE "${prefix}%""""
 
     query(ctx.bucket, qStr).map(_.void)
   }
@@ -71,7 +70,7 @@ object common {
     prefix: String
   ): Task[FileSystemError \/ List[DocTypeValue]] = {
     val qStr = s"""SELECT distinct type FROM `${ctx.bucket.name}`
-                   WHERE "${ctx.docTypeKey.v}" LIKE "${prefix}%""""
+                   WHERE `${ctx.docTypeKey.v}` LIKE "${prefix}%""""
     query(ctx.bucket, qStr).map(_.map(_.toList.map(r => DocTypeValue(r.value.getString(ctx.docTypeKey.v)))))
   }
 
@@ -80,7 +79,7 @@ object common {
     prefix: String
   ): Task[FileSystemError \/ Boolean] = {
     val qStr = s"""SELECT count(*) > 0 v FROM `${ctx.bucket.name}`
-                   WHERE "${ctx.docTypeKey.v}" = "${prefix}" OR "${ctx.docTypeKey.v}" like "${prefix}/%""""
+                   WHERE `${ctx.docTypeKey.v}` = "${prefix}" OR `${ctx.docTypeKey.v}` like "${prefix}/%""""
     query(ctx.bucket, qStr).map(_.map(_.toList.exists(_.value.getBoolean("v").booleanValue === true)))
   }
 

--- a/couchbase/src/main/scala/quasar/physical/couchbase/common.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/common.scala
@@ -19,6 +19,7 @@ package quasar.physical.couchbase
 import slamdata.Predef._
 import quasar.{Data, DataCodec}
 import quasar.contrib.pathy._
+import quasar.contrib.scalaz.MonadReader_
 import quasar.fs.FileSystemError
 
 import scala.collection.JavaConverters._
@@ -31,6 +32,12 @@ import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 
 object common {
+
+  type BucketNameReader[F[_]] = MonadReader_[F, BucketName]
+
+  object BucketNameReader {
+    def apply[F[_]](implicit R: MonadReader_[F, BucketName]) = R
+  }
 
   final case class Context(bucket: Bucket)
 

--- a/couchbase/src/main/scala/quasar/physical/couchbase/common.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/common.scala
@@ -51,7 +51,7 @@ object common {
   val CBDataCodec = DataCodec.Precise
 
   def docTypeFromPath(p: APath): DocType =
-    DocType(Path.flatten(None, None, None, Some(_), Some(_), p).toIList.intercalate("/".some).orZero)
+    DocType(Path.flatten(None, None, None, Some(_), Some(_), p).toIList.unite.intercalate("/"))
 
   def deleteHavingPrefix(
     bucket: Bucket,

--- a/couchbase/src/main/scala/quasar/physical/couchbase/fs/managefile.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/fs/managefile.scala
@@ -69,7 +69,7 @@ object managefile {
       _         <- dstExists.whenM(EitherT(delete(scenario.dst)))
       qStr      =  s"""update `${ctx.bucket.name}`
                        set `${ctx.docTypeKey.v}`=("${dst.v}" || REGEXP_REPLACE(`${ctx.docTypeKey.v}`, "^${src.v}", ""))
-                       where "${ctx.docTypeKey.v}" like "${src.v}%""""
+                       where `${ctx.docTypeKey.v}` like "${src.v}%""""
       _         <- EitherT(lift(query(ctx.bucket, qStr)).into)
     } yield ()).run
 

--- a/couchbase/src/main/scala/quasar/physical/couchbase/fs/package.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/fs/package.scala
@@ -40,7 +40,7 @@ import scalaz.concurrent.Task
 
 // TODO: Injection? Parameterized queries could help but don't appear to handle bucket names within ``
 // TODO: Handle query returned errors field
-// TODO: It might make sene to add connection uri parameter to configure collection field (currently always type)
+// TODO: It might make sense to add connection uri parameter to configure collection field (currently always type)
 //       So when people list a bucket they would see type values
 //       What about a bucket with no type field, should we make it optional? If optional Quasar would see the entire file
 

--- a/couchbase/src/main/scala/quasar/physical/couchbase/fs/queryfile.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/fs/queryfile.scala
@@ -101,7 +101,7 @@ object queryfile {
                     uuid.toString,
                     JsonObject
                       .create()
-                      .put("${ctx.doctype.v}", col.v)
+                      .put(ctx.docTypeKey.v, col.v)
                       .put("value", jsonTranscoder.stringToJsonObject(d)))
                 )).liftF
       exists <- EitherT(lift(existsWithPrefix(ctx, col.v)).into.liftM[PhaseResultT])

--- a/couchbase/src/main/scala/quasar/physical/couchbase/fs/readfile.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/fs/readfile.scala
@@ -52,7 +52,7 @@ object readfile {
       col     <- docTypeValueFromPath(file).η[FileSystemErrT[Free[S, ?], ?]]
       limit   =  readOpts.limit.map(lim => s"LIMIT ${lim.unwrap}").orZero
       qStr    =  s"""SELECT ifmissing(d.`value`, d).* FROM `${ctx.bucket.name}` d
-                     WHERE "${ctx.docTypeKey.v}"="${col.v}"
+                     WHERE `${ctx.docTypeKey.v}`="${col.v}"
                      $limit OFFSET ${readOpts.offset.unwrap.shows}"""
       qResult <- EitherT(lift(queryData(ctx.bucket, qStr)).into)
     } yield Cursor(qResult)).run

--- a/couchbase/src/main/scala/quasar/physical/couchbase/fs/readfile.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/fs/readfile.scala
@@ -52,7 +52,7 @@ object readfile {
       col     <- docTypeFromPath(file).η[FileSystemErrT[Free[S, ?], ?]]
       limit   =  readOpts.limit.map(lim => s"LIMIT ${lim.unwrap}").orZero
       qStr    =  s"""SELECT ifmissing(d.`value`, d).* FROM `${ctx.bucket.name}` d
-                     WHERE type="${col}"
+                     WHERE type="${col.v}"
                      $limit OFFSET ${readOpts.offset.unwrap.shows}"""
       qResult <- EitherT(lift(queryData(ctx.bucket, qStr)).into)
     } yield Cursor(qResult)).run

--- a/couchbase/src/main/scala/quasar/physical/couchbase/fs/readfile.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/fs/readfile.scala
@@ -35,7 +35,7 @@ object readfile {
     implicit
     S0: KeyValueStore[ReadFile.ReadHandle, Cursor, ?] :<: S,
     S1: MonotonicSeq :<: S,
-    S2: Read[Context, ?] :<:  S,
+    S2: Read[ClientContext, ?] :<:  S,
     S3: Task :<: S
   ): ReadFile ~> Free[S, ?] =
     impl.read[Cursor, Free[S, ?]](open, read, close)
@@ -45,14 +45,14 @@ object readfile {
     file: AFile, readOpts: ReadOpts
   )(implicit
     S1: Task :<: S,
-    context: Read.Ops[Context, S]
+    context: Read.Ops[ClientContext, S]
   ): Free[S, FileSystemError \/ Cursor] =
     (for {
       ctx     <- context.ask.liftM[FileSystemErrT]
-      col     <- docTypeFromPath(file).η[FileSystemErrT[Free[S, ?], ?]]
+      col     <- docTypeValueFromPath(file).η[FileSystemErrT[Free[S, ?], ?]]
       limit   =  readOpts.limit.map(lim => s"LIMIT ${lim.unwrap}").orZero
       qStr    =  s"""SELECT ifmissing(d.`value`, d).* FROM `${ctx.bucket.name}` d
-                     WHERE type="${col.v}"
+                     WHERE "${ctx.docTypeKey.v}"="${col.v}"
                      $limit OFFSET ${readOpts.offset.unwrap.shows}"""
       qResult <- EitherT(lift(queryData(ctx.bucket, qStr)).into)
     } yield Cursor(qResult)).run

--- a/couchbase/src/main/scala/quasar/physical/couchbase/fs/writefile.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/fs/writefile.scala
@@ -91,7 +91,7 @@ object writefile {
                 .map(str =>
                   JsonObject
                     .create()
-                    .put("${ctx.docTypeKey.v}", st.collection)
+                    .put(ctx.docTypeKey.v, st.collection.v)
                     .put("value", jsonTranscoder.stringToJsonObject(str))))).into.liftM[EitherT[?[_], Vector[FileSystemError], ?]]
       docs <- data.traverse(d => GenUUID.Ops[S].asks(uuid =>
                 JsonDocument.create(uuid.toString, d)

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/Planner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/Planner.scala
@@ -55,11 +55,11 @@ object Planner {
     : Planner[T, F, Const[ShiftedRead[ADir], ?]] =
     new UnreachablePlanner[T, F, Const[ShiftedRead[ADir], ?]]
 
-  implicit def constShiftedReadFile[T[_[_]]: CorecursiveT, F[_]: Monad: BucketNameReader: NameGenerator]
+  implicit def constShiftedReadFile[T[_[_]]: CorecursiveT, F[_]: Monad: ContextReader: NameGenerator]
     : Planner[T, F, Const[ShiftedRead[AFile], ?]] =
     new ShiftedReadFilePlanner[T, F]
 
-  implicit def equiJoinPlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: BucketNameReader: NameGenerator]
+  implicit def equiJoinPlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: ContextReader: NameGenerator]
     : Planner[T, F, EquiJoin[T, ?]] =
     new EquiJoinPlanner[T, F]
 
@@ -71,7 +71,7 @@ object Planner {
     : Planner[T, F, ProjectBucket[T, ?]] =
     new UnreachablePlanner[T, F, ProjectBucket[T, ?]]
 
-  implicit def qScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: BucketNameReader: NameGenerator]
+  implicit def qScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: ContextReader: NameGenerator]
     : Planner[T, F, QScriptCore[T, ?]] =
     new QScriptCorePlanner[T, F]
 

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/Planner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/Planner.scala
@@ -19,7 +19,7 @@ package quasar.physical.couchbase.planner
 import quasar.NameGenerator
 import quasar.common.PhaseResultT
 import quasar.contrib.pathy.{ADir, AFile}
-import quasar.physical.couchbase._
+import quasar.physical.couchbase._, common.BucketName
 import quasar.qscript._
 
 import matryoshka._
@@ -55,11 +55,11 @@ object Planner {
     : Planner[T, F, Const[ShiftedRead[ADir], ?]] =
     new UnreachablePlanner[T, F, Const[ShiftedRead[ADir], ?]]
 
-  implicit def constShiftedReadFile[T[_[_]]: CorecursiveT, F[_]: Monad: NameGenerator]
+  implicit def constShiftedReadFile[T[_[_]]: CorecursiveT, F[_]: MonadReader[?[_], BucketName]: NameGenerator]
     : Planner[T, F, Const[ShiftedRead[AFile], ?]] =
     new ShiftedReadFilePlanner[T, F]
 
-  implicit def equiJoinPlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: NameGenerator]
+  implicit def equiJoinPlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: MonadReader[?[_], BucketName]: NameGenerator]
     : Planner[T, F, EquiJoin[T, ?]] =
     new EquiJoinPlanner[T, F]
 
@@ -71,7 +71,8 @@ object Planner {
     : Planner[T, F, ProjectBucket[T, ?]] =
     new UnreachablePlanner[T, F, ProjectBucket[T, ?]]
 
-  implicit def qScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: NameGenerator]
+  // TODO: Create a type alias for MonadReader[?[_], BucketName], maybe call it BucketNameReader
+  implicit def qScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: MonadReader[?[_], BucketName]: NameGenerator]
     : Planner[T, F, QScriptCore[T, ?]] =
     new QScriptCorePlanner[T, F]
 

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/Planner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/Planner.scala
@@ -19,7 +19,7 @@ package quasar.physical.couchbase.planner
 import quasar.NameGenerator
 import quasar.common.PhaseResultT
 import quasar.contrib.pathy.{ADir, AFile}
-import quasar.physical.couchbase._, common.BucketName
+import quasar.physical.couchbase._, common._
 import quasar.qscript._
 
 import matryoshka._
@@ -55,11 +55,11 @@ object Planner {
     : Planner[T, F, Const[ShiftedRead[ADir], ?]] =
     new UnreachablePlanner[T, F, Const[ShiftedRead[ADir], ?]]
 
-  implicit def constShiftedReadFile[T[_[_]]: CorecursiveT, F[_]: MonadReader[?[_], BucketName]: NameGenerator]
+  implicit def constShiftedReadFile[T[_[_]]: CorecursiveT, F[_]: Monad: BucketNameReader: NameGenerator]
     : Planner[T, F, Const[ShiftedRead[AFile], ?]] =
     new ShiftedReadFilePlanner[T, F]
 
-  implicit def equiJoinPlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: MonadReader[?[_], BucketName]: NameGenerator]
+  implicit def equiJoinPlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: BucketNameReader: NameGenerator]
     : Planner[T, F, EquiJoin[T, ?]] =
     new EquiJoinPlanner[T, F]
 
@@ -71,8 +71,7 @@ object Planner {
     : Planner[T, F, ProjectBucket[T, ?]] =
     new UnreachablePlanner[T, F, ProjectBucket[T, ?]]
 
-  // TODO: Create a type alias for MonadReader[?[_], BucketName], maybe call it BucketNameReader
-  implicit def qScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: MonadReader[?[_], BucketName]: NameGenerator]
+  implicit def qScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: BucketNameReader: NameGenerator]
     : Planner[T, F, QScriptCore[T, ?]] =
     new QScriptCorePlanner[T, F]
 

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/QScriptCorePlanner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/QScriptCorePlanner.scala
@@ -18,16 +18,15 @@ package quasar.physical.couchbase.planner
 
 import slamdata.Predef._
 import quasar.{Data => QData, NameGenerator}
-import quasar.Planner.InternalError
 import quasar.ejson
 import quasar.fp._
 import quasar.fp.ski.κ
 import quasar.physical.couchbase._,
-  common.BucketName,
+  common.BucketNameReader,
   N1QL.{Id, Union, Unreferenced, _},
-  Case._,
-  Select.{Filter, Value, _}
-import quasar.physical.couchbase.planner.Planner._
+  planner.Planner._,
+  Select.{Filter, Value, _}, Case._
+import quasar.Planner.InternalError
 import quasar.qscript, qscript._
 
 import matryoshka._
@@ -36,7 +35,7 @@ import matryoshka.implicits._
 import matryoshka.patterns._
 import scalaz._, Scalaz._, NonEmptyList.nels
 
-final class QScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: MonadReader[?[_], BucketName]: NameGenerator]
+final class QScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: BucketNameReader: NameGenerator]
   extends Planner[T, F, QScriptCore[T, ?]] {
 
   def int(i: Int) = Data[T[N1QL]](QData.Int(i)).embed

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/QScriptCorePlanner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/QScriptCorePlanner.scala
@@ -22,7 +22,7 @@ import quasar.ejson
 import quasar.fp._
 import quasar.fp.ski.κ
 import quasar.physical.couchbase._,
-  common.BucketNameReader,
+  common.ContextReader,
   N1QL.{Id, Union, Unreferenced, _},
   planner.Planner._,
   Select.{Filter, Value, _}, Case._
@@ -35,7 +35,7 @@ import matryoshka.implicits._
 import matryoshka.patterns._
 import scalaz._, Scalaz._, NonEmptyList.nels
 
-final class QScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: BucketNameReader: NameGenerator]
+final class QScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: ContextReader: NameGenerator]
   extends Planner[T, F, QScriptCore[T, ?]] {
 
   def int(i: Int) = Data[T[N1QL]](QData.Int(i)).embed

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/QScriptCorePlanner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/QScriptCorePlanner.scala
@@ -23,6 +23,7 @@ import quasar.ejson
 import quasar.fp._
 import quasar.fp.ski.κ
 import quasar.physical.couchbase._,
+  common.BucketName,
   N1QL.{Id, Union, Unreferenced, _},
   Case._,
   Select.{Filter, Value, _}
@@ -35,7 +36,7 @@ import matryoshka.implicits._
 import matryoshka.patterns._
 import scalaz._, Scalaz._, NonEmptyList.nels
 
-final class QScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: Monad: NameGenerator]
+final class QScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, F[_]: MonadReader[?[_], BucketName]: NameGenerator]
   extends Planner[T, F, QScriptCore[T, ?]] {
 
   def int(i: Int) = Data[T[N1QL]](QData.Int(i)).embed

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/ShiftedReadFilePlanner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/ShiftedReadFilePlanner.scala
@@ -18,19 +18,18 @@ package quasar.physical.couchbase.planner
 
 import slamdata.Predef._
 import quasar.{Data => QData, NameGenerator}
-import quasar.Planner.{PlannerError, PlanPathError}
 import quasar.common.PhaseResultT
+import quasar.connector.PlannerErrT
 import quasar.contrib.pathy.AFile
 import quasar.contrib.scalaz.eitherT._
-import quasar.physical.couchbase._, N1QL.{Eq, Id, _}, Select.{Filter, Value, _}
-import quasar.physical.couchbase.common.BucketCollection
+import quasar.physical.couchbase._, common.BucketName, N1QL.{Eq, Id, _}, Select.{Filter, Value, _}
 import quasar.qscript, qscript._
 
 import matryoshka._
 import matryoshka.implicits._
 import scalaz._, Scalaz._
 
-final class ShiftedReadFilePlanner[T[_[_]]: CorecursiveT, F[_]: Monad: NameGenerator]
+final class ShiftedReadFilePlanner[T[_[_]]: CorecursiveT, F[_]: MonadReader[?[_], BucketName]: NameGenerator]
   extends Planner[T, F, Const[ShiftedRead[AFile], ?]] {
 
   def str(v: String) = Data[T[N1QL]](QData.Str(v))
@@ -38,34 +37,34 @@ final class ShiftedReadFilePlanner[T[_[_]]: CorecursiveT, F[_]: Monad: NameGener
 
   val plan: AlgebraM[M, Const[ShiftedRead[AFile], ?], T[N1QL]] = {
     case Const(ShiftedRead(absFile, idStatus)) =>
-      (genId[T[N1QL], M] ⊛
-       EitherT(
-         BucketCollection.fromPath(absFile)
-           .leftMap[PlannerError](PlanPathError(_)).η[F].liftM[PhaseResultT])
-      ) { (gId, bc) =>
+      (genId[T[N1QL], M] ⊛ MonadReader[F, BucketName].ask.liftM[PhaseResultT].liftM[PlannerErrT]) { (gId, bkt) =>
+        val collection = common.docTypeFromPath(absFile)
+
         val v =
           IfMissing(
             SelectField(gId.embed, str("value").embed).embed,
             gId.embed).embed
+
         val mId = SelectField(Meta(gId.embed).embed, str("id").embed)
+
         val r = idStatus match {
           case IdOnly    => gId.embed
           case IncludeId => Arr(List(gId.embed, v)).embed
           case ExcludeId => v
         }
+
         Select(
           Value(true),
           ResultExpr(r, none).wrapNel,
-          Keyspace(id(bc.bucket).embed, gId.some).some,
+          Keyspace(id(bkt.v).embed, gId.some).some,
           join    = none,
           unnest  = none,
           let     = nil,
-          filter  = bc.collection.nonEmpty.option(
-                      Eq(id("type").embed, str(bc.collection).embed).embed
+          filter  = collection.v.nonEmpty.option(
+                      Eq(id("type").embed, str(collection.v).embed).embed
                     ) ∘ (Filter(_)),
           groupBy = none,
           orderBy = nil).embed
       }
   }
-
 }

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/ShiftedReadFilePlanner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/ShiftedReadFilePlanner.scala
@@ -42,7 +42,7 @@ final class ShiftedReadFilePlanner[T[_[_]]: CorecursiveT, F[_]: Monad: BucketNam
     case Const(ShiftedRead(absFile, idStatus)) =>
       (genId[T[N1QL], M] ⊛ BucketNameReader[F].ask.liftM[PhaseResultT].liftM[PlannerErrT]) { (gId, bkt) =>
         val collection = common.docTypeFromPath(absFile)
-
+        
         val v =
           IfMissing(
             SelectField(gId.embed, str("value").embed).embed,

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/ShiftedReadFilePlanner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/ShiftedReadFilePlanner.scala
@@ -45,7 +45,7 @@ final class ShiftedReadFilePlanner[T[_[_]]: CorecursiveT, F[_]: Monad: ContextRe
         
         val v =
           IfMissing(
-            SelectField(gId.embed, str(ctx.docTypeKey.v).embed).embed,
+            SelectField(gId.embed, str("value").embed).embed,
             gId.embed).embed
 
         val mId = SelectField(Meta(gId.embed).embed, str("id").embed)

--- a/couchbase/src/test/scala/quasar/physical/couchbase/BasicQueryEnablementSpec.scala
+++ b/couchbase/src/test/scala/quasar/physical/couchbase/BasicQueryEnablementSpec.scala
@@ -54,13 +54,11 @@ class BasicQueryEnablementSpec
 
   sequential
 
-  val bktStr = "beer-sample"
-
   def compileLogicalPlan(query: String): Fix[LogicalPlan] =
     compile(query).map(optimizer.optimize).fold(e => scala.sys.error(e.shows), ι)
 
   def listc[S[_]]: DiscoverPath.ListContents[Plan[S, ?]] =
-    Kleisli[Id, ADir, Set[PathSegment]](listContents >>> (_ + FileName(bktStr).right))
+    Kleisli[Id, ADir, Set[PathSegment]](listContents >>> (_ + FileName("beer").right + FileName("brewery").right))
       .transform(λ[Id ~> Plan[S, ?]](_.η[Plan[S, ?]]))
       .run
 
@@ -92,32 +90,32 @@ class BasicQueryEnablementSpec
 
   "SQL² to N1QL" should {
     testSql2ToN1ql(
-      "select * from `beer-sample`",
-      """select v from (select value `_1` from (select value ifmissing(`_0`.['value'], `_0`) from `beer-sample` as `_0`) as `_1`) v""")
+      "select * from `beer`",
+      """select v from (select value `_1` from (select value ifmissing(`_0`.['value'], `_0`) from `beer-sample` as `_0` where (`type` = 'beer')) as `_1`) v""")
 
     testSql2ToN1ql(
-      "select name from `beer-sample`",
-      """select v from (select value `_1`.['name'] from (select value ifmissing(`_0`.['value'], `_0`) from `beer-sample` as `_0`) as `_1`) v""")
+      "select name from `beer`",
+      """select v from (select value `_1`.['name'] from (select value ifmissing(`_0`.['value'], `_0`) from `beer-sample` as `_0` where (`type` = 'beer')) as `_1`) v""")
 
     testSql2ToN1ql(
-      "select name, type from `beer-sample`",
-      """select v from (select value {'name': `_1`.['name'], 'type': `_1`.['type']} from (select value ifmissing(`_0`.['value'], `_0`) from `beer-sample` as `_0`) as `_1`) v""")
+      "select name, type from `beer`",
+      """select v from (select value {'name': `_1`.['name'], 'type': `_1`.['type']} from (select value ifmissing(`_0`.['value'], `_0`) from `beer-sample` as `_0` where (`type` = 'beer')) as `_1`) v""")
 
     testSql2ToN1ql(
-      "select name from `beer-sample` offset 1",
-      """select v from (select value `_7`.['name'] from (select value `_4` from (select (select value ifmissing(`_5`.['value'], `_5`) from `beer-sample` as `_5`) as `_1`, (select value 1 from (select value (select value [])) as `_6`) as `_2` from (select value []) as `_0`) as `_3` unnest `_1`[`_2`[0]:] as `_4`) as `_7`) v""")
+      "select name from `beer` offset 1",
+      """select v from (select value `_7`.['name'] from (select value `_4` from (select (select value ifmissing(`_5`.['value'], `_5`) from `beer-sample` as `_5` where (`type` = 'beer')) as `_1`, (select value 1 from (select value (select value [])) as `_6`) as `_2` from (select value []) as `_0`) as `_3` unnest `_1`[`_2`[0]:] as `_4`) as `_7`) v""")
 
     testSql2ToN1ql(
-      "select count(*) from `beer-sample`",
-      """select v from (select value `_2` from (select count(`_1`) as `_2` from (select value ifmissing(`_0`.['value'], `_0`) from `beer-sample` as `_0`) as `_1` group by null) as `_3` where (`_2` is not null)) v""")
+      "select count(*) from `beer`",
+      """select v from (select value `_2` from (select count(`_1`) as `_2` from (select value ifmissing(`_0`.['value'], `_0`) from `beer-sample` as `_0` where (`type` = 'beer')) as `_1` group by null) as `_3` where (`_2` is not null)) v""")
 
     testSql2ToN1ql(
-      "select count(name) from `beer-sample`",
-      """select v from (select value `_2` from (select count(`_1`.['name']) as `_2` from (select value ifmissing(`_0`.['value'], `_0`) from `beer-sample` as `_0`) as `_1` group by null) as `_3` where (`_2` is not null)) v""")
+      "select count(name) from `beer`",
+      """select v from (select value `_2` from (select count(`_1`.['name']) as `_2` from (select value ifmissing(`_0`.['value'], `_0`) from `beer-sample` as `_0` where (`type` = 'beer')) as `_1` group by null) as `_3` where (`_2` is not null)) v""")
 
     testSql2ToN1ql(
-      "select geo.lat + geo.lon from `beer-sample`",
-      """select v from (select value (`_1`.['geo'].['lat'] + `_1`.['geo'].['lon']) from (select value ifmissing(`_0`.['value'], `_0`) from `beer-sample` as `_0`) as `_1`) v""")
+      "select geo.lat + geo.lon from `brewery`",
+      """select v from (select value (`_1`.['geo'].['lat'] + `_1`.['geo'].['lon']) from (select value ifmissing(`_0`.['value'], `_0`) from `beer-sample` as `_0` where (`type` = 'brewery')) as `_1`) v""")
   }
 
   "QScript to N1QL" should {
@@ -134,7 +132,7 @@ class BasicQueryEnablementSpec
 
       val n1ql = n1qlFromQS(qs)
 
-      n1ql must_= """select v from (select value (`_1`.['a'] + `_1`.['b']) from (select value ifmissing(`_0`.['value'], `_0`) from `foo` as `_0`) as `_1`) v"""
+      n1ql must_= """select v from (select value (`_1`.['a'] + `_1`.['b']) from (select value ifmissing(`_0`.['value'], `_0`) from `beer-sample` as `_0` where (`type` = 'foo')) as `_1`) v"""
     }
   }
 

--- a/docker/scripts/assembleTestingConf
+++ b/docker/scripts/assembleTestingConf
@@ -34,7 +34,7 @@ configure_marklogic_json() {
 #
 configure_couchbase() {
   CONTAINERNAME=$1
-  echo "$CONTAINERNAME=\"couchbase://${DOCKERIP}/quasar-test?password=&docTypeKey=type&socketConnectTimeoutSeconds=15\"" >> $CONFIGFILE
+  echo "$CONTAINERNAME=\"couchbase://${DOCKERIP}/beer-sample?password=&docTypeKey=type&socketConnectTimeoutSeconds=15\"" >> $CONFIGFILE
 }
 
 ##########################################
@@ -51,7 +51,7 @@ configure_metastore() {
 #
 configure_postgresql() {
   CONTAINERNAME=$1
-  echo "$CONTAINERNAME=\"jdbc:postgresql://${DOCKERIP}:5433/quasar-test?user=postgres&password=postgres\"" >> $CONFIGFILE
+  echo "$CONTAINERNAME=\"jdbc:postgresql://${DOCKERIP}:5433/beer-sample?user=postgres&password=postgres\"" >> $CONFIGFILE
 }
 
 ##########################################

--- a/docker/scripts/assembleTestingConf
+++ b/docker/scripts/assembleTestingConf
@@ -51,7 +51,7 @@ configure_metastore() {
 #
 configure_postgresql() {
   CONTAINERNAME=$1
-  echo "$CONTAINERNAME=\"jdbc:postgresql://${DOCKERIP}:5433/beer-sample?user=postgres&password=postgres\"" >> $CONFIGFILE
+  echo "$CONTAINERNAME=\"jdbc:postgresql://${DOCKERIP}:5433/quasar-test?user=postgres&password=postgres\"" >> $CONFIGFILE
 }
 
 ##########################################

--- a/docker/scripts/assembleTestingConf
+++ b/docker/scripts/assembleTestingConf
@@ -34,7 +34,7 @@ configure_marklogic_json() {
 #
 configure_couchbase() {
   CONTAINERNAME=$1
-  echo "$CONTAINERNAME=\"couchbase://${DOCKERIP}/quasar-test?password=&socketConnectTimeoutSeconds=15\"" >> $CONFIGFILE
+  echo "$CONTAINERNAME=\"couchbase://${DOCKERIP}/quasar-test?password=&docTypeKey=type&socketConnectTimeoutSeconds=15\"" >> $CONFIGFILE
 }
 
 ##########################################

--- a/docker/scripts/assembleTestingConf
+++ b/docker/scripts/assembleTestingConf
@@ -34,7 +34,7 @@ configure_marklogic_json() {
 #
 configure_couchbase() {
   CONTAINERNAME=$1
-  echo "$CONTAINERNAME=\"couchbase://${DOCKERIP}?username=Administrator&password=password&socketConnectTimeoutSeconds=15\"" >> $CONFIGFILE
+  echo "$CONTAINERNAME=\"couchbase://${DOCKERIP}/quasar-test?password=&socketConnectTimeoutSeconds=15\"" >> $CONFIGFILE
 }
 
 ##########################################

--- a/docker/scripts/initCouchbase
+++ b/docker/scripts/initCouchbase
@@ -40,12 +40,6 @@ printf "\n\n"
 
 sleep 10
 
-echo "setting up couchbase default buckets..."
-curl -v $CB:8091/pools/default/buckets -d 'ramQuotaMB=100&name=default&authType=sasl'
-printf "\n\n"
-
-sleep 10
-
 echo "setting up couchbase quasar-test buckets..."
 curl -v $CB:8091/pools/default/buckets -d 'ramQuotaMB=100&name=quasar-test&authType=sasl'
 printf "\n\n"

--- a/docker/scripts/initCouchbase
+++ b/docker/scripts/initCouchbase
@@ -3,27 +3,26 @@ set -euo pipefail # STRICT MODE
 IFS=$'\n\t'       # http://redsymbol.net/articles/unofficial-bash-strict-mode/
 
 
-CBWOP='http://admin:password@localhost'
-CB='http://Administrator:password@localhost'
+CB='http://admin:password@127.0.0.1'
 
 sleep 10
 
 # doing this as suggested here by Dan Douglass on 22/Jan/16 12:13PM
 # https://issues.couchbase.com/browse/MB-16233
 echo "setting up couchbase memory quota../"
-curl -v -s -X POST $CBWOP:8091/pools/default -d memoryQuota=512
+curl -v -s -X POST $CB:8091/pools/default -d memoryQuota=512
 printf "\n\n"
 
 sleep 10
 
 echo "setting up couchbase services../"
-curl -v $CBWOP:8091/node/controller/setupServices -d services=kv%2Cn1ql%2Cindex%2Cfts
+curl -v $CB:8091/node/controller/setupServices -d services=kv%2Cn1ql%2Cindex%2Cfts
 printf "\n\n"
 
 sleep 10
 
 echo "setting up couchbase web console with username and password..."
-curl -v $CBWOP:8091/settings/web -d port=8091 -d username=Administrator -d password=password
+curl -v $CB:8091/settings/web -d port=8091 -d username=admin -d password=password
 printf "\n\n"
 
 sleep 10
@@ -35,31 +34,19 @@ printf "\n\n"
 sleep 10
 
 echo "setting up couchbase pools..."
-curl -v -X POST $CB:8091/pools/default -d memoryQuota=400 -d indexMemoryQuota=1024
-printf "\n\n"
-
-sleep 10
-
-echo "setting up couchbase quasar-test buckets..."
-curl -v $CB:8091/pools/default/buckets -d 'ramQuotaMB=100&name=quasar-test&authType=sasl'
-printf "\n\n"
-
-sleep 10
-
-echo "setting up couchbase for primary index on quasar-test..."
-curl -v $CB:8093/query -d 'statement=create primary index on `quasar-test`'
-printf "\n\n"
-
-sleep 10
-
-echo "setting up couchbase index on quasar-test..."
-curl -v $CB:8093/query -d 'statement=create index quasar_test_type_idx on `quasar-test`(type)'
+curl -v -X POST $CB:8091/pools/default -d indexMemoryQuota=1024
 printf "\n\n"
 
 sleep 10
 
 echo "setting up couchbase sample beer buckets..."
 curl -v $CB:8091/sampleBuckets/install -d '["beer-sample"]'
+printf "\n\n"
+
+sleep 20
+
+echo "setting up couchbase index on beer-sample..."
+curl -v $CB:8093/query -d 'statement=create index beer_sample_type_idx on `beer-sample`(type)'
 printf "\n\n"
 
 echo "couchbase configuration done!"

--- a/it/src/main/resources/tests/couchbase/leftKeyJoin.test
+++ b/it/src/main/resources/tests/couchbase/leftKeyJoin.test
@@ -15,8 +15,8 @@
     "data": [],
     "query": "select meta(brewery).id as brewery_meta_id, brewery.name as brewery_name,
                      beer.name as beer_name, beer.brewery_id as beer_brewery_id
-              from `/beer-sample/brewery` as brewery
-              join `/beer-sample/beer` as beer on meta(brewery).id = beer.brewery_id
+              from `brewery` as brewery
+              join `beer` as beer on meta(brewery).id = beer.brewery_id
               where beer.name = \"Pale\"",
     "ignoreFieldOrder": [ "couchbase" ],
     "predicate": "containsExactly",

--- a/it/src/main/resources/tests/couchbase/leftKeyJoinMultipleSelect.test
+++ b/it/src/main/resources/tests/couchbase/leftKeyJoinMultipleSelect.test
@@ -18,7 +18,7 @@
                      beer.name AS beer_name,
                      beer.brewery_id AS beer_brewery_id,
                      beer.category AS beer_category
-              FROM `/beer-sample/brewery` AS brewery JOIN `/beer-sample/beer` AS beer
+              FROM `brewery` AS brewery JOIN `beer` AS beer
               ON META(brewery).id = beer.brewery_id
               WHERE beer.category = \"North American Ale\"",
     "ignoreFieldOrder": [ "couchbase" ],

--- a/it/src/main/resources/tests/couchbase/rightKeyJoin.test
+++ b/it/src/main/resources/tests/couchbase/rightKeyJoin.test
@@ -15,8 +15,8 @@
     "data": [],
     "query": "select meta(brewery).id as brewery_meta_id, brewery.name as brewery_name,
                      beer.name as beer_name, beer.brewery_id as beer_brewery_id
-              from `/beer-sample/beer` as beer
-              join `/beer-sample/brewery` as brewery on beer.brewery_id = meta(brewery).id
+              from `beer` as beer
+              join `brewery` as brewery on beer.brewery_id = meta(brewery).id
               where beer.name = \"Pale\"",
     "ignoreFieldOrder": [ "couchbase" ],
     "predicate": "containsExactly",

--- a/it/src/test/scala/quasar/physical/couchbase/CouchbaseStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/couchbase/CouchbaseStdLibSpec.scala
@@ -148,8 +148,8 @@ class CouchbaseStdLibSpec extends StdLibSpec {
   TestConfig.fileSystemConfigs(FsType).flatMap(_ traverse_ { case (backend, uri, _) =>
     context(uri).fold(
       err => Task.fail(new RuntimeException(err.shows)),
-      ctx => Task.now(backend.name.shows should tests(runner(ctx)))
-    ).void
+      ctx => Task.now(backend.name.shows should tests(runner(ctx._1)))
+    ).join.void
   }).unsafePerformSync
 
 }

--- a/it/testing.conf.example
+++ b/it/testing.conf.example
@@ -7,4 +7,4 @@
 #spark_local       ="<path_to_folder>"
 #spark_hdfs        ="spark://<spark_host>:<spark_port>|hdfs://<hdfs_host>:<hdfs_port>|<root_path>"
 #marklogic         ="xcc://<username>:<password>@<host>:<port>/<database>"
-#couchbase         ="couchbase://<host>[:<port>]?username=<username>&password=<password>[&queryTimeoutSeconds=<seconds>]"
+#couchbase         ="couchbase://<host>[:<port>]/<bucket-name>?password=<password>&docTypeKey=<type>[&queryTimeoutSeconds=<seconds>]"


### PR DESCRIPTION
Fixes: #1740

This PR changes the couchbase connection URI format in two ways:
a) bucket name needs to be specified after `couchbase://<host>[:<port>]/`
b) a document type needs to be specified using `docTypeKey`

In addition, a Quasar couchbase mount now maps directly to a couchbase bucket.