### PR TITLE
Skip distinctStar test for marklogic because it is flaky.

### DIFF
--- a/it/src/main/resources/tests/distinctStar.test
+++ b/it/src/main/resources/tests/distinctStar.test
@@ -2,6 +2,8 @@
     "name": "distinct *",
     "backends": {
         "couchbase": "skip",
+        "marklogic_json": "skip",
+        "marklogic_xml": "skip",
         "mimir":"pending",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
@@ -10,7 +12,8 @@
         "mongodb_3_4":       "pending",
         "mongodb_q_3_2": "pending"
     },
-    "NB": "Skipped for couchbase due to #2329 failure to load test data.",
+    "NB": "Skipped for couchbase due to #2329 failure to load test data.
+           Skipped for marklogic due to #2241 mem alloc error and #2319 tree cache full.",
     "data": "cities.data",
     "query": "select distinct * from cities where city = \"BOSTON\"",
     "predicate": "exactly",


### PR DESCRIPTION
This test is failing frequently enough in travis that I propose skipping it so that we can have a reliable build.