### PR TITLE
Fix up outer join integration tests.

### DIFF
--- a/it/src/main/resources/tests/cars2.data
+++ b/it/src/main/resources/tests/cars2.data
@@ -1,0 +1,4 @@
+{ "_id": "1", "year": [2015], "name": "Dodge-Caravan" }
+{ "_id": "3", "year": [2009], "name": "Jeep-Liberty" }
+{ "_id": "4", "year": [2003], "name": "Chrysler-Sebring" }
+{ "_id": "5", "year": [2017], "name": "Toyota-Prius" }

--- a/it/src/main/resources/tests/joins/fullOuterEquiJoin.test
+++ b/it/src/main/resources/tests/joins/fullOuterEquiJoin.test
@@ -6,7 +6,6 @@
         "mimir": "pending",
         "marklogic_json": "pending",
         "marklogic_xml": "pending",
-        "mongodb_read_only": "pending",
         "mongodb_q_2_6": "pending",
         "mongodb_q_3_0": "pending",
         "mongodb_q_3_2": "pending",

--- a/it/src/main/resources/tests/joins/fullOuterEquiJoin.test
+++ b/it/src/main/resources/tests/joins/fullOuterEquiJoin.test
@@ -5,6 +5,7 @@
         "couchbase": "skip",
         "marklogic_json": "pending",
         "marklogic_xml": "pending",
+        "mimir": "ignoreFieldOrder",
         "mongodb_q_2_6": "pending",
         "mongodb_q_3_0": "pending",
         "mongodb_q_3_2": "pending",

--- a/it/src/main/resources/tests/joins/fullOuterEquiJoin.test
+++ b/it/src/main/resources/tests/joins/fullOuterEquiJoin.test
@@ -2,34 +2,29 @@
     "name": "perform full-outer equi-join",
 
     "backends": {
-        "couchbase": "pending",
+        "couchbase": "skip",
+        "mimir": "pending",
         "marklogic_json": "pending",
         "marklogic_xml": "pending",
-        "mongodb_2_6": "pending",
-        "mongodb_3_0": "pending",
-        "mongodb_3_2": "pending",
-        "mongodb_3_4": "pending",
         "mongodb_read_only": "pending",
         "mongodb_q_2_6": "pending",
         "mongodb_q_3_0": "pending",
         "mongodb_q_3_2": "pending",
-        "mongodb_q_3_4": "pending",
-        "spark_hdfs": "pending",
-        "spark_local": "pending"
+        "mongodb_q_3_4": "pending"
     },
 
-    "data": ["../cars.data", "../divide.data"],
+    "data": ["../cars.data", "../cars2.data"],
 
-    "query": "select *
-              from `../cars` full outer join `../divide`
-              on cars.`_id` = divide.val2",
+    "query": "select cars.name as c1, cars2.name as c2
+              from `../cars` full outer join `../cars2`
+              on cars.`_id` = cars2.`_id`",
 
-    "predicate": "atLeast",
+    "predicate": "exactly",
     "ignoreResultOrder": true,
-    "ignoreFieldOrder": true,
 
-    "expected": [{ "_id": "1", "year": [2012], "name": "RangeRover-Evoque" },
-                 { "_id": "2", "year": [2010], "name": "Honda-civic" },
-                 { "_id": "3", "year": [2003], "name": "BMW-X5" },
-                 { "nr": 4, "val1":   1.0, "val2":  4.0 }]
+    "expected": [{ "c1": "RangeRover-Evoque", "c2": "Dodge-Caravan" },
+                 { "c1": "BMW-X5",            "c2": "Jeep-Liberty" },
+                 {                            "c2": "Chrysler-Sebring" },
+                 {                            "c2": "Toyota-Prius" },
+                 { "c1": "Honda-civic" }]
 }

--- a/it/src/main/resources/tests/joins/innerEquiJoin.test
+++ b/it/src/main/resources/tests/joins/innerEquiJoin.test
@@ -2,31 +2,24 @@
     "name": "perform inner equi-join",
 
     "backends": {
-        "couchbase":         "pending",
-        "marklogic_json":    "timeout",
-        "marklogic_xml":     "timeout",
-        "mongodb_q_3_2":     "pending"
+        "couchbase": "skip",
+        "marklogic_json": "pending",
+        "mimir": "ignoreFieldOrder",
+        "mongodb_q_2_6": "pending",
+        "mongodb_q_3_0": "pending",
+        "mongodb_q_3_2": "pending",
+        "mongodb_q_3_4": "pending"
     },
 
-    "NB": "#1587: Disabled in couchbase due to lack of general join.",
+    "data": ["../cars.data", "../cars2.data"],
 
-    "data": ["../smallZips.data", "../zips.data"],
+    "query": "select cars.name as c1, cars2.name as c2
+              from `../cars` inner join `../cars2`
+              on cars.`_id` = cars2.`_id`",
 
-    "query": "select smallZips.city, zips.state
-              from `../smallZips` join `../zips`
-              on smallZips.`_id` = zips.`_id`",
-
-    "predicate": "atLeast",
+    "predicate": "exactly",
     "ignoreResultOrder": true,
 
-    "expected": [{"city": "AGAWAM",       "state": "MA"},
-                 {"city": "CUSHMAN",      "state": "MA"},
-                 {"city": "BARRE",        "state": "MA"},
-                 {"city": "BELCHERTOWN",  "state": "MA"},
-                 {"city": "BLANDFORD",    "state": "MA"},
-                 {"city": "BRIMFIELD",    "state": "MA"},
-                 {"city": "CHESTER",      "state": "MA"},
-                 {"city": "CHESTERFIELD", "state": "MA"},
-                 {"city": "CHICOPEE",     "state": "MA"},
-                 {"city": "CHICOPEE",     "state": "MA"}]
+    "expected": [{ "c1": "RangeRover-Evoque", "c2": "Dodge-Caravan" },
+                 { "c1": "BMW-X5",            "c2": "Jeep-Liberty" }]
 }

--- a/it/src/main/resources/tests/joins/innerEquiJoinLarge.test
+++ b/it/src/main/resources/tests/joins/innerEquiJoinLarge.test
@@ -5,6 +5,7 @@
         "couchbase":         "pending",
         "marklogic_json":    "timeout",
         "marklogic_xml":     "timeout",
+        "mimir": "ignoreFieldOrder",
         "mongodb_q_3_2":     "pending"
     },
 

--- a/it/src/main/resources/tests/joins/innerEquiJoinLarge.test
+++ b/it/src/main/resources/tests/joins/innerEquiJoinLarge.test
@@ -1,0 +1,32 @@
+{
+    "name": "perform large inner equi-join",
+
+    "backends": {
+        "couchbase":         "pending",
+        "marklogic_json":    "timeout",
+        "marklogic_xml":     "timeout",
+        "mongodb_q_3_2":     "pending"
+    },
+
+    "NB": "#1587: Disabled in couchbase due to lack of general join.",
+
+    "data": ["../smallZips.data", "../zips.data"],
+
+    "query": "select smallZips.city, zips.state
+              from `../smallZips` join `../zips`
+              on smallZips.`_id` = zips.`_id`",
+
+    "predicate": "atLeast",
+    "ignoreResultOrder": true,
+
+    "expected": [{"city": "AGAWAM",       "state": "MA"},
+                 {"city": "CUSHMAN",      "state": "MA"},
+                 {"city": "BARRE",        "state": "MA"},
+                 {"city": "BELCHERTOWN",  "state": "MA"},
+                 {"city": "BLANDFORD",    "state": "MA"},
+                 {"city": "BRIMFIELD",    "state": "MA"},
+                 {"city": "CHESTER",      "state": "MA"},
+                 {"city": "CHESTERFIELD", "state": "MA"},
+                 {"city": "CHICOPEE",     "state": "MA"},
+                 {"city": "CHICOPEE",     "state": "MA"}]
+}

--- a/it/src/main/resources/tests/joins/leftOuterEquiJoin.test
+++ b/it/src/main/resources/tests/joins/leftOuterEquiJoin.test
@@ -2,34 +2,28 @@
     "name": "perform left-outer equi-join",
 
     "backends": {
-        "couchbase": "pending",
+        "couchbase": "skip",
         "marklogic_json": "pending",
         "marklogic_xml": "pending",
-        "mongodb_2_6": "pending",
-        "mongodb_3_0": "pending",
-        "mongodb_3_2": "pending",
-        "mongodb_3_4": "pending",
+        "mimir": "pending",
         "mongodb_read_only": "pending",
         "mongodb_q_2_6": "pending",
         "mongodb_q_3_0": "pending",
         "mongodb_q_3_2": "pending",
-        "mongodb_q_3_4": "pending",
-        "spark_hdfs": "pending",
-        "spark_local": "pending"
+        "mongodb_q_3_4": "pending"
     },
 
-    "data": ["../cars.data", "../divide.data"],
+    "data": ["../cars.data", "../cars2.data"],
 
-    "query": "select *
-              from `../divide` left outer join `../cars`
-              on cars.`_id` = divide.nr",
+    "query": "select cars.name as c1, cars2.name as c2
+              from `../cars2` left outer join `../cars`
+              on cars.`_id` = cars2.`_id`",
 
-    "predicate": "atLeast",
+    "predicate": "exactly",
     "ignoreResultOrder": true,
-    "ignoreFieldOrder": true,
 
-    "expected": [{ "_id": "1", "year": [2012], "name": "RangeRover-Evoque" },
-                 { "_id": "2", "year": [2010], "name": "Honda-civic" },
-                 { "_id": "3", "year": [2003], "name": "BMW-X5" },
-                 { "nr": 4, "val1":   1.0, "val2":  4.0 }]
+    "expected": [{ "c1": "RangeRover-Evoque", "c2": "Dodge-Caravan" },
+                 { "c1": "BMW-X5",            "c2": "Jeep-Liberty" },
+                 {                            "c2": "Chrysler-Sebring" },
+                 {                            "c2": "Toyota-Prius" }]
 }

--- a/it/src/main/resources/tests/joins/leftOuterEquiJoin.test
+++ b/it/src/main/resources/tests/joins/leftOuterEquiJoin.test
@@ -6,7 +6,6 @@
         "marklogic_json": "pending",
         "marklogic_xml": "pending",
         "mimir": "pending",
-        "mongodb_read_only": "pending",
         "mongodb_q_2_6": "pending",
         "mongodb_q_3_0": "pending",
         "mongodb_q_3_2": "pending",

--- a/it/src/main/resources/tests/joins/rightOuterEquiJoin.test
+++ b/it/src/main/resources/tests/joins/rightOuterEquiJoin.test
@@ -6,7 +6,6 @@
         "marklogic_json": "pending",
         "marklogic_xml": "pending",
         "mimir": "pending",
-        "mongodb_read_only": "pending",
         "mongodb_q_2_6": "pending",
         "mongodb_q_3_0": "pending",
         "mongodb_q_3_2": "pending",

--- a/it/src/main/resources/tests/joins/rightOuterEquiJoin.test
+++ b/it/src/main/resources/tests/joins/rightOuterEquiJoin.test
@@ -2,34 +2,28 @@
     "name": "perform right-outer equi-join",
 
     "backends": {
-        "couchbase": "pending",
+        "couchbase": "skip",
         "marklogic_json": "pending",
         "marklogic_xml": "pending",
-        "mongodb_2_6": "pending",
-        "mongodb_3_0": "pending",
-        "mongodb_3_2": "pending",
-        "mongodb_3_4": "pending",
+        "mimir": "pending",
         "mongodb_read_only": "pending",
         "mongodb_q_2_6": "pending",
         "mongodb_q_3_0": "pending",
         "mongodb_q_3_2": "pending",
-        "mongodb_q_3_4": "pending",
-        "spark_hdfs": "pending",
-        "spark_local": "pending"
+        "mongodb_q_3_4": "pending"
     },
 
-    "data": ["../cars.data", "../divide.data"],
+    "data": ["../cars.data", "../cars2.data"],
 
-    "query": "select *
-              from `../cars` right outer join `../divide`
-              on cars.`_id` = divide.nr",
+    "query": "select cars.name as c1, cars2.name as c2
+              from `../cars` right outer join `../cars2`
+              on cars.`_id` = cars2.`_id`",
 
-    "predicate": "atLeast",
+    "predicate": "exactly",
     "ignoreResultOrder": true,
-    "ignoreFieldOrder": true,
 
-    "expected": [{ "_id": "1", "year": [2012], "name": "RangeRover-Evoque" },
-                 { "_id": "2", "year": [2010], "name": "Honda-civic" },
-                 { "_id": "3", "year": [2003], "name": "BMW-X5" },
-                 { "nr": 4, "val1":   1.0, "val2":  4.0 }]
+    "expected": [{ "c1": "RangeRover-Evoque", "c2": "Dodge-Caravan" },
+                 { "c1": "BMW-X5",            "c2": "Jeep-Liberty" },
+                 {                            "c2": "Chrysler-Sebring" },
+                 {                            "c2": "Toyota-Prius" }]
 }


### PR DESCRIPTION
The previous outer join integration tests had incorrect expected results. This fixes the results as well as uses a different dataset for the queries so that we can fully tested the "outerness" of the joins.

The tests pass in old mongo and spark. They do not pass in mimir or marklogic.