### PR TITLE
Include integration tests for mimir.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ before_cache:
 env:
   matrix:
     - CONNECTOR=mongodb_2_6
+    - CONNECTOR=mimir
     - CONNECTOR=marklogic_xml
     - CONNECTOR=marklogic_json
     - CONNECTOR=couchbase

--- a/blueeyes/src/main/scala/quasar/precog/common/ingest/Ingest.scala
+++ b/blueeyes/src/main/scala/quasar/precog/common/ingest/Ingest.scala
@@ -62,7 +62,7 @@ object Ingest {
   implicit def seqExtractor[A: Extractor]: Extractor[Seq[A]] = implicitly[Extractor[List[A]]].map(_.toSeq)
 
   val decomposerV1: Decomposer[Ingest] = decomposerV[Ingest](schemaV1, Some("1.1".v))
-  val extractorV1: Extractor[Ingest]   = extractorV[Ingest](schemaV1, Some("1.1".v))
+  val extractorV1: Extractor[Ingest] = extractorV[Ingest](schemaV1, Some("1.1".v))
 
   // A transitionary format similar to V1 structure, but lacks a version number and only carries a single data element
   val extractorV1a = new Extractor[Ingest] {
@@ -94,13 +94,13 @@ object Ingest {
   }
 
   implicit val decomposer: Decomposer[Ingest] = decomposerV1
-  implicit val extractor: Extractor[Ingest]   = extractorV1 <+> extractorV1a <+> extractorV0
+  implicit val extractor: Extractor[Ingest] = extractorV1 <+> extractorV1a <+> extractorV0
 }
 
 case class Archive(apiKey: APIKey, path: Path, jobId: Option[JobId], timestamp: Instant) extends Event {
   def fold[A](ingest: Ingest => A, archive: Archive => A): A = archive(this)
-  def split(n: Int)                                          = List(this) // can't split an archive
-  def length                                                 = 1
+  def split(n: Int) = List(this) // can't split an archive
+  def length = 1
 }
 
 object Archive {
@@ -108,7 +108,7 @@ object Archive {
   val schemaV0 = "tokenId" :: "path" :: Omit :: ("timestamp" ||| EventMessage.defaultTimestamp) :: HNil
 
   val decomposerV1: Decomposer[Archive] = decomposerV[Archive](schemaV1, Some("1.0".v))
-  val extractorV1: Extractor[Archive]   = extractorV[Archive](schemaV1, Some("1.0".v)) <+> extractorV1a
+  val extractorV1: Extractor[Archive] = extractorV[Archive](schemaV1, Some("1.0".v)) <+> extractorV1a
 
   // Support un-versioned V1 schemas and out-of-order fields due to an earlier bug
   val extractorV1a: Extractor[Archive] = extractorV[Archive](schemaV1, None) map {
@@ -122,7 +122,7 @@ object Archive {
   val extractorV0: Extractor[Archive] = extractorV[Archive](schemaV0, None)
 
   implicit val decomposer: Decomposer[Archive] = decomposerV1
-  implicit val extractor: Extractor[Archive]   = extractorV1 <+> extractorV0
+  implicit val extractor: Extractor[Archive] = extractorV1 <+> extractorV0
 }
 
 sealed trait StreamRef {
@@ -133,32 +133,32 @@ sealed trait StreamRef {
 
 object StreamRef {
   def forWriteMode(mode: WriteMode, terminal: Boolean): StreamRef = mode match {
-    case AccessMode.Create  => StreamRef.Create(randomUuid, terminal)
+    case AccessMode.Create => StreamRef.Create(randomUuid, terminal)
     case AccessMode.Replace => StreamRef.Replace(randomUuid, terminal)
-    case AccessMode.Append  => StreamRef.Append
+    case AccessMode.Append => StreamRef.Append
   }
 
   case class Create(streamId: UUID, terminal: Boolean) extends StreamRef {
-    def terminate                     = copy(terminal = true)
+    def terminate = copy(terminal = true)
     def split(n: Int): Seq[StreamRef] = Vector.fill(n - 1) { copy(terminal = false) } :+ this
   }
 
   case class Replace(streamId: UUID, terminal: Boolean) extends StreamRef {
-    def terminate                     = copy(terminal = true)
+    def terminate = copy(terminal = true)
     def split(n: Int): Seq[StreamRef] = Vector.fill(n - 1) { copy(terminal = false) } :+ this
   }
 
   case object Append extends StreamRef {
     val terminal = false
-    def terminate                     = this
+    def terminate = this
     def split(n: Int): Seq[StreamRef] = Vector.fill(n) { this }
   }
 
   implicit val decomposer: Decomposer[StreamRef] = new Decomposer[StreamRef] {
     def decompose(streamRef: StreamRef) = streamRef match {
-      case Create(uuid, terminal)  => JObject("create" -> JObject("uuid" -> uuid.jv, "terminal" -> terminal.jv))
+      case Create(uuid, terminal) => JObject("create" -> JObject("uuid" -> uuid.jv, "terminal" -> terminal.jv))
       case Replace(uuid, terminal) => JObject("replace" -> JObject("uuid" -> uuid.jv, "terminal" -> terminal.jv))
-      case Append                  => JString("append")
+      case Append => JString("append")
     }
   }
 

--- a/connector/src/main/scala/quasar/qscript/DiscoverPath.scala
+++ b/connector/src/main/scala/quasar/qscript/DiscoverPath.scala
@@ -232,7 +232,11 @@ private[qscript] final class DiscoverPathT[T[_[_]]: BirecursiveT, O[_]: Functor]
       type IT[F[_]] = T[F]
       type OUT[A] = O[A]
 
-      def handleDirs[M[_]: Monad: MonadFsErr](g: ListContents[M], dirs: List[ADir], field: String) =
+      def handleDirs[M[_]: Monad: MonadFsErr](
+        g: ListContents[M],
+        dirs: List[ADir],
+        field: String)
+          : M[List[ADir] \&/ T[OUT]] =
         dirs.traverseM(fileType(g).apply(_, field).fold(
           df => List(df ∘ (file => RF.inj(Const[Read[AFile], T[OUT]](Read(file))).embed)),
           Nil)) ∘ {

--- a/docker/scripts/assembleTestingConf
+++ b/docker/scripts/assembleTestingConf
@@ -13,6 +13,13 @@ configure_spark() {
   echo "spark_local=\"${HOME}/spark_local_test/\"" >> $CONFIGFILE
 }
 
+##########################################
+# injects mimir path into
+# it/testing.conf
+#
+configure_mimir() {
+  echo "mimir=\"/tmp/precog/\"" >> $CONFIGFILE
+}
 
 ##########################################
 # injects marklogic xml and json url
@@ -70,13 +77,14 @@ configure_mongo() {
 
 container_lookup() {
   CONTAINER=$(echo "$1" | cut -d_ -f2-)
-  if [[ $CONTAINER =~ "mongodb"              ]]; then configure_mongo          $CONTAINER;      fi
-  if [[ $CONTAINER == "postgresql"           ]]; then configure_postgresql     $CONTAINER;      fi
-  if [[ $CONTAINER == "marklogic_xml"        ]]; then configure_marklogic_xml  $CONTAINER 8001; fi
-  if [[ $CONTAINER == "marklogic_json"       ]]; then configure_marklogic_json $CONTAINER 9001; fi
-  if [[ $CONTAINER == "couchbase"            ]]; then configure_couchbase      $CONTAINER;      fi
-  if [[ $CONTAINER == "spark_local_test"     ]]; then configure_spark;                          fi
-  if [[ $CONTAINER == "metastore"            ]]; then configure_metastore;                      fi
+  if [[ $CONTAINER =~ "mongodb"          ]]; then configure_mongo          $CONTAINER;      fi
+  if [[ $CONTAINER == "postgresql"       ]]; then configure_postgresql     $CONTAINER;      fi
+  if [[ $CONTAINER == "marklogic_xml"    ]]; then configure_marklogic_xml  $CONTAINER 8001; fi
+  if [[ $CONTAINER == "marklogic_json"   ]]; then configure_marklogic_json $CONTAINER 9001; fi
+  if [[ $CONTAINER == "couchbase"        ]]; then configure_couchbase      $CONTAINER;      fi
+  if [[ $CONTAINER == "spark_local_test" ]]; then configure_spark;                          fi
+  if [[ $CONTAINER == "metastore"        ]]; then configure_metastore;                      fi
+  if [[ $CONTAINER == "mimir"            ]]; then configure_mimir;                          fi
 }
 
 

--- a/docker/scripts/initContainer
+++ b/docker/scripts/initContainer
@@ -7,6 +7,9 @@ CONTAINER=$1
 if [[ $CONTAINER == "quasar_spark_local_test" ]]
 then
     echo "$CONTAINER: not starting a container for spark_local_test..."
+elif [[ $CONTAINER == "quasar_mimir" ]]
+then
+    echo "$CONTAINER: not starting a container for mimir..."
 else
   cd $TRAVIS_BUILD_DIR
   docker-compose -f ./docker/docker-compose.yml up -d $CONTAINER

--- a/interface/src/main/scala/quasar/main/package.scala
+++ b/interface/src/main/scala/quasar/main/package.scala
@@ -56,11 +56,11 @@ package object main {
       readChunkSize  = 10000L,
       writeChunkSize = 10000L
     ).definition translate injectFT[Task, PhysFsEff],
+    mimir.Mimir.definition translate injectFT[Task, PhysFsEff],
     mongodb.fs.definition[PhysFsEff],
     mongodb.fs.qscriptDefinition[PhysFsEff],
     postgresql.fs.definition[PhysFsEff],
     skeleton.Skeleton.definition translate injectFT[Task, PhysFsEff],
-    mimir.Mimir.definition translate injectFT[Task, PhysFsEff],
     sparkcore.fs.hdfs.definition[PhysFsEff],
     sparkcore.fs.local.definition[PhysFsEff]
   ).fold

--- a/it/src/main/resources/tests/aliasedFieldSortedByOriginal.test
+++ b/it/src/main/resources/tests/aliasedFieldSortedByOriginal.test
@@ -1,6 +1,7 @@
 {
     "name": "select aliased field sorted by original name",
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/basicAnalyticQuery.test
+++ b/it/src/main/resources/tests/basicAnalyticQuery.test
@@ -1,6 +1,7 @@
 {
     "name": "basic analytic query",
     "backends": {
+        "mimir": "skip",
         "couchbase":  "skip",
         "mongodb_q_3_2": "pending",
         "postgresql": "pending"

--- a/it/src/main/resources/tests/boulderLikePop.test
+++ b/it/src/main/resources/tests/boulderLikePop.test
@@ -2,6 +2,7 @@
   "name": "population of Boulder-like towns",
 
   "backends": {
+        "mimir": "skip",
       "postgresql": "pending"
   },
 

--- a/it/src/main/resources/tests/boulderPop.test
+++ b/it/src/main/resources/tests/boulderPop.test
@@ -1,6 +1,7 @@
 {
     "name": "population of Boulder",
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/caseVariations.test
+++ b/it/src/main/resources/tests/caseVariations.test
@@ -2,6 +2,7 @@
     "name": "four different kinds of CASE expressions (switch/match, with and without ELSE)",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":  "skip",
         "marklogic_json": "skip",
         "marklogic_xml":  "skip",

--- a/it/src/main/resources/tests/caseWithGroup.test
+++ b/it/src/main/resources/tests/caseWithGroup.test
@@ -2,6 +2,7 @@
     "name": "combine case (3-arg expr) with group by",
 
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending",
         "marklogic_json":  "skip",
         "marklogic_xml":   "skip",

--- a/it/src/main/resources/tests/citiesByLargestZip.test
+++ b/it/src/main/resources/tests/citiesByLargestZip.test
@@ -1,6 +1,7 @@
 {
     "name": "cities with largest individual zip codes",
     "backends": {
+        "mimir": "skip",
         "couchbase":  "skip",
         "marklogic_json": "pending",
         "marklogic_xml":  "pending",

--- a/it/src/main/resources/tests/citiesByTotalPopulation.test
+++ b/it/src/main/resources/tests/citiesByTotalPopulation.test
@@ -4,6 +4,7 @@
     "NB": "Couchbase is skipped due to largish generated N1QL that leads to a timeout.",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":  "skip",
         "postgresql": "pending"
     },

--- a/it/src/main/resources/tests/complex-vars.test
+++ b/it/src/main/resources/tests/complex-vars.test
@@ -2,6 +2,7 @@
     "name": "variable with a non-trivial value",
 
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
 

--- a/it/src/main/resources/tests/concatArray.test
+++ b/it/src/main/resources/tests/concatArray.test
@@ -1,6 +1,7 @@
 {
     "name": "concat known array structure",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/concatArrayWithLiteral.test
+++ b/it/src/main/resources/tests/concatArrayWithLiteral.test
@@ -1,6 +1,7 @@
 {
     "name": "concat unknown with literal array",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"

--- a/it/src/main/resources/tests/concatArrayWithUnknown.test
+++ b/it/src/main/resources/tests/concatArrayWithUnknown.test
@@ -1,6 +1,7 @@
 {
     "name": "concat array with unknown structure",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"

--- a/it/src/main/resources/tests/concatBetween.test
+++ b/it/src/main/resources/tests/concatBetween.test
@@ -1,6 +1,7 @@
 {
     "name": "concat BETWEEN with other fields",
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
     "data": "smallZips.data",

--- a/it/src/main/resources/tests/concatFieldAndConstant.test
+++ b/it/src/main/resources/tests/concatFieldAndConstant.test
@@ -1,6 +1,7 @@
 {
     "name": "concat field with constant array",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/constantAndGrouped.test
+++ b/it/src/main/resources/tests/constantAndGrouped.test
@@ -2,6 +2,7 @@
     "name": "constant and a grouped value",
 
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
 

--- a/it/src/main/resources/tests/convertFromString.test
+++ b/it/src/main/resources/tests/convertFromString.test
@@ -1,6 +1,7 @@
 {
     "name": "convert values from strings",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/convertToFromString.test
+++ b/it/src/main/resources/tests/convertToFromString.test
@@ -1,6 +1,7 @@
 {
     "name": "convert values to/from strings",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/couchbase/leftKeyJoin.test
+++ b/it/src/main/resources/tests/couchbase/leftKeyJoin.test
@@ -1,6 +1,7 @@
 {
     "name": "left key join (Couchbase)",
     "backends": {
+        "mimir": "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
         "mongodb_2_6":       "skip",

--- a/it/src/main/resources/tests/couchbase/leftKeyJoinMultipleSelect.test
+++ b/it/src/main/resources/tests/couchbase/leftKeyJoinMultipleSelect.test
@@ -1,6 +1,7 @@
 {
     "name": "left key join with multiple fields selected (Couchbase)",
     "backends": {
+        "mimir": "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
         "mongodb_2_6":       "skip",

--- a/it/src/main/resources/tests/couchbase/rightKeyJoin.test
+++ b/it/src/main/resources/tests/couchbase/rightKeyJoin.test
@@ -1,6 +1,7 @@
 {
     "name": "right key join (Couchbase)",
     "backends": {
+        "mimir": "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
         "mongodb_2_6":       "skip",

--- a/it/src/main/resources/tests/countDistinct.test
+++ b/it/src/main/resources/tests/countDistinct.test
@@ -2,6 +2,7 @@
     "name": "count distinct",
 
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
 

--- a/it/src/main/resources/tests/countDistinctStar.test
+++ b/it/src/main/resources/tests/countDistinctStar.test
@@ -1,6 +1,7 @@
 {
     "name": "count distinct *",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"

--- a/it/src/main/resources/tests/delete.test
+++ b/it/src/main/resources/tests/delete.test
@@ -1,6 +1,7 @@
 {
     "name": "delete",
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/demo/nestedSelectWithReduce.test
+++ b/it/src/main/resources/tests/demo/nestedSelectWithReduce.test
@@ -1,6 +1,7 @@
 {
     "name": "select reduction from nested select",
     "backends": {
+        "mimir": "skip",
         "couchbase": "skip",
         "marklogic_json": "skip",
         "marklogic_xml": "skip",

--- a/it/src/main/resources/tests/demo/timeSeriesAggregation.test
+++ b/it/src/main/resources/tests/demo/timeSeriesAggregation.test
@@ -1,6 +1,7 @@
 {
     "name": "time series aggregation",
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
     "data": "smalltimeseries.data",

--- a/it/src/main/resources/tests/different-flattens.test
+++ b/it/src/main/resources/tests/different-flattens.test
@@ -1,6 +1,7 @@
 {
     "name": "merge differently-nested flattens",
     "backends": {
+        "mimir": "skip",
         "couchbase":      "skip",
         "marklogic_json": "skip",
         "marklogic_xml":  "skip",

--- a/it/src/main/resources/tests/distinctStar.test
+++ b/it/src/main/resources/tests/distinctStar.test
@@ -1,6 +1,7 @@
 {
     "name": "distinct *",
     "backends": {
+        "mimir": "skip",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
         "mongodb_read_only": "pending",

--- a/it/src/main/resources/tests/divide.test
+++ b/it/src/main/resources/tests/divide.test
@@ -4,6 +4,7 @@
         "couchbase": "pending",
         "marklogic_json": "pending",
         "marklogic_xml": "pending",
+        "mimir": "skip",
         "spark_local": "pending",
         "spark_hdfs": "pending"
     },

--- a/it/src/main/resources/tests/divide0.test
+++ b/it/src/main/resources/tests/divide0.test
@@ -4,6 +4,7 @@
         "couchbase": "pending",
         "marklogic_json": "pending",
         "marklogic_xml": "pending",
+        "mimir": "skip",
         "spark_local": "pending",
         "spark_hdfs": "pending"
     },

--- a/it/src/main/resources/tests/doubleFlatten.test
+++ b/it/src/main/resources/tests/doubleFlatten.test
@@ -1,6 +1,7 @@
 {
     "name": "flatten a flattened field",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/doubleFlattenWithIntervening.test
+++ b/it/src/main/resources/tests/doubleFlattenWithIntervening.test
@@ -1,6 +1,7 @@
 {
     "name": "double flatten with intervening field",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/fieldOrder.test
+++ b/it/src/main/resources/tests/fieldOrder.test
@@ -2,6 +2,7 @@
     "name": "reduced expressions which trigger bad field ordering in MongoDB (#598)",
 
     "backends": {
+        "mimir": "skip",
         "marklogic_xml": "pending",
         "postgresql":    "pending"
     },

--- a/it/src/main/resources/tests/filter-vars.test
+++ b/it/src/main/resources/tests/filter-vars.test
@@ -2,6 +2,7 @@
     "name": "filter with pipeline using variables in query",
 
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
 

--- a/it/src/main/resources/tests/filter.test
+++ b/it/src/main/resources/tests/filter.test
@@ -2,6 +2,7 @@
     "name": "filter with pipeline and JS",
 
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/filterByJsWithOnlyReducing.test
+++ b/it/src/main/resources/tests/filterByJsWithOnlyReducing.test
@@ -2,6 +2,7 @@
     "name": "filter by JS expression, with only reducing projections",
 
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/filterComplement.test
+++ b/it/src/main/resources/tests/filterComplement.test
@@ -1,6 +1,7 @@
 {
     "name": "filter on list complement",
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/filterMembership.test
+++ b/it/src/main/resources/tests/filterMembership.test
@@ -1,6 +1,7 @@
 {
     "name": "filter on list membership",
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/filterOnContains.test
+++ b/it/src/main/resources/tests/filterOnContains.test
@@ -1,6 +1,7 @@
 {
     "name": "filter on contains",
     "backends": {
+        "mimir": "skip",
         "postgresql":        "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/filterOnFieldComparison.test
+++ b/it/src/main/resources/tests/filterOnFieldComparison.test
@@ -1,6 +1,7 @@
 {
     "name": "filter on field comparison",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/filterOnOid.test
+++ b/it/src/main/resources/tests/filterOnOid.test
@@ -2,6 +2,7 @@
     "name": "match on ObjectId",
     "NB": "This test isn’t really valid. This is neither the correct way to represent an OID (there is no generic way to do so), nor should the `_id` field even be in the data. But this is a reasonable placeholder until we actually expose the correct way to do more or less what this intends.",
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
     "data": "days.data",

--- a/it/src/main/resources/tests/filterSkipLimitCount.test
+++ b/it/src/main/resources/tests/filterSkipLimitCount.test
@@ -2,6 +2,7 @@
     "name": "filter, skip, limit, and count",
 
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
 

--- a/it/src/main/resources/tests/filterSortLimit.test
+++ b/it/src/main/resources/tests/filterSortLimit.test
@@ -2,6 +2,7 @@
     "name": "filter, sort, and limit",
 
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
 

--- a/it/src/main/resources/tests/filterWithComplexNot.test
+++ b/it/src/main/resources/tests/filterWithComplexNot.test
@@ -4,6 +4,7 @@
     "NB": "Couchbase disabled due to heap exhaustion",
 
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending",
         "couchbase":         "skip"

--- a/it/src/main/resources/tests/filterWithNot.test
+++ b/it/src/main/resources/tests/filterWithNot.test
@@ -2,6 +2,7 @@
   "name": "filter with negated regex selector",
 
   "backends": {
+        "mimir": "skip",
     "postgresql": "pending"
   },
 

--- a/it/src/main/resources/tests/filteredDistinct.test
+++ b/it/src/main/resources/tests/filteredDistinct.test
@@ -1,6 +1,7 @@
 {
     "name": "filtered distinct of one field",
     "backends": {
+        "mimir": "skip",
         "mongodb_q_3_2": "pending",
         "postgresql": "pending"
     },

--- a/it/src/main/resources/tests/flattenArray.test
+++ b/it/src/main/resources/tests/flattenArray.test
@@ -1,6 +1,7 @@
 {
     "name": "flatten array",
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/flattenArrayLeftWithUnflattened.test
+++ b/it/src/main/resources/tests/flattenArrayLeftWithUnflattened.test
@@ -1,6 +1,7 @@
 {
     "name": "flatten array on the left with unflattened field",
     "backends": {
+        "mimir": "skip",
         "couchbase": "skip",
         "mongodb_q_3_2": "pending",
         "postgresql": "pending"

--- a/it/src/main/resources/tests/flattenArrayProjection.test
+++ b/it/src/main/resources/tests/flattenArrayProjection.test
@@ -1,6 +1,7 @@
 {
     "name": "flatten an object resulting from an array projection",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/flattenArrayWithUnflattened.test
+++ b/it/src/main/resources/tests/flattenArrayWithUnflattened.test
@@ -1,6 +1,7 @@
 {
     "name": "flatten array with unflattened field",
     "backends": {
+        "mimir": "skip",
         "couchbase":  "skip",
         "postgresql": "pending"
     },

--- a/it/src/main/resources/tests/flattenGroupedObject.test
+++ b/it/src/main/resources/tests/flattenGroupedObject.test
@@ -1,6 +1,7 @@
 {
     "name": "flatten a grouped object with filter",
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/flattenNestedObject.test
+++ b/it/src/main/resources/tests/flattenNestedObject.test
@@ -1,6 +1,7 @@
 {
     "name": "flatten an object inside a field projection",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/flattenObject.test
+++ b/it/src/main/resources/tests/flattenObject.test
@@ -1,6 +1,7 @@
 {
     "name": "flatten object",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/flattenObjectLike.test
+++ b/it/src/main/resources/tests/flattenObjectLike.test
@@ -1,6 +1,7 @@
 {
     "name": "flatten a single field as an object",
     "backends": {
+        "mimir": "skip",
         "couchbase":         "pending",
         "marklogic_json":    "pending",
         "marklogic_xml":     "pending",

--- a/it/src/main/resources/tests/generatedFieldNames.test
+++ b/it/src/main/resources/tests/generatedFieldNames.test
@@ -2,6 +2,7 @@
   "name": "generated field names",
 
   "backends": {
+        "mimir": "skip",
     "marklogic_xml":     "pending",
     "mongodb_read_only": "pending",
     "postgresql":        "pending"

--- a/it/src/main/resources/tests/groupAndFilterWithNoUnreduced.test
+++ b/it/src/main/resources/tests/groupAndFilterWithNoUnreduced.test
@@ -2,6 +2,7 @@
     "name": "explicitly grouped, with only reduced projections, and a filter",
 
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
 

--- a/it/src/main/resources/tests/groupAndWildcard.test
+++ b/it/src/main/resources/tests/groupAndWildcard.test
@@ -2,6 +2,7 @@
   "name": "select wildcard with group by",
 
   "backends": {
+        "mimir": "skip",
     "postgresql": "pending"
   },
 

--- a/it/src/main/resources/tests/groupByArray.test
+++ b/it/src/main/resources/tests/groupByArray.test
@@ -1,6 +1,7 @@
 {
     "name": "group by array",
     "backends": {
+        "mimir": "skip",
         "mongodb_q_3_2": "pending",
         "postgresql": "pending"
     },

--- a/it/src/main/resources/tests/groupByExpression.test
+++ b/it/src/main/resources/tests/groupByExpression.test
@@ -2,6 +2,7 @@
     "name": "group by a computed value",
 
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
     "ignoreFieldOrder": [

--- a/it/src/main/resources/tests/groupByFlatten.test
+++ b/it/src/main/resources/tests/groupByFlatten.test
@@ -1,6 +1,7 @@
 {
     "name": "group by flattened field",
     "backends": {
+        "mimir": "skip",
         "couchbase":  "skip",
         "marklogic_json": "skip",
         "marklogic_xml":  "skip",

--- a/it/src/main/resources/tests/guardedExpression.test
+++ b/it/src/main/resources/tests/guardedExpression.test
@@ -1,6 +1,7 @@
 {
   "name": "regex on non-string field",
   "backends": {
+        "mimir": "skip",
       "marklogic_json":    "pending",
       "mongodb_read_only": "pending",
       "postgresql":        "pending"

--- a/it/src/main/resources/tests/idAliased.test
+++ b/it/src/main/resources/tests/idAliased.test
@@ -2,6 +2,7 @@
   "name": "select _id as zip",
 
   "backends": {
+        "mimir": "skip",
     "postgresql": "pending"
   },
 

--- a/it/src/main/resources/tests/ifUndefined.test
+++ b/it/src/main/resources/tests/ifUndefined.test
@@ -1,6 +1,7 @@
 {
     "name": "handle undefined values",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/implicitGroupWithFilter.test
+++ b/it/src/main/resources/tests/implicitGroupWithFilter.test
@@ -2,6 +2,7 @@
     "name": "implicitly grouped, with filtering",
 
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
 

--- a/it/src/main/resources/tests/inBareElement.test
+++ b/it/src/main/resources/tests/inBareElement.test
@@ -1,6 +1,7 @@
 {
     "name": "filter field “in” a bare value",
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/joins/3WayJoin.test
+++ b/it/src/main/resources/tests/joins/3WayJoin.test
@@ -2,6 +2,7 @@
     "name": "perform 3-way inner equi-join",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/joins/constantOnLeft.test
+++ b/it/src/main/resources/tests/joins/constantOnLeft.test
@@ -2,6 +2,7 @@
     "name": "join where the left hand side is constant",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/joins/crossJoin.test
+++ b/it/src/main/resources/tests/joins/crossJoin.test
@@ -2,6 +2,7 @@
     "name": "simple join written in 'cross join' form (must be optimized to an inner join or else the join explodes, taking several minutes to complete)",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/joins/crossJoinWithOneSidedConditions.test
+++ b/it/src/main/resources/tests/joins/crossJoinWithOneSidedConditions.test
@@ -2,6 +2,7 @@
     "name": "cross join with conditions that must be pushed ahead of the join (or else the join explodes, taking several minutes to complete)",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",

--- a/it/src/main/resources/tests/joins/groupedJoin.test
+++ b/it/src/main/resources/tests/joins/groupedJoin.test
@@ -2,6 +2,7 @@
     "name": "count grouped joined tables",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/joins/innerEquiJoin.test
+++ b/it/src/main/resources/tests/joins/innerEquiJoin.test
@@ -2,6 +2,7 @@
     "name": "perform inner equi-join",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/joins/innerEquiJoinWithWildcard.test
+++ b/it/src/main/resources/tests/joins/innerEquiJoinWithWildcard.test
@@ -2,6 +2,7 @@
     "name": "perform inner equi-join with wildcard",
 
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2": "pending",
         "postgresql":        "pending",

--- a/it/src/main/resources/tests/joins/joinSubSelects.test
+++ b/it/src/main/resources/tests/joins/joinSubSelects.test
@@ -2,6 +2,7 @@
     "name": "join the results of a pair of sub-queries",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/joins/joinWithComplexCondition.test
+++ b/it/src/main/resources/tests/joins/joinWithComplexCondition.test
@@ -2,6 +2,7 @@
     "name": "join with complex conditions",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/joins/joinWithMultipleConditions.test
+++ b/it/src/main/resources/tests/joins/joinWithMultipleConditions.test
@@ -2,6 +2,7 @@
     "name": "join with multiple conditions",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/joins/joinWithReversedCondition.test
+++ b/it/src/main/resources/tests/joins/joinWithReversedCondition.test
@@ -2,6 +2,7 @@
     "name": "join with reversed condition and complex condition expression",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",

--- a/it/src/main/resources/tests/joins/multipleSelectJoin.test
+++ b/it/src/main/resources/tests/joins/multipleSelectJoin.test
@@ -2,6 +2,7 @@
     "name": "join with multiple fields selected",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":         "pending",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",

--- a/it/src/main/resources/tests/joins/nonJsJoinCondition.test
+++ b/it/src/main/resources/tests/joins/nonJsJoinCondition.test
@@ -2,6 +2,7 @@
     "name": "flatten one side of a join condition",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/joins/orderJoinByAlias.test
+++ b/it/src/main/resources/tests/joins/orderJoinByAlias.test
@@ -2,6 +2,7 @@
     "name": "order join by alias",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/joins/sameFieldName.test
+++ b/it/src/main/resources/tests/joins/sameFieldName.test
@@ -2,6 +2,7 @@
     "name": "select over fields with same name",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2": "pending",

--- a/it/src/main/resources/tests/joins/sameFieldNameComplex.test
+++ b/it/src/main/resources/tests/joins/sameFieldNameComplex.test
@@ -2,6 +2,7 @@
     "name": "select over fields with same name and condition with AND",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",

--- a/it/src/main/resources/tests/joins/selfjoinConstantOnLeft.test
+++ b/it/src/main/resources/tests/joins/selfjoinConstantOnLeft.test
@@ -2,6 +2,7 @@
     "name": "self-join where the left hand side is constant",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/joins/selfjoinWithComplexCondition.test
+++ b/it/src/main/resources/tests/joins/selfjoinWithComplexCondition.test
@@ -2,6 +2,7 @@
     "name": "self-join with complex conditions",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/joins/symmetricNonJsJoinCondition.test
+++ b/it/src/main/resources/tests/joins/symmetricNonJsJoinCondition.test
@@ -2,6 +2,7 @@
     "name": "flattening both sides of a join condition",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/jsWithNonJsFilter.test
+++ b/it/src/main/resources/tests/jsWithNonJsFilter.test
@@ -1,6 +1,7 @@
 {
     "name": "filter on JS with non-JS",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/largestCities.test
+++ b/it/src/main/resources/tests/largestCities.test
@@ -4,6 +4,7 @@
     "NB": "Couchbase is skipped due to largish generated N1QL that leads to a timeout.",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":  "skip",
         "postgresql": "pending"
     },

--- a/it/src/main/resources/tests/largestZips.test
+++ b/it/src/main/resources/tests/largestZips.test
@@ -1,6 +1,7 @@
 {
     "name": "largest zips",
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending",
         "spark_local": "pending",
         "spark_hdfs": "pending"

--- a/it/src/main/resources/tests/letBinding.test
+++ b/it/src/main/resources/tests/letBinding.test
@@ -2,6 +2,7 @@
     "name": "handle nested let binding and selects",
 
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
 

--- a/it/src/main/resources/tests/letBindingSelect.test
+++ b/it/src/main/resources/tests/letBindingSelect.test
@@ -2,6 +2,7 @@
     "name": "handle select in form of let",
 
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
 

--- a/it/src/main/resources/tests/letInSelectProjection.test
+++ b/it/src/main/resources/tests/letInSelectProjection.test
@@ -2,6 +2,7 @@
     "name": "handle let as project of select",
 
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
 

--- a/it/src/main/resources/tests/likeWithConstantFoldablePattern.test
+++ b/it/src/main/resources/tests/likeWithConstantFoldablePattern.test
@@ -1,6 +1,7 @@
 {
     "name": "LIKE with constant-foldable pattern",
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/locationCount.test
+++ b/it/src/main/resources/tests/locationCount.test
@@ -1,6 +1,7 @@
 {
     "name": "job postings by city ",
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "marklogic_json":    "pending",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/longCitiesWithLength.test
+++ b/it/src/main/resources/tests/longCitiesWithLength.test
@@ -1,6 +1,7 @@
 {
     "name": "long city names in Colorado",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2": "pending",
         "postgresql":        "pending"

--- a/it/src/main/resources/tests/manySimpleProjections.test
+++ b/it/src/main/resources/tests/manySimpleProjections.test
@@ -2,6 +2,7 @@
   "name": "many simple projections (order matters)",
 
   "backends": {
+        "mimir": "skip",
     "postgresql": "pending"
   },
 

--- a/it/src/main/resources/tests/matchCaseInsensitiveRegex.test
+++ b/it/src/main/resources/tests/matchCaseInsensitiveRegex.test
@@ -1,6 +1,7 @@
 {
     "name": "match on case-insensitive string",
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/matchLikeComplement.test
+++ b/it/src/main/resources/tests/matchLikeComplement.test
@@ -1,6 +1,7 @@
 {
     "name": "match like complement",
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/matchLikePattern.test
+++ b/it/src/main/resources/tests/matchLikePattern.test
@@ -1,6 +1,7 @@
 {
     "name": "match like pattern",
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/matchRegexPattern.test
+++ b/it/src/main/resources/tests/matchRegexPattern.test
@@ -1,6 +1,7 @@
 {
     "name": "match regex pattern",
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/matchRegexPatternWithExpressions.test
+++ b/it/src/main/resources/tests/matchRegexPatternWithExpressions.test
@@ -2,6 +2,7 @@
   "name": "regexes in expressions and filter, with fields and constants providing the pattern",
 
   "backends": {
+        "mimir": "skip",
     "mongodb_read_only": "pending",
     "mongodb_q_3_2":  "pending",
     "postgresql":        "pending"

--- a/it/src/main/resources/tests/mongodb/distinctStar.test
+++ b/it/src/main/resources/tests/mongodb/distinctStar.test
@@ -1,6 +1,7 @@
 {
     "name": "distinct * (MongoDB)",
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/mongodb/fakeObjectId.test
+++ b/it/src/main/resources/tests/mongodb/fakeObjectId.test
@@ -1,6 +1,7 @@
 {
     "name": "convert a field to ObjectId",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2": "pending",
         "postgresql":        "pending",

--- a/it/src/main/resources/tests/mongodb/temporal/filterOnDate.test
+++ b/it/src/main/resources/tests/mongodb/temporal/filterOnDate.test
@@ -1,6 +1,7 @@
 {
     "name": "filter with date literals",
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/mongodb/temporal/time.test
+++ b/it/src/main/resources/tests/mongodb/temporal/time.test
@@ -2,6 +2,7 @@
     "name": "filter on time_of_day (MongoDB)",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/mongodb/temporal/toFromString.test
+++ b/it/src/main/resources/tests/mongodb/temporal/toFromString.test
@@ -1,6 +1,7 @@
 {
     "name": "convert dates to/from strings (MongoDB)",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "skip",
         "marklogic_json":    "skip",

--- a/it/src/main/resources/tests/multilineLike.test
+++ b/it/src/main/resources/tests/multilineLike.test
@@ -1,6 +1,7 @@
 {
     "name": "match LIKE with multiple lines",
     "backends": {
+        "mimir": "skip",
         "marklogic_json": "pending",
         "marklogic_xml":  "pending",
         "postgresql":     "pending",

--- a/it/src/main/resources/tests/multistageFlatten.test
+++ b/it/src/main/resources/tests/multistageFlatten.test
@@ -1,6 +1,7 @@
 {
     "name": "multi-flatten with fields at various depths",
     "backends": {
+        "mimir": "skip",
         "couchbase":  "skip",
         "marklogic_json": "skip",
         "marklogic_xml":  "skip",

--- a/it/src/main/resources/tests/multitypeFlatten.test
+++ b/it/src/main/resources/tests/multitypeFlatten.test
@@ -1,6 +1,7 @@
 {
     "name": "flatten a single field as both object and array",
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/negatedRegex.test
+++ b/it/src/main/resources/tests/negatedRegex.test
@@ -1,6 +1,7 @@
 {
     "name": "negate matches in filter and projection",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/null/notNullFilter.test
+++ b/it/src/main/resources/tests/null/notNullFilter.test
@@ -1,6 +1,7 @@
 {
     "name": "filter on is not null",
     "backends": {
+        "mimir": "skip",
         "marklogic_json": "pending",
         "mongodb_q_3_2":  "pending",
         "postgresql":     "pending"

--- a/it/src/main/resources/tests/null/nullComparison.test
+++ b/it/src/main/resources/tests/null/nullComparison.test
@@ -1,6 +1,7 @@
 {
     "name": "filter on `!= null`",
     "backends": {
+        "mimir": "skip",
         "marklogic_json": "pending",
         "mongodb_q_3_2":  "pending",
         "postgresql":     "pending"

--- a/it/src/main/resources/tests/null/nullFilter.test
+++ b/it/src/main/resources/tests/null/nullFilter.test
@@ -2,6 +2,7 @@
     "name": "filter on is null",
 
     "backends": {
+        "mimir": "skip",
         "marklogic_json": "pending",
         "mongodb_q_3_2":  "pending",
         "postgresql":     "pending"

--- a/it/src/main/resources/tests/null/nullTestExprs.test
+++ b/it/src/main/resources/tests/null/nullTestExprs.test
@@ -1,6 +1,7 @@
 {
     "name": "expressions with `= null` and `is null`",
     "backends": {
+        "mimir": "skip",
         "marklogic_json": "skip",
         "marklogic_xml":  "skip",
         "postgresql": "pending"

--- a/it/src/main/resources/tests/null/nullTestExprsWithMissing.test
+++ b/it/src/main/resources/tests/null/nullTestExprsWithMissing.test
@@ -1,6 +1,7 @@
 {
     "name": "expressions with `= null` and `is null`, with missing fields (pending #465)",
     "backends": {
+        "mimir": "skip",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
         "mongodb_read_only": "pending",

--- a/it/src/main/resources/tests/null/toFromString.test
+++ b/it/src/main/resources/tests/null/toFromString.test
@@ -1,6 +1,7 @@
 {
     "name": "convert null to/from strings",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/numericFieldNames.test
+++ b/it/src/main/resources/tests/numericFieldNames.test
@@ -2,6 +2,7 @@
   "name": "numeric field names",
 
   "backends": {
+        "mimir": "skip",
     "marklogic_xml": "pending",
     "postgresql":    "pending"
   },

--- a/it/src/main/resources/tests/orderedWildcardWithProjection.test
+++ b/it/src/main/resources/tests/orderedWildcardWithProjection.test
@@ -1,6 +1,7 @@
 {
     "name": "wildcard with projection and synthetic field",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/projectCaseInsensitiveRegex.test
+++ b/it/src/main/resources/tests/projectCaseInsensitiveRegex.test
@@ -1,6 +1,7 @@
 {
     "name": "case-insensitive regex in projections",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/projectFieldWithFlatten.test
+++ b/it/src/main/resources/tests/projectFieldWithFlatten.test
@@ -1,6 +1,7 @@
 {
     "name": "project unrelated field with object flatten",
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"

--- a/it/src/main/resources/tests/projectFromConcattedArray.test
+++ b/it/src/main/resources/tests/projectFromConcattedArray.test
@@ -1,6 +1,7 @@
 {
     "name": "project from non-static concatted array",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2": "pending",
         "postgresql":        "pending"

--- a/it/src/main/resources/tests/projectFromConcattedArrayPrefix.test
+++ b/it/src/main/resources/tests/projectFromConcattedArrayPrefix.test
@@ -1,6 +1,7 @@
 {
     "name": "project from static concatted array prefix",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/projectIndexFromGroup.test
+++ b/it/src/main/resources/tests/projectIndexFromGroup.test
@@ -1,6 +1,7 @@
 {
     "name": "project index from group",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/projectIndexFromGroupWithFilter.test
+++ b/it/src/main/resources/tests/projectIndexFromGroupWithFilter.test
@@ -1,6 +1,7 @@
 {
     "name": "project index from group with filter",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/projectIndexWithObjectFlatten.test
+++ b/it/src/main/resources/tests/projectIndexWithObjectFlatten.test
@@ -1,6 +1,7 @@
 {
     "name": "project index with object flatten",
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",

--- a/it/src/main/resources/tests/selectArrayElement.test
+++ b/it/src/main/resources/tests/selectArrayElement.test
@@ -1,6 +1,7 @@
 {
     "name": "select array element",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/selectTwentyFields.test
+++ b/it/src/main/resources/tests/selectTwentyFields.test
@@ -1,6 +1,7 @@
 {
     "name": "select twenty fields quickly",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/selectWildcardAndField.test
+++ b/it/src/main/resources/tests/selectWildcardAndField.test
@@ -1,6 +1,7 @@
 {
     "name": "select wildcard and field",
     "backends": {
+        "mimir": "skip",
         "postgresql":        "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/selfOrderedDistinct.test
+++ b/it/src/main/resources/tests/selfOrderedDistinct.test
@@ -2,6 +2,7 @@
     "name": "self-ordered distinct",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":      "skip",
         "marklogic_json": "skip",
         "marklogic_xml":  "skip",

--- a/it/src/main/resources/tests/servlet.test
+++ b/it/src/main/resources/tests/servlet.test
@@ -1,6 +1,7 @@
 {
     "name": "servlets with and without init-param (pending #465, #467)",
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "marklogic_json":    "pending",
         "marklogic_xml":     "pending",

--- a/it/src/main/resources/tests/shortCities.test
+++ b/it/src/main/resources/tests/shortCities.test
@@ -1,6 +1,7 @@
 {
     "name": "shortest city names",
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "marklogic_json":    "pending",
         "marklogic_xml":     "pending",

--- a/it/src/main/resources/tests/simpleDistinct.test
+++ b/it/src/main/resources/tests/simpleDistinct.test
@@ -2,6 +2,7 @@
   "name": "simple distinct",
 
   "backends": {
+        "mimir": "skip",
     "mongodb_q_3_2": "pending",
     "postgresql": "pending"
   },

--- a/it/src/main/resources/tests/simpleJsFilter.test
+++ b/it/src/main/resources/tests/simpleJsFilter.test
@@ -1,6 +1,7 @@
 {
     "name": "filter on simple JS",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/simpleProjectWithOneRenamed.test
+++ b/it/src/main/resources/tests/simpleProjectWithOneRenamed.test
@@ -2,6 +2,7 @@
     "name": "simple $project with one renamed field and one unchanged (see #598)",
 
     "backends": {
+        "mimir": "skip",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
         "mongodb_read_only": "pending",

--- a/it/src/main/resources/tests/singleElementSet.test
+++ b/it/src/main/resources/tests/singleElementSet.test
@@ -1,6 +1,7 @@
 {
     "name": "filter field in single-element set",
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/singleFieldDistinct.test
+++ b/it/src/main/resources/tests/singleFieldDistinct.test
@@ -1,6 +1,7 @@
 {
   "name": "distinct of one field",
   "backends": {
+        "mimir": "skip",
     "mongodb_q_3_2": "pending",
     "postgresql": "pending"
   },

--- a/it/src/main/resources/tests/singleFieldOrderedDistinct.test
+++ b/it/src/main/resources/tests/singleFieldOrderedDistinct.test
@@ -1,6 +1,7 @@
 {
     "name": "distinct of one ordered field",
     "backends": {
+        "mimir": "skip",
         "couchbase":      "pending",
         "marklogic_json": "pending",
         "marklogic_xml":  "pending",

--- a/it/src/main/resources/tests/skipCount.test
+++ b/it/src/main/resources/tests/skipCount.test
@@ -2,6 +2,7 @@
     "name": "skip and count",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":      "skip",
         "marklogic_json": "skip",
         "marklogic_xml":  "skip",

--- a/it/src/main/resources/tests/sortByJS.test
+++ b/it/src/main/resources/tests/sortByJS.test
@@ -2,6 +2,7 @@
   "name": "sort by JS expression with filter",
 
   "backends": {
+        "mimir": "skip",
     "mongodb_read_only": "pending",
     "postgresql":        "pending"
   },

--- a/it/src/main/resources/tests/sortProjectLimit.test
+++ b/it/src/main/resources/tests/sortProjectLimit.test
@@ -2,6 +2,7 @@
     "name": "sort, project, and limit",
 
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
 

--- a/it/src/main/resources/tests/sortWildcardOnExpression.test
+++ b/it/src/main/resources/tests/sortWildcardOnExpression.test
@@ -1,6 +1,7 @@
 {
     "name": "sort wildcard on expression",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/statesByShortestFirstCity.test
+++ b/it/src/main/resources/tests/statesByShortestFirstCity.test
@@ -1,6 +1,7 @@
 {
     "name": "states sorted by the length of name of their first city, alphabetically",
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"

--- a/it/src/main/resources/tests/temporal/convertTimestamp.test
+++ b/it/src/main/resources/tests/temporal/convertTimestamp.test
@@ -2,6 +2,7 @@
   "name": "convert epoch milliseconds value to timestamp",
 
   "backends": {
+        "mimir": "skip",
     "mongodb_q_3_2": "pending",
     "postgresql":    "pending"
   },

--- a/it/src/main/resources/tests/temporal/dateFilter.test
+++ b/it/src/main/resources/tests/temporal/dateFilter.test
@@ -2,6 +2,7 @@
   "name": "filter on date part",
 
   "backends": {
+        "mimir": "skip",
     "mongodb_q_3_2":  "pending",
     "postgresql":     "pending"
   },

--- a/it/src/main/resources/tests/temporal/datePartsConverted.test
+++ b/it/src/main/resources/tests/temporal/datePartsConverted.test
@@ -2,6 +2,7 @@
   "name": "date_part with (virtually) all selectors, after conversion to JS (see #1238)",
 
   "backends": {
+        "mimir": "skip",
       "mongodb_read_only": "pending",
       "postgresql":        "pending",
       "marklogic_xml":     "pending"

--- a/it/src/main/resources/tests/temporal/datePartsConvertedSimple.test
+++ b/it/src/main/resources/tests/temporal/datePartsConvertedSimple.test
@@ -2,6 +2,7 @@
   "name": "date_part, after conversion to JS (see #1238)",
 
   "backends": {
+        "mimir": "skip",
     "mongodb_read_only": "pending",
     "postgresql":        "pending"
   },

--- a/it/src/main/resources/tests/temporal/days.test
+++ b/it/src/main/resources/tests/temporal/days.test
@@ -2,6 +2,7 @@
   "name": "dow and isodow",
 
   "backends": {
+        "mimir": "skip",
     "mongodb_q_3_2": "pending",
     "postgresql": "pending"
   },

--- a/it/src/main/resources/tests/temporal/filterOnDate.test
+++ b/it/src/main/resources/tests/temporal/filterOnDate.test
@@ -1,6 +1,7 @@
 {
     "name": "filter with date literals",
     "backends": {
+        "mimir": "skip",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
         "mongodb_read_only": "pending",

--- a/it/src/main/resources/tests/temporal/invalidDateFilter.test
+++ b/it/src/main/resources/tests/temporal/invalidDateFilter.test
@@ -2,6 +2,7 @@
     "name": "filter on date part, where the field isn't a timestamp",
 
     "backends": {
+        "mimir": "skip",
         "mongodb_q_3_2": "pending",
         "postgresql":    "pending"
     },

--- a/it/src/main/resources/tests/temporal/time.test
+++ b/it/src/main/resources/tests/temporal/time.test
@@ -4,6 +4,7 @@
     "NB": "Couchbase disabled due to heap exhaustion",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",

--- a/it/src/main/resources/tests/temporal/timestampsAndIntervals.test
+++ b/it/src/main/resources/tests/temporal/timestampsAndIntervals.test
@@ -2,6 +2,7 @@
     "name": "timestamp and interval syntax",
 
     "backends": {
+        "mimir": "skip",
         "couchbase":      "skip",
         "marklogic_json": "pending",
         "marklogic_xml":  "pending",

--- a/it/src/main/resources/tests/temporal/toFromString.test
+++ b/it/src/main/resources/tests/temporal/toFromString.test
@@ -1,6 +1,7 @@
 {
     "name": "convert dates to/from strings",
     "backends": {
+        "mimir": "skip",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
         "mongodb_read_only": "pending",

--- a/it/src/main/resources/tests/tripleFlatten.test
+++ b/it/src/main/resources/tests/tripleFlatten.test
@@ -1,6 +1,7 @@
 {
     "name": "triple flatten with mixed content",
     "backends": {
+        "mimir": "skip",
         "marklogic_json":    "pending",
         "marklogic_xml":     "pending",
         "mongodb_read_only": "pending",

--- a/it/src/main/resources/tests/trivial.test
+++ b/it/src/main/resources/tests/trivial.test
@@ -2,6 +2,7 @@
   "name": "simple read",
 
   "backends": {
+    "mimir": "skip",
     "postgresql": "pending"
   },
 
@@ -13,7 +14,7 @@
 
   "ignoredFields": ["_id"],
 
-  "ignoreFieldOrder": [ "couchbase", "marklogic_json" ],
+  "ignoreFieldOrder": [ "couchbase", "marklogic_json", "mimir" ],
 
   "expected": [
     { "city": "NEW SALEM", "loc": [-72.306241 , 42.514643], "pop": 456, "state": "MA" }

--- a/it/src/main/resources/tests/trivialGroup.test
+++ b/it/src/main/resources/tests/trivialGroup.test
@@ -1,6 +1,7 @@
 {
     "name": "trivial group by",
     "backends": {
+        "mimir": "skip",
         "postgresql":    "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/typeOf.test
+++ b/it/src/main/resources/tests/typeOf.test
@@ -1,6 +1,7 @@
 {
     "name": "use type_of function",
     "backends": {
+        "mimir": "skip",
         "couchbase":      "pending",
         "marklogic_json": "pending",
         "marklogic_xml":  "pending",

--- a/it/src/main/resources/tests/undefinedJsInExpr.test
+++ b/it/src/main/resources/tests/undefinedJsInExpr.test
@@ -1,6 +1,7 @@
 {
     "name": "propagate undefined and null in JS",
     "backends": {
+        "mimir": "skip",
         "couchbase":         "pending",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",

--- a/it/src/main/resources/tests/unifyFlattenedFields.test
+++ b/it/src/main/resources/tests/unifyFlattenedFields.test
@@ -1,6 +1,7 @@
 {
     "name": "unify flattened fields",
     "backends": {
+        "mimir": "skip",
         "couchbase":  "skip",
         "postgresql": "pending"
     },

--- a/it/src/main/resources/tests/unifyFlattenedFieldsWithMultipleUses.test
+++ b/it/src/main/resources/tests/unifyFlattenedFieldsWithMultipleUses.test
@@ -1,6 +1,7 @@
 {
     "name": "unify flattened fields with multiple shape-preserving ops.",
     "backends": {
+        "mimir": "skip",
         "couchbase":  "skip",
         "marklogic_json": "skip",
         "marklogic_xml":  "skip",

--- a/it/src/main/resources/tests/unifyFlattenedFieldsWithUnflattened.test
+++ b/it/src/main/resources/tests/unifyFlattenedFieldsWithUnflattened.test
@@ -1,6 +1,7 @@
 {
     "name": "unify flattened fields with unflattened field",
     "backends": {
+        "mimir": "skip",
         "couchbase":  "skip",
         "marklogic_json": "skip",
         "marklogic_xml":  "skip",

--- a/it/src/main/resources/tests/union.test
+++ b/it/src/main/resources/tests/union.test
@@ -1,6 +1,7 @@
 {
     "name": "union",
     "backends": {
+        "mimir": "skip",
         "couchbase":         "skip",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",

--- a/it/src/main/resources/tests/unshiftAggregation.test
+++ b/it/src/main/resources/tests/unshiftAggregation.test
@@ -2,6 +2,7 @@
     "name": "unshift aggregation",
     "NB": "Couchbase pending due to different ordering of pop array. Enable once group contents ordering is possible.",
     "backends": {
+        "mimir": "skip",
         "couchbase":  "pending",
         "postgresql": "pending"
     },

--- a/it/src/main/resources/tests/var-relation.test
+++ b/it/src/main/resources/tests/var-relation.test
@@ -2,6 +2,7 @@
     "name": "select from a table named by a variable",
 
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
 

--- a/it/src/main/resources/tests/variable.test
+++ b/it/src/main/resources/tests/variable.test
@@ -2,6 +2,7 @@
     "name": "handle variable referenced in filter",
 
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
 

--- a/it/src/main/resources/tests/wildcardWithExtraProjections.test
+++ b/it/src/main/resources/tests/wildcardWithExtraProjections.test
@@ -2,6 +2,7 @@
   "name": "wildcard with additional projections and filtering",
 
   "backends": {
+        "mimir": "skip",
     "mongodb_read_only": "pending",
     "postgresql":        "pending"
   },

--- a/it/src/main/resources/tests/wildcardWithMultipleConstants.test
+++ b/it/src/main/resources/tests/wildcardWithMultipleConstants.test
@@ -2,6 +2,7 @@
     "name": "splice a wildcard with multiple constants",
 
     "backends": {
+        "mimir": "skip",
       "mongodb_2_6":       "pending",
       "mongodb_3_0":       "pending",
       "mongodb_read_only": "pending",

--- a/it/src/main/resources/tests/wildcardWithSort.test
+++ b/it/src/main/resources/tests/wildcardWithSort.test
@@ -1,6 +1,7 @@
 {
     "name": "wildcard with sort",
     "backends": {
+        "mimir": "skip",
         "postgresql": "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/zipsByCityLength.test
+++ b/it/src/main/resources/tests/zipsByCityLength.test
@@ -1,6 +1,7 @@
 {
     "name": "count occurrences of each value of length(city), with filtering",
     "backends": {
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/test/scala/quasar/TestConfig.scala
+++ b/it/src/test/scala/quasar/TestConfig.scala
@@ -44,6 +44,7 @@ object TestConfig {
   val COUCHBASE       = ExternalBackendRef(BackendRef(BackendName("couchbase")        , BackendCapability.All), couchbase.fs.FsType)
   val MARKLOGIC_JSON  = ExternalBackendRef(BackendRef(BackendName("marklogic_json")   , BackendCapability.All), marklogic.fs.FsType)
   val MARKLOGIC_XML   = ExternalBackendRef(BackendRef(BackendName("marklogic_xml")    , BackendCapability.All), marklogic.fs.FsType)
+  val MIMIR           = ExternalBackendRef(BackendRef(BackendName("mimir")            , ISet singleton BackendCapability.query()), mimir.Mimir.Type)
   val MONGO_2_6       = ExternalBackendRef(BackendRef(BackendName("mongodb_2_6")      , BackendCapability.All), mongodb.fs.FsType)
   val MONGO_3_0       = ExternalBackendRef(BackendRef(BackendName("mongodb_3_0")      , BackendCapability.All), mongodb.fs.FsType)
   val MONGO_3_2       = ExternalBackendRef(BackendRef(BackendName("mongodb_3_2")      , BackendCapability.All), mongodb.fs.FsType)
@@ -58,6 +59,7 @@ object TestConfig {
   lazy val backendRefs: List[ExternalBackendRef] = List(
     COUCHBASE,
     MARKLOGIC_JSON, MARKLOGIC_XML,
+    MIMIR,
     MONGO_2_6, MONGO_3_0, MONGO_3_2, MONGO_READ_ONLY,
     MONGO_Q_2_6, MONGO_Q_3_0, MONGO_Q_3_2,
     POSTGRESQL,

--- a/it/src/test/scala/quasar/fs/QueryFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/QueryFilesSpec.scala
@@ -78,11 +78,10 @@ class QueryFilesSpec extends FileSystemTest[AnalyticalFileSystem](FileSystemTest
         val p = e.liftM[Process].drain ++ read.scanAll(c)
 
         runLogT(fs.testInterpM, p).runEither must beRight(containTheSameElementsAs(Vector[Data](
-          Data.Obj("c" -> Data._int(2))
-        )))
+          Data.Obj("c" -> Data._int(2)))))
       }
 
-      "listing directory returns immediate child nodes" >> {
+      "listing directory returns immediate child nodes" >> pendingFor(fs)(Set("mimir")) {
         val d = queryPrefix </> dir("lschildren")
         val d1 = d </> dir("d1")
         val f1 = d1 </> file("f1")
@@ -91,6 +90,7 @@ class QueryFilesSpec extends FileSystemTest[AnalyticalFileSystem](FileSystemTest
 
         val setup = write.save(f1, oneDoc.toProcess).drain ++
                     write.save(f2, anotherDoc.toProcess).drain
+
         execT(fs.setupInterpM, setup).runVoid
 
         val p = query.ls(d1)
@@ -105,12 +105,12 @@ class QueryFilesSpec extends FileSystemTest[AnalyticalFileSystem](FileSystemTest
         runT(fs.testInterpM)(query.ls(rootDir)).runEither must beRight
       }
 
-      "listing nonexistent directory returns dir NotFound" >> {
+      "listing nonexistent directory returns dir NotFound" >> pendingFor(fs)(Set("mimir")) {
         val d = queryPrefix </> dir("lsdne")
         runT(fs.testInterpM)(query.ls(d)).runEither must beLeft(pathErr(pathNotFound(d)))
       }
 
-      "listing results should not contain deleted files" >> {
+      "listing results should not contain deleted files" >> pendingFor(fs)(Set("mimir")) {
         val d = queryPrefix </> dir("lsdeleted")
         val f1 = d </> file("f1")
         val f2 = d </> file("f2")

--- a/mimir/src/main/scala/quasar/mimir/Mimir.scala
+++ b/mimir/src/main/scala/quasar/mimir/Mimir.scala
@@ -37,7 +37,7 @@ import quasar.yggdrasil.PathMetadata
 import quasar.yggdrasil.vfs.ResourceError
 import quasar.yggdrasil.bytecode.JType
 
-import fs2.async.mutable.Queue
+import fs2.async.mutable.{Queue, Signal}
 import fs2.interop.scalaz._
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
@@ -61,7 +61,7 @@ import scala.util.Random
 
 object Mimir extends BackendModule with Logging {
 
-  // pessimisticaly equal to couchbase's
+  // pessimistically equal to couchbase's
   type QS[T[_[_]]] =
     QScriptCore[T, ?] :\:
     EquiJoin[T, ?] :/:
@@ -132,7 +132,7 @@ object Mimir extends BackendModule with Logging {
   final case class Config(dataDir: java.io.File)
 
   def parseConfig(uri: ConnectionUri): FileSystemDef.DefErrT[Task, Config] =
-    Config(new java.io.File("/tmp")).point[FileSystemDef.DefErrT[Task, ?]]
+    Config(new java.io.File("/tmp/precog")).point[FileSystemDef.DefErrT[Task, ?]]
 
   def compile(cfg: Config): FileSystemDef.DefErrT[Task, (M ~> Task, Task[Unit])] = {
     val t = for {
@@ -288,14 +288,16 @@ object Mimir extends BackendModule with Logging {
   private def fileToPath(file: AFile): Path = Path(pathy.Path.posixCodec.printPath(file))
 
   private def toSegment: PathMetadata => PathSegment = {
+    // ShiftedRead[ADir]
     case PathMetadata(path, PathMetadata.DataDir(_)) =>
       DirName(path.components.mkString("/")).left[FileName]
 
+    // ShiftedRead[AFile]
     case PathMetadata(path, PathMetadata.DataOnly(_)) =>
       FileName(path.components.mkString("/")).right[DirName]
 
     case PathMetadata(path, PathMetadata.PathOnly) =>
-      sys.error(s"found path $path")
+      DirName(path.components.mkString("/")).left[FileName]
   }
 
   private def children(dir: ADir): EitherT[M, ResourceError, Set[PathSegment]] = {
@@ -349,11 +351,7 @@ object Mimir extends BackendModule with Logging {
 
     def listContents(dir: ADir): Backend[Set[PathSegment]] = {
       val segments: FileSystemErrT[M, Set[PathSegment]] =
-        for {
-          precog <- cake[FileSystemErrT[M, ?]]
-          key <- precog.RootAPIKey.toTask.liftM[MT].liftM[FileSystemErrT]
-          stuff <- children(dir).leftMap(toFSError)
-        } yield stuff
+        children(dir).leftMap(toFSError)
 
       val result: FileSystemErrT[M, ?] ~> Backend =
         Hoist[FileSystemErrT].hoist[M, PhaseResultT[Configured, ?]](
@@ -367,8 +365,6 @@ object Mimir extends BackendModule with Logging {
       val dir: ADir = pathy.Path.fileParent(file)
 
       val res: M[Boolean] = for {
-        precog <- cake[M]
-        key <- precog.RootAPIKey.toTask.liftM[MT]
         back <- children(dir).fold(_ => false, _.contains(pathy.Path.fileName(file).right))
       } yield back
 
@@ -389,7 +385,7 @@ object Mimir extends BackendModule with Logging {
 
     private val QueueLimit = 100
 
-    private val map: ConcurrentHashMap[WriteHandle, Queue[Task, Vector[Data]]] =
+    private val map: ConcurrentHashMap[WriteHandle, (Queue[Task, Vector[Data]], Signal[Task, Boolean])] =
       new ConcurrentHashMap
 
     private val cur = new AtomicLong(0L)
@@ -403,20 +399,23 @@ object Mimir extends BackendModule with Logging {
 
         for {
           queue <- Queue.bounded[Task, Vector[Data]](QueueLimit).liftM[MT]
-          _ <- Task.delay(log.debug(s"got a queue $queue")).liftM[MT]
+          signal <- fs2.async.signalOf[Task, Boolean](false).liftM[MT]
 
           path = fileToPath(file)
           jvs = dequeueStreamT(queue)(_.isEmpty).map(_.map(JValue.fromData))
 
           precog <- cake[M]
 
-          ingestion = precog.ingest(path, jvs.trans(λ[Task ~> Future](_.unsafeToFuture))).toTask
+          ingestion = for {
+            _ <- precog.ingest(path, jvs.trans(λ[Task ~> Future](_.unsafeToFuture))).toTask
+            _ <- signal.set(true)
+          } yield ()
 
           // run asynchronously forever
           _ <- Task.delay(ingestion.unsafePerformAsync(_ => ())).liftM[MT]
-          _ <- Task.delay(log.debug(s"started the ingest stuff")).liftM[MT]
+          _ <- Task.delay(log.debug(s"Started ingest.")).liftM[MT]
 
-          _ <- Task.delay(map.put(handle, queue)).liftM[MT]
+          _ <- Task.delay(map.put(handle, (queue, signal))).liftM[MT]
         } yield handle
       }
 
@@ -430,8 +429,9 @@ object Mimir extends BackendModule with Logging {
         Vector.empty[FileSystemError].point[Configured]
       } else {
         val t = for {
-          optQueue <- Task.delay(Option(map.get(h)))
-          _ <- optQueue.map(_.enqueue1(chunk)).getOrElse(Task.now(()))
+          pair <- Task.delay(Option(map.get(h)).get)
+          (queue, _) = pair
+          _ <- queue.enqueue1(chunk)
         } yield Vector.empty[FileSystemError]
 
         t.liftM[MT].liftM[ConfiguredT]
@@ -440,14 +440,19 @@ object Mimir extends BackendModule with Logging {
 
     def close(h: WriteHandle): Configured[Unit] = {
       val t = for {
-        optQueue <- Task.delay(Option(map.get(h)))
-
-        _ <- Task.delay(log.debug(s"close $h"))
-
-        _ <- optQueue.map(_.enqueue1(Vector.empty)).getOrElse(Task.now(()))
+        // yolo we crash because quasar
+        pair <- Task.delay(Option(map.get(h)).get).liftM[MT]
+        (queue, signal) = pair
+        _ <- Task.delay(log.debug(s"close $h")).liftM[MT]
+        // ask queue to stop
+        _ <- queue.enqueue1(Vector.empty).liftM[MT]
+        // wait until queue actually stops; task async completes when signal completes
+        _ <- signal.discrete.takeWhile(!_).run.liftM[MT]
+        precog <- cake[M]
+        _ <- Task.delay(precog.stopPath(fileToPath(h.file))).liftM[MT]
       } yield ()
 
-      t.liftM[MT].liftM[ConfiguredT]
+      t.liftM[ConfiguredT]
     }
   }
 
@@ -479,11 +484,16 @@ object Mimir extends BackendModule with Logging {
       } yield ()
 
       t.liftB
+      //().point[Backend]
     }
 
     def tempFile(near: APath): Backend[AFile] = {
       for {
         seed <- Task.delay(Random.nextLong.toString).liftM[MT].liftB
+
+        precog <- cake[M].liftB
+        newDir <- Task.delay(new File(precog.Config.dataDir, pathy.Path.posixCodec.printPath(parentDir(near).get))).liftM[MT].liftB
+        _ <- Task.delay(newDir.mkdirs()).liftM[MT].liftB
 
         // yolo
         target = parentDir(near).get </> file(seed)

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/VFS.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/VFS.scala
@@ -91,8 +91,7 @@ trait VFSModule[M[+ _], Block] extends Logging {
       EitherT {
         resource.fold(
           br => br.asString.run.map(_.toRightDisjunction(notAQuery)),
-          _ => \/.left(notAQuery).point[M]
-        )
+          _ => \/.left(notAQuery).point[M])
       }
     }
 

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/VersionLog.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/VersionLog.scala
@@ -144,7 +144,7 @@ class VersionLog(logFiles: VersionLog.LogFiles, initVersion: Option[VersionEntry
   def addVersion(entry: VersionEntry): IO[Unit] = allVersions.find(_ == entry) map { _ =>
     IO(())
   } getOrElse {
-    log.debug("Adding version entry: " + entry)
+    log.debug(s"Adding version entry $entry for base directory $baseDir.")
     IOUtils.writeToFile(entry.serialize.renderCompact + "\n", logFile, true) flatMap { _ =>
       IO(allVersions = allVersions :+ entry)
     }


### PR DESCRIPTION
Closes #2254 

Includes mimir in the travis build matrix. Enables an integration test that represents a constant value (query never makes it to qscript). The enabling of queries that require loaded data is pending #2320.