### PR TITLE
Don’t create an autojoin when one side is a constant.

### DIFF
--- a/connector/src/main/scala/quasar/qscript/Transform.scala
+++ b/connector/src/main/scala/quasar/qscript/Transform.scala
@@ -86,9 +86,11 @@ class Transform
 
     (left.value, right.value) match {
       case (Embed(QC(Unreferenced())), r) =>
-        AutoJoinResult(AutoJoinBase(r, rann.provenance), lann.values, rann.values)
+        val buckets = prov.joinProvenances(List(provenance.Nada()), rann.provenance)
+        AutoJoinResult(AutoJoinBase(r, buckets), lann.values, rann.values)
       case (l, Embed(QC(Unreferenced()))) =>
-        AutoJoinResult(AutoJoinBase(l, lann.provenance), lann.values, rann.values)
+        val buckets = prov.joinProvenances(lann.provenance, List(provenance.Nada()))
+        AutoJoinResult(AutoJoinBase(l, buckets), lann.values, rann.values)
       case (l, r) =>
         val SrcMerge(src, lBranch, rBranch) = merge.mergeT(l, r)
 

--- a/connector/src/main/scala/quasar/qscript/Transform.scala
+++ b/connector/src/main/scala/quasar/qscript/Transform.scala
@@ -86,10 +86,10 @@ class Transform
 
     (left.value, right.value) match {
       case (Embed(QC(Unreferenced())), r) =>
-        val buckets = prov.joinProvenances(List(provenance.Nada()), rann.provenance)
+        val buckets = prov.joinProvenances(lann.provenance, rann.provenance)
         AutoJoinResult(AutoJoinBase(r, buckets), lann.values, rann.values)
       case (l, Embed(QC(Unreferenced()))) =>
-        val buckets = prov.joinProvenances(lann.provenance, List(provenance.Nada()))
+        val buckets = prov.joinProvenances(lann.provenance, rann.provenance)
         AutoJoinResult(AutoJoinBase(l, buckets), lann.values, rann.values)
       case (l, r) =>
         val SrcMerge(src, lBranch, rBranch) = merge.mergeT(l, r)

--- a/connector/src/test/scala/quasar/qscript/QScript.scala
+++ b/connector/src/test/scala/quasar/qscript/QScript.scala
@@ -408,35 +408,26 @@ class QScriptSpec
           HoleF,
           IncludeId,
           Free.roll(ConcatArrays(
-            Free.roll(ConcatArrays(
-              Free.roll(MakeArray(
-                Free.roll(MakeArray(ProjectIndexR(RightSideF, IntLit(0)))))),
-              Free.roll(MakeArray(ProjectIndexR(RightSideF, IntLit(1)))))),
-            Free.roll(Constant(ejsonArr(ejsonStr("loc")))))))),
+            Free.roll(MakeArray(LeftSideF)),
+            Free.roll(MakeArray(RightSideF)))))),
         QC.inj(LeftShift((),
           ProjectFieldR(
-            ProjectIndexR(HoleF, IntLit(1)),
-            ProjectIndexR(HoleF, IntLit(2))),
+            ProjectIndexR(ProjectIndexR(HoleF, IntLit(1)), IntLit(1)),
+            StrLit("loc")),
           IdOnly,
           Free.roll(ConcatArrays(
-            Free.roll(ConcatArrays(
-              Free.roll(MakeArray(
-                Free.roll(ConcatArrays(
-                  Free.roll(MakeArray(RightSideF)),
-                  Free.roll(MakeArray(
-                    ProjectIndexR(
-                      ProjectIndexR(LeftSideF, IntLit(0)),
-                      IntLit(0)))))))),
-              Free.roll(MakeArray(RightSideF)))),
-            Free.roll(Constant(ejsonArr(ejsonInt(10)))))))),
+            Free.roll(MakeArray(LeftSideF)),
+            Free.roll(MakeArray(RightSideF)))))),
         QC.inj(Reduce((),
           Free.roll(MakeArray(
-            ProjectIndexR(ProjectIndexR(HoleF, IntLit(0)), IntLit(1)))),
+            ProjectIndexR(
+              ProjectIndexR(ProjectIndexR(HoleF, IntLit(0)), IntLit(1)),
+              IntLit(0)))),
           List(
             ReduceFuncs.UnshiftArray(
               Free.roll(Multiply(
                 ProjectIndexR(HoleF, IntLit(1)),
-                ProjectIndexR(HoleF, IntLit(2)))))),
+                IntLit(10))))),
           Free.roll(MakeMap[Fix, FreeMapA[ReduceIndex]](
             StrLit[Fix, ReduceIndex]("0"),
             ReduceIndexF(0.some))))))(
@@ -946,50 +937,47 @@ class QScriptSpec
           ConcatArraysR(
             MakeArrayR(ConcatArraysR(
               ConcatArraysR(
-                MakeArrayR(MakeArrayR(ProjectIndexR(RightSideF, IntLit(0)))),
-                Free.roll(Constant(ejsonArr(ejsonStr("city"))))),
-              MakeArrayR(
-                ProjectFieldR(
+                ConcatArraysR(
+                  MakeArrayR(MakeArrayR(ProjectIndexR(RightSideF, IntLit(0)))),
+                  MakeArrayR(MakeArrayR(ProjectIndexR(RightSideF, IntLit(0))))),
+                MakeArrayR(ProjectIndexR(RightSideF, IntLit(1)))),
+              MakeArrayR(ProjectIndexR(RightSideF, IntLit(1))))),
+            MakeArrayR(ConcatArraysR(
+              ConcatArraysR(
+                ConcatArraysR(
+                  MakeArrayR(MakeArrayR(ProjectIndexR(RightSideF, IntLit(0)))),
+                  MakeArrayR(MakeArrayR(ProjectIndexR(RightSideF, IntLit(0))))),
+                MakeArrayR(ProjectFieldR(
                   Free.roll(Guard(
                     ProjectIndexR(RightSideF, IntLit(1)),
                     Type.Obj(ScalaMap(), Some(Type.Top)),
                     ProjectIndexR(RightSideF, IntLit(1)),
                     Free.roll(Undefined()))),
-                  StrLit("city"))))),
-            MakeArrayR(ConcatArraysR(
-              ConcatArraysR(
-                MakeArrayR(MakeArrayR(ProjectIndexR(RightSideF, IntLit(0)))),
-                MakeArrayR(ConcatArraysR(
-                  ConcatArraysR(
-                    ConcatArraysR(
-                      MakeArrayR(MakeArrayR(ProjectIndexR(RightSideF, IntLit(0)))),
-                      MakeArrayR(MakeArrayR(ProjectIndexR(RightSideF, IntLit(0))))),
-                    MakeArrayR(ProjectFieldR(
-                      Free.roll(Guard(
-                        ProjectIndexR(RightSideF, IntLit(1)),
-                        Type.Obj(ScalaMap(), Some(Type.Top)),
-                        ProjectIndexR(RightSideF, IntLit(1)),
-                        Free.roll(Undefined()))),
-                      StrLit("loc")))),
-                  MakeArrayR(ProjectFieldR(
-                    Free.roll(Guard(
-                      ProjectIndexR(RightSideF, IntLit(1)),
-                      Type.Obj(ScalaMap(), Some(Type.Top)),
-                      ProjectIndexR(RightSideF, IntLit(1)),
-                      Free.roll(Undefined()))),
-                    StrLit("loc")))))),
-              MakeArrayR(Free.roll(Undefined()))))))),
+                  StrLit("loc")))),
+              MakeArrayR(ProjectFieldR(
+                Free.roll(Guard(
+                  ProjectIndexR(RightSideF, IntLit(1)),
+                  Type.Obj(ScalaMap(), Some(Type.Top)),
+                  ProjectIndexR(RightSideF, IntLit(1)),
+                  Free.roll(Undefined()))),
+                StrLit("loc")))))))),
         QC.inj(LeftShift((),
           Free.roll(Guard(
-            ProjectIndexR(ProjectIndexR(ProjectIndexR(HoleF, IntLit(1)), IntLit(1)), IntLit(2)),
+            ProjectIndexR(ProjectIndexR(HoleF, IntLit(1)), IntLit(2)),
             Type.FlexArr(0, None, Type.Top),
-            ProjectIndexR(ProjectIndexR(ProjectIndexR(HoleF, IntLit(1)), IntLit(1)), IntLit(3)),
-            ProjectIndexR(ProjectIndexR(HoleF, IntLit(1)), IntLit(2)))),
+            ProjectIndexR(ProjectIndexR(HoleF, IntLit(1)), IntLit(3)),
+            Free.roll(Undefined()))),
           ExcludeId,
           ConcatMapsR(
             MakeMapR(
-              ProjectIndexR(ProjectIndexR(LeftSideF, IntLit(0)), IntLit(1)),
-              ProjectIndexR(ProjectIndexR(LeftSideF, IntLit(0)), IntLit(2))),
+              StrLit("city"),
+              ProjectFieldR(
+                Free.roll(Guard(
+                  ProjectIndexR(ProjectIndexR(LeftSideF, IntLit(0)), IntLit(2)),
+                  Type.Obj(ScalaMap(), Some(Type.Top)),
+                  ProjectIndexR(ProjectIndexR(LeftSideF, IntLit(0)), IntLit(3)),
+                  Free.roll(Undefined()))),
+                StrLit("city"))),
             MakeMapR(StrLit("loc"), RightSideF)))))(
         implicitly, Corecursive[Fix[QS], QS])))
     }

--- a/it/src/main/resources/tests/flattenArrayLeftWithUnflattened.test
+++ b/it/src/main/resources/tests/flattenArrayLeftWithUnflattened.test
@@ -4,7 +4,6 @@
         "mimir": "skip",
         "couchbase": "pending",
         "marklogic_json": "ignoreFieldOrder",
-        "mongodb_q_3_2": "pending",
         "postgresql": "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/projectIndexWithObjectFlatten.test
+++ b/it/src/main/resources/tests/projectIndexWithObjectFlatten.test
@@ -4,7 +4,6 @@
         "couchbase":         "pending",
         "marklogic_json": "ignoreFieldOrder",
         "mimir": "skip",
-        "mongodb_q_3_2":     "pending",
         "postgresql":        "pending"
     },
     "data": "slamengine_commits.data",

--- a/it/src/main/resources/tests/selectCount.test
+++ b/it/src/main/resources/tests/selectCount.test
@@ -1,0 +1,16 @@
+{
+    "name": "select count and another field",
+    "backends": {
+        "couchbase": "pending",
+        "mimir": "skip",
+        "mongodb_q_3_2": "pending",
+        "postgresql": "pending"
+    },
+    "data": "slamengine_commits.data",
+    "query": "select committer.login, count(*) from slamengine_commits",
+    "predicate": "atLeast",
+    "ignoreResultOrder": true,
+    "expected": [
+        { "login": "sellout", "1": 30 },
+        { "login": "mossprescott", "1": 30 }]
+}

--- a/it/src/main/resources/tests/unifyFlattenedFieldsWithUnflattened.test
+++ b/it/src/main/resources/tests/unifyFlattenedFieldsWithUnflattened.test
@@ -3,7 +3,6 @@
     "backends": {
         "mimir": "skip",
         "couchbase":  "pending",
-        "mongodb_q_3_2": "pending",
         "postgresql": "pending"
     },
     "data": "zips.data",


### PR DESCRIPTION
This avoids indirect access to constant values, which is something we can hopefully promise to connectors – that constants never have to be dereferenced.

The Mongo tests that are fixed by this is somewhat accidental. First, we can’t do `ProjectField` or `MakeMap` in Mongo expressions if the name of the field isn’t a constant string, which means we fall back to JS. And the old code _should_ work in JS, but isn’t currently supported (because it involves reaching outside our pure subset of JS, since you can only add dynamic field names with mutation 😭).