### PR TITLE
Use pending instead of skip whenever possible in integration tests.

### DIFF
--- a/it/src/main/resources/tests/basicAnalyticQuery.test
+++ b/it/src/main/resources/tests/basicAnalyticQuery.test
@@ -1,7 +1,7 @@
 {
     "name": "basic analytic query",
     "backends": {
-        "couchbase":      "skip",
+        "couchbase": "ignoreFieldOrder",
         "marklogic_json": "ignoreFieldOrder",
         "mimir":          "skip",
         "mongodb_q_3_2":  "pending",

--- a/it/src/main/resources/tests/caseVariations.test
+++ b/it/src/main/resources/tests/caseVariations.test
@@ -3,16 +3,16 @@
 
     "backends": {
         "mimir": "skip",
-        "couchbase":  "skip",
-        "marklogic_json": "skip",
-        "marklogic_xml":  "skip",
+        "couchbase":  "pending",
+        "marklogic_json": "pending",
+        "marklogic_xml":  "pending",
         "mongodb_q_3_2": "pending",
         "postgresql": "pending",
         "spark_local": "pending",
         "spark_hdfs": "pending"
     },
 
-    "NB": "Skipped for all connectors due to reduce/sort ordering bug.
+    "NB": "Disabled for all connectors due to reduce/sort ordering bug.
            Bug is fixed on @sellout's new mongo branch, but the fix breaks old mongo.
 
            This is tricky because the sort key does not appear in the result.

--- a/it/src/main/resources/tests/caseWithGroup.test
+++ b/it/src/main/resources/tests/caseWithGroup.test
@@ -4,10 +4,10 @@
     "backends": {
         "mimir": "skip",
         "postgresql": "pending",
-        "marklogic_json":  "skip",
-        "marklogic_xml":   "skip",
+        "marklogic_json": "pending",
+        "marklogic_xml": "pending",
         "mongodb_q_3_2": "pending",
-        "couchbase":  "skip",
+        "couchbase": "pending",
         "spark_local": "pending",
         "spark_hdfs": "pending"
     },
@@ -28,7 +28,7 @@
                 group by state
                 order by funnel, state",
 
-    "note": "should be `equalsInitial`, with a separate `containsAtLeast` with
+    "FIXME": "should be `equalsInitial`, with a separate `containsAtLeast` with
              the IL entry (and perhaps others).",
     "predicate": "containsAtLeast",
     "expected": [{ "abbr": "CO", "quantity":  414, "funnel":   1 },

--- a/it/src/main/resources/tests/citiesByLargestZip.test
+++ b/it/src/main/resources/tests/citiesByLargestZip.test
@@ -2,7 +2,7 @@
     "name": "cities with largest individual zip codes",
     "backends": {
         "mimir": "skip",
-        "couchbase":  "skip",
+        "couchbase":  "pending",
         "marklogic_json": "pending",
         "marklogic_xml":  "pending",
         "mongodb_q_3_2": "pending",

--- a/it/src/main/resources/tests/citiesByTotalPopulation.test
+++ b/it/src/main/resources/tests/citiesByTotalPopulation.test
@@ -1,10 +1,8 @@
 {
     "name": "top 5 cities by total population",
 
-    "NB": "Couchbase is skipped due to largish generated N1QL that leads to a timeout.",
-
     "backends": {
-        "couchbase":         "skip",
+        "couchbase":         "ignoreFieldOrder",
         "mimir":             "skip",
         "mongodb_2_6":       "ignoreFieldOrder",
         "mongodb_3_0":       "ignoreFieldOrder",

--- a/it/src/main/resources/tests/demo/nestedSelectWithReduce.test
+++ b/it/src/main/resources/tests/demo/nestedSelectWithReduce.test
@@ -2,9 +2,9 @@
     "name": "select reduction from nested select",
     "backends": {
         "mimir": "skip",
-        "couchbase": "skip",
-        "marklogic_json": "skip",
-        "marklogic_xml": "skip",
+        "couchbase": "pending",
+        "marklogic_json": "pending",
+        "marklogic_xml": "pending",
         "mongodb_read_only": "pending",
         "mongodb_2_6": "pending",
         "mongodb_3_0": "pending",

--- a/it/src/main/resources/tests/filterWithComplexNot.test
+++ b/it/src/main/resources/tests/filterWithComplexNot.test
@@ -1,18 +1,17 @@
 {
     "name": "filter with complex query involving not",
 
-    "NB": "Couchbase disabled due to heap exhaustion",
-
     "backends": {
         "mimir": "skip",
-        "postgresql":        "pending",
-        "couchbase":         "skip"
+        "postgresql": "pending"
     },
 
     "data": "largeZips.data",
 
-    "query": "select `_id` as zip from largeZips
-              where not (city not like \"BOULD%\" or state != \"CO\" or (pop between 20000 and 40000 and loc[1] != 40.017235))",
+    "query": "select `_id` as zip from largeZips where
+                not (city not like \"BOULD%\" or
+                state != \"CO\" or
+                (pop between 20000 and 40000 and loc[1] != 40.017235))",
 
     "predicate": "containsExactly",
     "expected": [{ "zip": "80301" },

--- a/it/src/main/resources/tests/flattenArrayLeftWithUnflattened.test
+++ b/it/src/main/resources/tests/flattenArrayLeftWithUnflattened.test
@@ -2,7 +2,7 @@
     "name": "flatten array on the left with unflattened field",
     "backends": {
         "mimir": "skip",
-        "couchbase": "skip",
+        "couchbase": "pending",
         "marklogic_json": "ignoreFieldOrder",
         "mongodb_q_3_2": "pending",
         "postgresql": "pending"

--- a/it/src/main/resources/tests/flattenArrayWithUnflattened.test
+++ b/it/src/main/resources/tests/flattenArrayWithUnflattened.test
@@ -1,7 +1,7 @@
 {
     "name": "flatten array with unflattened field",
     "backends": {
-        "couchbase":  "skip",
+        "couchbase": "pending",
         "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
         "postgresql": "pending"

--- a/it/src/main/resources/tests/flattenGroupedObject.test
+++ b/it/src/main/resources/tests/flattenGroupedObject.test
@@ -2,7 +2,7 @@
     "name": "flatten a grouped object with filter",
     "backends": {
         "mimir": "skip",
-        "couchbase":         "skip",
+        "couchbase":         "pending",
         "marklogic_json":    "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending",

--- a/it/src/main/resources/tests/groupByFlatten.test
+++ b/it/src/main/resources/tests/groupByFlatten.test
@@ -2,9 +2,9 @@
     "name": "group by flattened field",
     "backends": {
         "mimir": "skip",
-        "couchbase":  "skip",
-        "marklogic_json": "skip",
-        "marklogic_xml":  "skip",
+        "couchbase": "pending",
+        "marklogic_json": "pending",
+        "marklogic_xml": "pending",
         "mongodb_q_3_2": "pending",
         "postgresql": "pending",
 	"spark_local": "pending",

--- a/it/src/main/resources/tests/largestCities.test
+++ b/it/src/main/resources/tests/largestCities.test
@@ -1,10 +1,7 @@
 {
     "name": "largest cities",
 
-    "NB": "Couchbase is skipped due to largish generated N1QL that leads to a timeout.",
-
     "backends": {
-        "couchbase":  "skip",
         "mimir": "skip",
         "mongodb_2_6": "ignoreFieldOrder",
         "mongodb_3_0": "ignoreFieldOrder",

--- a/it/src/main/resources/tests/locationCount.test
+++ b/it/src/main/resources/tests/locationCount.test
@@ -2,7 +2,7 @@
     "name": "job postings by city ",
     "backends": {
         "mimir": "skip",
-        "couchbase":         "skip",
+        "couchbase":         "pending",
         "marklogic_json":    "pending",
         "marklogic_xml":     "skip",
         "mongodb_2_6":       "pending",
@@ -15,6 +15,7 @@
         "spark_hdfs":        "pending",
         "spark_local":       "pending"
     },
+    "NB": "Skipped for marklogic_xml because it times out.",
     "data": "jobs_jobinfo.data",
     "query": "select count(PositionHeader.PositionLocation.LocationCity) as counter,
               PositionHeader.PositionLocation.LocationCity as location

--- a/it/src/main/resources/tests/multistageFlatten.test
+++ b/it/src/main/resources/tests/multistageFlatten.test
@@ -2,14 +2,15 @@
     "name": "multi-flatten with fields at various depths",
     "backends": {
         "mimir": "skip",
-        "couchbase":  "skip",
-        "marklogic_json": "skip",
-        "marklogic_xml":  "skip",
+        "couchbase": "pending",
+        "marklogic_json": "pending",
+        "marklogic_xml": "skip",
         "mongodb_q_3_2": "pending",
         "postgresql": "pending",
         "spark_local": "skip",
         "spark_hdfs": "skip"
     },
+    "NB": "Skipped for spark and marklogic_xml because it times out.",
     "data": "nested_foo.data",
     "query": "select * from nested_foo where (
                 foo              LIKE \"%zap%\" OR

--- a/it/src/main/resources/tests/multitypeFlatten.test
+++ b/it/src/main/resources/tests/multitypeFlatten.test
@@ -2,14 +2,15 @@
     "name": "flatten a single field as both object and array",
     "backends": {
         "mimir": "skip",
-        "couchbase":         "skip",
-        "marklogic_json":    "skip",
+        "couchbase":         "pending",
+        "marklogic_json":    "pending",
         "marklogic_xml":     "skip",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending",
-        "spark_local":       "skip",
-        "spark_hdfs":        "skip"
+        "spark_local":       "pending",
+        "spark_hdfs":        "pending"
     },
+    "NB": "Skipped for marklogic_xml because it times out.",
     "data": "nested_foo.data",
     "query": "select * from nested_foo where (
                 foo{*} LIKE \"%15%\" OR

--- a/it/src/main/resources/tests/null/nullTestExprs.test
+++ b/it/src/main/resources/tests/null/nullTestExprs.test
@@ -3,8 +3,8 @@
     "backends": {
         "couchbase": "ignoreFieldOrder",
         "mimir": "skip",
-        "marklogic_json": "skip",
-        "marklogic_xml":  "skip",
+        "marklogic_json": "pending",
+        "marklogic_xml": "pending",
         "postgresql": "pending"
     },
     "data": "nulls.data",

--- a/it/src/main/resources/tests/null/nullTestExprsWithMissing.test
+++ b/it/src/main/resources/tests/null/nullTestExprsWithMissing.test
@@ -9,11 +9,11 @@
         "mongodb_3_4":       "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending",
-        "marklogic_json":    "skip",
-        "marklogic_xml":     "skip",
-        "couchbase":         "skip",
-        "spark_local": "skip",
-        "spark_hdfs": "skip"
+        "marklogic_json":    "pending",
+        "marklogic_xml":     "pending",
+        "couchbase":         "pending",
+        "spark_local": "pending",
+        "spark_hdfs": "pending"
     },
     "data": "nullsWithMissing.data",
     "query": "select name,

--- a/it/src/main/resources/tests/projectFieldWithFlatten.test
+++ b/it/src/main/resources/tests/projectFieldWithFlatten.test
@@ -1,7 +1,7 @@
 {
     "name": "project unrelated field with object flatten",
     "backends": {
-        "couchbase": "skip",
+        "couchbase": "pending",
         "mimir": "skip",
         "postgresql": "pending"
     },

--- a/it/src/main/resources/tests/projectIndexWithObjectFlatten.test
+++ b/it/src/main/resources/tests/projectIndexWithObjectFlatten.test
@@ -1,7 +1,7 @@
 {
     "name": "project index with object flatten",
     "backends": {
-        "couchbase":         "skip",
+        "couchbase":         "pending",
         "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
         "mongodb_q_3_2":     "pending",

--- a/it/src/main/resources/tests/servlet.test
+++ b/it/src/main/resources/tests/servlet.test
@@ -2,7 +2,7 @@
     "name": "servlets with and without init-param (pending #465, #467)",
     "backends": {
         "mimir": "skip",
-        "couchbase":         "skip",
+        "couchbase":         "pending",
         "marklogic_json":    "pending",
         "marklogic_xml":     "pending",
         "mongodb_2_6":       "pending",

--- a/it/src/main/resources/tests/shortCities.test
+++ b/it/src/main/resources/tests/shortCities.test
@@ -2,7 +2,7 @@
     "name": "shortest city names",
     "backends": {
         "mimir": "skip",
-        "couchbase":         "skip",
+        "couchbase":         "pending",
         "marklogic_json":    "pending",
         "marklogic_xml":     "pending",
         "mongodb_q_3_2":     "pending",
@@ -10,7 +10,7 @@
         "spark_hdfs":        "pending",
         "spark_local":       "pending"
     },
-    "NB": "Skipped for all QScript connectors due to reduce/sort ordering bug.
+    "NB": "Pending for all QScript connectors due to reduce/sort ordering bug.
            Bug is fixed on @sellout's new mongo branch, but the fix breaks old mongo.",
     "data": "largeZips.data",
     "query": "select distinct city from largeZips order by length(city), city limit 5",

--- a/it/src/main/resources/tests/skipCount.test
+++ b/it/src/main/resources/tests/skipCount.test
@@ -3,7 +3,7 @@
 
     "backends": {
         "mimir": "skip",
-        "couchbase":      "skip",
+        "couchbase":      "pending",
         "marklogic_json": "skip",
         "marklogic_xml":  "skip",
         "mongodb_q_3_2":  "pending",
@@ -13,7 +13,8 @@
     },
 
     "NB": "#1748: Disabled in spark due to ListMap serialization stack overflow.
-           #2122: Improves the qscript, but the qscript _should_ currently be correct.",
+           #2122: Improves the qscript, but the qscript _should_ currently be correct.
+           Skipped for marklogic because it times out.",
 
     "data": "zips.data",
 

--- a/it/src/main/resources/tests/statesByShortestFirstCity.test
+++ b/it/src/main/resources/tests/statesByShortestFirstCity.test
@@ -2,7 +2,7 @@
     "name": "states sorted by the length of name of their first city, alphabetically",
     "backends": {
         "mimir": "skip",
-        "couchbase": "skip",
+        "couchbase": "pending",
         "postgresql": "pending"
     },
     "description": "combines an aggregate function (min) with a function implemented in JS (length)",

--- a/it/src/main/resources/tests/temporal/time.test
+++ b/it/src/main/resources/tests/temporal/time.test
@@ -1,10 +1,8 @@
 {
     "name": "filter on time_of_day",
 
-    "NB": "Couchbase disabled due to heap exhaustion",
-
     "backends": {
-        "couchbase":         "skip",
+        "couchbase":         "pending",
         "mimir": "skip",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",

--- a/it/src/main/resources/tests/temporal/timestampsAndIntervals.test
+++ b/it/src/main/resources/tests/temporal/timestampsAndIntervals.test
@@ -3,7 +3,7 @@
 
     "backends": {
         "mimir": "skip",
-        "couchbase":      "skip",
+        "couchbase":      "pending",
         "marklogic_json": "pending",
         "marklogic_xml":  "pending",
         "mongodb_q_3_2":  "pending",

--- a/it/src/main/resources/tests/unifyFlattenedFields.test
+++ b/it/src/main/resources/tests/unifyFlattenedFields.test
@@ -2,7 +2,7 @@
     "name": "unify flattened fields",
     "backends": {
         "mimir": "skip",
-        "couchbase":  "skip",
+        "couchbase":  "pending",
         "postgresql": "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/unifyFlattenedFieldsWithMultipleUses.test
+++ b/it/src/main/resources/tests/unifyFlattenedFieldsWithMultipleUses.test
@@ -2,14 +2,15 @@
     "name": "unify flattened fields with multiple shape-preserving ops.",
     "backends": {
         "mimir": "skip",
-        "couchbase":  "skip",
+        "couchbase": "pending",
         "marklogic_json": "skip",
-        "marklogic_xml":  "skip",
+        "marklogic_xml": "skip",
         "mongodb_q_3_2": "pending",
         "postgresql": "pending",
         "spark_local": "pending",
         "spark_hdfs": "pending"
     },
+    "NB": "Skipped in marklogic because it times out.",
     "data": "zips.data",
     "query": "select `_id` as zip, loc[*] from zips where loc[*] > 68 order by loc[*]",
     "predicate": "equalsExactly",

--- a/it/src/main/resources/tests/unifyFlattenedFieldsWithUnflattened.test
+++ b/it/src/main/resources/tests/unifyFlattenedFieldsWithUnflattened.test
@@ -2,7 +2,7 @@
     "name": "unify flattened fields with unflattened field",
     "backends": {
         "mimir": "skip",
-        "couchbase":  "skip",
+        "couchbase":  "pending",
         "mongodb_q_3_2": "pending",
         "postgresql": "pending"
     },

--- a/it/src/main/resources/tests/union.test
+++ b/it/src/main/resources/tests/union.test
@@ -2,7 +2,7 @@
     "name": "union",
     "backends": {
         "mimir": "skip",
-        "couchbase":         "skip",
+        "couchbase":         "pending",
         "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },


### PR DESCRIPTION
Adds a note about why a test is skipped if it is indeed still skipped.

Also note that all `mimir` tests that require loaded data are skipped. After we enable loading we will en masse change these over to `pending`.