### PR TITLE
Avoid obscuring write errors when attempting to cleanup nonexistent temp file

### DIFF
--- a/connector/src/main/scala/quasar/fs/InMemory.scala
+++ b/connector/src/main/scala/quasar/fs/InMemory.scala
@@ -121,7 +121,6 @@ object InMemory {
         for {
           h <- nextSeq ∘ (WriteHandle(f, _))
           _ <- wFileL(h) := Some(f)
-          _ <- fileL(f) %= (_ orElse Some(Vector()))
         } yield h.right
 
       case WriteFile.Write(h, xs) =>

--- a/connector/src/test/scala/quasar/fs/FileSystemFixture.scala
+++ b/connector/src/test/scala/quasar/fs/FileSystemFixture.scala
@@ -158,8 +158,8 @@ object FileSystemFixture {
           nw <- nextWriteL.st.lift[F]
           ws <- restWritesL.st.lift[F]
           _  <- (writesL := ws.orZero).lift[F]
-          es <- f(Write(h, d)).liftM[ReadWriteT]
-        } yield es ++ nw.orZero
+          es <- nw.cata(_.point[ReadWriteT[F, ?]], f(Write(h, d)).liftM[ReadWriteT])
+        } yield es
 
         case _ => f(wf).liftM[ReadWriteT]
       }


### PR DESCRIPTION
Fixes #2197.