### PR TITLE
Use `ZonedDateTime` in precog along with misc blueeyes cleanup

### DIFF
--- a/blueeyes/src/main/scala/quasar/blueeyes/Perf.scala
+++ b/blueeyes/src/main/scala/quasar/blueeyes/Perf.scala
@@ -19,6 +19,8 @@ package quasar.blueeyes
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
+import scala.annotation.tailrec
+
 /**
   * This object contains some methods to do faster iteration over primitives.
   *

--- a/blueeyes/src/main/scala/quasar/blueeyes/json/AsyncParser.scala
+++ b/blueeyes/src/main/scala/quasar/blueeyes/json/AsyncParser.scala
@@ -22,6 +22,7 @@ import scala.math.max
 
 import java.nio.ByteBuffer
 
+import scala.annotation.switch
 import scala.collection.mutable
 
 case class AsyncParse(errors: Seq[ParseException], values: Seq[JValue])

--- a/blueeyes/src/main/scala/quasar/blueeyes/json/ByteBasedParser.scala
+++ b/blueeyes/src/main/scala/quasar/blueeyes/json/ByteBasedParser.scala
@@ -16,7 +16,7 @@
 
 package quasar.blueeyes.json
 
-import quasar.blueeyes._
+import scala.annotation.switch
 
 /**
   * Trait used when the data to be parsed is in UTF-8.

--- a/blueeyes/src/main/scala/quasar/blueeyes/json/CharBasedParser.scala
+++ b/blueeyes/src/main/scala/quasar/blueeyes/json/CharBasedParser.scala
@@ -16,9 +16,9 @@
 
 package quasar.blueeyes.json
 
-import quasar.blueeyes._
-
 import java.lang.Character.isHighSurrogate
+
+import scala.annotation.switch
 
 /**
   * Trait used when the data to be parsed is in UTF-16.

--- a/blueeyes/src/main/scala/quasar/blueeyes/json/JValue.scala
+++ b/blueeyes/src/main/scala/quasar/blueeyes/json/JValue.scala
@@ -22,6 +22,7 @@ import quasar.precog.ToString
 
 import scalaz._, Scalaz._
 
+import scala.annotation.{switch, tailrec}
 import scala.collection.immutable.ListMap
 import scala.util.Sorting.quickSort
 import scala.util.Try

--- a/blueeyes/src/main/scala/quasar/blueeyes/json/Parser.scala
+++ b/blueeyes/src/main/scala/quasar/blueeyes/json/Parser.scala
@@ -16,9 +16,8 @@
 
 package quasar.blueeyes.json
 
-import quasar.blueeyes._
+import scala.annotation.{switch, tailrec}
 
-import scala.annotation.{ switch, tailrec }
 import java.lang.Integer.parseInt
 
 // underlying parser code adapted from jawn under MIT license.

--- a/blueeyes/src/main/scala/quasar/blueeyes/json/SyncParser.scala
+++ b/blueeyes/src/main/scala/quasar/blueeyes/json/SyncParser.scala
@@ -16,8 +16,7 @@
 
 package quasar.blueeyes.json
 
-import quasar.blueeyes._
-
+import scala.annotation.switch
 import scala.collection.mutable
 
 private[json] trait SyncParser extends Parser {

--- a/blueeyes/src/main/scala/quasar/blueeyes/json/serialization/Decomposer.scala
+++ b/blueeyes/src/main/scala/quasar/blueeyes/json/serialization/Decomposer.scala
@@ -18,6 +18,7 @@ package quasar.blueeyes.json.serialization
 
 import quasar.blueeyes._
 import quasar.blueeyes.json._
+import quasar.precog.{MimeType, MimeTypes}
 
 import scalaz._, Scalaz._
 import ExtractorDecomposer.by

--- a/blueeyes/src/main/scala/quasar/blueeyes/json/serialization/IsoSerialization.scala
+++ b/blueeyes/src/main/scala/quasar/blueeyes/json/serialization/IsoSerialization.scala
@@ -16,7 +16,7 @@
 
 package quasar.blueeyes.json.serialization
 
-import quasar.blueeyes.{HNil => _, _}, json._, Extractor._
+import quasar.blueeyes._, json._, Extractor._
 
 import scalaz._
 import shapeless._

--- a/blueeyes/src/main/scala/quasar/blueeyes/package.scala
+++ b/blueeyes/src/main/scala/quasar/blueeyes/package.scala
@@ -35,9 +35,6 @@ package object blueeyes extends precog.PackageTime {
 
   type ByteBufferPoolS[A] = State[(ByteBufferPool, List[ByteBuffer]), A]
 
-  val HNil = shapeless.HNil
-  val Iso  = shapeless.Generic
-
   def Utf8Charset: Charset                                               = Charset forName "UTF-8"
   def utf8Bytes(s: String): Array[Byte]                                  = s getBytes Utf8Charset
   def uuid(s: String): UUID                                              = UUID fromString s

--- a/blueeyes/src/main/scala/quasar/blueeyes/package.scala
+++ b/blueeyes/src/main/scala/quasar/blueeyes/package.scala
@@ -29,10 +29,6 @@ import java.nio.charset.Charset
 import java.util.UUID
 
 package object blueeyes extends precog.PackageTime {
-  type MimeType = quasar.precog.MimeType
-  val MimeType  = quasar.precog.MimeType
-  val MimeTypes = quasar.precog.MimeTypes
-
   type ByteBufferPoolS[A] = State[(ByteBufferPool, List[ByteBuffer]), A]
 
   def Utf8Charset: Charset                                               = Charset forName "UTF-8"

--- a/blueeyes/src/main/scala/quasar/blueeyes/package.scala
+++ b/blueeyes/src/main/scala/quasar/blueeyes/package.scala
@@ -16,6 +16,7 @@
 
 package quasar
 
+import quasar.precog.BitSet
 import quasar.precog.util._
 
 import scalaz._
@@ -32,9 +33,6 @@ package object blueeyes extends precog.PackageTime {
   val MimeType  = quasar.precog.MimeType
   val MimeTypes = quasar.precog.MimeTypes
 
-  type BitSet             = quasar.precog.BitSet
-  type RawBitSet          = Array[Int]
-  val RawBitSet           = quasar.precog.util.RawBitSet
   type ByteBufferPoolS[A] = State[(ByteBufferPool, List[ByteBuffer]), A]
 
   val HNil = shapeless.HNil

--- a/blueeyes/src/main/scala/quasar/blueeyes/package.scala
+++ b/blueeyes/src/main/scala/quasar/blueeyes/package.scala
@@ -32,18 +32,12 @@ package object blueeyes extends precog.PackageTime {
   type ByteBufferPoolS[A] = State[(ByteBufferPool, List[ByteBuffer]), A]
 
   def Utf8Charset: Charset                                               = Charset forName "UTF-8"
-  def utf8Bytes(s: String): Array[Byte]                                  = s getBytes Utf8Charset
   def uuid(s: String): UUID                                              = UUID fromString s
   def randomUuid(): UUID                                                 = UUID.randomUUID
-  def randomInt(end: Int): Int                                           = scala.util.Random.nextInt(end)
   def ByteBufferWrap(xs: Array[Byte]): ByteBuffer                        = ByteBuffer.wrap(xs)
   def ByteBufferWrap(xs: Array[Byte], offset: Int, len: Int): ByteBuffer = ByteBuffer.wrap(xs, offset, len)
   def abort(msg: String): Nothing                                        = throw new RuntimeException(msg)
   def decimal(d: String): BigDecimal                                     = BigDecimal(d, java.math.MathContext.UNLIMITED)
-  def lp[T](label: String): T => Unit                                    = (t: T) => println(label + ": " + t)
-  def lpf[T](label: String)(f: T => Any): T => Unit                      = (t: T) => println(label + ": " + f(t))
-
-  def doto[A](x: A)(f: A => Unit): A = { f(x) ; x }
 
   implicit val GlobalEC: ExecutionContext = scala.concurrent.ExecutionContext.global
 
@@ -60,6 +54,7 @@ package object blueeyes extends precog.PackageTime {
     def sortMe(implicit z: scalaz.Order[A]): Vector[A] =
       xs sortWith ((a, b) => z.order(a, b) == Ordering.LT) toVector
   }
+
   def arrayEq[@specialized A](a1: Array[A], a2: Array[A]): Boolean = {
     val len = a1.length
     if (len != a2.length) return false

--- a/blueeyes/src/main/scala/quasar/blueeyes/package.scala
+++ b/blueeyes/src/main/scala/quasar/blueeyes/package.scala
@@ -28,15 +28,10 @@ import java.nio.charset.Charset
 import java.util.UUID
 
 package object blueeyes extends precog.PackageTime {
-  type spec    = scala.specialized
-  type switch  = scala.annotation.switch
-  type tailrec = scala.annotation.tailrec
-
   type MimeType = quasar.precog.MimeType
   val MimeType  = quasar.precog.MimeType
   val MimeTypes = quasar.precog.MimeTypes
 
-  // Temporary
   type BitSet             = quasar.precog.BitSet
   type RawBitSet          = Array[Int]
   val RawBitSet           = quasar.precog.util.RawBitSet

--- a/blueeyes/src/main/scala/quasar/blueeyes/util/Clock.scala
+++ b/blueeyes/src/main/scala/quasar/blueeyes/util/Clock.scala
@@ -61,16 +61,16 @@ object Clock {
 
 trait ClockSystem {
   implicit val realtimeClock = new Clock {
-    def now(): LocalDateTime    = dateTime.now()
+    def now(): LocalDateTime = dateTime.now()
     def instant(): Instant = quasar.blueeyes.instant.now()
-    def nanoTime(): Long   = System.nanoTime()
+    def nanoTime(): Long = System.nanoTime()
   }
 }
 object ClockSystem extends ClockSystem
 
 trait ClockMock {
   protected class MockClock extends Clock {
-    private var _now: LocalDateTime  = dateTime.zero
+    private var _now: LocalDateTime = dateTime.zero
     private var _nanoTime: Long = 0
 
     def now() = _now

--- a/blueeyes/src/main/scala/quasar/precog/common/CValue.scala
+++ b/blueeyes/src/main/scala/quasar/precog/common/CValue.scala
@@ -22,7 +22,7 @@ import quasar.blueeyes._, json._, serialization._
 import DefaultSerialization._
 import scalaz._, Scalaz._, Ordering._
 import java.math.MathContext.UNLIMITED
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 sealed trait RValue { self =>
   def toJValue: JValue
@@ -342,7 +342,7 @@ object CType {
 }
 
 object CValueType {
-  def apply[A](implicit A: CValueType[A]): CValueType[A]          = A
+  def apply[A](implicit A: CValueType[A]): CValueType[A] = A
   def apply[A](a: A)(implicit A: CValueType[A]): CWrappedValue[A] = A(a)
 
   // These let us do, def const[A: CValueType](a: A): CValue = CValueType[A](a)
@@ -351,7 +351,7 @@ object CValueType {
   implicit def long: CValueType[Long]                     = CLong
   implicit def double: CValueType[Double]                 = CDouble
   implicit def bigDecimal: CValueType[BigDecimal]         = CNum
-  implicit def dateTime: CValueType[LocalDateTime]             = CDate
+  implicit def dateTime: CValueType[ZonedDateTime]        = CDate
   implicit def period: CValueType[Period]                 = CPeriod
   implicit def array[A](implicit elemType: CValueType[A]) = CArrayType(elemType)
 }
@@ -505,15 +505,15 @@ case object CNum extends CNumericType[BigDecimal] {
 //
 // Dates and Periods
 //
-case class CDate(value: LocalDateTime) extends CWrappedValue[LocalDateTime] {
+case class CDate(value: ZonedDateTime) extends CWrappedValue[ZonedDateTime] {
   val cType = CDate
 }
 
-case object CDate extends CValueType[LocalDateTime] {
-  val classTag: CTag[LocalDateTime]      = implicitly[CTag[LocalDateTime]]
+case object CDate extends CValueType[ZonedDateTime] {
+  val classTag: CTag[ZonedDateTime]      = implicitly[CTag[ZonedDateTime]]
   def readResolve()                     = CDate
-  def order(v1: LocalDateTime, v2: LocalDateTime) = sys.error("todo")
-  def jValueFor(v: LocalDateTime)            = JString(v.toString)
+  def order(v1: ZonedDateTime, v2: ZonedDateTime) = sys.error("todo")
+  def jValueFor(v: ZonedDateTime)            = JString(v.toString)
 }
 
 case class CPeriod(value: Period) extends CWrappedValue[Period] {

--- a/blueeyes/src/main/scala/quasar/precog/common/Metadata.scala
+++ b/blueeyes/src/main/scala/quasar/precog/common/Metadata.scala
@@ -25,6 +25,8 @@ import quasar.blueeyes.json.serialization.Versioned._
 import scalaz._
 import scalaz.std.string._
 
+import shapeless.HNil
+
 sealed trait MetadataType
 
 object MetadataType {

--- a/blueeyes/src/main/scala/quasar/precog/common/accounts/Account.scala
+++ b/blueeyes/src/main/scala/quasar/precog/common/accounts/Account.scala
@@ -26,6 +26,8 @@ import quasar.blueeyes.json.serialization.Versioned._
 
 import scalaz.syntax.plus._
 
+import shapeless.HNil
+
 import java.time.LocalDateTime
 
 case class AccountPlan(planType: String)

--- a/blueeyes/src/main/scala/quasar/precog/common/accounts/AccountDetails.scala
+++ b/blueeyes/src/main/scala/quasar/precog/common/accounts/AccountDetails.scala
@@ -22,6 +22,8 @@ import quasar.precog.common.security.APIKey
 import quasar.blueeyes._, json._, serialization._
 import Iso8601Serialization._, Versioned._
 
+import shapeless.HNil
+
 import java.time.LocalDateTime
 
 case class AccountDetails(accountId: AccountId,

--- a/blueeyes/src/main/scala/quasar/precog/common/ingest/FileContent.scala
+++ b/blueeyes/src/main/scala/quasar/precog/common/ingest/FileContent.scala
@@ -18,6 +18,8 @@ package quasar.precog.common
 package ingest
 
 import quasar.blueeyes._, json._, serialization._
+import quasar.precog.{MimeType, MimeTypes}
+
 import DefaultSerialization._
 import Versioned._
 import Extractor._

--- a/blueeyes/src/main/scala/quasar/precog/common/ingest/Ingest.scala
+++ b/blueeyes/src/main/scala/quasar/precog/common/ingest/Ingest.scala
@@ -25,6 +25,8 @@ import IsoSerialization._, Iso8601Serialization._, Versioned._
 import Extractor._
 import scalaz._, Scalaz._, Validation._
 
+import shapeless.HNil
+
 import java.util.UUID
 
 sealed trait Event {

--- a/blueeyes/src/main/scala/quasar/precog/common/ingest/IngestMessage.scala
+++ b/blueeyes/src/main/scala/quasar/precog/common/ingest/IngestMessage.scala
@@ -22,6 +22,9 @@ import security._
 
 import quasar.blueeyes._, json._, serialization._
 import IsoSerialization._, Iso8601Serialization._, Versioned._, Extractor._
+
+import shapeless.HNil
+
 import scalaz._, Scalaz._, Validation._
 
 sealed trait EventMessage {

--- a/blueeyes/src/main/scala/quasar/precog/common/jobs/FileStorage.scala
+++ b/blueeyes/src/main/scala/quasar/precog/common/jobs/FileStorage.scala
@@ -16,7 +16,7 @@
 
 package quasar.precog.common.jobs
 
-import quasar.blueeyes.MimeType
+import quasar.precog.MimeType
 
 import scalaz.StreamT
 

--- a/blueeyes/src/main/scala/quasar/precog/common/jobs/InMemoryFileStorage.scala
+++ b/blueeyes/src/main/scala/quasar/precog/common/jobs/InMemoryFileStorage.scala
@@ -18,7 +18,7 @@ package quasar.precog.common.jobs
 
 import scala.collection.mutable
 
-import quasar.blueeyes.MimeType
+import quasar.precog.MimeType
 
 import scalaz._
 

--- a/blueeyes/src/main/scala/quasar/precog/common/jobs/JobManager.scala
+++ b/blueeyes/src/main/scala/quasar/precog/common/jobs/JobManager.scala
@@ -17,7 +17,7 @@
 package quasar.precog.common.jobs
 
 import quasar.blueeyes.json._
-import quasar.blueeyes.MimeType
+import quasar.precog.MimeType
 import quasar.precog.common.security._
 
 import java.time.LocalDateTime

--- a/blueeyes/src/main/scala/quasar/precog/common/security/APIKey.scala
+++ b/blueeyes/src/main/scala/quasar/precog/common/security/APIKey.scala
@@ -19,6 +19,9 @@ package security
 
 import quasar.blueeyes._, json._, serialization._
 import IsoSerialization._, Iso8601Serialization._, Versioned._
+
+import shapeless.HNil
+
 import scalaz._, Scalaz._
 
 case class APIKeyRecord(apiKey: APIKey, name: Option[String], description: Option[String], issuerKey: APIKey, grants: Set[GrantId], isRoot: Boolean)

--- a/blueeyes/src/main/scala/quasar/precog/common/security/Grant.scala
+++ b/blueeyes/src/main/scala/quasar/precog/common/security/Grant.scala
@@ -27,6 +27,8 @@ import quasar.blueeyes.json.serialization.Versioned._
 
 import scalaz._, Scalaz._
 
+import shapeless.HNil
+
 import java.time.LocalDateTime
 
 case class Grant(grantId: GrantId,

--- a/blueeyes/src/main/scala/quasar/precog/common/security/service/v1.scala
+++ b/blueeyes/src/main/scala/quasar/precog/common/security/service/v1.scala
@@ -23,6 +23,8 @@ import quasar.blueeyes.json.serialization.Iso8601Serialization._
 
 import quasar.precog.common.security._
 
+import shapeless.HNil
+
 import java.time.LocalDateTime
 
 object v1 {

--- a/blueeyes/src/main/scala/quasar/precog/util/BitSetUtil.scala
+++ b/blueeyes/src/main/scala/quasar/precog/util/BitSetUtil.scala
@@ -17,6 +17,9 @@
 package quasar.precog.util
 
 import quasar.blueeyes._
+import quasar.precog.BitSet
+
+import scala.annotation.tailrec
 
 object BitSetUtil {
   class BitSetOperations(private val bs: BitSet) extends AnyVal {

--- a/blueeyes/src/main/scala/quasar/precog/util/utilclasses.scala
+++ b/blueeyes/src/main/scala/quasar/precog/util/utilclasses.scala
@@ -38,7 +38,7 @@ import java.io.{File, FileReader, IOException}
 import java.io.RandomAccessFile
 import java.nio.channels.{ FileChannel, FileLock => JFileLock }
 import java.nio.file.Files
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 import java.util.Arrays.fill
 import java.util.Properties
 
@@ -335,7 +335,7 @@ object NumericComparisons {
 
   @inline def compare(a: BigDecimal, b: BigDecimal): Int = a compare b
 
-  @inline def compare(a: LocalDateTime, b: LocalDateTime): Int = {
+  @inline def compare(a: ZonedDateTime, b: ZonedDateTime): Int = {
     val res: Int = a compareTo b
     if (res < 0) -1
     else if (res > 0) 1
@@ -379,7 +379,7 @@ object NumericComparisons {
   @inline def order(a: BigDecimal, b: BigDecimal): scalaz.Ordering =
     scalaz.Ordering.fromInt(compare(a, b))
 
-  @inline def order(a: LocalDateTime, b: LocalDateTime): scalaz.Ordering =
+  @inline def order(a: ZonedDateTime, b: ZonedDateTime): scalaz.Ordering =
     scalaz.Ordering.fromInt(compare(a, b))
 }
 

--- a/blueeyes/src/main/scala/quasar/precog/util/utilclasses.scala
+++ b/blueeyes/src/main/scala/quasar/precog/util/utilclasses.scala
@@ -29,6 +29,7 @@ import scalaz._
 import scalaz.effect.IO
 import scalaz.Ordering.{LT, EQ, GT}
 
+import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable.Builder
@@ -384,7 +385,7 @@ object NumericComparisons {
 }
 
 object RawBitSet {
-  final def create(size: Int): RawBitSet = new Array[Int]((size >>> 5) + 1)
+  final def create(size: Int): Array[Int] = new Array[Int]((size >>> 5) + 1)
 
   final def get(bits: Array[Int], i: Int): Boolean = {
     val pos = i >>> 5

--- a/blueeyes/src/test/scala/quasar/precog/common/jobs/FileStorageSpec.scala
+++ b/blueeyes/src/test/scala/quasar/precog/common/jobs/FileStorageSpec.scala
@@ -16,8 +16,8 @@
 
 package quasar.precog.common.jobs
 
-import quasar.blueeyes._
-import quasar.blueeyes.MimeTypes.{html, plain}
+import quasar.precog.MimeTypes
+import quasar.precog.MimeTypes.{html, plain}
 
 import org.specs2.mutable._
 

--- a/mimir/src/main/scala/quasar/mimir/AssignClusters.scala
+++ b/mimir/src/main/scala/quasar/mimir/AssignClusters.scala
@@ -16,10 +16,10 @@
 
 package quasar.mimir
 
+import quasar.precog.BitSet
+import quasar.precog.common._
 import quasar.precog.util._
 import quasar.yggdrasil._, table._
-import quasar.blueeyes._
-import quasar.precog.common._
 
 import scalaz._, Scalaz._
 import spire.implicits._

--- a/mimir/src/main/scala/quasar/mimir/Evaluator.scala
+++ b/mimir/src/main/scala/quasar/mimir/Evaluator.scala
@@ -26,8 +26,11 @@ import quasar.yggdrasil.vfs._
 import quasar.precog.util._
 
 import org.slf4j.LoggerFactory
-import scala.collection.immutable.Queue
+
 import scalaz._, Scalaz._, StateT._
+
+import scala.annotation.tailrec
+import scala.collection.immutable.Queue
 
 trait EvaluatorModule[M[+ _]]
     extends CrossOrdering

--- a/mimir/src/main/scala/quasar/mimir/ModelLib.scala
+++ b/mimir/src/main/scala/quasar/mimir/ModelLib.scala
@@ -16,10 +16,11 @@
 
 package quasar.mimir
 
-import quasar.blueeyes._
+import quasar.precog.BitSet
+import quasar.precog.common._
 import quasar.precog.util._
 import quasar.yggdrasil._, table._
-import quasar.precog.common._
+
 import scalaz._, Scalaz._
 
 trait ModelLibModule[M[+ _]] {

--- a/mimir/src/main/scala/quasar/mimir/QueryLogger.scala
+++ b/mimir/src/main/scala/quasar/mimir/QueryLogger.scala
@@ -16,15 +16,15 @@
 
 package quasar.mimir
 
-import quasar.blueeyes._
-
 import org.slf4j.LoggerFactory
 
 import scalaz._
 import scalaz.syntax.monad._
 
-import scala.collection.JavaConverters._
 import java.util.concurrent.ConcurrentHashMap
+
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
 
 trait QueryLogger[M[+ _], -P] { self =>
   def contramap[P0](f: P0 => P): QueryLogger[M, P0] = new QueryLogger[M, P0] {

--- a/mimir/src/main/scala/quasar/mimir/StdLib.scala
+++ b/mimir/src/main/scala/quasar/mimir/StdLib.scala
@@ -23,7 +23,7 @@ import quasar.yggdrasil.table._
 
 import scalaz._, Scalaz._
 
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 trait TableLibModule[M[+ _]] extends TableModule[M] with TransSpecModule {
   type Lib <: TableLib
@@ -301,7 +301,7 @@ object StdLib {
       def apply(row: Int) = f(c(row))
     }
 
-    class Dt(c: DateColumn, defined: LocalDateTime => Boolean, f: LocalDateTime => String) extends Map1Column(c) with StrColumn {
+    class Dt(c: DateColumn, defined: ZonedDateTime => Boolean, f: ZonedDateTime => String) extends Map1Column(c) with StrColumn {
 
       override def isDefinedAt(row: Int) =
         super.isDefinedAt(row) && defined(c(row))
@@ -362,7 +362,7 @@ object StdLib {
       def apply(row: Int) = f(c(row))
     }
 
-    class Dt(c: DateColumn, defined: LocalDateTime => Boolean, f: LocalDateTime => Long) extends Map1Column(c) with LongColumn {
+    class Dt(c: DateColumn, defined: ZonedDateTime => Boolean, f: ZonedDateTime => Long) extends Map1Column(c) with LongColumn {
 
       override def isDefinedAt(row: Int) =
         super.isDefinedAt(row) && defined(c(row))
@@ -738,7 +738,7 @@ object StdLib {
       def apply(row: Int) = f(c1(row), c2(row))
     }
 
-    class Dt(c: DateColumn, defined: LocalDateTime => Boolean, f: LocalDateTime => Boolean) extends Map1Column(c) with BoolColumn {
+    class Dt(c: DateColumn, defined: ZonedDateTime => Boolean, f: ZonedDateTime => Boolean) extends Map1Column(c) with BoolColumn {
 
       override def isDefinedAt(row: Int) =
         super.isDefinedAt(row) && defined(c(row))
@@ -746,7 +746,7 @@ object StdLib {
       def apply(row: Int) = f(c(row))
     }
 
-    class DtDt(c1: DateColumn, c2: DateColumn, defined: (LocalDateTime, LocalDateTime) => Boolean, f: (LocalDateTime, LocalDateTime) => Boolean)
+    class DtDt(c1: DateColumn, c2: DateColumn, defined: (ZonedDateTime, ZonedDateTime) => Boolean, f: (ZonedDateTime, ZonedDateTime) => Boolean)
         extends Map2Column(c1, c2)
         with BoolColumn {
 

--- a/mimir/src/main/scala/quasar/mimir/StringLib.scala
+++ b/mimir/src/main/scala/quasar/mimir/StringLib.scala
@@ -16,7 +16,7 @@
 
 package quasar.mimir
 
-import quasar.blueeyes._
+import quasar.precog.BitSet
 import quasar.precog.common._
 import quasar.yggdrasil.bytecode._
 

--- a/niflheim/src/main/scala/quasar/niflheim/Segments.scala
+++ b/niflheim/src/main/scala/quasar/niflheim/Segments.scala
@@ -23,7 +23,7 @@ import quasar.precog.util._
 
 import scala.collection.mutable
 
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 case class CTree(path: CPath, fields: mutable.Map[String, CTree], indices: mutable.ArrayBuffer[CTree], types: mutable.Map[CType, Int]) {
   def getField(s: String): CTree = fields.getOrElseUpdate(s, CTree.empty(CPath(path.nodes :+ CPathField(s))))
@@ -111,10 +111,10 @@ case class Segments(id: Long, var length: Int, t: CTree, a: mutable.ArrayBuffer[
     }
   }
 
-  def detectDateTime(s: String): LocalDateTime = {
+  def detectDateTime(s: String): ZonedDateTime = {
     if (!DateTimeUtil.looksLikeIso8601(s)) return null
     try {
-      DateTimeUtil.parseDateTime(s/*, true*/).toLocalDateTime // !!???
+      DateTimeUtil.parseDateTime(s)
     } catch {
       case e: IllegalArgumentException => null
     }
@@ -129,19 +129,19 @@ case class Segments(id: Long, var length: Int, t: CTree, a: mutable.ArrayBuffer[
     }
   }
 
-  def addRealDateTime(row: Int, tree: CTree, s: LocalDateTime) {
+  def addRealDateTime(row: Int, tree: CTree, s: ZonedDateTime) {
     val n = tree.getType(CDate)
     if (n >= 0) {
-      val seg = a(n).asInstanceOf[ArraySegment[LocalDateTime]]
+      val seg = a(n).asInstanceOf[ArraySegment[ZonedDateTime]]
       seg.defined.set(row)
       seg.values(row) = s
     } else {
       tree.setType(CDate, a.length)
       val d = new BitSet()
       d.set(row)
-      val v = new Array[LocalDateTime](length)
+      val v = new Array[ZonedDateTime](length)
       v(row) = s
-      a.append(ArraySegment[LocalDateTime](id, tree.path, CDate, d, v))
+      a.append(ArraySegment[ZonedDateTime](id, tree.path, CDate, d, v))
     }
   }
 

--- a/niflheim/src/main/scala/quasar/niflheim/Segments.scala
+++ b/niflheim/src/main/scala/quasar/niflheim/Segments.scala
@@ -16,8 +16,8 @@
 
 package quasar.niflheim
 
-import quasar.blueeyes._
 import quasar.blueeyes.json._
+import quasar.precog.BitSet
 import quasar.precog.common._
 import quasar.precog.util._
 

--- a/niflheim/src/main/scala/quasar/niflheim/V1SegmentFormat.scala
+++ b/niflheim/src/main/scala/quasar/niflheim/V1SegmentFormat.scala
@@ -213,7 +213,7 @@ object V1SegmentFormat extends SegmentFormat {
     case CLong => Codec.PackedLongCodec
     case CDouble => Codec.DoubleCodec
     case CNum => Codec.BigDecimalCodec
-    case CDate => Codec.DateCodec
+    case CDate => Codec.ZonedDateTimeCodec
     case CArrayType(elemType) =>
       Codec.ArrayCodec(getCodecFor(elemType))(elemType.classTag)
   }

--- a/niflheim/src/test/scala/quasar/niflheim/SegmentFormatSpec.scala
+++ b/niflheim/src/test/scala/quasar/niflheim/SegmentFormatSpec.scala
@@ -24,7 +24,7 @@ import org.specs2._
 import org.specs2.mutable.Specification
 import org.scalacheck._, Prop._
 
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 class V1SegmentFormatSpec extends SegmentFormatSpec {
   val format = V1SegmentFormat
@@ -72,7 +72,7 @@ trait SegmentFormatSpec extends Specification with ScalaCheck with SegmentFormat
       surviveRoundTrip(ArraySegment(1234L, CPath("a.b.c"), CDouble, EmptyBitSet, new Array[Double](0)))
       surviveRoundTrip(ArraySegment(1234L, CPath("a.b.c"), CNum, EmptyBitSet, new Array[BigDecimal](0)))
       surviveRoundTrip(ArraySegment(1234L, CPath("a.b.c"), CString, EmptyBitSet, new Array[String](0)))
-      surviveRoundTrip(ArraySegment(1234L, CPath("a.b.c"), CDate, EmptyBitSet, new Array[LocalDateTime](0)))
+      surviveRoundTrip(ArraySegment(1234L, CPath("a.b.c"), CDate, EmptyBitSet, new Array[ZonedDateTime](0)))
     }
     "roundtrip simple boolean segment" in {
       val segment = BooleanSegment(1234L, CPath("a.b.c"),

--- a/niflheim/src/test/scala/quasar/niflheim/SegmentFormatSupport.scala
+++ b/niflheim/src/test/scala/quasar/niflheim/SegmentFormatSupport.scala
@@ -33,7 +33,7 @@ import scala.reflect.ClassTag
 import java.io.IOException
 import java.nio.ByteBuffer
 import java.nio.channels._
-import java.time.{LocalDateTime, ZoneOffset}
+import java.time.{Instant, ZonedDateTime, ZoneOffset}
 
 trait SegmentFormatSupport {
   import Gen._
@@ -59,7 +59,8 @@ trait SegmentFormatSupport {
     case CDouble => arbitrary[Double]
     case CNum => arbitrary[BigDecimal]
     case CDate =>
-      Gen.choose[Long](0, 1494284624296L).map(LocalDateTime.ofEpochSecond(_, 0, ZoneOffset.UTC))
+      Gen.choose[Long](0, 1494284624296L).map(t =>
+        ZonedDateTime.ofInstant(Instant.ofEpochSecond(t % Instant.MAX.getEpochSecond), ZoneOffset.UTC))
     case CArrayType(elemType: CValueType[a]) =>
       implicit val tag = elemType.classTag    // don't try to pass this explicitly!
       val list: Gen[List[a]] = listOf(genForCType(elemType))

--- a/precog/src/main/scala/quasar/precog/time.scala
+++ b/precog/src/main/scala/quasar/precog/time.scala
@@ -36,7 +36,7 @@ trait PackageTime {
     def getMillis: Long       = toDuration.getMillis
     def toDuration: Duration = java.time.Duration from x
   }
-  implicit class QuasarDateTimeOps(private val x: LocalDateTime) {
+  implicit class QuasarLocalDateTimeOps(private val x: LocalDateTime) {
     def until(end: LocalDateTime): Period = java.time.Period.between(x.toLocalDate, end.toLocalDate)
     def toUtcInstant: Instant        = x toInstant UTC
     def getMillis: Long              = toUtcInstant.toEpochMilli

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/Schema.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/Schema.scala
@@ -17,9 +17,10 @@
 package quasar.yggdrasil
 
 import quasar.blueeyes._
-import table._
+import quasar.precog.BitSet
 import quasar.precog.common._
 import quasar.yggdrasil.bytecode._
+import quasar.yggdrasil.table._
 
 object Schema {
   def ctypes(jtype: JType): Set[CType] = jtype match {

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/StorageMetadata.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/StorageMetadata.scala
@@ -16,7 +16,7 @@
 
 package quasar.yggdrasil
 
-import quasar.blueeyes._
+import quasar.precog.MimeType
 import quasar.precog.common._
 
 case class PathMetadata(path: Path, pathType: PathMetadata.PathType)

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/TableModule.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/TableModule.scala
@@ -29,7 +29,7 @@ import scalaz._
 import scalaz.syntax.monad._
 
 import java.nio.CharBuffer
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 // TODO: define better upper/lower bound methods, better comparisons,
 // better names, better everything!
@@ -140,7 +140,7 @@ trait TableModule[M[+ _]] extends TransSpecModule {
     def constLong(v: Set[Long]): Table
     def constDouble(v: Set[Double]): Table
     def constDecimal(v: Set[BigDecimal]): Table
-    def constDate(v: Set[LocalDateTime]): Table
+    def constDate(v: Set[ZonedDateTime]): Table
     def constBoolean(v: Set[Boolean]): Table
     def constNull: Table
 

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/execution/EvaluationContext.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/execution/EvaluationContext.scala
@@ -20,6 +20,8 @@ import quasar.blueeyes._, json._, serialization._
 import Iso8601Serialization._, Versioned._
 import quasar.precog.common._, security._, accounts._
 
+import shapeless.HNil
+
 import java.time.LocalDateTime
 
 final case class EvaluationContext(apiKey: APIKey, account: AccountDetails, basePath: Path, scriptPath: Path, startTime: LocalDateTime)

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/execution/Platform.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/execution/Platform.scala
@@ -17,7 +17,6 @@
 package quasar.yggdrasil.execution
 
 import quasar.precog.common.security._
-import quasar.yggdrasil.vfs._
 
 import scalaz._
 

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/execution/QueryExecutor.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/execution/QueryExecutor.scala
@@ -21,7 +21,7 @@ import quasar.yggdrasil.vfs._
 
 import quasar.precog.common._
 
-import quasar.blueeyes.{ MimeType, MimeTypes }
+import quasar.precog.{MimeType, MimeTypes}
 
 import scala.concurrent.duration.Duration
 

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/jdbm3/ByteArraySerializer.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/jdbm3/ByteArraySerializer.scala
@@ -16,9 +16,11 @@
 
 package quasar.yggdrasil.jdbm3
 
-import quasar.blueeyes._
-import java.io.{ DataInput, DataOutput }
 import org.apache.jdbm.Serializer
+
+import java.io.{DataInput, DataOutput}
+
+import scala.annotation.tailrec
 
 object ByteArraySerializer extends Serializer[Array[Byte]] with Serializable {
 

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/jdbm3/JDBMSlice.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/jdbm3/JDBMSlice.scala
@@ -17,10 +17,12 @@
 package quasar.yggdrasil
 package jdbm3
 
-import quasar.blueeyes._
 import quasar.precog.common._
-import org.slf4j.LoggerFactory
 import quasar.yggdrasil.table._
+
+import org.slf4j.LoggerFactory
+
+import scala.annotation.tailrec
 
 object JDBMSlice {
   private lazy val log = LoggerFactory.getLogger("quasar.yggdrasil.jdbm3.JDBMSlice")

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/jdbm3/RowFormat.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/jdbm3/RowFormat.scala
@@ -24,7 +24,7 @@ import scalaz._, Scalaz._
 import quasar.precog.util.{ ByteBufferMonad, ByteBufferPool, NumericComparisons }, ByteBufferPool._
 
 import java.nio.ByteBuffer
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 import scala.collection.mutable
 
@@ -178,8 +178,8 @@ trait RowFormatSupport { self: StdCodecs =>
       }
 
     case (CDate, col: DateColumn) =>
-      new SimpleColumnValueEncoder[LocalDateTime] {
-        val codec = Codec[LocalDateTime]
+      new SimpleColumnValueEncoder[ZonedDateTime] {
+        val codec = Codec[ZonedDateTime]
 
         def encode(row: Int, buffer: ByteBuffer, pool: ByteBufferPool): Option[List[ByteBuffer]] = {
           codec.writeInit(col(row), buffer) match {
@@ -246,7 +246,7 @@ trait RowFormatSupport { self: StdCodecs =>
       }
     case (CDate, col: ArrayDateColumn) =>
       new ColumnValueDecoder {
-        def decode(row: Int, buf: ByteBuffer) = col.update(row, Codec[LocalDateTime].read(buf))
+        def decode(row: Int, buf: ByteBuffer) = col.update(row, Codec[ZonedDateTime].read(buf))
       }
     case (CPeriod, col: ArrayPeriodColumn) =>
       new ColumnValueDecoder {
@@ -429,7 +429,7 @@ trait ValueRowFormat extends RowFormat with RowFormatSupport { self: StdCodecs =
         (x match {
           case CBoolean(x)      => wrappedWriteInit[Boolean](x, sink)
           case CString(x)       => wrappedWriteInit[String](x, sink)
-          case CDate(x)         => wrappedWriteInit[LocalDateTime](x, sink)
+          case CDate(x)         => wrappedWriteInit[ZonedDateTime](x, sink)
           case CPeriod(x)       => wrappedWriteInit[Period](x, sink)
           case CLong(x)         => wrappedWriteInit[Long](x, sink)
           case CDouble(x)       => wrappedWriteInit[Double](x, sink)

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/jdbm3/RowFormat.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/jdbm3/RowFormat.scala
@@ -26,6 +26,7 @@ import quasar.precog.util.{ ByteBufferMonad, ByteBufferPool, NumericComparisons 
 import java.nio.ByteBuffer
 import java.time.ZonedDateTime
 
+import scala.annotation.tailrec
 import scala.collection.mutable
 
 trait ColumnEncoder {

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/jdbm3/StdCodecs.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/jdbm3/StdCodecs.scala
@@ -22,7 +22,7 @@ import quasar.blueeyes._
 import quasar.precog.common._
 import quasar.precog.util._
 
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 /**
   * Defines a base set of codecs that are often used in `RowFormat`s.
@@ -33,7 +33,7 @@ trait StdCodecs {
   implicit def BigDecimalCodec: Codec[BigDecimal]
   implicit def StringCodec: Codec[String]
   implicit def BooleanCodec: Codec[Boolean]
-  implicit def DateTimeCodec: Codec[LocalDateTime]
+  implicit def DateTimeCodec: Codec[ZonedDateTime]
   implicit def PeriodCodec: Codec[Period]
   implicit def BitSetCodec: Codec[BitSet]
   implicit def RawBitSetCodec: Codec[RawBitSet]
@@ -58,7 +58,7 @@ trait RowFormatCodecs extends StdCodecs { self: RowFormat =>
   implicit def BigDecimalCodec: Codec[BigDecimal] = Codec.BigDecimalCodec
   implicit def StringCodec: Codec[String]         = Codec.Utf8Codec
   implicit def BooleanCodec: Codec[Boolean]       = Codec.BooleanCodec
-  implicit def DateTimeCodec: Codec[LocalDateTime]     = Codec.DateCodec
+  implicit def DateTimeCodec: Codec[ZonedDateTime] = Codec.ZonedDateTimeCodec
   implicit def PeriodCodec: Codec[Period]         = Codec.PeriodCodec
   // implicit def BitSetCodec: Codec[BitSet] = Codec.BitSetCodec
   //@transient implicit lazy val BitSetCodec: Codec[BitSet] = Codec.SparseBitSetCodec(columnRefs.size)

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/jdbm3/StdCodecs.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/jdbm3/StdCodecs.scala
@@ -20,7 +20,6 @@ package jdbm3
 import quasar.precog._
 import quasar.blueeyes._
 import quasar.precog.common._
-import quasar.precog.util._
 
 import java.time.ZonedDateTime
 
@@ -36,7 +35,7 @@ trait StdCodecs {
   implicit def DateTimeCodec: Codec[ZonedDateTime]
   implicit def PeriodCodec: Codec[Period]
   implicit def BitSetCodec: Codec[BitSet]
-  implicit def RawBitSetCodec: Codec[RawBitSet]
+  implicit def RawBitSetCodec: Codec[Array[Int]]
   implicit def IndexedSeqCodec[A](implicit elemCodec: Codec[A]): Codec[IndexedSeq[A]]
   implicit def ArrayCodec[A](implicit elemCodec: Codec[A], m: CTag[A]): Codec[Array[A]]
 
@@ -63,7 +62,7 @@ trait RowFormatCodecs extends StdCodecs { self: RowFormat =>
   // implicit def BitSetCodec: Codec[BitSet] = Codec.BitSetCodec
   //@transient implicit lazy val BitSetCodec: Codec[BitSet] = Codec.SparseBitSetCodec(columnRefs.size)
   @transient implicit lazy val BitSetCodec: Codec[BitSet]       = Codec.SparseBitSetCodec(columnRefs.size)
-  @transient implicit lazy val RawBitSetCodec: Codec[RawBitSet] = Codec.SparseRawBitSetCodec(columnRefs.size)
+  @transient implicit lazy val RawBitSetCodec: Codec[Array[Int]] = Codec.SparseRawBitSetCodec(columnRefs.size)
   implicit def IndexedSeqCodec[A](implicit elemCodec: Codec[A]): Codec[IndexedSeq[A]]       = Codec.IndexedSeqCodec(elemCodec)
   implicit def ArrayCodec[A](implicit elemCodec: Codec[A], m: CTag[A]): Codec[Array[A]] = Codec.ArrayCodec(elemCodec)(m)
 }

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/ArrayColumn.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/ArrayColumn.scala
@@ -21,7 +21,7 @@ import quasar.precog._
 import quasar.precog.common._
 import quasar.precog.util._
 
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 trait DefinedAtIndex {
   private[table] val defined: BitSet
@@ -151,22 +151,22 @@ object ArrayStrColumn {
     new ArrayStrColumn(new BitSet, new Array[String](size))
 }
 
-class ArrayDateColumn(val defined: BitSet, values: Array[LocalDateTime]) extends ArrayColumn[LocalDateTime] with DateColumn {
+class ArrayDateColumn(val defined: BitSet, values: Array[ZonedDateTime]) extends ArrayColumn[ZonedDateTime] with DateColumn {
   def apply(row: Int) = values(row)
 
-  def update(row: Int, value: LocalDateTime) = {
+  def update(row: Int, value: ZonedDateTime) = {
     defined.set(row)
     values(row) = value
   }
 }
 
 object ArrayDateColumn {
-  def apply(values: Array[LocalDateTime]) =
+  def apply(values: Array[ZonedDateTime]) =
     new ArrayDateColumn(BitSetUtil.range(0, values.length), values)
-  def apply(defined: BitSet, values: Array[LocalDateTime]) =
+  def apply(defined: BitSet, values: Array[ZonedDateTime]) =
     new ArrayDateColumn(defined.copy, values)
   def empty(size: Int): ArrayDateColumn =
-    new ArrayDateColumn(new BitSet, new Array[LocalDateTime](size))
+    new ArrayDateColumn(new BitSet, new Array[ZonedDateTime](size))
 }
 
 class ArrayPeriodColumn(val defined: BitSet, values: Array[Period]) extends ArrayColumn[Period] with PeriodColumn {

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/ArrayColumn.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/ArrayColumn.scala
@@ -23,16 +23,18 @@ import quasar.precog.util._
 
 import java.time.ZonedDateTime
 
+import scala.specialized
+
 trait DefinedAtIndex {
   private[table] val defined: BitSet
   def isDefinedAt(row: Int) = defined(row)
 }
 
-trait ArrayColumn[@spec(Boolean, Long, Double) A] extends DefinedAtIndex with ExtensibleColumn {
+trait ArrayColumn[@specialized(Boolean, Long, Double) A] extends DefinedAtIndex with ExtensibleColumn {
   def update(row: Int, value: A): Unit
 }
 
-class ArrayHomogeneousArrayColumn[@spec(Boolean, Long, Double) A](val defined: BitSet, values: Array[Array[A]])(val tpe: CArrayType[A])
+class ArrayHomogeneousArrayColumn[@specialized(Boolean, Long, Double) A](val defined: BitSet, values: Array[Array[A]])(val tpe: CArrayType[A])
     extends HomogeneousArrayColumn[A]
     with ArrayColumn[Array[A]] {
   def apply(row: Int) = values(row)
@@ -44,11 +46,11 @@ class ArrayHomogeneousArrayColumn[@spec(Boolean, Long, Double) A](val defined: B
 }
 
 object ArrayHomogeneousArrayColumn {
-  def apply[@spec(Boolean, Long, Double) A: CValueType](values: Array[Array[A]]) =
+  def apply[@specialized(Boolean, Long, Double) A: CValueType](values: Array[Array[A]]) =
     new ArrayHomogeneousArrayColumn(BitSetUtil.range(0, values.length), values)(CArrayType(CValueType[A]))
-  def apply[@spec(Boolean, Long, Double) A: CValueType](defined: BitSet, values: Array[Array[A]]) =
+  def apply[@specialized(Boolean, Long, Double) A: CValueType](defined: BitSet, values: Array[Array[A]]) =
     new ArrayHomogeneousArrayColumn(defined.copy, values)(CArrayType(CValueType[A]))
-  def empty[@spec(Boolean, Long, Double) A](size: Int)(implicit elemType: CValueType[A]): ArrayHomogeneousArrayColumn[A] = {
+  def empty[@specialized(Boolean, Long, Double) A](size: Int)(implicit elemType: CValueType[A]): ArrayHomogeneousArrayColumn[A] = {
     implicit val m: CTag[A] = elemType.classTag
 
     new ArrayHomogeneousArrayColumn(new BitSet, new Array[Array[A]](size))(CArrayType(elemType))

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/BlockStoreColumnarTableModule.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/BlockStoreColumnarTableModule.scala
@@ -34,6 +34,7 @@ import scalaz._, Scalaz._, Ordering._
 import scala.collection.mutable
 import TableModule._
 
+import scala.annotation.tailrec
 import scala.collection.mutable
 
 trait BlockStoreColumnarTableModuleConfig {

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/BlockStoreColumnarTableModule.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/BlockStoreColumnarTableModule.scala
@@ -18,6 +18,7 @@ package quasar.yggdrasil
 package table
 
 import quasar.blueeyes._
+import quasar.precog.BitSet
 import quasar.precog.common._
 import quasar.precog.common.security._
 import quasar.yggdrasil.bytecode._

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/CFN.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/CFN.scala
@@ -21,7 +21,7 @@ import quasar.yggdrasil.bytecode.JType
 import quasar.blueeyes._
 import quasar.precog.common._
 
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 sealed trait CFId
 case class LeafCFId(identity: String)            extends CFId
@@ -276,7 +276,7 @@ trait ArrayMapperS[M[+ _]] extends CMapperS[M] {
 
       case (tpe @ CDate, (cols0, defined)) => {
         val max  = maxIds(cols0, defined)
-        val cols = cols0.asInstanceOf[Array[Array[LocalDateTime]]]
+        val cols = cols0.asInstanceOf[Array[Array[ZonedDateTime]]]
 
         val columns: Map[ColumnRef, Column] = (0 until max).map({ i =>
           ColumnRef(CPath(CPathIndex(i)), tpe) -> new DateColumn {

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/CFN.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/CFN.scala
@@ -17,9 +17,10 @@
 package quasar.yggdrasil
 package table
 
-import quasar.yggdrasil.bytecode.JType
 import quasar.blueeyes._
+import quasar.precog.BitSet
 import quasar.precog.common._
+import quasar.yggdrasil.bytecode.JType
 
 import java.time.ZonedDateTime
 

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/CPathTraversal.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/CPathTraversal.scala
@@ -20,8 +20,11 @@ package table
 import quasar.blueeyes._
 import quasar.precog.common._
 import quasar.yggdrasil.util._
-import scala.collection.mutable
+
 import scalaz._, Scalaz._
+
+import scala.annotation.tailrec
+import scala.collection.mutable
 
 /**
   * Represents a way to traverse a list of CPaths in sorted order. This takes

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/Column.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/Column.scala
@@ -25,7 +25,9 @@ import scalaz.Semigroup
 
 import java.time.ZonedDateTime
 
+import scala.annotation.tailrec
 import scala.collection.mutable
+import scala.specialized
 
 sealed trait Column {
   def isDefinedAt(row: Int): Boolean
@@ -48,7 +50,7 @@ sealed trait Column {
 
 private[yggdrasil] trait ExtensibleColumn extends Column // TODO: or should we just unseal Column?
 
-trait HomogeneousArrayColumn[@spec(Boolean, Long, Double) A] extends Column with (Int => Array[A]) { self =>
+trait HomogeneousArrayColumn[@specialized(Boolean, Long, Double) A] extends Column with (Int => Array[A]) { self =>
   val tpe: CArrayType[A]
   def apply(row: Int): Array[A]
   def isDefinedAt(row: Int): Boolean
@@ -432,7 +434,7 @@ object Column {
     def apply(row: Int) = v
   }
 
-  @inline def const[@spec(Boolean, Long, Double) A: CValueType](v: Array[A]) = new InfiniteColumn with HomogeneousArrayColumn[A] {
+  @inline def const[@specialized(Boolean, Long, Double) A: CValueType](v: Array[A]) = new InfiniteColumn with HomogeneousArrayColumn[A] {
     val tpe = CArrayType(CValueType[A])
     def apply(row: Int) = v
   }

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/Column.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/Column.scala
@@ -23,7 +23,7 @@ import quasar.precog.util._
 
 import scalaz.Semigroup
 
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 import scala.collection.mutable
 
@@ -138,7 +138,7 @@ object HomogeneousArrayColumn {
       new DateColumn {
         def isDefinedAt(row: Int): Boolean =
           i >= 0 && col.isDefinedAt(row) && i < col(row).length
-        def apply(row: Int): LocalDateTime = col(row)(i)
+        def apply(row: Int): ZonedDateTime = col(row)(i)
       }
     case col @ HomogeneousArrayColumn(CPeriod) =>
       new PeriodColumn {
@@ -247,8 +247,8 @@ trait StrColumn extends Column with (Int => String) {
   override def toString                   = "StrColumn"
 }
 
-trait DateColumn extends Column with (Int => LocalDateTime) {
-  def apply(row: Int): LocalDateTime
+trait DateColumn extends Column with (Int => ZonedDateTime) {
+  def apply(row: Int): ZonedDateTime
   def rowEq(row1: Int, row2: Int): Boolean = apply(row1) == apply(row2)
   def rowCompare(row1: Int, row2: Int): Int =
     apply(row1) compareTo apply(row2)
@@ -424,7 +424,7 @@ object Column {
     def apply(row: Int) = v
   }
 
-  @inline def const(v: LocalDateTime) = new InfiniteColumn with DateColumn {
+  @inline def const(v: ZonedDateTime) = new InfiniteColumn with DateColumn {
     def apply(row: Int) = v
   }
 

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnSupport.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnSupport.scala
@@ -20,7 +20,7 @@ package table
 import quasar.blueeyes._
 import quasar.precog.common._
 
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 class BitsetColumn(definedAt: BitSet) {
   this: Column =>
@@ -257,7 +257,7 @@ object ArraySetColumn {
 
       case CDate =>
         new ArraySetColumn[DateColumn](ctype, columnSet.map(_.asInstanceOf[DateColumn])) with DateColumn {
-          def apply(row: Int): LocalDateTime = backing(firstDefinedIndexAt(row)).asInstanceOf[DateColumn].apply(row)
+          def apply(row: Int): ZonedDateTime = backing(firstDefinedIndexAt(row)).asInstanceOf[DateColumn].apply(row)
         }
 
       case CPeriod =>

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnSupport.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnSupport.scala
@@ -22,6 +22,8 @@ import quasar.precog.common._
 
 import java.time.ZonedDateTime
 
+import scala.annotation.tailrec
+
 class BitsetColumn(definedAt: BitSet) {
   this: Column =>
   def isDefinedAt(row: Int): Boolean = definedAt(row)

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnSupport.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnSupport.scala
@@ -18,6 +18,7 @@ package quasar.yggdrasil
 package table
 
 import quasar.blueeyes._
+import quasar.precog.BitSet
 import quasar.precog.common._
 
 import java.time.ZonedDateTime

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnarTableModule.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnarTableModule.scala
@@ -20,6 +20,7 @@ package table
 import quasar.blueeyes._, json._
 import quasar.precog.common._
 import quasar.precog.common.ingest.FileContent
+import quasar.precog.util.RawBitSet
 import quasar.yggdrasil.bytecode._
 import quasar.yggdrasil.util._
 import quasar.yggdrasil.table.cf.util.{ Remap, Empty }

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnarTableModule.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnarTableModule.scala
@@ -32,7 +32,7 @@ import scalaz._, Scalaz._, Ordering._
 
 import java.io.File
 import java.nio.CharBuffer
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 import scala.collection.mutable
 
@@ -386,7 +386,7 @@ trait ColumnarTableModule[M[+ _]]
       Table(Slice(Map(ColumnRef(CPath.Identity, CString) -> column), v.size) :: StreamT.empty[M, Slice], ExactSize(v.size))
     }
 
-    def constDate(v: collection.Set[LocalDateTime]): Table = {
+    def constDate(v: collection.Set[ZonedDateTime]): Table = {
       val column = ArrayDateColumn(v.toArray)
       Table(Slice(Map(ColumnRef(CPath.Identity, CDate) -> column), v.size) :: StreamT.empty[M, Slice], ExactSize(v.size))
     }

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnarTableModule.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnarTableModule.scala
@@ -34,6 +34,7 @@ import java.io.File
 import java.nio.CharBuffer
 import java.time.ZonedDateTime
 
+import scala.annotation.tailrec
 import scala.collection.mutable
 
 trait ColumnarTableTypes[M[+ _]] {

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnarTableModule.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnarTableModule.scala
@@ -18,6 +18,7 @@ package quasar.yggdrasil
 package table
 
 import quasar.blueeyes._, json._
+import quasar.precog.{MimeType, MimeTypes}
 import quasar.precog.common._
 import quasar.precog.common.ingest.FileContent
 import quasar.precog.util.RawBitSet

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/HashedSlice.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/HashedSlice.scala
@@ -21,6 +21,7 @@ import quasar.precog.util._
 import quasar.blueeyes._
 import quasar.precog.common._
 
+import scala.annotation.tailrec
 import scala.collection.mutable
 
 /**

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/MemoColumn.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/MemoColumn.scala
@@ -17,7 +17,7 @@
 package quasar.yggdrasil
 package table
 
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 class MemoBoolColumn(c: BoolColumn) extends BoolColumn {
   private[this] var row0          = -1
@@ -71,7 +71,7 @@ class MemoStrColumn(c: StrColumn) extends StrColumn {
 
 class MemoDateColumn(c: DateColumn) extends DateColumn {
   private[this] var row0           = -1
-  private[this] var memo: LocalDateTime = _
+  private[this] var memo: ZonedDateTime = _
   def isDefinedAt(row: Int) = c.isDefinedAt(row)
   def apply(row: Int) = {
     if (row != row0) { row0 = row; memo = c(row) }

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/RowComparator.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/RowComparator.scala
@@ -17,8 +17,9 @@
 package quasar.yggdrasil
 package table
 
-import quasar.blueeyes._
 import scalaz.Ordering._
+
+import scala.annotation.tailrec
 
 trait RowComparator { self =>
   def compare(i1: Int, i2: Int): scalaz.Ordering

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/SamplableTableModule.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/SamplableTableModule.scala
@@ -22,6 +22,7 @@ import quasar.yggdrasil._
 
 import scalaz._, Scalaz._
 
+import scala.annotation.tailrec
 import scala.collection.mutable
 
 trait SamplableTableModule[M[+ _]] extends TableModule[M] {

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/Slice.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/Slice.scala
@@ -32,7 +32,9 @@ import scalaz._, Scalaz._, Ordering._
 import java.nio.CharBuffer
 import java.time.ZonedDateTime
 
+import scala.annotation.{switch, tailrec}
 import scala.collection.mutable
+import scala.specialized
 
 trait Slice { source =>
   import Slice._
@@ -104,7 +106,7 @@ trait Slice { source =>
     val cols0 = (source.columns).toList sortBy { case (ref, _) => ref.selector }
     val cols  = cols0 map { case (_, col)                      => col }
 
-    def inflate[@spec A: CTag](cols: Array[Int => A], row: Int) = {
+    def inflate[@specialized A: CTag](cols: Array[Int => A], row: Int) = {
       val as = new Array[A](cols.length)
       var i = 0
       while (i < cols.length) {

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/Slice.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/Slice.scala
@@ -30,7 +30,7 @@ import quasar.blueeyes._, json._
 import scalaz._, Scalaz._, Ordering._
 
 import java.nio.CharBuffer
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 import scala.collection.mutable
 
@@ -873,7 +873,7 @@ trait Slice { source =>
 
         case col: DateColumn =>
           val defined = col.definedAt(0, source.size)
-          val values  = new Array[LocalDateTime](source.size)
+          val values  = new Array[ZonedDateTime](source.size)
           Loop.range(0, source.size) { row =>
             if (defined(row)) values(row) = col(row)
           }
@@ -1269,7 +1269,7 @@ trait Slice { source =>
         }
 
         @inline
-        def renderDate(date: LocalDateTime) {
+        def renderDate(date: ZonedDateTime) {
           renderString(date.toString)
         }
 

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/SliceTransform.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/SliceTransform.scala
@@ -18,9 +18,10 @@ package quasar.yggdrasil
 package table
 
 import quasar.blueeyes._
+import quasar.precog.BitSet
 import quasar.precog.common._
-import quasar.yggdrasil.bytecode.{ JBooleanT, JObjectUnfixedT, JArrayUnfixedT }
 import quasar.precog.util._
+import quasar.yggdrasil.bytecode.{ JBooleanT, JObjectUnfixedT, JArrayUnfixedT }
 
 import scalaz._
 import scalaz.std.tuple._

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/util/CPathComparator.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/util/CPathComparator.scala
@@ -17,13 +17,15 @@
 package quasar.yggdrasil
 package util
 
-import java.time.ZonedDateTime
-
-import quasar.precog._
 import quasar.blueeyes._
+import quasar.precog._
 import quasar.precog.common._
 import quasar.yggdrasil.table._
+
 import scalaz._, Scalaz._
+
+import java.time.ZonedDateTime
+import scala.specialized
 
 /**
   * Represents the result of an ordering, but with the possibility that no
@@ -65,7 +67,7 @@ object CPathComparator {
     def compare(a: ZonedDateTime, b: ZonedDateTime) = a compareTo b
   }
 
-  def apply[@spec(Boolean, Long, Double, AnyRef) A, @spec(Boolean, Long, Double, AnyRef) B](lCol: Int => A, rCol: Int => B)(implicit order: HetOrder[A, B]) = {
+  def apply[@specialized(Boolean, Long, Double, AnyRef) A, @specialized(Boolean, Long, Double, AnyRef) B](lCol: Int => A, rCol: Int => B)(implicit order: HetOrder[A, B]) = {
     new CPathComparator {
       def compare(r1: Int, r2: Int, i: Array[Int]) =
         MaybeOrdering.fromInt(order.compare(lCol(r1), rCol(r2)))
@@ -186,7 +188,7 @@ private[yggdrasil] trait ArrayCPathComparatorSupport {
   * A non-boxing CPathComparator where the left-side is a homogeneous array and
   * the right side is not.
   */
-private[yggdrasil] final class HalfArrayCPathComparator[@spec(Boolean, Long, Double) A, @spec(Boolean, Long, Double) B](
+private[yggdrasil] final class HalfArrayCPathComparator[@specialized(Boolean, Long, Double) A, @specialized(Boolean, Long, Double) B](
     lPath: CPath,
     lCol: HomogeneousArrayColumn[_],
     rCol: Int => B)(implicit ma: CTag[A], ho: HetOrder[A, B])
@@ -217,7 +219,7 @@ private[yggdrasil] final class HalfArrayCPathComparator[@spec(Boolean, Long, Dou
 /**
   * A non-boxing CPathComparator for homogeneous arrays.
   */
-private[yggdrasil] final class ArrayCPathComparator[@spec(Boolean, Long, Double) A, @spec(Boolean, Long, Double) B](
+private[yggdrasil] final class ArrayCPathComparator[@specialized(Boolean, Long, Double) A, @specialized(Boolean, Long, Double) B](
     lPath: CPath,
     lCol: HomogeneousArrayColumn[_],
     rPath: CPath,
@@ -225,7 +227,7 @@ private[yggdrasil] final class ArrayCPathComparator[@spec(Boolean, Long, Double)
     extends CPathComparator
     with ArrayCPathComparatorSupport {
 
-  // FIXME: These are lazy to get around a bug in @spec. We can probably remove
+  // FIXME: These are lazy to get around a bug in @specialized. We can probably remove
   // this in 2.10.
 
   final lazy val lMask: Array[Boolean] = makeMask(lPath)
@@ -264,7 +266,7 @@ private[yggdrasil] final class ArrayCPathComparator[@spec(Boolean, Long, Double)
   * ArraySelector provides a non-boxing way of accessing the leaf elements in a
   * bunch of nested arrays.
   */
-private[yggdrasil] final class ArraySelector[@spec(Boolean, Long, Double) A](implicit m: CTag[A]) {
+private[yggdrasil] final class ArraySelector[@specialized(Boolean, Long, Double) A](implicit m: CTag[A]) {
   private val am = m.wrap
 
   def canPluck(a: Array[_], indices: Array[Int], mask: Array[Boolean]): Boolean = {

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/util/CPathComparator.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/util/CPathComparator.scala
@@ -17,7 +17,7 @@
 package quasar.yggdrasil
 package util
 
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 import quasar.precog._
 import quasar.blueeyes._
@@ -61,8 +61,8 @@ trait CPathComparator { self =>
 object CPathComparator {
   import MaybeOrdering._
 
-  implicit object DateTimeOrder extends spire.algebra.Order[LocalDateTime] {
-    def compare(a: LocalDateTime, b: LocalDateTime) = a compareTo b
+  implicit object DateTimeOrder extends spire.algebra.Order[ZonedDateTime] {
+    def compare(a: ZonedDateTime, b: ZonedDateTime) = a compareTo b
   }
 
   def apply[@spec(Boolean, Long, Double, AnyRef) A, @spec(Boolean, Long, Double, AnyRef) B](lCol: Int => A, rCol: Int => B)(implicit order: HetOrder[A, B]) = {
@@ -110,7 +110,7 @@ object CPathComparator {
       case (CNum, CNum)         => new ArrayCPathComparator[BigDecimal, BigDecimal](lPath, lCol, rPath, rCol)
       case (CBoolean, CBoolean) => new ArrayCPathComparator[Boolean, Boolean](lPath, lCol, rPath, rCol)
       case (CString, CString)   => new ArrayCPathComparator[String, String](lPath, lCol, rPath, rCol)
-      case (CDate, CDate)       => new ArrayCPathComparator[LocalDateTime, LocalDateTime](lPath, lCol, rPath, rCol)
+      case (CDate, CDate)       => new ArrayCPathComparator[ZonedDateTime, ZonedDateTime](lPath, lCol, rPath, rCol)
       case (tpe1, tpe2) =>
         val ordering = MaybeOrdering.fromInt(implicitly[scalaz.Order[CType]].apply(lCol.tpe, rCol.tpe).toInt)
         new CPathComparator with ArrayCPathComparatorSupport {
@@ -149,7 +149,7 @@ object CPathComparator {
       case (CNum, rCol: NumColumn)       => new HalfArrayCPathComparator[BigDecimal, BigDecimal](lPath, lCol, rCol(_))
       case (CBoolean, rCol: BoolColumn)  => new HalfArrayCPathComparator[Boolean, Boolean](lPath, lCol, rCol(_))
       case (CString, rCol: StrColumn)    => new HalfArrayCPathComparator[String, String](lPath, lCol, rCol(_))
-      case (CDate, rCol: DateColumn)     => new HalfArrayCPathComparator[LocalDateTime, LocalDateTime](lPath, lCol, rCol(_))
+      case (CDate, rCol: DateColumn)     => new HalfArrayCPathComparator[ZonedDateTime, ZonedDateTime](lPath, lCol, rCol(_))
       case (tpe1, _) =>
         val ordering = MaybeOrdering.fromInt(implicitly[scalaz.Order[CType]].apply(tpe1, rCol.tpe).toInt)
         new CPathComparator with ArrayCPathComparatorSupport {

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/CogroupSpec.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/CogroupSpec.scala
@@ -29,6 +29,8 @@ import scalaz.syntax.comonad._
 import org.specs2._
 import org.scalacheck._, Gen._
 
+import scala.annotation.tailrec
+
 trait CogroupSpec[M[+_]] extends TableModuleTestSupport[M] with SpecificationLike with ScalaCheck {
   import SampleData._
   import trans._

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/jdbm3/RowFormatSpec.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/jdbm3/RowFormatSpec.scala
@@ -17,11 +17,13 @@
 package quasar.yggdrasil
 package jdbm3
 
-import quasar.blueeyes._
 import quasar.precog.common._
-import quasar.yggdrasil.table._
-import org.scalacheck.Shrink
 import quasar.precog.TestSupport._
+import quasar.yggdrasil.table._
+
+import org.scalacheck.Shrink
+
+import scala.annotation.tailrec
 
 class RowFormatSpec extends Specification with ScalaCheck with CValueGenerators {
   import Arbitrary._

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/jdbm3/RowFormatSpec.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/jdbm3/RowFormatSpec.scala
@@ -137,8 +137,6 @@ class RowFormatSpec extends Specification with ScalaCheck with CValueGenerators 
         implicit val arbRows: Arbitrary[List[List[CValue]]] =
           Arbitrary(Gen.listOfN(10, genCValuesForColumnRefs(refs)))
 
-
-
         prop { (vals: List[List[CValue]]) =>
           val valueEncoded = vals map (valueRowFormat.encode(_))
           val sortEncoded = vals map (sortingKeyRowFormat.encode(_))
@@ -168,6 +166,7 @@ class RowFormatSpec extends Specification with ScalaCheck with CValueGenerators 
         }
       }
     }
+
     "survive rountrip from CValue -> Array[Byte] -> Column -> Array[Byte] -> CValue" in {
       val size = 10
 
@@ -196,5 +195,3 @@ class RowFormatSpec extends Specification with ScalaCheck with CValueGenerators 
     }
   }
 }
-
-

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/table/BlockStoreTestSupport.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/table/BlockStoreTestSupport.scala
@@ -17,11 +17,13 @@
 package quasar.yggdrasil
 package table
 
+import quasar.blueeyes._, json._
 import quasar.precog.common._
 import quasar.precog.common.security.APIKey
 
-import quasar.blueeyes._, json._
 import scalaz._, Scalaz._
+
+import scala.annotation.tailrec
 
 trait BlockStoreTestModule[M[+_]] extends BaseBlockStoreTestModule[M] {
   implicit def M: Monad[M] with Comonad[M]

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/table/ColumnarTableModuleTestSupport.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/table/ColumnarTableModuleTestSupport.scala
@@ -18,12 +18,14 @@ package quasar.yggdrasil
 package table
 
 import quasar.blueeyes._
+import quasar.blueeyes.json._
 import quasar.precog.common._
 import quasar.precog.util._
 
-import quasar.blueeyes.json._
 import scalaz._
 import scalaz.syntax.std.boolean._
+
+import scala.annotation.tailrec
 
 trait ColumnarTableModuleTestSupport[M[+_]] extends ColumnarTableModule[M] with TableModuleTestSupport[M] {
   def newGroupId: GroupId

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/table/CompactSpec.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/table/CompactSpec.scala
@@ -16,13 +16,14 @@
 
 package quasar.yggdrasil.table
 
-import quasar.yggdrasil._
-import quasar.blueeyes._
-import quasar.precog.util._
+import quasar.precog.BitSet
+import quasar.precog.TestSupport._
 import quasar.precog.common._
+import quasar.precog.util._
+import quasar.yggdrasil._
+
 import scala.util.Random
 import scalaz._, Scalaz._
-import quasar.precog.TestSupport._
 
 trait CompactSpec[M[+_]] extends ColumnarTableModuleTestSupport[M] with SpecificationLike with ScalaCheck {
   import SampleData._

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/table/SliceSpec.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/table/SliceSpec.scala
@@ -16,10 +16,11 @@
 
 package quasar.yggdrasil.table
 
-import quasar.precog.TestSupport._
 import quasar.blueeyes._
-import quasar.precog.util._
+import quasar.precog.BitSet
+import quasar.precog.TestSupport._
 import quasar.precog.common._
+import quasar.precog.util._
 
 import java.time.{Instant, ZoneOffset, ZonedDateTime}
 import scala.util.Random

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/table/SliceSpec.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/table/SliceSpec.scala
@@ -21,6 +21,7 @@ import quasar.blueeyes._
 import quasar.precog.util._
 import quasar.precog.common._
 
+import java.time.{Instant, ZoneOffset, ZonedDateTime}
 import scala.util.Random
 import org.scalacheck.{ Arbitrary, Gen }
 import Gen.listOfN
@@ -186,6 +187,7 @@ class SliceSpec extends Specification with ScalaCheck {
 object ArbitrarySlice {
   private def genBitSet(size: Int): Gen[BitSet] = listOfN(size, genBool) ^^ (BitsetColumn bitset _)
 
+  // TODO remove duplication with `SegmentFormatSupport#genForCType`
   def genColumn(col: ColumnRef, size: Int): Gen[Column] = {
     def bs = BitSetUtil.range(0, size)
     col.ctype match {
@@ -193,7 +195,7 @@ object ArbitrarySlice {
       case CBoolean      => arrayOfN(size, genBool) ^^ (ArrayBoolColumn(bs, _))
       case CLong         => arrayOfN(size, genLong) ^^ (ArrayLongColumn(bs, _))
       case CDouble       => arrayOfN(size, genDouble) ^^ (ArrayDoubleColumn(bs, _))
-      case CDate         => arrayOfN(size, genLong) ^^ (ns => ArrayDateColumn(bs, ns map dateTime.fromMillis))
+      case CDate         => arrayOfN(size, genLong) ^^ (ns => ArrayDateColumn(bs, ns.map(n => ZonedDateTime.ofInstant(Instant.ofEpochSecond(n % Instant.MAX.getEpochSecond), ZoneOffset.UTC))))
       case CPeriod       => arrayOfN(size, genLong) ^^ (ns => ArrayPeriodColumn(bs, ns map period.fromMillis))
       case CNum          => arrayOfN(size, genDouble) ^^ (ns => ArrayNumColumn(bs, ns map (v => BigDecimal(v))))
       case CNull         => genBitSet(size) ^^ (s => new BitsetColumn(s) with NullColumn)

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/util/CPathTraversalSpec.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/util/CPathTraversalSpec.scala
@@ -18,21 +18,23 @@ package quasar.yggdrasil
 
 import quasar.blueeyes._
 import quasar.precog.common._
-import quasar.yggdrasil.table._
-import quasar.precog.util._
 import quasar.precog._, TestSupport._
+import quasar.precog.util._
+import quasar.yggdrasil.table._
 
 import java.time.ZonedDateTime
+
+import scala.specialized
 
 class CPathTraversalSpec extends Specification {
   import CPathTraversal._
 
-  sealed trait ColBuilder[@spec(Boolean, Long, Double) A] {
+  sealed trait ColBuilder[@specialized(Boolean, Long, Double) A] {
     def apply(defined: BitSet, items: Array[A]): Column
   }
 
   object ColBuilder {
-    private def builder[@spec(Boolean, Long, Double) A](f: (BitSet, Array[A]) => Column): ColBuilder[A] = {
+    private def builder[@specialized(Boolean, Long, Double) A](f: (BitSet, Array[A]) => Column): ColBuilder[A] = {
       new ColBuilder[A] {
         def apply(defined: BitSet, items: Array[A]): Column = f(defined, items)
       }
@@ -44,7 +46,7 @@ class CPathTraversalSpec extends Specification {
     implicit val DoubleColBuilder = builder[Double](ArrayDoubleColumn(_, _))
     implicit val NumColBuilder    = builder[BigDecimal](ArrayNumColumn(_, _))
     implicit val DateColBuilder   = builder[ZonedDateTime](ArrayDateColumn(_, _))
-    implicit def HomogeneousArrayColBuilder[@spec(Boolean, Long, Double) A: CValueType] =
+    implicit def HomogeneousArrayColBuilder[@specialized(Boolean, Long, Double) A: CValueType] =
       builder[Array[A]](ArrayHomogeneousArrayColumn(_, _))
   }
 
@@ -62,7 +64,7 @@ class CPathTraversalSpec extends Specification {
       )))
     }
   }
-  def col[@spec(Boolean, Long, Double) A](defined: Int*)(values: A*)(implicit builder: ColBuilder[A], m: CTag[A]) = {
+  def col[@specialized(Boolean, Long, Double) A](defined: Int*)(values: A*)(implicit builder: ColBuilder[A], m: CTag[A]) = {
     val max = defined.max + 1
     val column = m.newArray(max)
     (defined zip values) foreach { case (i, x) =>

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/util/CPathTraversalSpec.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/util/CPathTraversalSpec.scala
@@ -16,7 +16,6 @@
 
 package quasar.yggdrasil
 
-import quasar.blueeyes._
 import quasar.precog.common._
 import quasar.precog._, TestSupport._
 import quasar.precog.util._

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/util/CPathTraversalSpec.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/util/CPathTraversalSpec.scala
@@ -22,7 +22,7 @@ import quasar.yggdrasil.table._
 import quasar.precog.util._
 import quasar.precog._, TestSupport._
 
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 class CPathTraversalSpec extends Specification {
   import CPathTraversal._
@@ -43,7 +43,7 @@ class CPathTraversalSpec extends Specification {
     implicit val BoolColBuilder   = builder[Boolean](ArrayBoolColumn(_, _))
     implicit val DoubleColBuilder = builder[Double](ArrayDoubleColumn(_, _))
     implicit val NumColBuilder    = builder[BigDecimal](ArrayNumColumn(_, _))
-    implicit val DateColBuilder   = builder[LocalDateTime](ArrayDateColumn(_, _))
+    implicit val DateColBuilder   = builder[ZonedDateTime](ArrayDateColumn(_, _))
     implicit def HomogeneousArrayColBuilder[@spec(Boolean, Long, Double) A: CValueType] =
       builder[Array[A]](ArrayHomogeneousArrayColumn(_, _))
   }


### PR DESCRIPTION
Closes #2166 

This is the prep work for #2438.

`LocalDateTime` is still used in the security/account stuff in precog. We are ripping that out, so we don't even need to figure out what the correct date time representation is for that functionality.
