### PR TITLE
Fix pretty printing of modules

### DIFF
--- a/core/src/main/scala/quasar/fs/mount/MountConfig.scala
+++ b/core/src/main/scala/quasar/fs/mount/MountConfig.scala
@@ -85,7 +85,7 @@ object MountConfig {
     case FileSystemConfig(typ, uri) =>
       typ.value -> uri.value
     case ModuleConfig(statements) =>
-      "module" -> statements.pprint[Fix[Sql]]
+      "module" -> statements.pprint
   }
 
   val fromConfigPair: (String, String) => String \/ MountConfig = {
@@ -102,7 +102,7 @@ object MountConfig {
   implicit val mountConfigCodecJson: CodecJson[MountConfig] =
     CodecJson({
       case ModuleConfig(statements)   =>
-        Json("module" := statements.pprint[Fix[Sql]])
+        Json("module" := statements.pprint)
       case ViewConfig(query, vars)    =>
         Json("view" := Json("connectionUri" := ConnectionUri(viewCfgAsUri(query, vars)).value))
       case FileSystemConfig(typ, uri) =>

--- a/frontend/src/main/scala/quasar/sql/ScopedExpr.scala
+++ b/frontend/src/main/scala/quasar/sql/ScopedExpr.scala
@@ -19,8 +19,10 @@ package quasar.sql
 import slamdata.Predef._
 import quasar._, RenderTree.ops._
 
+import matryoshka.Recursive
 import monocle.macros.Lenses
 import scalaz._, Scalaz._
+import scalaz.Liskov._
 
 @Lenses final case class ScopedExpr[T](expr: T, scope: List[Statement[T]]) {
   def mapExpressionM[M[_]:Functor](f: T => M[T]): M[ScopedExpr[T]] =
@@ -29,6 +31,10 @@ import scalaz._, Scalaz._
     scope.collect { case i: Import[_] => i }
   def defs: List[FunctionDecl[T]] =
     scope.collect { case d: FunctionDecl[_] => d }
+  def pprint[T1](implicit ev: T <~< T1, T1: Recursive.Aux[T1, Sql]): String = {
+    val scopeString = if (scope.isEmpty) "" else scope.pprint + ";\n"
+    scopeString + sql.pprint(ev(expr))
+  }
 }
 
 object ScopedExpr {

--- a/frontend/src/main/scala/quasar/sql/ScopedExpr.scala
+++ b/frontend/src/main/scala/quasar/sql/ScopedExpr.scala
@@ -22,7 +22,6 @@ import quasar._, RenderTree.ops._
 import matryoshka.Recursive
 import monocle.macros.Lenses
 import scalaz._, Scalaz._
-import scalaz.Liskov._
 
 @Lenses final case class ScopedExpr[T](expr: T, scope: List[Statement[T]]) {
   def mapExpressionM[M[_]:Functor](f: T => M[T]): M[ScopedExpr[T]] =
@@ -31,9 +30,9 @@ import scalaz.Liskov._
     scope.collect { case i: Import[_] => i }
   def defs: List[FunctionDecl[T]] =
     scope.collect { case d: FunctionDecl[_] => d }
-  def pprint[T1](implicit ev: T <~< T1, T1: Recursive.Aux[T1, Sql]): String = {
+  def pprint(implicit T: Recursive.Aux[T, Sql]): String = {
     val scopeString = if (scope.isEmpty) "" else scope.pprint + ";\n"
-    scopeString + sql.pprint(ev(expr))
+    scopeString + sql.pprint(expr)
   }
 }
 

--- a/frontend/src/main/scala/quasar/sql/package.scala
+++ b/frontend/src/main/scala/quasar/sql/package.scala
@@ -208,8 +208,8 @@ package object sql {
     def imports: List[Import[A]] =
       a.collect { case i: Import[_] => i }
 
-    def pprint[T](implicit T: Recursive.Aux[T, Sql], ev: A <~< T): String =
-      a.map(st => st.map(b => sql.pprint(ev(b))).pprint).mkString(";\n")
+    def pprint(implicit T: Recursive.Aux[A, Sql]): String =
+      a.map(st => st.map(b => sql.pprint(b)).pprint).mkString(";\n")
   }
 
   def pprint[T](sql: T)(implicit T: Recursive.Aux[T, Sql]) = sql.para(pprintƒ)

--- a/frontend/src/test/scala/quasar/sql/ExprArbitrary.scala
+++ b/frontend/src/test/scala/quasar/sql/ExprArbitrary.scala
@@ -34,11 +34,11 @@ trait ExprArbitrary {
   implicit val exprArbitrary: Arbitrary[Fix[Sql]] = Arbitrary(selectGen(4))
 
   implicit val exprShrink: Shrink[Fix[Sql]] = Shrink (expr => (expr.project match {
-    case s @ Select(distinct, proj, relation, filter, groupBy, orderBy) =>
-      shrink(distinct).map(d => s.copy(isDistinct = d)) append
-      relation.map(κ(s.copy(relation = None))).toStream    append
-      filter.map(κ(s.copy(filter = None))).toStream        append
-      groupBy.map(κ(s.copy(groupBy = None))).toStream      append
+    case s @ Select(_, projections, relation, filter, groupBy, orderBy) =>
+      shrink(projections).map(p => s.copy(projections = p)) append
+      relation.map(κ(s.copy(relation = None))).toStream     append
+      filter.map(κ(s.copy(filter = None))).toStream         append
+      groupBy.map(κ(s.copy(groupBy = None))).toStream       append
       orderBy.map(κ(s.copy(orderBy = None))).toStream
     case ArrayLiteral(elems) => shrink(elems).map(ArrayLiteral(_))
     case SetLiteral(elems)  => shrink(elems).map(SetLiteral(_))

--- a/frontend/src/test/scala/quasar/sql/SqlParserSpec.scala
+++ b/frontend/src/test/scala/quasar/sql/SqlParserSpec.scala
@@ -681,14 +681,14 @@ class SQLParserSpec extends quasar.Qspec {
     }.set(minTestsOk = 1000) // one cannot test a parser too much
 
     "round-trip module" >> prop { module: List[Statement[Fix[Sql]]] =>
-      val back = fixParser.parseModule(module.pprint[Fix[Sql]])
+      val back = fixParser.parseModule(module.pprint)
 
       back must beRightDisjOrDiff(module)
     }
 
     "pprint an import statement should escpae backticks" >> {
       val `import` = Import[Fix[Sql]](currentDir </> dir("di") </> dir("k`~ireW.5u1+fOh") </> dir("j"))
-      val string = List(`import`).pprint[Fix[Sql]]
+      val string = List(`import`).pprint
       string must_== raw"import `./di/k\`~ireW.5u1+fOh/j/`"
       fixParser.parseModule(string) must_=== List(`import`).right
     }


### PR DESCRIPTION
Incorrect pretty printing of module mounts was making them invalid and unable to be mounted.

- Fix pretty printing of import statements
  - First off the `posicCodec.printPath` was not being called yielding completely bogus Sql^2
  - Secondly backticks need to be espcaped
- Generator for `Statement` was changed to produce only alpha characters in import paths for now in order for the round-trip to work
- Add instances of `Shrink` for `Fix[Sql]` and `Statement[Fix[Sql]]`
- remove unnecessary call to `makeTables(Nil)` in tests (since it's already being called in the parser)
- Add a space in pretty printing between arguments of a function
- Add tests for module round-trip and specific backtick situation
- Fix small bug in function `_qq`