### PR TITLE
Vastly superior ??? operator

### DIFF
--- a/core/src/main/scala/quasar/package.scala
+++ b/core/src/main/scala/quasar/package.scala
@@ -28,6 +28,10 @@ import quasar.std.StdLib.set._
 import matryoshka._
 import matryoshka.data.Fix
 import matryoshka.implicits._
+import org.scalactic.source.Position
+import scala.NotImplementedError
+import scala.annotation.unchecked.uncheckedVariance
+import scala.reflect.runtime.universe.WeakTypeTag
 import scalaz._, Scalaz._
 
 package object quasar {
@@ -97,4 +101,11 @@ package object quasar {
       skipped)(
       l => Take(skipped, constant[T](Data.Int(l.value)).embed).embed)
   }
+
+  // better type hole
+  type UnsafeWeakTypeTag[+A] = WeakTypeTag[A @uncheckedVariance]
+
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def ???[A](implicit A: UnsafeWeakTypeTag[A], pos: Position): A =
+    throw new NotImplementedError(s"unimplemented value of type ${A.tpe} at ${pos.fileName}:${pos.lineNumber}")
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -61,6 +61,7 @@ object Dependencies {
     "com.fasterxml.uuid" % "java-uuid-generator" % "3.1.4"
   )
   def core = Seq(
+    "org.scalactic" %% "scalactic" % "3.0.1",     // this is just for the Position macro
     CommonDependencies.doobie.core,
     CommonDependencies.doobie.hikari,
     CommonDependencies.doobie.postgres,


### PR DESCRIPTION
This replaces the `???` operator with something which provides the following two features:

- Type inference based on call site
- Line information

For example:

```
scala> val x: Int = ???
scala.NotImplementedError: unimplemented value of type Int at <console>:14
  at quasar.package$.$qmark$qmark$qmark(package.scala:110)
  ... 42 elided

scala> def x[A]: List[A] = ???
x: [A]=> List[A]

scala> x[String]
scala.NotImplementedError: unimplemented value of type scala.List[A] at <console>:14
  at quasar.package$.$qmark$qmark$qmark(package.scala:110)
  at .x(<console>:14)
  ... 42 elided
```

It's much more interesting if you do it in an actual file, since you'll get the filename instead of `<console>`, but you get the idea.  Had to bring in scalactic for the `Position` macro (thanks, @bvenners!).

This should eventually go into `slamdata.Predef`, but @alissapajer and I actually need this sooner rather than later, so I thought I would drop it into core.