### PR TITLE
Skip distinctStar test for CB because it is flaky.

### DIFF
--- a/it/src/main/resources/tests/distinctStar.test
+++ b/it/src/main/resources/tests/distinctStar.test
@@ -1,6 +1,7 @@
 {
     "name": "distinct *",
     "backends": {
+        "couchbase": "skip",
         "mimir":"pending",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
@@ -9,6 +10,7 @@
         "mongodb_3_4":       "pending",
         "mongodb_q_3_2": "pending"
     },
+    "NB": "Skipped for couchbase due to #2329 failure to load test data.",
     "data": "cities.data",
     "query": "select distinct * from cities where city = \"BOSTON\"",
     "predicate": "exactly",


### PR DESCRIPTION
This test has been failing a lot recently.

I don't like skipping tests that sometimes pass because that means the test isn't ever being run and so a bug could be introduced, but we also cannot have a couchbase build that fails so frequently.