### PR TITLE
Fix improper parsing of modules statement blobs

### DIFF
--- a/core/src/main/scala/quasar/fs/mount/MountConfig.scala
+++ b/core/src/main/scala/quasar/fs/mount/MountConfig.scala
@@ -85,7 +85,7 @@ object MountConfig {
     case ("view", uri) =>
       viewCfgFromUri(uri).map(i => viewConfig(i))
     case ("module", stmts) =>
-      sql.fixParser.parseWithParser(stmts, sql.fixParser.statements).bimap(
+      sql.fixParser.parseModule(stmts).bimap(
         _.message,
         moduleConfig(_))
     case (typ, uri) =>

--- a/frontend/src/main/scala/quasar/sql/parser.scala
+++ b/frontend/src/main/scala/quasar/sql/parser.scala
@@ -487,6 +487,9 @@ private[sql] class SQLParser[T[_[_]]: BirecursiveT]
   def parseBlob(blobString: String): ParsingError \/ Blob[T[Sql]] =
     parseWithParser(blobString, blob).map(_.map(normalize))
 
+  def parseModule(moduleString: String): ParsingError \/ List[Statement[T[Sql]]] =
+    parseWithParser(moduleString, statements).map(_.map(_.map(normalize)))
+
   val parseExpr: Query => ParsingError \/ T[Sql] = query =>
     parseWithParser(query.value, expr).map(normalize)
 


### PR DESCRIPTION
It would appear, one needs to always call `normalize` after parsing SQL. This was not being done when parsing statements when loading a module mount.