### PR TITLE
Multiple Spark based connectors by sharing SparkContext

### DIFF
--- a/interface/src/main/scala/quasar/main/package.scala
+++ b/interface/src/main/scala/quasar/main/package.scala
@@ -31,6 +31,7 @@ import quasar.physical._, couchbase.Couchbase
 
 import scala.util.control.NonFatal
 
+import org.apache.spark._
 import doobie.imports.Transactor
 import eu.timepit.refined.auto._
 import monocle.Lens
@@ -49,6 +50,8 @@ package object main {
   type MainTask[A]       = MainErrT[Task, A]
   val MainTask           = MonadError[EitherT[Task, String, ?], String]
 
+  val refSc: Task[TaskRef[Option[(Int, SparkContext)]]] = TaskRef[Option[(Int, SparkContext)]](none)
+
   /** The physical filesystems currently supported. */
   val physicalFileSystems: FileSystemDef[PhysFsEffM] = IList(
     Couchbase.definition translate injectFT[Task, PhysFsEff],
@@ -61,8 +64,8 @@ package object main {
     postgresql.fs.definition[PhysFsEff],
     skeleton.Skeleton.definition translate injectFT[Task, PhysFsEff],
     mimir.Mimir.definition translate injectFT[Task, PhysFsEff],
-    sparkcore.fs.hdfs.definition[PhysFsEff],
-    sparkcore.fs.local.definition[PhysFsEff]
+    sparkcore.fs.hdfs.definition[PhysFsEff](refSc),
+    sparkcore.fs.local.definition[PhysFsEff](refSc)
   ).fold
 
   /** A "terminal" effect, encompassing failures and other effects which

--- a/interface/src/main/scala/quasar/main/package.scala
+++ b/interface/src/main/scala/quasar/main/package.scala
@@ -50,6 +50,7 @@ package object main {
   type MainTask[A]       = MainErrT[Task, A]
   val MainTask           = MonadError[EitherT[Task, String, ?], String]
 
+  // TODO this requires passing TaskRef to connectors, not Task of TaskRef
   val refSc: Task[TaskRef[Option[(Int, SparkContext)]]] = TaskRef[Option[(Int, SparkContext)]](none)
 
   /** The physical filesystems currently supported. */

--- a/it/src/test/scala/quasar/fs/FileSystemTest.scala
+++ b/it/src/test/scala/quasar/fs/FileSystemTest.scala
@@ -32,6 +32,7 @@ import quasar.regression.{interpretHfsIO, HfsIO}
 
 import scala.Either
 
+import org.apache.spark._
 import eu.timepit.refined.auto._
 import monocle.Optional
 import monocle.function.Index
@@ -142,6 +143,8 @@ object FileSystemTest {
       filesystems.testFileSystem(uri, dir, fsDef.apply(fsType, uri).run)
   }
 
+  val refSc: Task[TaskRef[Option[(Int, SparkContext)]]] = TaskRef[Option[(Int, SparkContext)]](none)
+
   def externalFsUT = {
     val marklogicDef =
       MarkLogic(10000L, 10000L).definition translate injectFT[Task, filesystems.Eff]
@@ -152,8 +155,8 @@ object FileSystemTest {
       fsTestConfig(mongodb.fs.FsType,         mongodb.fs.definition)         orElse
       fsTestConfig(mongodb.fs.QScriptFsType,  mongodb.fs.qscriptDefinition)  orElse
       fsTestConfig(postgresql.fs.FsType,      postgresql.fs.definition)      orElse
-      fsTestConfig(sparkcore.fs.hdfs.FsType,  sparkcore.fs.hdfs.definition)  orElse
-      fsTestConfig(sparkcore.fs.local.FsType, sparkcore.fs.local.definition)
+      fsTestConfig(sparkcore.fs.hdfs.FsType,  sparkcore.fs.hdfs.definition(refSc))  orElse
+      fsTestConfig(sparkcore.fs.local.FsType, sparkcore.fs.local.definition(refSc))
     }
   }
 


### PR DESCRIPTION
This is second attempt to provide https://github.com/quasar-analytics/quasar/issues/2297 functionality.

This time we init `SparkContext` when connector is mounted, however when second connector (based on Spark) wants to be mounted, instead of returning an error we can reuse existing `SparkContext` - as long as mount connects to the same cluster