### PR TITLE
Change ignoreFieldOrder handling.

### DIFF
--- a/it/src/main/resources/tests/aliasedFieldSortedByOriginal.test
+++ b/it/src/main/resources/tests/aliasedFieldSortedByOriginal.test
@@ -1,20 +1,18 @@
 {
     "name": "select aliased field sorted by original name",
     "backends": {
-        "mimir": "skip",
-        "postgresql": "pending"
+        "couchbase":         "ignoreFieldOrder",
+        "marklogic_json":    "ignoreFieldOrder",
+        "mimir":             "skip",
+        "mongodb_2_6":       "ignoreFieldOrder",
+        "mongodb_3_0":       "ignoreFieldOrder",
+        "mongodb_3_2":       "ignoreFieldOrder",
+        "mongodb_read_only": "ignoreFieldOrder",
+        "mongodb_q_3_2":     "ignoreFieldOrder",
+        "postgresql":        "pending"
     },
     "data": "zips.data",
     "query": "SELECT state AS `ResultAlias`, COUNT(*) as cnt FROM zips GROUP BY state ORDER BY state",
-    "ignoreFieldOrder": [
-        "couchbase",
-        "marklogic_json",
-        "mongodb_2_6",
-        "mongodb_3_0",
-        "mongodb_3_2",
-        "mongodb_read_only",
-        "mongodb_q_3_2"
-    ],
     "predicate": "containsAtLeast",
     "expected": [{ "ResultAlias": "AK", "cnt":  195 },
                  { "ResultAlias": "AL", "cnt":  567 },

--- a/it/src/main/resources/tests/basicAnalyticQuery.test
+++ b/it/src/main/resources/tests/basicAnalyticQuery.test
@@ -1,15 +1,15 @@
 {
     "name": "basic analytic query",
     "backends": {
-        "mimir": "skip",
-        "couchbase":  "skip",
-        "mongodb_q_3_2": "pending",
-        "postgresql": "pending"
+        "couchbase":      "skip",
+        "marklogic_json": "ignoreFieldOrder",
+        "mimir":          "skip",
+        "mongodb_q_3_2":  "pending",
+        "postgresql":     "pending"
     },
     "data": "zips.data",
     "query": "SELECT state, COUNT(*) AS count, SUM(pop) AS sum, AVG(pop) AS avg, MIN(pop) AS min, MAX(pop) AS max FROM zips WHERE pop > 10000 GROUP BY state ORDER BY max DESC, state OFFSET 1 LIMIT 10",
     "predicate": "equalsExactly",
-    "ignoreFieldOrder": ["couchbase", "marklogic_json"],
     "expected": [
         { "state": "NY", "count": 489, "sum": 14914135, "avg": 30499.25357873, "min": 10008, "max": 111396 },
         { "state": "CA", "count": 849, "sum": 27845412, "avg": 32797.89399293,  "min": 10009, "max": 99568 },

--- a/it/src/main/resources/tests/citiesByTotalPopulation.test
+++ b/it/src/main/resources/tests/citiesByTotalPopulation.test
@@ -4,20 +4,17 @@
     "NB": "Couchbase is skipped due to largish generated N1QL that leads to a timeout.",
 
     "backends": {
-        "mimir": "skip",
-        "couchbase":  "skip",
-        "postgresql": "pending"
+        "couchbase":         "skip",
+        "mimir":             "skip",
+        "mongodb_2_6":       "ignoreFieldOrder",
+        "mongodb_3_0":       "ignoreFieldOrder",
+        "mongodb_3_2":       "ignoreFieldOrder",
+        "mongodb_read_only": "ignoreFieldOrder",
+        "postgresql":        "pending"
     },
     "data": "zips.data",
     "query": "select city, state, sum(pop) as population from zips group by city, state order by population desc limit 5",
     "predicate": "equalsExactly",
-    "ignoreFieldOrder": [
-        "couchbase",
-        "mongodb_2_6",
-        "mongodb_3_0",
-        "mongodb_3_2",
-        "mongodb_read_only"
-    ],
     "expected": [
         { "city": "CHICAGO",      "state": "IL", "population": 2452177 },
         { "city": "BROOKLYN",     "state": "NY", "population": 2300504 },

--- a/it/src/main/resources/tests/concatArray.test
+++ b/it/src/main/resources/tests/concatArray.test
@@ -2,7 +2,6 @@
     "name": "concat known array structure",
     "backends": {
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/concatArrayWithLiteral.test
+++ b/it/src/main/resources/tests/concatArrayWithLiteral.test
@@ -3,7 +3,6 @@
     "backends": {
         "marklogic_json":    "ignoreFieldOrder",
         "mimir":             "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/concatArrayWithLiteral.test
+++ b/it/src/main/resources/tests/concatArrayWithLiteral.test
@@ -1,7 +1,8 @@
 {
     "name": "concat unknown with literal array",
     "backends": {
-        "mimir": "skip",
+        "marklogic_json":    "ignoreFieldOrder",
+        "mimir":             "skip",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
@@ -9,7 +10,6 @@
     "data": "largeZips.data",
     "query": "select loc || [1, 2] as arr, city from largeZips",
     "predicate": "containsAtLeast",
-    "ignoreFieldOrder": ["marklogic_json"],
     "expected": [{ "arr": [-72.51565,  42.377017, 1, 2], "city": "CUSHMAN"          },
                  { "arr": [-72.576142, 42.176443, 1, 2], "city": "CHICOPEE"         },
                  { "arr": [-72.626193, 42.202007, 1, 2], "city": "HOLYOKE"          },

--- a/it/src/main/resources/tests/concatArrayWithUnknown.test
+++ b/it/src/main/resources/tests/concatArrayWithUnknown.test
@@ -4,7 +4,6 @@
         "couchbase":         "ignoreFieldOrder",
         "marklogic_json":    "ignoreFieldOrder",
         "mimir":             "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/concatArrayWithUnknown.test
+++ b/it/src/main/resources/tests/concatArrayWithUnknown.test
@@ -1,7 +1,9 @@
 {
     "name": "concat array with unknown structure",
     "backends": {
-        "mimir": "skip",
+        "couchbase":         "ignoreFieldOrder",
+        "marklogic_json":    "ignoreFieldOrder",
+        "mimir":             "skip",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
@@ -9,7 +11,6 @@
     "data": "largeZips.data",
     "query": "select city, state, loc || [ pop ] as lp from largeZips",
     "predicate": "containsAtLeast",
-    "ignoreFieldOrder": [ "couchbase", "marklogic_json" ],
     "expected": [{ "city": "CUSHMAN",            "state": "MA", "lp": [ -72.51565, 42.377017, 36963] },
                  { "city": "CHICOPEE",           "state": "MA", "lp": [-72.576142, 42.176443, 31495] },
                  { "city": "HOLYOKE",            "state": "MA", "lp": [-72.626193, 42.202007, 43704] },

--- a/it/src/main/resources/tests/concatBetween.test
+++ b/it/src/main/resources/tests/concatBetween.test
@@ -1,13 +1,14 @@
 {
     "name": "concat BETWEEN with other fields",
     "backends": {
-        "mimir": "skip",
-        "postgresql": "pending"
+        "couchbase":      "ignoreFieldOrder",
+        "marklogic_json": "ignoreFieldOrder",
+        "mimir":          "skip",
+        "postgresql":     "pending"
     },
     "data": "smallZips.data",
     "query": "select city, pop, pop between 1000 and 10000 as midsized from smallZips",
     "predicate": "containsAtLeast",
-    "ignoreFieldOrder": [ "couchbase", "marklogic_json" ],
     "expected": [{ "city": "AGAWAM",       "pop": 15338, "midsized": false },
                  { "city": "CUSHMAN",      "pop": 36963, "midsized": false },
                  { "city": "BARRE",        "pop": 4546,  "midsized": true  },

--- a/it/src/main/resources/tests/concatFieldAndConstant.test
+++ b/it/src/main/resources/tests/concatFieldAndConstant.test
@@ -2,7 +2,6 @@
     "name": "concat field with constant array",
     "backends": {
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/constantAndGrouped.test
+++ b/it/src/main/resources/tests/constantAndGrouped.test
@@ -2,8 +2,10 @@
     "name": "constant and a grouped value",
 
     "backends": {
-        "mimir": "skip",
-        "postgresql": "pending"
+        "couchbase":      "ignoreFieldOrder",
+        "marklogic_json": "ignoreFieldOrder",
+        "mimir":          "skip",
+        "postgresql":     "pending"
     },
 
     "data": "zips.data",
@@ -15,6 +17,5 @@
     "query": "select :state as state, count(*) as `count` from zips where state = :state",
 
     "predicate": "containsExactly",
-    "ignoreFieldOrder": ["couchbase", "marklogic_json"],
     "expected": [{ "state": "CO", "count": 414 }]
 }

--- a/it/src/main/resources/tests/convertFromString.test
+++ b/it/src/main/resources/tests/convertFromString.test
@@ -4,7 +4,6 @@
         "couchbase":         "ignoreFieldOrder",
         "marklogic_json":    "ignoreFieldOrder",
         "mimir":             "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
     "data": "smallZips.data",

--- a/it/src/main/resources/tests/convertFromString.test
+++ b/it/src/main/resources/tests/convertFromString.test
@@ -1,14 +1,15 @@
 {
     "name": "convert values from strings",
     "backends": {
-        "mimir": "skip",
+        "couchbase":         "ignoreFieldOrder",
+        "marklogic_json":    "ignoreFieldOrder",
+        "mimir":             "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
     "data": "smallZips.data",
     "query": "select integer(`_id`) as intId, decimal(`_id`) as decId from smallZips",
     "predicate": "containsAtLeast",
-    "ignoreFieldOrder": [ "couchbase", "marklogic_json" ],
     "expected": [
         { "intId": 1001, "decId": 1001.0 },
         { "intId": 1002, "decId": 1002.0 },

--- a/it/src/main/resources/tests/convertToFromString.test
+++ b/it/src/main/resources/tests/convertToFromString.test
@@ -1,11 +1,10 @@
 {
     "name": "convert values to/from strings",
     "backends": {
-        "couchbase":         "ignoreFieldOrder",
-        "marklogic_json":    "ignoreFieldOrder",
+        "couchbase": "ignoreFieldOrder",
+        "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
-        "mongodb_read_only": "pending",
-        "postgresql":        "pending"
+        "postgresql": "pending"
     },
     "data": "zips.data",
     "query": "select integer(`_id`) as intId, decimal(`_id`) as decId, to_string(pop) as popStr, to_string(loc[0]) as locStr, to_string(length(city) < 9) as boolStr from zips",

--- a/it/src/main/resources/tests/convertToFromString.test
+++ b/it/src/main/resources/tests/convertToFromString.test
@@ -1,6 +1,8 @@
 {
     "name": "convert values to/from strings",
     "backends": {
+        "couchbase":         "ignoreFieldOrder",
+        "marklogic_json":    "ignoreFieldOrder",
         "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
@@ -8,7 +10,6 @@
     "data": "zips.data",
     "query": "select integer(`_id`) as intId, decimal(`_id`) as decId, to_string(pop) as popStr, to_string(loc[0]) as locStr, to_string(length(city) < 9) as boolStr from zips",
     "predicate": "containsAtLeast",
-    "ignoreFieldOrder": ["couchbase", "marklogic_json"],
     "expected": [
         { "intId": 1001, "decId": 1001.0, "popStr": "15338", "locStr": "-72.622739", "boolStr": "true"  },
         { "intId": 1002, "decId": 1002.0, "popStr": "36963", "locStr": "-72.51565",  "boolStr": "true"  },

--- a/it/src/main/resources/tests/couchbase/leftKeyJoin.test
+++ b/it/src/main/resources/tests/couchbase/leftKeyJoin.test
@@ -1,17 +1,18 @@
 {
     "name": "left key join (Couchbase)",
     "backends": {
-        "mimir": "skip",
+        "couchbase":         "ignoreFieldOrder",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
+        "mimir":             "skip",
         "mongodb_2_6":       "skip",
         "mongodb_3_0":       "skip",
         "mongodb_read_only": "skip",
         "mongodb_3_2":       "skip",
         "mongodb_q_3_2":     "skip",
         "postgresql":        "skip",
-        "spark_local":       "skip",
-        "spark_hdfs":        "skip"
+        "spark_hdfs":        "skip",
+        "spark_local":       "skip"
     },
     "data": [],
     "query": "select meta(brewery).id as brewery_meta_id, brewery.name as brewery_name,
@@ -19,7 +20,6 @@
               from `brewery` as brewery
               join `beer` as beer on meta(brewery).id = beer.brewery_id
               where beer.name = \"Pale\"",
-    "ignoreFieldOrder": [ "couchbase" ],
     "predicate": "containsExactly",
     "expected": [
         {

--- a/it/src/main/resources/tests/couchbase/leftKeyJoinMultipleSelect.test
+++ b/it/src/main/resources/tests/couchbase/leftKeyJoinMultipleSelect.test
@@ -1,17 +1,18 @@
 {
     "name": "left key join with multiple fields selected (Couchbase)",
     "backends": {
-        "mimir": "skip",
+        "couchbase":         "ignoreFieldOrder",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
+        "mimir": "skip",
         "mongodb_2_6":       "skip",
         "mongodb_3_0":       "skip",
         "mongodb_read_only": "skip",
         "mongodb_3_2":       "skip",
         "mongodb_q_3_2":     "skip",
         "postgresql":        "skip",
-        "spark_local":       "skip",
-        "spark_hdfs":        "skip"
+        "spark_hdfs":        "skip",
+        "spark_local":       "skip"
     },
     "data": [],
     "query": "SELECT META(brewery).id AS brewery_meta_id,
@@ -22,7 +23,6 @@
               FROM `brewery` AS brewery JOIN `beer` AS beer
               ON META(brewery).id = beer.brewery_id
               WHERE beer.category = \"North American Ale\"",
-    "ignoreFieldOrder": [ "couchbase" ],
     "predicate": "containsAtLeast",
     "expected": [
         {

--- a/it/src/main/resources/tests/couchbase/rightKeyJoin.test
+++ b/it/src/main/resources/tests/couchbase/rightKeyJoin.test
@@ -1,17 +1,18 @@
 {
     "name": "right key join (Couchbase)",
     "backends": {
-        "mimir": "skip",
+        "couchbase":         "ignoreFieldOrder",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
+        "mimir":             "skip",
         "mongodb_2_6":       "skip",
         "mongodb_3_0":       "skip",
         "mongodb_read_only": "skip",
         "mongodb_3_2":       "skip",
         "mongodb_q_3_2":     "skip",
         "postgresql":        "skip",
-        "spark_local":       "skip",
-        "spark_hdfs":        "skip"
+        "spark_hdfs":        "skip",
+        "spark_local":       "skip"
     },
     "data": [],
     "query": "select meta(brewery).id as brewery_meta_id, brewery.name as brewery_name,
@@ -19,7 +20,6 @@
               from `beer` as beer
               join `brewery` as brewery on beer.brewery_id = meta(brewery).id
               where beer.name = \"Pale\"",
-    "ignoreFieldOrder": [ "couchbase" ],
     "predicate": "containsExactly",
     "expected": [
         {

--- a/it/src/main/resources/tests/countDistinctStar.test
+++ b/it/src/main/resources/tests/countDistinctStar.test
@@ -2,7 +2,6 @@
     "name": "count distinct *",
     "backends": {
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/delete.test
+++ b/it/src/main/resources/tests/delete.test
@@ -1,6 +1,8 @@
 {
     "name": "delete",
     "backends": {
+        "couchbase":         "ignoreFieldOrder",
+        "marklogic_json":    "ignoreFieldOrder",
         "mimir": "skip",
         "postgresql": "pending"
     },
@@ -8,7 +10,6 @@
     "query": "delete from zips where pop < 100000",
     "predicate": "containsExactly",
     "ignoredFields": ["_id"],
-    "ignoreFieldOrder": [ "couchbase", "marklogic_json" ],
     "expected": [
         { "city": "NEW YORK", "loc": [-73.958805, 40.768476], "pop": 106564, "state": "NY" },
         { "city": "NEW YORK", "loc": [-73.968312, 40.797466], "pop": 100027, "state": "NY" },

--- a/it/src/main/resources/tests/demo/nestedSelectWithReduce.test
+++ b/it/src/main/resources/tests/demo/nestedSelectWithReduce.test
@@ -18,7 +18,7 @@
                 WHERE codes[*].desc LIKE \"%flu%\"
                 GROUP BY state, gender
                 ORDER BY COUNT(*) DESC) as meh",
-    "predicate": "containsAtLeast",
+    "predicate": "equalsInitial",
     "expected": [{ "measure": 1.238095238095, "category": "NE" },
                  { "measure": 1.238095238095, "category": "MS" },
                  { "measure": 1.238095238095, "category": "AL" },

--- a/it/src/main/resources/tests/demo/timeSeriesAggregation.test
+++ b/it/src/main/resources/tests/demo/timeSeriesAggregation.test
@@ -11,7 +11,7 @@
         GROUP BY sensor, dt
         ORDER BY sensor ASC, dt ASC",
     "ignoreFieldOrder": [ "couchbase" ],
-    "predicate": "containsExactly",
+    "predicate": "equalsExactly",
     "expected": [
         { "measure": 62, "dimension": { "$timestamp": "2017-05-15T16:54:29.615Z" }, "series": "S0" },
         { "measure": 54, "dimension": { "$timestamp": "2017-05-17T16:54:29.615Z" }, "series": "S0" },

--- a/it/src/main/resources/tests/demo/timeSeriesAggregation.test
+++ b/it/src/main/resources/tests/demo/timeSeriesAggregation.test
@@ -1,6 +1,7 @@
 {
     "name": "time series aggregation",
     "backends": {
+        "couchbase": "ignoreFieldOrder",
         "mimir": "skip",
         "postgresql": "pending"
     },
@@ -10,8 +11,8 @@
         FROM smalltimeseries
         GROUP BY sensor, dt
         ORDER BY sensor ASC, dt ASC",
-    "ignoreFieldOrder": [ "couchbase" ],
-    "predicate": "equalsExactly",
+    "NB": "The query is ordered, but not uniquely, so we have to use containsExactly instead of equalsExactly.",
+    "predicate": "containsExactly",
     "expected": [
         { "measure": 62, "dimension": { "$timestamp": "2017-05-15T16:54:29.615Z" }, "series": "S0" },
         { "measure": 54, "dimension": { "$timestamp": "2017-05-17T16:54:29.615Z" }, "series": "S0" },

--- a/it/src/main/resources/tests/doubleFlatten.test
+++ b/it/src/main/resources/tests/doubleFlatten.test
@@ -2,7 +2,6 @@
     "name": "flatten a flattened field",
     "backends": {
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
     "data": "slamengine_commits.data",

--- a/it/src/main/resources/tests/doubleFlattenWithIntervening.test
+++ b/it/src/main/resources/tests/doubleFlattenWithIntervening.test
@@ -2,8 +2,7 @@
     "name": "double flatten with intervening field",
     "backends": {
         "mimir": "skip",
-        "mongodb_read_only": "pending",
-        "postgresql":        "pending"
+        "postgresql": "pending"
     },
     "data": "nested.data",
     "query": "select topObj{*}.botObj{*} from nested",

--- a/it/src/main/resources/tests/filter.test
+++ b/it/src/main/resources/tests/filter.test
@@ -3,7 +3,6 @@
 
     "backends": {
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
 

--- a/it/src/main/resources/tests/filterByJsWithOnlyReducing.test
+++ b/it/src/main/resources/tests/filterByJsWithOnlyReducing.test
@@ -3,7 +3,6 @@
 
     "backends": {
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
 

--- a/it/src/main/resources/tests/filterOnContains.test
+++ b/it/src/main/resources/tests/filterOnContains.test
@@ -7,6 +7,6 @@
     "data": "zips.data",
     "query": "select * from zips where 43.058514 in loc[_]",
     "predicate": "equalsExactly",
-    "ignoreFieldOrder": [ "*" ],
+    "ignoreFieldOrder": true,
     "expected": [{ "city": "CANDIA", "state": "NH", "pop": 3557, "_id":"03034", "loc": [-71.304857, 43.058514] }]
 }

--- a/it/src/main/resources/tests/filterOnFieldComparison.test
+++ b/it/src/main/resources/tests/filterOnFieldComparison.test
@@ -8,7 +8,7 @@
     "data": "zips.data",
     "query": "select * from zips where pop < loc[1] order by `_id` limit 10",
     "predicate": "equalsExactly",
-    "ignoreFieldOrder": ["marklogic_json"],
+    "ignoreFieldOrder": ["*"],
     "expected": [
         { "_id": "01338", "city": "BUCKLAND",        "loc": [-72.764124, 42.615174], "pop": 16, "state": "MA" },
         { "_id": "02163", "city": "CAMBRIDGE",       "loc": [-71.141879, 42.364005], "pop": 0,  "state": "MA" },

--- a/it/src/main/resources/tests/filterOnFieldComparison.test
+++ b/it/src/main/resources/tests/filterOnFieldComparison.test
@@ -8,7 +8,7 @@
     "data": "zips.data",
     "query": "select * from zips where pop < loc[1] order by `_id` limit 10",
     "predicate": "equalsExactly",
-    "ignoreFieldOrder": ["*"],
+    "ignoreFieldOrder": true,
     "expected": [
         { "_id": "01338", "city": "BUCKLAND",        "loc": [-72.764124, 42.615174], "pop": 16, "state": "MA" },
         { "_id": "02163", "city": "CAMBRIDGE",       "loc": [-71.141879, 42.364005], "pop": 0,  "state": "MA" },

--- a/it/src/main/resources/tests/filterOnFieldComparison.test
+++ b/it/src/main/resources/tests/filterOnFieldComparison.test
@@ -2,7 +2,6 @@
     "name": "filter on field comparison",
     "backends": {
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/filterSortLimit.test
+++ b/it/src/main/resources/tests/filterSortLimit.test
@@ -12,7 +12,7 @@
 
     "predicate": "equalsExactly",
     "ignoredFields": ["_id"],
-    "ignoreFieldOrder": ["marklogic_json"],
+    "ignoreFieldOrder": ["*"],
     "expected": [
         { "city": "BOULDER",         "loc": [-109.540105, 42.688146], "pop":  112, "state": "WY"  },
         { "city": "BOULDER",         "loc": [-111.426646, 37.916606], "pop":  131, "state": "UT"  },

--- a/it/src/main/resources/tests/filterSortLimit.test
+++ b/it/src/main/resources/tests/filterSortLimit.test
@@ -12,7 +12,7 @@
 
     "predicate": "equalsExactly",
     "ignoredFields": ["_id"],
-    "ignoreFieldOrder": ["*"],
+    "ignoreFieldOrder": true,
     "expected": [
         { "city": "BOULDER",         "loc": [-109.540105, 42.688146], "pop":  112, "state": "WY"  },
         { "city": "BOULDER",         "loc": [-111.426646, 37.916606], "pop":  131, "state": "UT"  },

--- a/it/src/main/resources/tests/filterWithComplexNot.test
+++ b/it/src/main/resources/tests/filterWithComplexNot.test
@@ -5,7 +5,6 @@
 
     "backends": {
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending",
         "couchbase":         "skip"
     },

--- a/it/src/main/resources/tests/flattenArrayLeftWithUnflattened.test
+++ b/it/src/main/resources/tests/flattenArrayLeftWithUnflattened.test
@@ -3,13 +3,13 @@
     "backends": {
         "mimir": "skip",
         "couchbase": "skip",
+        "marklogic_json": "ignoreFieldOrder",
         "mongodb_q_3_2": "pending",
         "postgresql": "pending"
     },
     "data": "zips.data",
     "query": "SELECT loc[*] as coord, `_id` as zip FROM zips",
     "predicate": "containsAtLeast",
-    "ignoreFieldOrder": ["marklogic_json"],
     "expected": [
         {"coord": -72.622739, "zip": "01001"},
         {"coord": 42.070206,  "zip": "01001"},

--- a/it/src/main/resources/tests/flattenArrayProjection.test
+++ b/it/src/main/resources/tests/flattenArrayProjection.test
@@ -2,7 +2,6 @@
     "name": "flatten an object resulting from an array projection",
     "backends": {
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
     "data": "slamengine_commits.data",

--- a/it/src/main/resources/tests/flattenArrayWithUnflattened.test
+++ b/it/src/main/resources/tests/flattenArrayWithUnflattened.test
@@ -1,14 +1,14 @@
 {
     "name": "flatten array with unflattened field",
     "backends": {
-        "mimir": "skip",
         "couchbase":  "skip",
+        "marklogic_json": "ignoreFieldOrder",
+        "mimir": "skip",
         "postgresql": "pending"
     },
     "data": "zips.data",
     "query": "SELECT `_id` as zip, loc as loc, loc[*] as coord FROM zips",
     "predicate": "containsAtLeast",
-    "ignoreFieldOrder": ["marklogic_json"],
     "expected": [
         {"zip": "01001", "loc": [-72.622739, 42.070206], "coord": -72.622739},
         {"zip": "01001", "loc": [-72.622739, 42.070206], "coord": 42.070206},

--- a/it/src/main/resources/tests/flattenGroupedObject.test
+++ b/it/src/main/resources/tests/flattenGroupedObject.test
@@ -5,7 +5,6 @@
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending",
         "spark_local": "pending",

--- a/it/src/main/resources/tests/flattenNestedObject.test
+++ b/it/src/main/resources/tests/flattenNestedObject.test
@@ -2,7 +2,6 @@
     "name": "flatten an object inside a field projection",
     "backends": {
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
     "data": "slamengine_commits.data",

--- a/it/src/main/resources/tests/flattenObject.test
+++ b/it/src/main/resources/tests/flattenObject.test
@@ -1,6 +1,7 @@
 {
     "name": "flatten object",
     "backends": {
+        "couchbase":  "ignoreFieldOrder",
         "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
@@ -8,7 +9,6 @@
     "data": "usa_factbook.data",
     "query": "select geo{*} from usa_factbook",
     "predicate": "containsExactly",
-    "ignoreFieldOrder": ["couchbase"],
     "expected": [
         {"text":"North America, bordering both the North Atlantic Ocean and the North Pacific Ocean, between Canada and Mexico"},
         {"text":"38 00 N, 97 00 W"},

--- a/it/src/main/resources/tests/flattenObject.test
+++ b/it/src/main/resources/tests/flattenObject.test
@@ -3,7 +3,6 @@
     "backends": {
         "couchbase":  "ignoreFieldOrder",
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
     "data": "usa_factbook.data",

--- a/it/src/main/resources/tests/flattenObjectLike.test
+++ b/it/src/main/resources/tests/flattenObjectLike.test
@@ -13,5 +13,6 @@
     "query": "select * from nested_foo where foo{*} = 15",
     "predicate": "containsExactly",
     "ignoredFields": ["_id"],
+    "ignoreFieldOrder": ["*"],
     "expected": [{ "foo": { "bar": 15, "baz": ["qx"] }}]
 }

--- a/it/src/main/resources/tests/flattenObjectLike.test
+++ b/it/src/main/resources/tests/flattenObjectLike.test
@@ -13,6 +13,6 @@
     "query": "select * from nested_foo where foo{*} = 15",
     "predicate": "containsExactly",
     "ignoredFields": ["_id"],
-    "ignoreFieldOrder": ["*"],
+    "ignoreFieldOrder": true,
     "expected": [{ "foo": { "bar": 15, "baz": ["qx"] }}]
 }

--- a/it/src/main/resources/tests/generatedFieldNames.test
+++ b/it/src/main/resources/tests/generatedFieldNames.test
@@ -2,6 +2,7 @@
   "name": "generated field names",
 
   "backends": {
+    "couchbase": "ignoreFieldOrder",
     "mimir": "skip",
     "mongodb_read_only": "pending",
     "postgresql":        "pending"
@@ -12,8 +13,6 @@
   "query": "select TO_STRING(city), state || \"S\" from smallZips",
 
   "predicate": "containsAtLeast",
-
-  "ignoreFieldOrder": [ "couchbase" ],
 
   "expected": [
     { "0": "NEW SALEM", "1": "MAS" }

--- a/it/src/main/resources/tests/generatedFieldNames.test
+++ b/it/src/main/resources/tests/generatedFieldNames.test
@@ -4,7 +4,6 @@
   "backends": {
     "couchbase": "ignoreFieldOrder",
     "mimir": "skip",
-    "mongodb_read_only": "pending",
     "postgresql":        "pending"
   },
 

--- a/it/src/main/resources/tests/groupAndWildcard.test
+++ b/it/src/main/resources/tests/groupAndWildcard.test
@@ -14,7 +14,7 @@
 
   "ignoredFields": ["_id"],
 
-  "ignoreFieldOrder": ["marklogic_json"],
+  "ignoreFieldOrder": ["*"],
 
   "expected": [
       { "city": "BOULDER", "loc": [ -105.21426 , 40.049733], "pop": 18174, "state": "CO" },

--- a/it/src/main/resources/tests/groupAndWildcard.test
+++ b/it/src/main/resources/tests/groupAndWildcard.test
@@ -14,7 +14,7 @@
 
   "ignoredFields": ["_id"],
 
-  "ignoreFieldOrder": ["*"],
+  "ignoreFieldOrder": true,
 
   "expected": [
       { "city": "BOULDER", "loc": [ -105.21426 , 40.049733], "pop": 18174, "state": "CO" },

--- a/it/src/main/resources/tests/groupByExpression.test
+++ b/it/src/main/resources/tests/groupByExpression.test
@@ -2,17 +2,15 @@
     "name": "group by a computed value",
 
     "backends": {
+        "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
+        "mongodb_2_6": "ignoreFieldOrder",
+        "mongodb_3_0": "ignoreFieldOrder",
+        "mongodb_3_2": "ignoreFieldOrder",
+        "mongodb_read_only": "ignoreFieldOrder",
+        "mongodb_q_3_2": "ignoreFieldOrder",
         "postgresql": "pending"
     },
-    "ignoreFieldOrder": [
-        "marklogic_json",
-        "mongodb_2_6",
-        "mongodb_3_0",
-        "mongodb_3_2",
-        "mongodb_read_only",
-        "mongodb_q_3_2"
-    ],
     "data": "zips.data",
 
     "query": "select substring(city, 0, 1) as `first`, count(*) as numZips from zips group by substring(city, 0, 1)",

--- a/it/src/main/resources/tests/guardedExpression.test
+++ b/it/src/main/resources/tests/guardedExpression.test
@@ -3,7 +3,6 @@
   "backends": {
         "mimir": "skip",
       "marklogic_json":    "pending",
-      "mongodb_read_only": "pending",
       "postgresql":        "pending"
   },
   "data": "zips.data",

--- a/it/src/main/resources/tests/ifUndefined.test
+++ b/it/src/main/resources/tests/ifUndefined.test
@@ -1,6 +1,8 @@
 {
     "name": "handle undefined values",
     "backends": {
+        "couchbase": "ignoreFieldOrder",
+        "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
@@ -8,7 +10,6 @@
     "data": "zips.data",
     "query": "select foo ?? pop as p, city ?? false as c from zips",
     "predicate": "containsAtLeast",
-    "ignoreFieldOrder": [ "couchbase", "marklogic_json" ],
     "expected": [{ "p": 15338.0, "c": "AGAWAM"       },
                  { "p": 36963.0, "c": "CUSHMAN"      },
                  { "p":  4546.0, "c": "BARRE"        },

--- a/it/src/main/resources/tests/ifUndefined.test
+++ b/it/src/main/resources/tests/ifUndefined.test
@@ -4,7 +4,6 @@
         "couchbase": "ignoreFieldOrder",
         "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/implicitGroupWithFilter.test
+++ b/it/src/main/resources/tests/implicitGroupWithFilter.test
@@ -2,6 +2,7 @@
     "name": "implicitly grouped, with filtering",
 
     "backends": {
+        "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
         "postgresql": "pending"
     },
@@ -11,6 +12,5 @@
     "query": "select avg(pop) as avg_pop, sum(pop) as tot_pop from zips where city = \"BOULDER\" and state = \"CO\"",
 
     "predicate": "containsExactly",
-    "ignoreFieldOrder": ["marklogic_json"],
     "expected": [{ "avg_pop": 27242.0, "tot_pop": 108968 }]
 }

--- a/it/src/main/resources/tests/inBareElement.test
+++ b/it/src/main/resources/tests/inBareElement.test
@@ -8,7 +8,7 @@
     "query": "select * from zips where state in \"ME\" and pop < 10",
     "predicate": "containsExactly",
     "ignoredFields": ["_id"],
-    "ignoreFieldOrder": ["marklogic_json"],
+    "ignoreFieldOrder": ["*"],
     "expected": [
         { "city": "BUSTINS ISLAND",  "loc": [-70.042247, 43.79602 ], "pop": 0, "state": "ME" },
         { "city": "SQUIRREL ISLAND", "loc": [-69.630974, 43.809031], "pop": 3, "state": "ME" }]

--- a/it/src/main/resources/tests/inBareElement.test
+++ b/it/src/main/resources/tests/inBareElement.test
@@ -8,7 +8,7 @@
     "query": "select * from zips where state in \"ME\" and pop < 10",
     "predicate": "containsExactly",
     "ignoredFields": ["_id"],
-    "ignoreFieldOrder": ["*"],
+    "ignoreFieldOrder": true,
     "expected": [
         { "city": "BUSTINS ISLAND",  "loc": [-70.042247, 43.79602 ], "pop": 0, "state": "ME" },
         { "city": "SQUIRREL ISLAND", "loc": [-69.630974, 43.809031], "pop": 3, "state": "ME" }]

--- a/it/src/main/resources/tests/joins/3WayJoin.test
+++ b/it/src/main/resources/tests/joins/3WayJoin.test
@@ -6,7 +6,6 @@
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/joins/constantOnLeft.test
+++ b/it/src/main/resources/tests/joins/constantOnLeft.test
@@ -6,7 +6,6 @@
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/joins/crossJoin.test
+++ b/it/src/main/resources/tests/joins/crossJoin.test
@@ -6,7 +6,6 @@
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/joins/crossJoinWithOneSidedConditions.test
+++ b/it/src/main/resources/tests/joins/crossJoinWithOneSidedConditions.test
@@ -2,8 +2,9 @@
     "name": "cross join with conditions that must be pushed ahead of the join (or else the join explodes, taking several minutes to complete)",
 
     "backends": {
-        "mimir": "skip",
         "couchbase":         "skip",
+        "marklogic_json":    "ignoreFieldOrder",
+        "mimir":             "skip",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
@@ -18,8 +19,6 @@
             where a.`_id` like \"80301\" and b.`_id` like \"95928\"",
 
     "predicate": "equalsExactly",
-
-    "ignoreFieldOrder": ["marklogic_json"],
 
     "expected": [{ "a": "BOULDER", "b": "CHICO", "diff": 9278 }]
 }

--- a/it/src/main/resources/tests/joins/crossJoinWithOneSidedConditions.test
+++ b/it/src/main/resources/tests/joins/crossJoinWithOneSidedConditions.test
@@ -21,7 +21,5 @@
 
     "ignoreFieldOrder": ["marklogic_json"],
 
-    "expected": [
-        { "a": "BOULDER", "b": "CHICO", "diff": 9278 }
-    ]
+    "expected": [{ "a": "BOULDER", "b": "CHICO", "diff": 9278 }]
 }

--- a/it/src/main/resources/tests/joins/crossJoinWithOneSidedConditions.test
+++ b/it/src/main/resources/tests/joins/crossJoinWithOneSidedConditions.test
@@ -5,7 +5,6 @@
         "couchbase":         "skip",
         "marklogic_json":    "ignoreFieldOrder",
         "mimir":             "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/joins/groupedJoin.test
+++ b/it/src/main/resources/tests/joins/groupedJoin.test
@@ -6,6 +6,9 @@
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
+        "mongodb_2_6": "ignoreFieldOrder",
+        "mongodb_3_0": "ignoreFieldOrder",
+        "mongodb_3_2": "ignoreFieldOrder",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending",
@@ -23,12 +26,6 @@
               GROUP BY p.author.login",
 
     "predicate": "containsExactly",
-
-    "ignoreFieldOrder": ["mongodb_2_6",
-                         "mongodb_3_0",
-                         "mongodb_read_only",
-                         "mongodb_3_2",
-                         "mongodb_q_3_2"],
 
     "expected": [{ "login": "mossprescott", "count": 15 },
                  { "login": "sellout"     , "count":  9 },

--- a/it/src/main/resources/tests/joins/innerEquiJoin.test
+++ b/it/src/main/resources/tests/joins/innerEquiJoin.test
@@ -6,7 +6,6 @@
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/joins/innerEquiJoinWithWildcard.test
+++ b/it/src/main/resources/tests/joins/innerEquiJoinWithWildcard.test
@@ -3,7 +3,6 @@
 
     "backends": {
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2": "pending",
         "postgresql":        "pending",
         "marklogic_json":    "skip",

--- a/it/src/main/resources/tests/joins/innerEquiJoinWithWildcard.test
+++ b/it/src/main/resources/tests/joins/innerEquiJoinWithWildcard.test
@@ -20,7 +20,7 @@
 
     "predicate": "containsAtLeast",
 
-    "ignoreFieldOrder": ["*"],
+    "ignoreFieldOrder": true,
 
     "expected": [
         {"_id":"01001", "city":"AGAWAM",       "loc":[-72.622739,42.070206], "pop":15338, "state":"MA"},

--- a/it/src/main/resources/tests/joins/innerEquiJoinWithWildcard.test
+++ b/it/src/main/resources/tests/joins/innerEquiJoinWithWildcard.test
@@ -20,6 +20,8 @@
 
     "predicate": "containsAtLeast",
 
+    "ignoreFieldOrder": ["*"],
+
     "expected": [
         {"_id":"01001", "city":"AGAWAM",       "loc":[-72.622739,42.070206], "pop":15338, "state":"MA"},
         {"_id":"01002", "city":"CUSHMAN",      "loc":[-72.51565,42.377017],  "pop":36963, "state":"MA"},

--- a/it/src/main/resources/tests/joins/joinSubSelects.test
+++ b/it/src/main/resources/tests/joins/joinSubSelects.test
@@ -6,7 +6,6 @@
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/joins/joinWithComplexCondition.test
+++ b/it/src/main/resources/tests/joins/joinWithComplexCondition.test
@@ -6,7 +6,6 @@
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/joins/joinWithMultipleConditions.test
+++ b/it/src/main/resources/tests/joins/joinWithMultipleConditions.test
@@ -6,7 +6,6 @@
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/joins/joinWithReversedCondition.test
+++ b/it/src/main/resources/tests/joins/joinWithReversedCondition.test
@@ -5,7 +5,6 @@
         "couchbase":         "skip",
         "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/joins/joinWithReversedCondition.test
+++ b/it/src/main/resources/tests/joins/joinWithReversedCondition.test
@@ -2,8 +2,9 @@
     "name": "join with reversed condition and complex condition expression",
 
     "backends": {
-        "mimir": "skip",
         "couchbase":         "skip",
+        "marklogic_json": "ignoreFieldOrder",
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
@@ -18,8 +19,6 @@
               on r.sha = l.parents[0].sha",
 
     "predicate": "containsAtLeast",
-
-    "ignoreFieldOrder": ["marklogic_json"],
 
     "expected": [
         { "child": "b29d8f254e5df2c4d1792f077625924cd1fde2db", "c_auth": "mossprescott",

--- a/it/src/main/resources/tests/joins/multipleSelectJoin.test
+++ b/it/src/main/resources/tests/joins/multipleSelectJoin.test
@@ -5,7 +5,6 @@
         "couchbase":         "pending",
         "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/joins/multipleSelectJoin.test
+++ b/it/src/main/resources/tests/joins/multipleSelectJoin.test
@@ -2,8 +2,9 @@
     "name": "join with multiple fields selected",
 
     "backends": {
-        "mimir": "skip",
         "couchbase":         "pending",
+        "marklogic_json": "ignoreFieldOrder",
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
@@ -21,8 +22,6 @@
               FROM `../smallZips` JOIN `../extraSmallZips`
               ON smallZips.pop = extraSmallZips.pop
               WHERE extraSmallZips.state = \"MA\"",
-
-    "ignoreFieldOrder": [ "marklogic_json" ],
 
     "predicate": "containsAtLeast",
 

--- a/it/src/main/resources/tests/joins/nonJsJoinCondition.test
+++ b/it/src/main/resources/tests/joins/nonJsJoinCondition.test
@@ -6,7 +6,6 @@
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending",
         "spark_local":       "pending",

--- a/it/src/main/resources/tests/joins/orderJoinByAlias.test
+++ b/it/src/main/resources/tests/joins/orderJoinByAlias.test
@@ -6,7 +6,6 @@
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/joins/sameFieldName.test
+++ b/it/src/main/resources/tests/joins/sameFieldName.test
@@ -2,8 +2,9 @@
     "name": "select over fields with same name",
 
     "backends": {
-        "mimir": "skip",
         "couchbase":         "skip",
+        "marklogic_json": "ignoreFieldOrder",
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2": "pending",
         "postgresql":        "pending"
@@ -18,8 +19,6 @@
               on car.`_id` = owner.carId",
 
     "predicate": "containsExactly",
-
-    "ignoreFieldOrder": ["marklogic_json"],
 
     "expected": [{ "name": "emma",  "name0": "RangeRover-Evoque" },
                  { "name": "scott", "name0": "Honda-civic" },

--- a/it/src/main/resources/tests/joins/sameFieldName.test
+++ b/it/src/main/resources/tests/joins/sameFieldName.test
@@ -5,7 +5,6 @@
         "couchbase":         "skip",
         "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/joins/sameFieldNameComplex.test
+++ b/it/src/main/resources/tests/joins/sameFieldNameComplex.test
@@ -5,7 +5,6 @@
         "couchbase":         "skip",
         "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/joins/sameFieldNameComplex.test
+++ b/it/src/main/resources/tests/joins/sameFieldNameComplex.test
@@ -2,8 +2,9 @@
     "name": "select over fields with same name and condition with AND",
 
     "backends": {
-        "mimir": "skip",
         "couchbase":         "skip",
+        "marklogic_json": "ignoreFieldOrder",
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
@@ -18,8 +19,6 @@
               on car.`_id` = owner.carId and owner.year = car.year[0]",
 
     "predicate": "containsExactly",
-
-    "ignoreFieldOrder": ["marklogic_json"],
 
     "expected": [{ "name": "emma",  "name0": "RangeRover-Evoque" },
                  { "name": "scott", "name0": "Honda-civic" },

--- a/it/src/main/resources/tests/joins/selfjoinConstantOnLeft.test
+++ b/it/src/main/resources/tests/joins/selfjoinConstantOnLeft.test
@@ -6,7 +6,6 @@
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/joins/selfjoinWithComplexCondition.test
+++ b/it/src/main/resources/tests/joins/selfjoinWithComplexCondition.test
@@ -6,7 +6,6 @@
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/joins/symmetricNonJsJoinCondition.test
+++ b/it/src/main/resources/tests/joins/symmetricNonJsJoinCondition.test
@@ -6,7 +6,6 @@
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending",
         "spark_hdfs":        "pending",

--- a/it/src/main/resources/tests/jsWithNonJsFilter.test
+++ b/it/src/main/resources/tests/jsWithNonJsFilter.test
@@ -2,7 +2,6 @@
     "name": "filter on JS with non-JS",
     "backends": {
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/largestCities.test
+++ b/it/src/main/resources/tests/largestCities.test
@@ -4,12 +4,15 @@
     "NB": "Couchbase is skipped due to largish generated N1QL that leads to a timeout.",
 
     "backends": {
-        "mimir": "skip",
         "couchbase":  "skip",
+        "mimir": "skip",
+        "mongodb_2_6": "ignoreFieldOrder",
+        "mongodb_3_0": "ignoreFieldOrder",
+        "mongodb_3_2": "ignoreFieldOrder",
+        "mongodb_read_only": "ignoreFieldOrder",
         "postgresql": "pending"
     },
     "data": "zips.data",
-    "ignoreFieldOrder": [ "mongodb_2_6", "mongodb_3_0", "mongodb_3_2", "mongodb_read_only" ],
     "query": "select city, state, sum(pop) as total from zips group by city, state order by sum(pop) desc limit 10",
     "predicate": "equalsExactly",
     "expected": [{ "city": "CHICAGO",      "state": "IL", "total": 2452177 },

--- a/it/src/main/resources/tests/likeWithConstantFoldablePattern.test
+++ b/it/src/main/resources/tests/likeWithConstantFoldablePattern.test
@@ -9,7 +9,7 @@
     "query": "select * from zips where city like (\"%\" || :substr || \"%\")",
     "predicate": "containsExactly",
     "ignoredFields": ["_id"],
-    "ignoreFieldOrder": ["marklogic_json"],
+    "ignoreFieldOrder": ["*"],
     "expected": [
         { "city": "BOULDER JUNCTION", "loc": [ -89.632454, 46.111183], "pop": 563,   "state": "WI" },
         { "city": "BOULDER",          "loc": [-112.113757, 46.230647], "pop": 1737,  "state": "MT" },

--- a/it/src/main/resources/tests/likeWithConstantFoldablePattern.test
+++ b/it/src/main/resources/tests/likeWithConstantFoldablePattern.test
@@ -9,7 +9,7 @@
     "query": "select * from zips where city like (\"%\" || :substr || \"%\")",
     "predicate": "containsExactly",
     "ignoredFields": ["_id"],
-    "ignoreFieldOrder": ["*"],
+    "ignoreFieldOrder": true,
     "expected": [
         { "city": "BOULDER JUNCTION", "loc": [ -89.632454, 46.111183], "pop": 563,   "state": "WI" },
         { "city": "BOULDER",          "loc": [-112.113757, 46.230647], "pop": 1737,  "state": "MT" },

--- a/it/src/main/resources/tests/longCitiesWithLength.test
+++ b/it/src/main/resources/tests/longCitiesWithLength.test
@@ -1,6 +1,7 @@
 {
     "name": "long city names in Colorado",
     "backends": {
+        "couchbase":  "ignoreFieldOrder",
         "mimir": "skip",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2": "pending",
@@ -9,7 +10,6 @@
     "data": "largeZips.data",
     "query": "select distinct city, length(city) as len from largeZips where state=\"CO\" and length(city) >= 10",
     "predicate": "containsAtLeast",
-    "ignoreFieldOrder": [ "couchbase" ],
     "expected": [{ "city": "GRAND LAKE",       "len": 10 },
                  { "city": "MONTE VISTA",      "len": 11 },
                  { "city": "FORT GARLAND",     "len": 12 },

--- a/it/src/main/resources/tests/longCitiesWithLength.test
+++ b/it/src/main/resources/tests/longCitiesWithLength.test
@@ -3,7 +3,6 @@
     "backends": {
         "couchbase":  "ignoreFieldOrder",
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/manySimpleProjections.test
+++ b/it/src/main/resources/tests/manySimpleProjections.test
@@ -2,8 +2,9 @@
   "name": "many simple projections (order matters)",
 
   "backends": {
+        "marklogic_json":    "ignoreFieldOrder",
         "mimir": "skip",
-    "postgresql": "pending"
+        "postgresql": "pending"
   },
 
   "data": "zips.data",
@@ -11,8 +12,6 @@
   "query": "select city as a, city as b, city as c, city as d, city as e, city as f from zips where `_id` = \"80301\"",
 
   "predicate": "containsExactly",
-
-  "ignoreFieldOrder": ["marklogic_json"],
 
   "expected": [
     { "a": "BOULDER", "b": "BOULDER", "c": "BOULDER", "d": "BOULDER", "e": "BOULDER", "f": "BOULDER" }

--- a/it/src/main/resources/tests/matchCaseInsensitiveRegex.test
+++ b/it/src/main/resources/tests/matchCaseInsensitiveRegex.test
@@ -8,7 +8,7 @@
     "query": "select * from zips where city ~* \"^bOu\"",
     "predicate": "containsAtLeast",
     "ignoredFields": ["_id"],
-    "ignoreFieldOrder": ["marklogic_json"],
+    "ignoreFieldOrder": ["*"],
     "expected": [
         { "city": "BOUCKVILLE",       "loc": [ -75.567841,  42.894024], "pop":   650, "state": "NY" },
         { "city": "BOUTON",           "loc": [ -93.996286,  41.828432], "pop":   552, "state": "IA" },

--- a/it/src/main/resources/tests/matchCaseInsensitiveRegex.test
+++ b/it/src/main/resources/tests/matchCaseInsensitiveRegex.test
@@ -8,7 +8,7 @@
     "query": "select * from zips where city ~* \"^bOu\"",
     "predicate": "containsAtLeast",
     "ignoredFields": ["_id"],
-    "ignoreFieldOrder": ["*"],
+    "ignoreFieldOrder": true,
     "expected": [
         { "city": "BOUCKVILLE",       "loc": [ -75.567841,  42.894024], "pop":   650, "state": "NY" },
         { "city": "BOUTON",           "loc": [ -93.996286,  41.828432], "pop":   552, "state": "IA" },

--- a/it/src/main/resources/tests/matchRegexPatternWithExpressions.test
+++ b/it/src/main/resources/tests/matchRegexPatternWithExpressions.test
@@ -2,10 +2,12 @@
   "name": "regexes in expressions and filter, with fields and constants providing the pattern",
 
   "backends": {
+        "couchbase": "ignoreFieldOrder",
+        "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
-    "mongodb_read_only": "pending",
-    "mongodb_q_3_2":  "pending",
-    "postgresql":        "pending"
+        "mongodb_read_only": "pending",
+        "mongodb_q_3_2":  "pending",
+        "postgresql":        "pending"
   },
 
   "data": "largeZips.data",
@@ -16,8 +18,6 @@
       where city ~ \"^B[^ ]+ER$\" and \"BOULDER or BEELER\" ~ city",
 
   "predicate": "containsExactly",
-
-  "ignoreFieldOrder": ["couchbase", "marklogic_json"],
 
   "expected": [
     { "city": "BOULDER", "a": true,  "b": true  },

--- a/it/src/main/resources/tests/matchRegexPatternWithExpressions.test
+++ b/it/src/main/resources/tests/matchRegexPatternWithExpressions.test
@@ -5,7 +5,6 @@
         "couchbase": "ignoreFieldOrder",
         "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":  "pending",
         "postgresql":        "pending"
   },

--- a/it/src/main/resources/tests/mongodb/distinctStar.test
+++ b/it/src/main/resources/tests/mongodb/distinctStar.test
@@ -5,7 +5,6 @@
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "skip",
         "spark_hdfs":        "skip",

--- a/it/src/main/resources/tests/mongodb/fakeObjectId.test
+++ b/it/src/main/resources/tests/mongodb/fakeObjectId.test
@@ -2,7 +2,6 @@
     "name": "convert a field to ObjectId",
     "backends": {
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2": "pending",
         "postgresql":        "pending",
         "marklogic_json":    "skip",

--- a/it/src/main/resources/tests/mongodb/temporal/time.test
+++ b/it/src/main/resources/tests/mongodb/temporal/time.test
@@ -6,7 +6,6 @@
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "skip",
         "spark_local":       "skip",

--- a/it/src/main/resources/tests/mongodb/temporal/toFromString.test
+++ b/it/src/main/resources/tests/mongodb/temporal/toFromString.test
@@ -2,7 +2,6 @@
     "name": "convert dates to/from strings (MongoDB)",
     "backends": {
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/multistageFlatten.test
+++ b/it/src/main/resources/tests/multistageFlatten.test
@@ -20,6 +20,7 @@
                 a                LIKE \"%13%\")",
     "FIXME": "Should use `containsExactly`, but see issue #732.",
     "predicate": "equalsExactly",
+    "ignoreFieldOrder": ["*"],
     "expected": [
         { "_id": { "$oid": "5552744bd86735b7268fd002" }, "a": "13" },
         { "_id": { "$oid": "55538123d86735b7268fd003" }, "foo": "zap" },

--- a/it/src/main/resources/tests/multistageFlatten.test
+++ b/it/src/main/resources/tests/multistageFlatten.test
@@ -20,7 +20,7 @@
                 a                LIKE \"%13%\")",
     "FIXME": "Should use `containsExactly`, but see issue #732.",
     "predicate": "equalsExactly",
-    "ignoreFieldOrder": ["*"],
+    "ignoreFieldOrder": true,
     "expected": [
         { "_id": { "$oid": "5552744bd86735b7268fd002" }, "a": "13" },
         { "_id": { "$oid": "55538123d86735b7268fd003" }, "foo": "zap" },

--- a/it/src/main/resources/tests/multitypeFlatten.test
+++ b/it/src/main/resources/tests/multitypeFlatten.test
@@ -19,6 +19,7 @@
                 foo[*] = 15)",
     "predicate": "containsExactly",
     "ignoredFields": ["_id"],
+    "ignoreFieldOrder": ["*"],
     "expected": [{ "foo": [15, [{ "baz": ["quux"] }]] },
                  { "foo": ["15z", [{ "baz": ["qx"] }]] },
                  { "foo": { "bar": 15, "baz": ["qx"] } },

--- a/it/src/main/resources/tests/multitypeFlatten.test
+++ b/it/src/main/resources/tests/multitypeFlatten.test
@@ -19,7 +19,7 @@
                 foo[*] = 15)",
     "predicate": "containsExactly",
     "ignoredFields": ["_id"],
-    "ignoreFieldOrder": ["*"],
+    "ignoreFieldOrder": true,
     "expected": [{ "foo": [15, [{ "baz": ["quux"] }]] },
                  { "foo": ["15z", [{ "baz": ["qx"] }]] },
                  { "foo": { "bar": 15, "baz": ["qx"] } },

--- a/it/src/main/resources/tests/multitypeFlatten.test
+++ b/it/src/main/resources/tests/multitypeFlatten.test
@@ -5,7 +5,6 @@
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending",
         "spark_local":       "skip",

--- a/it/src/main/resources/tests/negatedRegex.test
+++ b/it/src/main/resources/tests/negatedRegex.test
@@ -1,6 +1,7 @@
 {
     "name": "negate matches in filter and projection",
     "backends": {
+        "couchbase": "ignoreFieldOrder",
         "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
@@ -8,7 +9,6 @@
     "data": "largeZips.data",
     "query": "select city, city !~ \"A\" as noA from largeZips where city !~ \"CHI\"",
     "predicate": "containsAtLeast",
-    "ignoreFieldOrder": [ "couchbase" ],
     "expected": [
         { "city": "CUSHMAN",     "noA": false },
         { "city": "WORCESTER",   "noA":  true },

--- a/it/src/main/resources/tests/negatedRegex.test
+++ b/it/src/main/resources/tests/negatedRegex.test
@@ -3,7 +3,6 @@
     "backends": {
         "couchbase": "ignoreFieldOrder",
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/null/nullTestExprs.test
+++ b/it/src/main/resources/tests/null/nullTestExprs.test
@@ -1,6 +1,7 @@
 {
     "name": "expressions with `= null` and `is null`",
     "backends": {
+        "couchbase": "ignoreFieldOrder",
         "mimir": "skip",
         "marklogic_json": "skip",
         "marklogic_xml":  "skip",
@@ -12,7 +13,6 @@
                      nested.val as nval, nested.val = null, nested.val is null, nested.val is not null
               from nulls",
     "predicate": "containsExactly",
-    "ignoreFieldOrder": [ "couchbase" ],
     "expected": [
         { "name": "null",  "val": null, "2": true,  "3": true,  "4": false, "nval": null, "6": true,  "7": true,  "8": false },
         { "name": "empty", "val": {},   "2": false, "3": false, "4": true,  "nval": {},   "6": false, "7": false, "8": true  },

--- a/it/src/main/resources/tests/null/toFromString.test
+++ b/it/src/main/resources/tests/null/toFromString.test
@@ -3,7 +3,6 @@
     "backends": {
         "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
     "data": "nulls.data",

--- a/it/src/main/resources/tests/null/toFromString.test
+++ b/it/src/main/resources/tests/null/toFromString.test
@@ -1,6 +1,7 @@
 {
     "name": "convert null to/from strings",
     "backends": {
+        "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
@@ -8,6 +9,5 @@
     "data": "nulls.data",
     "query": "select null(name) as n, to_string(val) as s from nulls where name = \"null\"",
     "predicate": "containsExactly",
-    "ignoreFieldOrder": ["marklogic_json"],
     "expected": [{ "n": null, "s": "null" }]
 }

--- a/it/src/main/resources/tests/numericFieldNames.test
+++ b/it/src/main/resources/tests/numericFieldNames.test
@@ -2,6 +2,7 @@
   "name": "numeric field names",
 
   "backends": {
+    "couchbase": "ignoreFieldOrder",
     "mimir": "skip",
     "postgresql": "pending"
   },
@@ -11,8 +12,6 @@
   "query": "select city as `12`, pop as `42` from smallZips",
 
   "predicate": "containsAtLeast",
-
-  "ignoreFieldOrder": [ "couchbase" ],
 
   "expected": [
     { "12": "NEW SALEM", "42": 14077 }

--- a/it/src/main/resources/tests/orderedWildcardWithProjection.test
+++ b/it/src/main/resources/tests/orderedWildcardWithProjection.test
@@ -8,7 +8,7 @@
     "data": "largeZips.data",
     "query": "select *, pop * 10 as dpop from largeZips order by pop / 10 desc",
     "predicate": "equalsInitial",
-    "ignoreFieldOrder": ["*"],
+    "ignoreFieldOrder": true,
     "expected": [
         { "_id": "60623", "city": "CHICAGO",      "loc": [ -87.7157,   41.849015], "pop": 112047.0, "state": "IL", "dpop": 1120470.0 },
         { "_id": "11226", "city": "BROOKLYN",     "loc": [ -73.956985, 40.646694], "pop": 111396.0, "state": "NY", "dpop": 1113960.0 },

--- a/it/src/main/resources/tests/orderedWildcardWithProjection.test
+++ b/it/src/main/resources/tests/orderedWildcardWithProjection.test
@@ -8,7 +8,7 @@
     "data": "largeZips.data",
     "query": "select *, pop * 10 as dpop from largeZips order by pop / 10 desc",
     "predicate": "equalsInitial",
-    "ignoreFieldOrder": [ "couchbase", "marklogic_json" ],
+    "ignoreFieldOrder": ["*"],
     "expected": [
         { "_id": "60623", "city": "CHICAGO",      "loc": [ -87.7157,   41.849015], "pop": 112047.0, "state": "IL", "dpop": 1120470.0 },
         { "_id": "11226", "city": "BROOKLYN",     "loc": [ -73.956985, 40.646694], "pop": 111396.0, "state": "NY", "dpop": 1113960.0 },

--- a/it/src/main/resources/tests/orderedWildcardWithProjection.test
+++ b/it/src/main/resources/tests/orderedWildcardWithProjection.test
@@ -2,7 +2,6 @@
     "name": "wildcard with projection and synthetic field",
     "backends": {
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/projectCaseInsensitiveRegex.test
+++ b/it/src/main/resources/tests/projectCaseInsensitiveRegex.test
@@ -1,6 +1,8 @@
 {
     "name": "case-insensitive regex in projections",
     "backends": {
+        "couchbase": "ignoreFieldOrder",
+        "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
@@ -9,7 +11,6 @@
     "query": "select city, city ~* \"boU\" as a, city !~* \"Bou\" as b from largeZips",
     "NB": "Should also test `doesNotContain`, see SD-577.",
     "predicate": "containsAtLeast",
-    "ignoreFieldOrder": [ "couchbase", "marklogic_json" ],
     "expected": [
         { "city": "CUSHMAN",          "a": false, "b": true  },
         { "city": "CHICOPEE",         "a": false, "b": true  },

--- a/it/src/main/resources/tests/projectCaseInsensitiveRegex.test
+++ b/it/src/main/resources/tests/projectCaseInsensitiveRegex.test
@@ -4,7 +4,6 @@
         "couchbase": "ignoreFieldOrder",
         "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/projectFieldWithFlatten.test
+++ b/it/src/main/resources/tests/projectFieldWithFlatten.test
@@ -1,10 +1,9 @@
 {
     "name": "project unrelated field with object flatten",
     "backends": {
+        "couchbase": "skip",
         "mimir": "skip",
-        "couchbase":         "skip",
-        "mongodb_read_only": "pending",
-        "postgresql":        "pending"
+        "postgresql": "pending"
     },
     "data": "usa_factbook.data",
     "query": "select intro from usa_factbook where geo{*}.text = \"19,924 km\"",

--- a/it/src/main/resources/tests/projectFromConcattedArray.test
+++ b/it/src/main/resources/tests/projectFromConcattedArray.test
@@ -2,7 +2,6 @@
     "name": "project from non-static concatted array",
     "backends": {
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2": "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/projectFromConcattedArrayPrefix.test
+++ b/it/src/main/resources/tests/projectFromConcattedArrayPrefix.test
@@ -2,7 +2,6 @@
     "name": "project from static concatted array prefix",
     "backends": {
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/projectIndexFromGroup.test
+++ b/it/src/main/resources/tests/projectIndexFromGroup.test
@@ -1,22 +1,19 @@
 {
     "name": "project index from group",
     "backends": {
+        "couchbase": "ignoreFieldOrder",
+        "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
+        "mongodb_2_6": "ignoreFieldOrder",
+        "mongodb_3_0": "ignoreFieldOrder",
+        "mongodb_3_2": "ignoreFieldOrder",
         "mongodb_read_only": "pending",
+        "mongodb_q_3_2": "ignoreFieldOrder",
         "postgresql":        "pending"
     },
     "data": "slamengine_commits.data",
     "query": "select parents[0].sha, count(*) as count from slamengine_commits group by parents[0].sha",
     "predicate": "containsAtLeast",
-    "ignoreFieldOrder": [
-      "couchbase",
-      "marklogic_json",
-      "mongodb_2_6",
-      "mongodb_3_0",
-      "mongodb_read_only",
-      "mongodb_3_2",
-      "mongodb_q_3_2"
-    ],
     "expected": [
         { "sha": "b812837ee2f72be3aaee582b42e3ad901d1f7371", "count": 1 },
         { "sha": "9897104b5a22571a5940f4ba2ba89addaef81ed0", "count": 1 },

--- a/it/src/main/resources/tests/projectIndexFromGroupWithFilter.test
+++ b/it/src/main/resources/tests/projectIndexFromGroupWithFilter.test
@@ -1,20 +1,18 @@
 {
     "name": "project index from group with filter",
     "backends": {
+        "couchbase": "ignoreFieldOrder",
+        "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
+        "mongodb_2_6": "ignoreFieldOrder",
+        "mongodb_3_0": "ignoreFieldOrder",
+        "mongodb_3_2": "ignoreFieldOrder",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
     "data": "slamengine_commits.data",
     "query": "select parents[0].sha, count(*) as count from slamengine_commits where parents[0].sha like \"5%\" group by parents[0].sha",
     "predicate": "containsExactly",
-    "ignoreFieldOrder": [
-      "couchbase",
-      "marklogic_json",
-      "mongodb_2_6",
-      "mongodb_3_0",
-      "mongodb_3_2"
-    ],
     "expected": [
         { "sha": "53d2e5684d9403194dff1cc63423c2590038d1c0", "count": 1 },
         { "sha": "56d1caf5d082d1a6840090986e277d36d03f1859", "count": 4 },

--- a/it/src/main/resources/tests/projectIndexWithObjectFlatten.test
+++ b/it/src/main/resources/tests/projectIndexWithObjectFlatten.test
@@ -4,7 +4,6 @@
         "couchbase":         "skip",
         "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/projectIndexWithObjectFlatten.test
+++ b/it/src/main/resources/tests/projectIndexWithObjectFlatten.test
@@ -1,8 +1,9 @@
 {
     "name": "project index with object flatten",
     "backends": {
-        "mimir": "skip",
         "couchbase":         "skip",
+        "marklogic_json": "ignoreFieldOrder",
+        "mimir": "skip",
         "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
@@ -10,7 +11,6 @@
     "data": "slamengine_commits.data",
     "query": "select parents[0] as parent, commit{*} from slamengine_commits",
     "predicate": "containsAtLeast",
-    "ignoreFieldOrder": ["marklogic_json"],
     "expected": [
         { "parent": { "sha": "3d44ce48fc0670aaf39ba1acd0e1c161f14cc2d6", "url": "https://api.github.com/repos/slamdata/slamengine/commits/3d44ce48fc0670aaf39ba1acd0e1c161f14cc2d6", "html_url": "https://github.com/slamdata/slamengine/commit/3d44ce48fc0670aaf39ba1acd0e1c161f14cc2d6" }, "commit": { "name": "Greg Pfeil", "email": "greg@technomadic.org", "date": "2015-01-29T15:52:37Z" } },
         { "parent": { "sha": "3d44ce48fc0670aaf39ba1acd0e1c161f14cc2d6", "url": "https://api.github.com/repos/slamdata/slamengine/commits/3d44ce48fc0670aaf39ba1acd0e1c161f14cc2d6", "html_url": "https://github.com/slamdata/slamengine/commit/3d44ce48fc0670aaf39ba1acd0e1c161f14cc2d6" }, "commit": { "name": "Greg Pfeil", "email": "greg@technomadic.org", "date": "2015-01-29T15:52:37Z" } },

--- a/it/src/main/resources/tests/selectArrayElement.test
+++ b/it/src/main/resources/tests/selectArrayElement.test
@@ -2,7 +2,6 @@
     "name": "select array element",
     "backends": {
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/selectTwentyFields.test
+++ b/it/src/main/resources/tests/selectTwentyFields.test
@@ -1,6 +1,7 @@
 {
     "name": "select twenty fields quickly",
     "backends": {
+        "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
@@ -12,7 +13,6 @@
       city as k, city as l, city as m, city as n, city as o,
       city as p, city as q, city as r, city as s, city as t from largeZips",
     "predicate": "containsAtLeast",
-    "ignoreFieldOrder": [ "marklogic_json" ],
     "expected": [{ "a": "CUSHMAN", "b": "CUSHMAN", "c": "CUSHMAN", "d": "CUSHMAN",
                    "e": "CUSHMAN", "f": "CUSHMAN", "g": "CUSHMAN", "h": "CUSHMAN",
                    "i": "CUSHMAN", "j": "CUSHMAN", "k": "CUSHMAN", "l": "CUSHMAN",

--- a/it/src/main/resources/tests/selectTwentyFields.test
+++ b/it/src/main/resources/tests/selectTwentyFields.test
@@ -3,7 +3,6 @@
     "backends": {
         "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/selectWildcardAndField.test
+++ b/it/src/main/resources/tests/selectWildcardAndField.test
@@ -7,7 +7,7 @@
     "data": "largeZips.data",
     "query": "select *, pop/1000 as popInK from largeZips",
     "predicate": "containsAtLeast",
-    "ignoreFieldOrder": [ "couchbase", "marklogic_json" ],
+    "ignoreFieldOrder": ["*"],
     "expected": [
         {"_id": "01002", "city": "CUSHMAN",          "loc": [ -72.51565, 42.377017], "pop": 36963, "state": "MA", "popInK": 36.963},
         {"_id": "01020", "city": "CHICOPEE",         "loc": [-72.576142, 42.176443], "pop": 31495, "state": "MA", "popInK": 31.495},

--- a/it/src/main/resources/tests/selectWildcardAndField.test
+++ b/it/src/main/resources/tests/selectWildcardAndField.test
@@ -7,7 +7,7 @@
     "data": "largeZips.data",
     "query": "select *, pop/1000 as popInK from largeZips",
     "predicate": "containsAtLeast",
-    "ignoreFieldOrder": ["*"],
+    "ignoreFieldOrder": true,
     "expected": [
         {"_id": "01002", "city": "CUSHMAN",          "loc": [ -72.51565, 42.377017], "pop": 36963, "state": "MA", "popInK": 36.963},
         {"_id": "01020", "city": "CHICOPEE",         "loc": [-72.576142, 42.176443], "pop": 31495, "state": "MA", "popInK": 31.495},

--- a/it/src/main/resources/tests/shortCities.test
+++ b/it/src/main/resources/tests/shortCities.test
@@ -5,7 +5,6 @@
         "couchbase":         "skip",
         "marklogic_json":    "pending",
         "marklogic_xml":     "pending",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending",
         "spark_hdfs":        "pending",

--- a/it/src/main/resources/tests/simpleDistinct.test
+++ b/it/src/main/resources/tests/simpleDistinct.test
@@ -2,9 +2,10 @@
   "name": "simple distinct",
 
   "backends": {
+        "marklogic_json":    "ignoreFieldOrder",
         "mimir": "skip",
-    "mongodb_q_3_2": "pending",
-    "postgresql": "pending"
+        "mongodb_q_3_2": "pending",
+        "postgresql": "pending"
   },
 
   "data": "olympics.data",
@@ -12,8 +13,6 @@
   "query": "select distinct discipline, event from olympics where event like \"%pursuit\"",
 
   "predicate": "containsExactly",
-
-  "ignoreFieldOrder": ["marklogic_json"],
 
   "expected": [
     { "discipline": "Speed skating",   "event": "Team pursuit" },

--- a/it/src/main/resources/tests/simpleJsFilter.test
+++ b/it/src/main/resources/tests/simpleJsFilter.test
@@ -2,8 +2,7 @@
     "name": "filter on simple JS",
     "backends": {
         "mimir": "skip",
-        "mongodb_read_only": "pending",
-        "postgresql":        "pending"
+        "postgresql": "pending"
     },
     "data": "largeZips.data",
     "query": "select city from largeZips where length(city) < 5",

--- a/it/src/main/resources/tests/simpleProjectWithOneRenamed.test
+++ b/it/src/main/resources/tests/simpleProjectWithOneRenamed.test
@@ -2,6 +2,7 @@
     "name": "simple $project with one renamed field and one unchanged (see #598)",
 
     "backends": {
+        "couchbase":    "ignoreFieldOrder",
         "mimir": "skip",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
@@ -15,7 +16,6 @@
     "query": "select `_id` as zip, city from zips where pop = 18174",
 
     "predicate": "containsExactly",
-    "ignoreFieldOrder": ["couchbase"],
     "expected": [{ "zip": "80301", "city": "BOULDER"   },
                  { "zip": "92029", "city": "ESCONDIDO" }]
 }

--- a/it/src/main/resources/tests/singleElementSet.test
+++ b/it/src/main/resources/tests/singleElementSet.test
@@ -8,7 +8,7 @@
     "query": "select * from zips where state in (\"MA\") and pop < 10",
     "predicate": "containsExactly",
     "ignoredFields": ["_id"],
-    "ignoreFieldOrder": ["marklogic_json"],
+    "ignoreFieldOrder": ["*"],
     "expected": [
         { "city": "CAMBRIDGE", "loc": [-71.141879, 42.364005], "pop": 0, "state": "MA" }]
 }

--- a/it/src/main/resources/tests/singleElementSet.test
+++ b/it/src/main/resources/tests/singleElementSet.test
@@ -8,7 +8,7 @@
     "query": "select * from zips where state in (\"MA\") and pop < 10",
     "predicate": "containsExactly",
     "ignoredFields": ["_id"],
-    "ignoreFieldOrder": ["*"],
+    "ignoreFieldOrder": true,
     "expected": [
         { "city": "CAMBRIDGE", "loc": [-71.141879, 42.364005], "pop": 0, "state": "MA" }]
 }

--- a/it/src/main/resources/tests/sortByJS.test
+++ b/it/src/main/resources/tests/sortByJS.test
@@ -3,8 +3,7 @@
 
   "backends": {
         "mimir": "skip",
-    "mongodb_read_only": "pending",
-    "postgresql":        "pending"
+        "postgresql": "pending"
   },
 
   "data": "zips.data",

--- a/it/src/main/resources/tests/sortWildcardOnExpression.test
+++ b/it/src/main/resources/tests/sortWildcardOnExpression.test
@@ -8,7 +8,7 @@
     "data": "largeZips.data",
     "query": "select * from largeZips order by pop/10 desc",
     "predicate": "equalsInitial",
-    "ignoreFieldOrder": ["marklogic_json"],
+    "ignoreFieldOrder": ["*"],
     "expected": [
         {"_id": "60623", "city": "CHICAGO",      "loc": [ -87.7157,   41.849015], "pop": 112047.0, "state": "IL"},
         {"_id": "11226", "city": "BROOKLYN",     "loc": [ -73.956985, 40.646694], "pop": 111396.0, "state": "NY"},

--- a/it/src/main/resources/tests/sortWildcardOnExpression.test
+++ b/it/src/main/resources/tests/sortWildcardOnExpression.test
@@ -2,7 +2,6 @@
     "name": "sort wildcard on expression",
     "backends": {
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/sortWildcardOnExpression.test
+++ b/it/src/main/resources/tests/sortWildcardOnExpression.test
@@ -8,7 +8,7 @@
     "data": "largeZips.data",
     "query": "select * from largeZips order by pop/10 desc",
     "predicate": "equalsInitial",
-    "ignoreFieldOrder": ["*"],
+    "ignoreFieldOrder": true,
     "expected": [
         {"_id": "60623", "city": "CHICAGO",      "loc": [ -87.7157,   41.849015], "pop": 112047.0, "state": "IL"},
         {"_id": "11226", "city": "BROOKLYN",     "loc": [ -73.956985, 40.646694], "pop": 111396.0, "state": "NY"},

--- a/it/src/main/resources/tests/statesByShortestFirstCity.test
+++ b/it/src/main/resources/tests/statesByShortestFirstCity.test
@@ -2,9 +2,8 @@
     "name": "states sorted by the length of name of their first city, alphabetically",
     "backends": {
         "mimir": "skip",
-        "couchbase":         "skip",
-        "mongodb_read_only": "pending",
-        "postgresql":        "pending"
+        "couchbase": "skip",
+        "postgresql": "pending"
     },
     "description": "combines an aggregate function (min) with a function implemented in JS (length)",
     "data": "zips.data",

--- a/it/src/main/resources/tests/temporal/convertTimestamp.test
+++ b/it/src/main/resources/tests/temporal/convertTimestamp.test
@@ -2,9 +2,14 @@
   "name": "convert epoch milliseconds value to timestamp",
 
   "backends": {
+        "couchbase": "ignoreFieldOrder",
         "mimir": "skip",
-    "mongodb_q_3_2": "pending",
-    "postgresql":    "pending"
+        "mongodb_2_6": "ignoreFieldOrder",
+        "mongodb_3_0": "ignoreFieldOrder",
+        "mongodb_3_2": "ignoreFieldOrder",
+        "mongodb_read_only": "ignoreFieldOrder",
+        "mongodb_q_3_2": "pending",
+        "postgresql":    "pending"
   },
 
   "data": "../days.data",
@@ -12,13 +17,6 @@
   "query": "select day, ts, to_timestamp(epoch) as converted from `../days` where ts = to_timestamp(1408255200000) or to_timestamp(epoch) = timestamp(\"2014-08-18T07:00:00Z\")",
 
   "predicate": "containsExactly",
-  "ignoreFieldOrder": [
-    "couchbase",
-    "mongodb_2_6",
-    "mongodb_3_0",
-    "mongodb_3_2",
-    "mongodb_read_only"
-  ],
   "expected": [
     { "day": "Sunday", "ts": { "$timestamp": "2014-08-17T06:00:00.000Z" }, "converted": { "$timestamp": "2014-08-17T06:00:00.000Z" } },
     { "day": "Monday", "ts": { "$timestamp": "2014-08-18T07:00:00.000Z" }, "converted": { "$timestamp": "2014-08-18T07:00:00.000Z" } }

--- a/it/src/main/resources/tests/temporal/datePartsConverted.test
+++ b/it/src/main/resources/tests/temporal/datePartsConverted.test
@@ -2,15 +2,16 @@
   "name": "date_part with (virtually) all selectors, after conversion to JS (see #1238)",
 
   "backends": {
+        "couchbase": "ignoreFieldOrder",
+        "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
-      "mongodb_read_only": "pending",
-      "postgresql":        "pending"
+        "mongodb_read_only": "pending",
+        "postgresql":        "pending"
   },
 
   "data": "../slamengine_commits.data",
 
   "nb": "`doy` and `week` are missing because we currently have no JS implementation.",
-  "ignoreFieldOrder": [ "marklogic_json", "couchbase" ],
   "query": "select
               date_part(\"millennium\", timestamp(commit.committer.date)) as millennium,
               date_part(\"century\", timestamp(commit.committer.date)) as century,

--- a/it/src/main/resources/tests/temporal/datePartsConverted.test
+++ b/it/src/main/resources/tests/temporal/datePartsConverted.test
@@ -5,8 +5,7 @@
         "couchbase": "ignoreFieldOrder",
         "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
-        "mongodb_read_only": "pending",
-        "postgresql":        "pending"
+        "postgresql": "pending"
   },
 
   "data": "../slamengine_commits.data",
@@ -34,10 +33,9 @@
 
   "expected": [
     {
-    "millennium": 3.0, "century": 21.0, "decade": 201.0, "year": 2015.0,
-    "quarter": 1.0, "month": 1.0, "dayOfMonth": 29.0, "dayOfWeek": 4.0, "dayOfWeek (ISO)": 4.0,
-    "hour": 15.0, "minute": 52.0, "second": 37.0, "millis": 37000.0, "micros": 3.7e7,
-    "id": "33031"
-    }
-  ]
+        "millennium": 3, "century": 21, "decade": 201, "year": 2015,
+        "quarter": 1, "month": 1, "dayOfMonth": 29, "dayOfWeek": 4, "dayOfWeek (ISO)": 4,
+        "hour": 15, "minute": 52, "second": 37, "millis": 37000, "micros": 3.7e7,
+        "id": "33031"
+    }]
 }

--- a/it/src/main/resources/tests/temporal/datePartsConvertedSimple.test
+++ b/it/src/main/resources/tests/temporal/datePartsConvertedSimple.test
@@ -5,7 +5,6 @@
         "couchbase": "ignoreFieldOrder",
         "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending"
   },
 

--- a/it/src/main/resources/tests/temporal/datePartsConvertedSimple.test
+++ b/it/src/main/resources/tests/temporal/datePartsConvertedSimple.test
@@ -2,9 +2,11 @@
   "name": "date_part, after conversion to JS (see #1238)",
 
   "backends": {
+        "couchbase": "ignoreFieldOrder",
+        "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
-    "mongodb_read_only": "pending",
-    "postgresql":        "pending"
+        "mongodb_read_only": "pending",
+        "postgresql":        "pending"
   },
 
   "data": "../slamengine_commits.data",
@@ -15,7 +17,6 @@
               from `../slamengine_commits`",
 
   "predicate": "containsAtLeast",
-  "ignoreFieldOrder": [ "couchbase", "marklogic_json" ],
   "expected": [
     { "dayOfMonth": 29.0, "id": "33031" }
   ]

--- a/it/src/main/resources/tests/temporal/days.test
+++ b/it/src/main/resources/tests/temporal/days.test
@@ -2,9 +2,10 @@
   "name": "dow and isodow",
 
   "backends": {
+        "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
-    "mongodb_q_3_2": "pending",
-    "postgresql": "pending"
+        "mongodb_q_3_2": "pending",
+        "postgresql": "pending"
   },
 
   "data": "../days.data",
@@ -12,8 +13,6 @@
   "query": "select distinct day, date_part(\"dow\", ts) as dow, date_part(\"isodow\", ts) as isodow from `../days`",
 
   "predicate": "containsExactly",
-
-  "ignoreFieldOrder": ["marklogic_json"],
 
   "expected": [
     { "day": "Sunday" ,   "dow": 0, "isodow" : 7 },

--- a/it/src/main/resources/tests/temporal/time.test
+++ b/it/src/main/resources/tests/temporal/time.test
@@ -4,8 +4,8 @@
     "NB": "Couchbase disabled due to heap exhaustion",
 
     "backends": {
-        "mimir": "skip",
         "couchbase":         "skip",
+        "mimir": "skip",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
         "mongodb_read_only": "pending",
@@ -20,7 +20,6 @@
     where time_of_day(ts) >= time(\"08:00\") and time_of_day(ts) < time(\"10:20:30.400\")",
 
     "predicate": "containsExactly",
-    "ignoreFieldOrder": ["couchbase"],
     "expected": [
         { "day": "Tuesday",   "tod": { "$time": "08:00:00.000" } },
         { "day": "Wednesday", "tod": { "$time": "09:00:00.000" } },

--- a/it/src/main/resources/tests/temporal/toFromString.test
+++ b/it/src/main/resources/tests/temporal/toFromString.test
@@ -1,17 +1,18 @@
 {
     "name": "convert dates to/from strings",
     "backends": {
+        "couchbase": "ignoreFieldOrder",
+        "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
-        "mongodb_read_only": "pending",
         "mongodb_3_2":       "pending",
+        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },
     "data": "../days.data",
     "query": "select date(substring(str, 0, 10)) as d, time(substring(str, 11, 8)) as t, timestamp(str) as ts, to_string(ts) as s from `../days`",
-    "ignoreFieldOrder": ["couchbase", "marklogic_json"],
     "predicate": "containsExactly",
     "expected": [
         { "d": { "$date": "2014-08-17" }, "t": { "$time": "06:00:00.000" }, "ts": { "$timestamp": "2014-08-17T06:00:00.000Z" }, "s": "2014-08-17T06:00:00.000Z" },

--- a/it/src/main/resources/tests/tripleFlatten.test
+++ b/it/src/main/resources/tests/tripleFlatten.test
@@ -4,7 +4,6 @@
         "mimir": "skip",
         "marklogic_json":    "pending",
         "marklogic_xml":     "pending",
-        "mongodb_read_only": "pending",
         "postgresql":        "pending",
         "spark_hdfs":        "pending",
         "spark_local":       "pending"

--- a/it/src/main/resources/tests/trivial.test
+++ b/it/src/main/resources/tests/trivial.test
@@ -14,7 +14,7 @@
 
   "ignoredFields": ["_id"],
 
-  "ignoreFieldOrder": ["*"],
+  "ignoreFieldOrder": true,
 
   "expected": [
     { "city": "NEW SALEM", "loc": [-72.306241 , 42.514643], "pop": 456, "state": "MA" }

--- a/it/src/main/resources/tests/trivial.test
+++ b/it/src/main/resources/tests/trivial.test
@@ -14,7 +14,7 @@
 
   "ignoredFields": ["_id"],
 
-  "ignoreFieldOrder": [ "couchbase", "marklogic_json", "mimir" ],
+  "ignoreFieldOrder": ["*"],
 
   "expected": [
     { "city": "NEW SALEM", "loc": [-72.306241 , 42.514643], "pop": 456, "state": "MA" }

--- a/it/src/main/resources/tests/trivialGroup.test
+++ b/it/src/main/resources/tests/trivialGroup.test
@@ -1,19 +1,19 @@
 {
     "name": "trivial group by",
     "backends": {
+        "couchbase": "ignoreFieldOrder",
         "mimir": "skip",
-        "postgresql":    "pending"
+        "mongodb_2_6": "ignoreFieldOrder",
+        "mongodb_3_0": "ignoreFieldOrder",
+        "mongodb_3_2": "ignoreFieldOrder",
+        "mongodb_read_only": "ignoreFieldOrder",
+        "mongodb_q_3_2": "ignoreFieldOrder",
+        "postgresql":    "pending",
+        "spark_hdfs": "ignoreFieldOrder",
+        "spark_local": "ignoreFieldOrder"
     },
     "data": "largeZips.data",
     "query": "select city, sum(pop) as totalPop from largeZips group by city",
     "predicate": "containsAtLeast",
-    "ignoreFieldOrder": ["couchbase",
-                         "mongodb_2_6",
-                         "mongodb_3_0",
-                         "mongodb_3_2",
-                         "mongodb_read_only",
-                         "mongodb_q_3_2",
-                         "spark_local",
-                         "spark_hdfs"],
     "expected": [{ "city": "BOULDER", "totalPop": 110948 }]
 }

--- a/it/src/main/resources/tests/undefinedJsInExpr.test
+++ b/it/src/main/resources/tests/undefinedJsInExpr.test
@@ -3,7 +3,6 @@
     "backends": {
         "mimir": "skip",
         "couchbase":         "pending",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/union.test
+++ b/it/src/main/resources/tests/union.test
@@ -3,7 +3,6 @@
     "backends": {
         "mimir": "skip",
         "couchbase":         "skip",
-        "mongodb_read_only": "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },

--- a/it/src/main/resources/tests/unshiftAggregation.test
+++ b/it/src/main/resources/tests/unshiftAggregation.test
@@ -2,22 +2,19 @@
     "name": "unshift aggregation",
     "NB": "Couchbase pending due to different ordering of pop array. Enable once group contents ordering is possible.",
     "backends": {
-        "mimir": "skip",
         "couchbase":  "pending",
+        "marklogic_json": "ignoreFieldOrder",
+        "mimir": "skip",
+        "mongodb_2_6": "ignoreFieldOrder",
+        "mongodb_3_0": "ignoreFieldOrder",
+        "mongodb_3_2": "ignoreFieldOrder",
+        "mongodb_read_only": "ignoreFieldOrder",
+        "mongodb_q_3_2": "ignoreFieldOrder",
         "postgresql": "pending"
     },
     "data": "zips.data",
     "query": "select state, city, [pop ...] as pop from zips group by state, city",
     "predicate": "containsAtLeast",
-    "ignoreFieldOrder": [
-      "couchbase",
-      "marklogic_json",
-      "mongodb_2_6",
-      "mongodb_3_0",
-      "mongodb_read_only",
-      "mongodb_3_2",
-      "mongodb_q_3_2"
-    ],
     "expected": [
         { "state": "AK", "city": "ANCHORAGE",   "pop": [14436, 15891, 12534, 32383, 20128, 29857, 17094, 18356, 15192, 8116] },
         { "state": "AK", "city": "KETCHIKAN",   "pop": [13886, 422]                                                          },

--- a/it/src/main/resources/tests/variable.test
+++ b/it/src/main/resources/tests/variable.test
@@ -12,7 +12,7 @@
 
     "ignoredFields": ["_id"],
 
-    "ignoreFieldOrder": ["marklogic_json"],
+    "ignoreFieldOrder": ["*"],
 
     "predicate": "containsAtLeast",
 

--- a/it/src/main/resources/tests/variable.test
+++ b/it/src/main/resources/tests/variable.test
@@ -12,7 +12,7 @@
 
     "ignoredFields": ["_id"],
 
-    "ignoreFieldOrder": ["*"],
+    "ignoreFieldOrder": true,
 
     "predicate": "containsAtLeast",
 

--- a/it/src/main/resources/tests/wildcardWithExtraProjections.test
+++ b/it/src/main/resources/tests/wildcardWithExtraProjections.test
@@ -3,8 +3,7 @@
 
   "backends": {
         "mimir": "skip",
-    "mongodb_read_only": "pending",
-    "postgresql":        "pending"
+        "postgresql": "pending"
   },
   "data": "zips.data",
   "query": "select *, concat(city, concat(\", \", state)) as city_state, city = \"BOULDER\" as boulderish from zips where city like \"BOULDER%\"",

--- a/it/src/main/resources/tests/wildcardWithExtraProjections.test
+++ b/it/src/main/resources/tests/wildcardWithExtraProjections.test
@@ -9,7 +9,7 @@
   "data": "zips.data",
   "query": "select *, concat(city, concat(\", \", state)) as city_state, city = \"BOULDER\" as boulderish from zips where city like \"BOULDER%\"",
   "predicate": "containsExactly",
-  "ignoreFieldOrder": [ "*" ],
+  "ignoreFieldOrder": true,
   "expected": [
     { "_id": "80301", "city": "BOULDER",          "loc": [ -105.21426, 40.049733 ],  "pop": 18174.0, "state": "CO", "city_state": "BOULDER, CO",          "boulderish": true  },
     { "_id": "80302", "city": "BOULDER",          "loc": [ -105.285131, 40.017235 ], "pop": 29384.0, "state": "CO", "city_state": "BOULDER, CO",          "boulderish": true  },

--- a/it/src/main/resources/tests/wildcardWithMultipleConstants.test
+++ b/it/src/main/resources/tests/wildcardWithMultipleConstants.test
@@ -3,11 +3,7 @@
 
     "backends": {
         "mimir": "skip",
-      "mongodb_2_6":       "pending",
-      "mongodb_3_0":       "pending",
-      "mongodb_read_only": "pending",
-      "mongodb_q_3_2": "pending",
-      "postgresql":        "pending"
+        "postgresql":        "pending"
     },
 
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/wildcardWithMultipleConstants.test
+++ b/it/src/main/resources/tests/wildcardWithMultipleConstants.test
@@ -16,13 +16,13 @@
     "query": "select *, '1' as one, '2' as two from largeZips",
 
     "predicate": "containsAtLeast",
-    "ignoreFieldOrder": [ "couchbase", "marklogic_json", "marklogic_xml", "spark_local", "spark_hdfs" ],
+    "ignoreFieldOrder": ["*"],
     "expected": [
-        { "_id": "01002", "one": "1", "two": "2", "city": "CUSHMAN",          "loc": [ -72.51565, 42.377017], "pop": 36963, "state": "MA" },
-        { "_id": "01020", "one": "1", "two": "2", "city": "CHICOPEE",         "loc": [-72.576142, 42.176443], "pop": 31495, "state": "MA" },
-        { "_id": "01040", "one": "1", "two": "2", "city": "HOLYOKE",          "loc": [-72.626193, 42.202007], "pop": 43704, "state": "MA" },
-        { "_id": "01060", "one": "1", "two": "2", "city": "FLORENCE",         "loc": [-72.654245, 42.324662], "pop": 27939, "state": "MA" },
-        { "_id": "01085", "one": "1", "two": "2", "city": "MONTGOMERY",       "loc": [-72.754318, 42.129484], "pop": 40117, "state": "MA" },
-        { "_id": "01089", "one": "1", "two": "2", "city": "WEST SPRINGFIELD", "loc": [-72.641109, 42.115066], "pop": 27537, "state": "MA" },
-        { "_id": "01108", "one": "1", "two": "2", "city": "SPRINGFIELD",      "loc": [-72.558432, 42.085314], "pop": 25519, "state": "MA" }]
+        { "_id": "01002", "city": "CUSHMAN",          "loc": [ -72.51565, 42.377017], "pop": 36963, "state": "MA", "one": "1", "two": "2" },
+        { "_id": "01020", "city": "CHICOPEE",         "loc": [-72.576142, 42.176443], "pop": 31495, "state": "MA", "one": "1", "two": "2" },
+        { "_id": "01040", "city": "HOLYOKE",          "loc": [-72.626193, 42.202007], "pop": 43704, "state": "MA", "one": "1", "two": "2" },
+        { "_id": "01060", "city": "FLORENCE",         "loc": [-72.654245, 42.324662], "pop": 27939, "state": "MA", "one": "1", "two": "2" },
+        { "_id": "01085", "city": "MONTGOMERY",       "loc": [-72.754318, 42.129484], "pop": 40117, "state": "MA", "one": "1", "two": "2" },
+        { "_id": "01089", "city": "WEST SPRINGFIELD", "loc": [-72.641109, 42.115066], "pop": 27537, "state": "MA", "one": "1", "two": "2" },
+        { "_id": "01108", "city": "SPRINGFIELD",      "loc": [-72.558432, 42.085314], "pop": 25519, "state": "MA", "one": "1", "two": "2" }]
 }

--- a/it/src/main/resources/tests/wildcardWithMultipleConstants.test
+++ b/it/src/main/resources/tests/wildcardWithMultipleConstants.test
@@ -6,7 +6,6 @@
       "mongodb_2_6":       "pending",
       "mongodb_3_0":       "pending",
       "mongodb_read_only": "pending",
-      "mongodb_3_2":       "pending",
       "mongodb_q_3_2": "pending",
       "postgresql":        "pending"
     },
@@ -16,7 +15,7 @@
     "query": "select *, '1' as one, '2' as two from largeZips",
 
     "predicate": "containsAtLeast",
-    "ignoreFieldOrder": ["*"],
+    "ignoreFieldOrder": true,
     "expected": [
         { "_id": "01002", "city": "CUSHMAN",          "loc": [ -72.51565, 42.377017], "pop": 36963, "state": "MA", "one": "1", "two": "2" },
         { "_id": "01020", "city": "CHICOPEE",         "loc": [-72.576142, 42.176443], "pop": 31495, "state": "MA", "one": "1", "two": "2" },

--- a/it/src/main/resources/tests/wildcardWithSort.test
+++ b/it/src/main/resources/tests/wildcardWithSort.test
@@ -8,7 +8,7 @@
     "query": "select * from zips order by pop, city limit 10",
     "predicate": "equalsExactly",
     "ignoredFields": ["_id"],
-    "ignoreFieldOrder": ["marklogic_json"],
+    "ignoreFieldOrder": ["*"],
     "expected": [
         { "city": "ALGODONES",      "loc": [-106.616589, 35.428527], "pop": 0, "state": "NM" },
         { "city": "ALLEGHANY",      "loc": [-120.727176, 39.512698], "pop": 0, "state": "CA" },

--- a/it/src/main/resources/tests/wildcardWithSort.test
+++ b/it/src/main/resources/tests/wildcardWithSort.test
@@ -8,7 +8,7 @@
     "query": "select * from zips order by pop, city limit 10",
     "predicate": "equalsExactly",
     "ignoredFields": ["_id"],
-    "ignoreFieldOrder": ["*"],
+    "ignoreFieldOrder": true,
     "expected": [
         { "city": "ALGODONES",      "loc": [-106.616589, 35.428527], "pop": 0, "state": "NM" },
         { "city": "ALLEGHANY",      "loc": [-120.727176, 39.512698], "pop": 0, "state": "CA" },

--- a/it/src/main/resources/tests/zipsByCityLength.test
+++ b/it/src/main/resources/tests/zipsByCityLength.test
@@ -1,7 +1,13 @@
 {
     "name": "count occurrences of each value of length(city), with filtering",
     "backends": {
+        "couchbase": "ignoreFieldOrder",
+        "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
+        "mongodb_2_6": "ignoreFieldOrder",
+        "mongodb_3_0": "ignoreFieldOrder",
+        "mongodb_3_2": "ignoreFieldOrder",
+        "mongodb_q_3_2": "ignoreFieldOrder",
         "mongodb_read_only": "pending",
         "postgresql":        "pending"
     },
@@ -11,14 +17,6 @@
                 where state != \"MI\"
                 group by length(city)",
     "predicate": "containsExactly",
-    "ignoreFieldOrder": [
-      "couchbase",
-      "marklogic_json",
-      "mongodb_2_6",
-      "mongodb_3_0",
-      "mongodb_3_2",
-      "mongodb_q_3_2"
-    ],
     "expected": [{ "len":  3, "cnt":   2 },
                  { "len":  4, "cnt":  65 },
                  { "len":  5, "cnt": 206 },

--- a/it/src/test/scala/quasar/regression/BackendIgnoreFieldOrder.scala
+++ b/it/src/test/scala/quasar/regression/BackendIgnoreFieldOrder.scala
@@ -21,5 +21,4 @@ import quasar.BackendName
 
 sealed abstract class IgnoreFieldOrderBackend
 
-final case object IgnoreFieldOrderAllBackends                           extends IgnoreFieldOrderBackend
 final case class  IgnoreFieldOrderBackends(backends: List[BackendName]) extends IgnoreFieldOrderBackend

--- a/it/src/test/scala/quasar/regression/ExpectedResult.scala
+++ b/it/src/test/scala/quasar/regression/ExpectedResult.scala
@@ -26,4 +26,4 @@ case class ExpectedResult(
   predicate:        Predicate,
   ignoredFields:    List[JsonField],
   ignoreFieldOrder: Boolean,
-  backends:         Map[BackendName, SkipDirective])
+  backends:         Map[BackendName, TestDirective])

--- a/it/src/test/scala/quasar/regression/ExpectedResult.scala
+++ b/it/src/test/scala/quasar/regression/ExpectedResult.scala
@@ -17,12 +17,13 @@
 package quasar.regression
 
 import slamdata.Predef._
+import quasar.BackendName
 
 import argonaut._, Json._
 
 case class ExpectedResult(
-  rows:                    List[Json],
-  predicate:               Predicate,
-  ignoredFields:           List[JsonField],
-  ignoreFieldOrderBackend: IgnoreFieldOrderBackend
-)
+  rows:             List[Json],
+  predicate:        Predicate,
+  ignoredFields:    List[JsonField],
+  ignoreFieldOrder: Boolean,
+  backends:         Map[BackendName, SkipDirective])

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -148,8 +148,6 @@ abstract class QueryRegressionTest[S[_]](
         case Some(SkipDirective.Pending) =>
           if (BuildInfo.coverageEnabled)
             Skipped("(pending example skipped during coverage run)")
-          else if (BuildInfo.isCIBuild)
-            Skipped("(pending example skipped during CI build)")
           else
             runTest.pendingUntilFixed
         case _                           => runTest

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -142,10 +142,10 @@ abstract class QueryRegressionTest[S[_]](
 
     s"${test.name} [${posixCodec.printPath(loc)}]" >> {
       test.backends.get(backendName) match {
-        case Some(SkipDirective.Skip)    => skipped
-        case Some(SkipDirective.SkipCI)  =>
+        case Some(TestDirective.Skip)    => skipped
+        case Some(TestDirective.SkipCI)  =>
           BuildInfo.isCIBuild.fold(Skipped("(skipped during CI build)"), runTest)
-        case Some(SkipDirective.Pending) =>
+        case Some(TestDirective.Pending) =>
           if (BuildInfo.coverageEnabled)
             Skipped("(pending example skipped during coverage run)")
           else
@@ -222,7 +222,7 @@ abstract class QueryRegressionTest[S[_]](
       // TODO: Error if a backend ignores field order when the query already does.
       if (exp.ignoreFieldOrder) FieldOrderIgnored
       else exp.backends.get(backendName) match {
-        case Some(SkipDirective.IgnoreAllOrder | SkipDirective.IgnoreFieldOrder) =>
+        case Some(TestDirective.IgnoreAllOrder | TestDirective.IgnoreFieldOrder) =>
           FieldOrderIgnored
         case _ =>
           FieldOrderPreserved

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -222,7 +222,7 @@ abstract class QueryRegressionTest[S[_]](
       // TODO: Error if a backend ignores field order when the query already does.
       if (exp.ignoreFieldOrder) FieldOrderIgnored
       else exp.backends.get(backendName) match {
-        case Some(SkipDirective.IgnoreFieldOrder) =>
+        case Some(SkipDirective.IgnoreAllOrder | SkipDirective.IgnoreFieldOrder) =>
           FieldOrderIgnored
         case _ =>
           FieldOrderPreserved

--- a/it/src/test/scala/quasar/regression/RegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/RegressionTest.scala
@@ -27,7 +27,7 @@ import scalaz._, Scalaz._
 
 case class RegressionTest(
   name:      String,
-  backends:  Map[BackendName, SkipDirective],
+  backends:  Map[BackendName, TestDirective],
   data:      List[RelFile[Unsandboxed]],
   query:     String,
   variables: Map[String, String],
@@ -41,9 +41,9 @@ object RegressionTest {
     DecodeJson(c => for {
       name             <- (c --\ "name").as[String]
       backends         <- if ((c --\ "backends").succeeded)
-                            (c --\ "backends").as[Map[String, SkipDirective]]
+                            (c --\ "backends").as[Map[String, TestDirective]]
                               .map(_ mapKeys (BackendName(_)))
-                          else ok(Map[BackendName, SkipDirective]())
+                          else ok(Map[BackendName, TestDirective]())
       data             <- (c --\ "data").as[List[RelFile[Unsandboxed]]] |||
                           optional[RelFile[Unsandboxed]](c--\ "data").map(_.toList)
       query            <- (c --\ "query").as[String]

--- a/it/src/test/scala/quasar/regression/RegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/RegressionTest.scala
@@ -49,13 +49,10 @@ object RegressionTest {
       query            <- (c --\ "query").as[String]
       variables        <- orElse(c --\ "variables", Map.empty[String, String])
       ignoredFields    <- orElse(c --\ "ignoredFields", List.empty[String])
-      ignoreFieldOrder <- orElse(c --\ "ignoreFieldOrder", List.empty[String]).map {
-                            case v if v.contains("*") => IgnoreFieldOrderAllBackends
-                            case v => IgnoreFieldOrderBackends(v ∘ BackendName.apply)
-                          }
+      ignoreFieldOrder <- orElse(c --\ "ignoreFieldOrder", false)
       rows             <- (c --\ "expected").as[List[Json]]
       predicate        <- (c --\ "predicate").as[Predicate]
     } yield RegressionTest(
       name, backends, data, query, variables,
-      ExpectedResult(rows, predicate, ignoredFields, ignoreFieldOrder)))
+      ExpectedResult(rows, predicate, ignoredFields, ignoreFieldOrder, backends)))
 }

--- a/it/src/test/scala/quasar/regression/SkipDirective.scala
+++ b/it/src/test/scala/quasar/regression/SkipDirective.scala
@@ -23,17 +23,19 @@ import argonaut._, Argonaut._
 sealed abstract class SkipDirective
 
 object SkipDirective {
-  final case object Skip    extends SkipDirective
-  final case object SkipCI  extends SkipDirective
-  final case object Pending extends SkipDirective
+  final case object Skip              extends SkipDirective
+  final case object SkipCI            extends SkipDirective
+  final case object Pending           extends SkipDirective
+  final case object IgnoreFieldOrder  extends SkipDirective
 
   import DecodeResult.{ok, fail}
 
   implicit val SkipDirectiveDecodeJson: DecodeJson[SkipDirective] =
     DecodeJson(c => c.as[String].flatMap {
-      case "skip"    => ok(Skip)
-      case "skipCI"  => ok(SkipCI)
-      case "pending" => ok(Pending)
-      case str       => fail("skip, skipCI, pending; found: \"" + str + "\"", c.history)
+      case "skip"              => ok(Skip)
+      case "skipCI"            => ok(SkipCI)
+      case "pending"           => ok(Pending)
+      case "ignoreFieldOrder"  => ok(IgnoreFieldOrder)
+      case str => fail("\"" + str + "\" is not a valid backend directive.", c.history)
     })
 }

--- a/it/src/test/scala/quasar/regression/SkipDirective.scala
+++ b/it/src/test/scala/quasar/regression/SkipDirective.scala
@@ -26,7 +26,9 @@ object SkipDirective {
   final case object Skip              extends SkipDirective
   final case object SkipCI            extends SkipDirective
   final case object Pending           extends SkipDirective
+  final case object IgnoreAllOrder    extends SkipDirective
   final case object IgnoreFieldOrder  extends SkipDirective
+  final case object IgnoreResultOrder extends SkipDirective
 
   import DecodeResult.{ok, fail}
 
@@ -35,7 +37,9 @@ object SkipDirective {
       case "skip"              => ok(Skip)
       case "skipCI"            => ok(SkipCI)
       case "pending"           => ok(Pending)
+      case "ignoreAllOrder"    => ok(IgnoreAllOrder)
       case "ignoreFieldOrder"  => ok(IgnoreFieldOrder)
+      case "ignoreResultOrder" => ok(IgnoreResultOrder)
       case str => fail("\"" + str + "\" is not a valid backend directive.", c.history)
     })
 }

--- a/it/src/test/scala/quasar/regression/TestDirective.scala
+++ b/it/src/test/scala/quasar/regression/TestDirective.scala
@@ -20,19 +20,19 @@ import slamdata.Predef._
 
 import argonaut._, Argonaut._
 
-sealed abstract class SkipDirective
+sealed abstract class TestDirective
 
-object SkipDirective {
-  final case object Skip              extends SkipDirective
-  final case object SkipCI            extends SkipDirective
-  final case object Pending           extends SkipDirective
-  final case object IgnoreAllOrder    extends SkipDirective
-  final case object IgnoreFieldOrder  extends SkipDirective
-  final case object IgnoreResultOrder extends SkipDirective
+object TestDirective {
+  final case object Skip              extends TestDirective
+  final case object SkipCI            extends TestDirective
+  final case object Pending           extends TestDirective
+  final case object IgnoreAllOrder    extends TestDirective
+  final case object IgnoreFieldOrder  extends TestDirective
+  final case object IgnoreResultOrder extends TestDirective
 
   import DecodeResult.{ok, fail}
 
-  implicit val SkipDirectiveDecodeJson: DecodeJson[SkipDirective] =
+  implicit val TestDirectiveDecodeJson: DecodeJson[TestDirective] =
     DecodeJson(c => c.as[String].flatMap {
       case "skip"              => ok(Skip)
       case "skipCI"            => ok(SkipCI)


### PR DESCRIPTION
We now treat `"ignoreFieldHandling"` the similarly to `"skip"` or `"pending"` in regression tests.