### PR TITLE
Don't distinguish between exclusive and normal tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,14 +18,6 @@ import slamdata.SbtSlamData.transferPublishAndTagResources
 
 val BothScopes = "test->test;compile->compile"
 
-// Exclusive execution settings
-lazy val ExclusiveTests = config("exclusive") extend Test
-
-val ExclusiveTest = Tags.Tag("exclusive-test")
-
-def exclusiveTasks(tasks: Scoped*) =
-  tasks.flatMap(inTask(_)(tags := Seq((ExclusiveTest, 1))))
-
 lazy val buildSettings = commonBuildSettings ++ Seq(
   organization := "org.quasar-analytics",
   initialize := {
@@ -54,10 +46,6 @@ lazy val buildSettings = commonBuildSettings ++ Seq(
     Wart.ImplicitParameter,     // - creates many compile errors when enabled - needs to be enabled incrementally
     Wart.ImplicitConversion,    // - see mpilquist/simulacrum#35
     Wart.Nothing),              // - see wartremover/wartremover#263
-  // Normal tests exclude those tagged in Specs2 with 'exclusive'.
-  testOptions in Test := Seq(Tests.Argument(Specs2, "exclude", "exclusive")),
-  // Exclusive tests include only those tagged with 'exclusive'.
-  testOptions in ExclusiveTests := Seq(Tests.Argument(Specs2, "include", "exclusive")),
 
   console := { (console in Test).value }) // console alias test:console
 
@@ -82,9 +70,6 @@ concurrentRestrictions in Global := {
   else
     (concurrentRestrictions in Global).value
 }
-
-// Tasks tagged with `ExclusiveTest` should be run exclusively.
-concurrentRestrictions in Global += Tags.exclusive(ExclusiveTest)
 
 lazy val publishSettings = commonPublishSettings ++ Seq(
   organizationName := "SlamData Inc.",
@@ -146,7 +131,6 @@ lazy val githubReleaseSettings =
 
 lazy val isCIBuild               = settingKey[Boolean]("True when building in any automated environment (e.g. Travis)")
 lazy val isIsolatedEnv           = settingKey[Boolean]("True if running in an isolated environment")
-lazy val exclusiveTestTag        = settingKey[String]("Tag for exclusive execution tests")
 lazy val sparkDependencyProvided = settingKey[Boolean]("Whether or not the spark dependency should be marked as provided. If building for use in a Spark cluster, one would set this to true otherwise setting it to false will allow you to run the assembly jar on it's own")
 
 lazy val root = project.in(file("."))
@@ -199,9 +183,8 @@ lazy val foundation = project
   .settings(publishTestsSettings)
   .settings(targetSettings)
   .settings(
-    buildInfoKeys := Seq[BuildInfoKey](version, ScoverageKeys.coverageEnabled, isCIBuild, isIsolatedEnv, exclusiveTestTag),
+    buildInfoKeys := Seq[BuildInfoKey](version, ScoverageKeys.coverageEnabled, isCIBuild, isIsolatedEnv),
     buildInfoPackage := "quasar.build",
-    exclusiveTestTag := "exclusive",
     isCIBuild := isTravisBuild.value,
     isIsolatedEnv := java.lang.Boolean.parseBoolean(java.lang.System.getProperty("isIsolatedEnv")),
     libraryDependencies ++= Dependencies.foundation)
@@ -434,15 +417,11 @@ lazy val web = project
 /** Integration tests that have some dependency on a running connector.
   */
 lazy val it = project
-  .configs(ExclusiveTests)
   .dependsOn(web % BothScopes, core % BothScopes)
   .settings(commonSettings)
   .settings(noPublishSettings)
   .settings(targetSettings)
   .settings(libraryDependencies ++= Dependencies.it)
-  // Configure various test tasks to run exclusively in the `ExclusiveTests` config.
-  .settings(inConfig(ExclusiveTests)(Defaults.testTasks): _*)
-  .settings(inConfig(ExclusiveTests)(exclusiveTasks(test, testOnly, testQuick)): _*)
   .settings(parallelExecution in Test := false)
   .enablePlugins(AutomateHeaderPlugin)
 

--- a/foundation/src/test/scala/quasar/QuasarSpecification.scala
+++ b/foundation/src/test/scala/quasar/QuasarSpecification.scala
@@ -78,17 +78,3 @@ trait QuasarSpecification extends AnyRef
     def skippedOnUserEnv(m: String): Result = if (isIsolatedEnv) AsResult(t) else Skipped(m)
   }
 }
-
-/** Trait that tags all examples in a spec for exclusive execution. Examples
-  * will be executed sequentially and parallel execution will be disabled.
-  *
-  * Use this when you have tests that muck with global state.
-  */
-trait ExclusiveQuasarSpecification extends QuasarSpecification {
-  import org.specs2.specification.core.Fragments
-  import org.specs2.specification.dsl.FragmentsDsl._
-
-  sequential
-  override def map(fs: => Fragments) =
-    section(exclusiveTestTag) ^ super.map(fs) ^ section(exclusiveTestTag)
-}

--- a/it/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
@@ -48,9 +48,10 @@ import scalaz.stream._
 
 /** Unit tests for the MongoDB filesystem implementation. */
 class MongoDbFileSystemSpec
-  extends FileSystemTest[AnalyticalFileSystemIO](mongoFsUT map (_ filter (_.ref supports BackendCapability.write())))
-  with quasar.ExclusiveQuasarSpecification {
+  extends FileSystemTest[AnalyticalFileSystemIO](mongoFsUT map (_ filter (_.ref supports BackendCapability.write()))) {
 
+  sequential
+  
   // TODO[scalaz]: Shadow the scalaz.Monad.monadMTMAB SI-2712 workaround
   import EitherT.eitherTMonad
 

--- a/scripts/build
+++ b/scripts/build
@@ -49,7 +49,7 @@ if [[ $CONNECTOR == "mongodb_2_6" ]]; then
 
   # Require that all header comments are present before proceeding, then
   # build and run all tests everywhere (including integration)
-  "$SBT" -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION checkHeaders test exclusive:test
+  "$SBT" -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION checkHeaders test
 
   # In a fresh JVM process, re-compile without coverage in order to get a jar
   # that does not contain instrumentation.
@@ -87,7 +87,7 @@ elif [[ $CONNECTOR == "mongodb_3_0" ]]; then
 
   # Require that all header comments are present before proceeding, then
   # build and run all tests everywhere (including integration)
-  "$SBT" -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION checkHeaders $COVERAGE test exclusive:test $COVERAGE_REPORT
+  "$SBT" -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION checkHeaders $COVERAGE test $COVERAGE_REPORT
 else
   # Compiling `connector` can take awhile, so allow it some extra time when
   # running on travis to avoid having the build killed due to lack of output.
@@ -103,5 +103,5 @@ else
 
   # Not the first job in Travis; run only integration tests (no sense
   # re-doing work that isn't affected by the available backends)
-  "$SBT" -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION it/test it/exclusive:test
+  "$SBT" -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION it/test
 fi


### PR DESCRIPTION
MongoDbFileSystemSpec is the only spec using ExclusiveQuasarSpecification and having this trait mixed in made the spec test nothing.
Also remove ExclusiveTests from build.sbt since its only purpose seems to be for ExclusiveQuasarSpecification