### PR TITLE
"Fixed" date parsing in mimir and added pendingIgnoreFieldOrder

### DIFF
--- a/blueeyes/src/main/scala/quasar/precog/util/DateTimeUtil.scala
+++ b/blueeyes/src/main/scala/quasar/precog/util/DateTimeUtil.scala
@@ -18,36 +18,20 @@ package quasar.precog.util
 
 import java.time._
 import java.time.format._
-import java.time.temporal.{TemporalAccessor, TemporalQuery}
 
 import java.util.regex.Pattern
 
 object DateTimeUtil {
-  // from http://stackoverflow.com/a/30072486/9815
-  private val fullParser = DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss[xxx]")
 
-  // from joda-time javadoc
-  private val basicParser = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss.SSSZ")
-
-  //2013-02-04T18:07:39.608835
-  private val dateTimeRegex = Pattern.compile("^[0-9]{4}-?[0-9]{2}-?[0-9]{2}.*$")
+  // mimics ISO_INSTANT
+  private val dateTimeRegex =
+    Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
 
   def looksLikeIso8601(s: String): Boolean = dateTimeRegex.matcher(s).matches
 
-  def parseDateTime(value0: String): ZonedDateTime = {
-    val value = value0.trim.replace(" ", "T")
-
-    val parser = if (value.contains("-") || value.contains(":")) {
-      fullParser
-    } else {
-      basicParser
-    }
-
-    parser.parse(value, new TemporalQuery[ZonedDateTime] {
-      def queryFrom(temporal: TemporalAccessor) =
-        ZonedDateTime.from(temporal)
-    })
-  }
+  // FIXME ok this really sucks.  Instant ≠ ZonedDateTime
+  def parseDateTime(value: String): ZonedDateTime =
+    Instant.parse(value).atZone(ZoneId.of("UTC"))
 
   def isValidISO(str: String): Boolean = try {
     parseDateTime(str); true

--- a/it/src/main/resources/tests/aliasedFieldSortedByOriginal.test
+++ b/it/src/main/resources/tests/aliasedFieldSortedByOriginal.test
@@ -3,7 +3,7 @@
     "backends": {
         "couchbase":         "ignoreFieldOrder",
         "marklogic_json":    "ignoreFieldOrder",
-        "mimir":             "pending",
+        "mimir":             "pendingIgnoreFieldOrder",
         "mongodb_2_6":       "ignoreFieldOrder",
         "mongodb_3_0":       "ignoreFieldOrder",
         "mongodb_3_2":       "ignoreFieldOrder",

--- a/it/src/main/resources/tests/backendStatuses.test
+++ b/it/src/main/resources/tests/backendStatuses.test
@@ -3,7 +3,6 @@
     "backends": {
         "couchbase":         "pending",
         "marklogic_xml":     "pending",
-        "mimir":             "pending",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
         "mongodb_3_2":       "pending",

--- a/it/src/main/resources/tests/basicAnalyticQuery.test
+++ b/it/src/main/resources/tests/basicAnalyticQuery.test
@@ -3,7 +3,7 @@
     "backends": {
         "couchbase": "ignoreFieldOrder",
         "marklogic_json": "ignoreFieldOrder",
-        "mimir":          "pending",
+        "mimir":          "pendingIgnoreFieldOrder",
         "mongodb_q_3_2":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/boulderLikePop.test
+++ b/it/src/main/resources/tests/boulderLikePop.test
@@ -2,7 +2,7 @@
   "name": "population of Boulder-like towns",
 
   "backends": {
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
   },
 
   "data": "zips.data",

--- a/it/src/main/resources/tests/caseVariations.test
+++ b/it/src/main/resources/tests/caseVariations.test
@@ -2,7 +2,7 @@
     "name": "four different kinds of CASE expressions (switch/match, with and without ELSE)",
 
     "backends": {
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "couchbase":  "pending",
         "marklogic_json": "pending",
         "marklogic_xml":  "pending",

--- a/it/src/main/resources/tests/caseWithGroup.test
+++ b/it/src/main/resources/tests/caseWithGroup.test
@@ -2,7 +2,7 @@
     "name": "combine case (3-arg expr) with group by",
 
     "backends": {
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "marklogic_json": "pending",
         "marklogic_xml": "pending",
         "mongodb_q_3_2": "pending",

--- a/it/src/main/resources/tests/citiesByTotalPopulation.test
+++ b/it/src/main/resources/tests/citiesByTotalPopulation.test
@@ -3,7 +3,7 @@
 
     "backends": {
         "couchbase":         "ignoreFieldOrder",
-        "mimir":             "pending",
+        "mimir":             "pendingIgnoreFieldOrder",
         "mongodb_2_6":       "ignoreFieldOrder",
         "mongodb_3_0":       "ignoreFieldOrder",
         "mongodb_3_2":       "ignoreFieldOrder",

--- a/it/src/main/resources/tests/concatArrayWithLiteral.test
+++ b/it/src/main/resources/tests/concatArrayWithLiteral.test
@@ -2,8 +2,8 @@
     "name": "concat unknown with literal array",
     "backends": {
         "marklogic_json":    "ignoreFieldOrder",
-        "mimir":             "pending",
-        "mongodb_q_3_2":     "pending"
+        "mimir":             "pendingIgnoreFieldOrder",
+        "mongodb_q_3_2":     "ignoreFieldOrder"
     },
     "data": "largeZips.data",
     "query": "select loc || [1, 2] as arr, city from largeZips",

--- a/it/src/main/resources/tests/concatArrayWithLiteral.test
+++ b/it/src/main/resources/tests/concatArrayWithLiteral.test
@@ -2,7 +2,7 @@
     "name": "concat unknown with literal array",
     "backends": {
         "marklogic_json":    "ignoreFieldOrder",
-        "mimir":             "pendingIgnoreFieldOrder",
+        "mimir":             "ignoreFieldOrder",
         "mongodb_q_3_2":     "ignoreFieldOrder"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/concatArrayWithLiteral.test
+++ b/it/src/main/resources/tests/concatArrayWithLiteral.test
@@ -3,7 +3,7 @@
     "backends": {
         "marklogic_json":    "ignoreFieldOrder",
         "mimir":             "ignoreFieldOrder",
-        "mongodb_q_3_2":     "ignoreFieldOrder"
+        "mongodb_q_3_2":     "pending"
     },
     "data": "largeZips.data",
     "query": "select loc || [1, 2] as arr, city from largeZips",

--- a/it/src/main/resources/tests/concatBetween.test
+++ b/it/src/main/resources/tests/concatBetween.test
@@ -3,7 +3,7 @@
     "backends": {
         "couchbase":      "ignoreFieldOrder",
         "marklogic_json": "ignoreFieldOrder",
-        "mimir":          "pending"
+        "mimir":          "pendingIgnoreFieldOrder"
     },
     "data": "smallZips.data",
     "query": "select city, pop, pop between 1000 and 10000 as midsized from smallZips",

--- a/it/src/main/resources/tests/constantAndGrouped.test
+++ b/it/src/main/resources/tests/constantAndGrouped.test
@@ -4,7 +4,7 @@
     "backends": {
         "couchbase":      "ignoreFieldOrder",
         "marklogic_json": "ignoreFieldOrder",
-        "mimir":          "pending"
+        "mimir":          "pendingIgnoreFieldOrder"
     },
 
     "data": "zips.data",

--- a/it/src/main/resources/tests/convertFromString.test
+++ b/it/src/main/resources/tests/convertFromString.test
@@ -3,7 +3,7 @@
     "backends": {
         "couchbase":         "ignoreFieldOrder",
         "marklogic_json":    "ignoreFieldOrder",
-        "mimir":             "pending"
+        "mimir":             "pendingIgnoreFieldOrder"
     },
     "data": "smallZips.data",
     "query": "select integer(`_id`) as intId, decimal(`_id`) as decId from smallZips",

--- a/it/src/main/resources/tests/convertToFromString.test
+++ b/it/src/main/resources/tests/convertToFromString.test
@@ -3,7 +3,7 @@
     "backends": {
         "couchbase": "ignoreFieldOrder",
         "marklogic_json": "ignoreFieldOrder",
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
     "data": "zips.data",
     "query": "select integer(`_id`) as intId, decimal(`_id`) as decId, to_string(pop) as popStr, to_string(loc[0]) as locStr, to_string(length(city) < 9) as boolStr from zips",

--- a/it/src/main/resources/tests/couchbase/leftKeyJoinMultipleSelect.test
+++ b/it/src/main/resources/tests/couchbase/leftKeyJoinMultipleSelect.test
@@ -4,7 +4,7 @@
         "couchbase":         "ignoreFieldOrder",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
-        "mimir":"pending",
+        "mimir":"skip",
         "mongodb_2_6":       "skip",
         "mongodb_3_0":       "skip",
         "mongodb_read_only": "skip",

--- a/it/src/main/resources/tests/delete.test
+++ b/it/src/main/resources/tests/delete.test
@@ -3,7 +3,7 @@
     "backends": {
         "couchbase":         "ignoreFieldOrder",
         "marklogic_json":    "ignoreFieldOrder",
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
     "data": "zips.data",
     "query": "delete from zips where pop < 100000",

--- a/it/src/main/resources/tests/demo/nestedSelectWithReduce.test
+++ b/it/src/main/resources/tests/demo/nestedSelectWithReduce.test
@@ -1,7 +1,7 @@
 {
     "name": "select reduction from nested select",
     "backends": {
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "couchbase": "pending",
         "marklogic_json": "pending",
         "marklogic_xml": "pending",

--- a/it/src/main/resources/tests/demo/timeSeriesAggregation.test
+++ b/it/src/main/resources/tests/demo/timeSeriesAggregation.test
@@ -2,7 +2,7 @@
     "name": "time series aggregation",
     "backends": {
         "couchbase": "ignoreFieldOrder",
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
     "data": "smalltimeseries.data",
     "query": "

--- a/it/src/main/resources/tests/derivedFunctionAbs.test
+++ b/it/src/main/resources/tests/derivedFunctionAbs.test
@@ -3,7 +3,7 @@
     "backends": {
       "couchbase": "ignoreFieldOrder",
       "marklogic_json": "ignoreFieldOrder",
-      "mimir": "pending"
+      "mimir": "pendingIgnoreFieldOrder"
     },
     "data": "divide.data",
     "query": "select nr, -val1 as neg1, abs(val1) as abs1 from divide",

--- a/it/src/main/resources/tests/derivedFunctionCeil.test
+++ b/it/src/main/resources/tests/derivedFunctionCeil.test
@@ -2,7 +2,7 @@
     "name": "derived function ceil",
     "backends": {
       "couchbase": "ignoreFieldOrder",
-      "mimir": "pending"
+      "mimir": "pendingIgnoreFieldOrder"
     },
     "data": "divide.data",
     "query": "select nr, ceil(val3) as ceil1 from divide",

--- a/it/src/main/resources/tests/derivedFunctionFloor.test
+++ b/it/src/main/resources/tests/derivedFunctionFloor.test
@@ -2,7 +2,7 @@
     "name": "derived function floor",
     "backends": {
       "couchbase": "ignoreFieldOrder",
-      "mimir": "pending"
+      "mimir": "pendingIgnoreFieldOrder"
     },
     "data": "divide.data",
     "query": "select nr, floor(val3) as floor1 from divide",

--- a/it/src/main/resources/tests/derivedFunctionTrunc.test
+++ b/it/src/main/resources/tests/derivedFunctionTrunc.test
@@ -1,7 +1,7 @@
 {
     "name": "derived function trunc",
     "backends": {
-      "mimir": "pending"
+      "mimir": "pendingIgnoreFieldOrder"
     },
     "data": "divide.data",
     "query": "select nr, trunc(val3) as trunc1 from divide",

--- a/it/src/main/resources/tests/different-flattens.test
+++ b/it/src/main/resources/tests/different-flattens.test
@@ -1,7 +1,7 @@
 {
     "name": "merge differently-nested flattens",
     "backends": {
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "couchbase": "pending",
         "marklogic_json": "pending",
         "mongodb_q_3_2":  "pending"

--- a/it/src/main/resources/tests/distinctStar.test
+++ b/it/src/main/resources/tests/distinctStar.test
@@ -2,7 +2,7 @@
     "name": "distinct *",
     "backends": {
         "couchbase": "skip",
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
         "mongodb_read_only": "pending",

--- a/it/src/main/resources/tests/doubleFlatten.test
+++ b/it/src/main/resources/tests/doubleFlatten.test
@@ -1,8 +1,5 @@
 {
     "name": "flatten a flattened field",
-    "backends": {
-        "mimir":"pending"
-    },
     "data": "slamengine_commits.data",
     "query": "select parents[*]{*} from slamengine_commits",
     "predicate": "atLeast",

--- a/it/src/main/resources/tests/fieldOrder.test
+++ b/it/src/main/resources/tests/fieldOrder.test
@@ -2,7 +2,7 @@
     "name": "reduced expressions which trigger bad field ordering in MongoDB (#598)",
 
     "backends": {
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
 
     "data": "zips.data",

--- a/it/src/main/resources/tests/filterByJsWithOnlyReducing.test
+++ b/it/src/main/resources/tests/filterByJsWithOnlyReducing.test
@@ -2,7 +2,7 @@
     "name": "filter by JS expression, with only reducing projections",
 
     "backends": {
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
 
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/filterMembership.test
+++ b/it/src/main/resources/tests/filterMembership.test
@@ -1,7 +1,7 @@
 {
     "name": "filter on list membership",
     "backends": {
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
     "data": "zips.data",
     "query": "select count(*) as cnt from zips where state in (\"AZ\", \"CO\")",

--- a/it/src/main/resources/tests/filterOnContains.test
+++ b/it/src/main/resources/tests/filterOnContains.test
@@ -1,7 +1,7 @@
 {
     "name": "filter on contains",
     "backends": {
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
     "data": "zips.data",
     "query": "select * from zips where 43.058514 in loc[_]",

--- a/it/src/main/resources/tests/filterOnFieldComparison.test
+++ b/it/src/main/resources/tests/filterOnFieldComparison.test
@@ -1,7 +1,7 @@
 {
     "name": "filter on field comparison",
     "backends": {
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
     "data": "zips.data",
     "query": "select * from zips where pop < loc[1] order by `_id` limit 10",

--- a/it/src/main/resources/tests/filterOnOid.test
+++ b/it/src/main/resources/tests/filterOnOid.test
@@ -1,9 +1,6 @@
 {
     "name": "match on ObjectId",
     "NB": "This test isn’t really valid. This is neither the correct way to represent an OID (there is no generic way to do so), nor should the `_id` field even be in the data. But this is a reasonable placeholder until we actually expose the correct way to do more or less what this intends.",
-    "backends": {
-        "mimir":"pending"
-    },
     "data": "days.data",
     "query": "select day from days where `_id` = oid(\"54b6f430d4c654959e963a62\")",
     "predicate": "exactly",

--- a/it/src/main/resources/tests/filterSortLimit.test
+++ b/it/src/main/resources/tests/filterSortLimit.test
@@ -2,7 +2,7 @@
     "name": "filter, sort, and limit",
 
     "backends": {
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
 
     "data": "zips.data",

--- a/it/src/main/resources/tests/filterWithNot.test
+++ b/it/src/main/resources/tests/filterWithNot.test
@@ -2,7 +2,7 @@
   "name": "filter with negated regex selector",
 
   "backends": {
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
   },
 
   "data": "zips.data",

--- a/it/src/main/resources/tests/flattenArrayProjection.test
+++ b/it/src/main/resources/tests/flattenArrayProjection.test
@@ -1,8 +1,5 @@
 {
     "name": "flatten an object resulting from an array projection",
-    "backends": {
-        "mimir":"pending"
-    },
     "data": "slamengine_commits.data",
     "query": "select parents[0]{*} as parent from slamengine_commits",
     "predicate": "atLeast",

--- a/it/src/main/resources/tests/flattenGroupedObject.test
+++ b/it/src/main/resources/tests/flattenGroupedObject.test
@@ -1,7 +1,7 @@
 {
     "name": "flatten a grouped object with filter",
     "backends": {
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "couchbase":         "pending",
         "marklogic_json":    "pending",
         "mongodb_q_3_2":     "pending",

--- a/it/src/main/resources/tests/flattenNestedObject.test
+++ b/it/src/main/resources/tests/flattenNestedObject.test
@@ -1,9 +1,10 @@
 {
     "name": "flatten an object inside a field projection",
-    "backends": {
-        "mimir":"pending"
-    },
     "data": "slamengine_commits.data",
+    "backends": {
+        "mimir": "pending"
+    },
+    "NB": "unmatched expected values 'Set(\"2015-01-29T15:52:37Z\", \"2015-01-29T00:23:14Z\", \"2015-01-26T17:37:40Z\")' is not empty (file:1)",
     "query": "select commit.author{*} from slamengine_commits",
     "predicate": "atLeast",
     "ignoreResultOrder": true,

--- a/it/src/main/resources/tests/flattenObject.test
+++ b/it/src/main/resources/tests/flattenObject.test
@@ -2,7 +2,7 @@
     "name": "flatten object",
     "backends": {
         "couchbase":  "ignoreFieldOrder",
-        "mimir":"pending"
+        "mimir":"ignoreFieldOrder"
     },
     "data": "usa_factbook.data",
     "query": "select geo{*} from usa_factbook",

--- a/it/src/main/resources/tests/flattenObjectLike.test
+++ b/it/src/main/resources/tests/flattenObjectLike.test
@@ -1,7 +1,7 @@
 {
     "name": "flatten a single field as an object",
     "backends": {
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "couchbase":         "pending",
         "marklogic_json":    "pending",
         "marklogic_xml":     "pending",

--- a/it/src/main/resources/tests/generatedFieldNames.test
+++ b/it/src/main/resources/tests/generatedFieldNames.test
@@ -3,7 +3,7 @@
 
   "backends": {
     "couchbase": "ignoreFieldOrder",
-    "mimir":"pending"
+    "mimir":"pendingIgnoreFieldOrder"
   },
 
   "data": "smallZips.data",

--- a/it/src/main/resources/tests/groupAndWildcard.test
+++ b/it/src/main/resources/tests/groupAndWildcard.test
@@ -2,7 +2,7 @@
   "name": "select wildcard with group by",
 
   "backends": {
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
   },
 
   "data": "zips.data",

--- a/it/src/main/resources/tests/groupByExpression.test
+++ b/it/src/main/resources/tests/groupByExpression.test
@@ -3,7 +3,7 @@
 
     "backends": {
         "marklogic_json": "ignoreFieldOrder",
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "mongodb_2_6": "ignoreFieldOrder",
         "mongodb_3_0": "ignoreFieldOrder",
         "mongodb_3_2": "ignoreFieldOrder",

--- a/it/src/main/resources/tests/groupByFlatten.test
+++ b/it/src/main/resources/tests/groupByFlatten.test
@@ -1,7 +1,7 @@
 {
     "name": "group by flattened field",
     "backends": {
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "couchbase": "pending",
         "marklogic_json": "pending",
         "marklogic_xml": "pending",

--- a/it/src/main/resources/tests/ifUndefined.test
+++ b/it/src/main/resources/tests/ifUndefined.test
@@ -3,7 +3,7 @@
     "backends": {
         "couchbase": "ignoreFieldOrder",
         "marklogic_json": "ignoreFieldOrder",
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
     "data": "zips.data",
     "query": "select foo ?? pop as p, city ?? false as c from zips",

--- a/it/src/main/resources/tests/implicitGroupWithFilter.test
+++ b/it/src/main/resources/tests/implicitGroupWithFilter.test
@@ -3,7 +3,7 @@
 
     "backends": {
         "marklogic_json": "ignoreFieldOrder",
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
 
     "data": "zips.data",

--- a/it/src/main/resources/tests/joins/changedTestStatus.test
+++ b/it/src/main/resources/tests/joins/changedTestStatus.test
@@ -5,7 +5,7 @@
         "couchbase":         "pending",
         "marklogic_json":    "pending",
         "marklogic_xml":     "pending",
-        "mimir":             "pending",
+        "mimir":             "pendingIgnoreFieldOrder",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
         "mongodb_3_2":       "pending",

--- a/it/src/main/resources/tests/joins/changedTestStatusInterim.test
+++ b/it/src/main/resources/tests/joins/changedTestStatusInterim.test
@@ -6,7 +6,7 @@
         "couchbase":         "pending",
         "marklogic_json":    "pending",
         "marklogic_xml":     "pending",
-        "mimir":             "pending",
+        "mimir":             "pendingIgnoreFieldOrder",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
         "mongodb_3_2":       "pending",

--- a/it/src/main/resources/tests/joins/crossJoinWithOneSidedConditions.test
+++ b/it/src/main/resources/tests/joins/crossJoinWithOneSidedConditions.test
@@ -4,7 +4,7 @@
     "backends": {
         "couchbase":         "pending",
         "marklogic_json":    "ignoreFieldOrder",
-        "mimir":             "pending",
+        "mimir":             "pendingIgnoreFieldOrder",
         "mongodb_q_3_2":     "pending"
     },
 

--- a/it/src/main/resources/tests/joins/groupedJoin.test
+++ b/it/src/main/resources/tests/joins/groupedJoin.test
@@ -2,7 +2,7 @@
     "name": "count grouped joined tables",
 
     "backends": {
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "couchbase":         "timeout",
         "marklogic_json":    "timeout",
         "marklogic_xml":     "timeout",

--- a/it/src/main/resources/tests/joins/joinSubSelects.test
+++ b/it/src/main/resources/tests/joins/joinSubSelects.test
@@ -5,7 +5,7 @@
         "couchbase":      "timeout",
         "marklogic_json": "timeout",
         "marklogic_xml":  "timeout",
-        "mimir":          "pending",
+        "mimir":          "pendingIgnoreFieldOrder",
         "mongodb_q_3_2":  "pending"
     },
 

--- a/it/src/main/resources/tests/joins/joinWithComplexCondition.test
+++ b/it/src/main/resources/tests/joins/joinWithComplexCondition.test
@@ -2,7 +2,7 @@
     "name": "join with complex conditions",
 
     "backends": {
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "couchbase":         "pending",
         "marklogic_json":    "timeout",
         "marklogic_xml":     "timeout",

--- a/it/src/main/resources/tests/joins/joinWithMultipleConditions.test
+++ b/it/src/main/resources/tests/joins/joinWithMultipleConditions.test
@@ -2,7 +2,6 @@
     "name": "join with multiple conditions",
 
     "backends": {
-        "mimir":"pending",
         "couchbase":         "pending",
         "marklogic_json":    "timeout",
         "marklogic_xml":     "timeout",

--- a/it/src/main/resources/tests/joins/joinWithMultipleConditions.test
+++ b/it/src/main/resources/tests/joins/joinWithMultipleConditions.test
@@ -5,6 +5,7 @@
         "couchbase":         "pending",
         "marklogic_json":    "timeout",
         "marklogic_xml":     "timeout",
+        "mimir": "ignoreFieldOrder",
         "mongodb_q_3_2":     "pending"
     },
 

--- a/it/src/main/resources/tests/joins/joinWithReversedCondition.test
+++ b/it/src/main/resources/tests/joins/joinWithReversedCondition.test
@@ -4,6 +4,7 @@
     "backends": {
         "couchbase":         "pending",
         "marklogic_json": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder",
         "mongodb_q_3_2":     "pending"
     },
 

--- a/it/src/main/resources/tests/joins/joinWithReversedCondition.test
+++ b/it/src/main/resources/tests/joins/joinWithReversedCondition.test
@@ -4,7 +4,6 @@
     "backends": {
         "couchbase":         "pending",
         "marklogic_json": "ignoreFieldOrder",
-        "mimir":"pending",
         "mongodb_q_3_2":     "pending"
     },
 

--- a/it/src/main/resources/tests/joins/nonJsJoinCondition.test
+++ b/it/src/main/resources/tests/joins/nonJsJoinCondition.test
@@ -5,7 +5,7 @@
         "couchbase":      "pending",
         "marklogic_json": "timeout",
         "marklogic_xml":  "timeout",
-        "mimir":          "pending",
+        "mimir":          "pendingIgnoreFieldOrder",
         "mongodb_q_3_2":  "pending",
         "spark_local":    "pending",
         "spark_hdfs":     "pending"

--- a/it/src/main/resources/tests/joins/orderJoinByAlias.test
+++ b/it/src/main/resources/tests/joins/orderJoinByAlias.test
@@ -5,7 +5,7 @@
         "couchbase":         "pending",
         "marklogic_json":    "timeout",
         "marklogic_xml":     "timeout",
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "mongodb_q_3_2":     "pending"
     },
 

--- a/it/src/main/resources/tests/joins/selfjoinWithComplexCondition.test
+++ b/it/src/main/resources/tests/joins/selfjoinWithComplexCondition.test
@@ -2,7 +2,7 @@
     "name": "self-join with complex conditions",
 
     "backends": {
-        "mimir":             "pending",
+        "mimir":             "pendingIgnoreFieldOrder",
         "couchbase":         "pending",
         "marklogic_json":    "timeout",
         "marklogic_xml":     "timeout",

--- a/it/src/main/resources/tests/joins/symmetricNonJsJoinCondition.test
+++ b/it/src/main/resources/tests/joins/symmetricNonJsJoinCondition.test
@@ -2,7 +2,7 @@
     "name": "flattening both sides of a join condition",
 
     "backends": {
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "couchbase":         "pending",
         "marklogic_json":    "timeout",
         "marklogic_xml":     "timeout",

--- a/it/src/main/resources/tests/jsWithNonJsFilter.test
+++ b/it/src/main/resources/tests/jsWithNonJsFilter.test
@@ -1,7 +1,7 @@
 {
     "name": "filter on JS with non-JS",
     "backends": {
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
     "data": "largeZips.data",
     "query": "select city, pop from largeZips where length(city) < 5 and pop < 30000",

--- a/it/src/main/resources/tests/largestCities.test
+++ b/it/src/main/resources/tests/largestCities.test
@@ -2,7 +2,7 @@
     "name": "largest cities",
 
     "backends": {
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "mongodb_2_6": "ignoreFieldOrder",
         "mongodb_3_0": "ignoreFieldOrder",
         "mongodb_3_2": "ignoreFieldOrder",

--- a/it/src/main/resources/tests/largestZips.test
+++ b/it/src/main/resources/tests/largestZips.test
@@ -1,7 +1,7 @@
 {
     "name": "largest zips",
     "backends": {
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
     "data": "zips.data",
     "query": "select city, pop from zips where pop > 90000 order by city, pop desc",

--- a/it/src/main/resources/tests/likeWithConstantFoldablePattern.test
+++ b/it/src/main/resources/tests/likeWithConstantFoldablePattern.test
@@ -1,7 +1,7 @@
 {
     "name": "LIKE with constant-foldable pattern",
     "backends": {
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
     "data": "zips.data",
     "variables": { "substr": "\"ULDER\"" },

--- a/it/src/main/resources/tests/locationCount.test
+++ b/it/src/main/resources/tests/locationCount.test
@@ -1,7 +1,7 @@
 {
     "name": "job postings by city ",
     "backends": {
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "couchbase":         "pending",
         "marklogic_json":    "pending",
         "marklogic_xml":     "timeout",

--- a/it/src/main/resources/tests/longCitiesWithLength.test
+++ b/it/src/main/resources/tests/longCitiesWithLength.test
@@ -2,7 +2,7 @@
     "name": "long city names in Colorado",
     "backends": {
         "couchbase":  "ignoreFieldOrder",
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "mongodb_q_3_2": "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/manySimpleProjections.test
+++ b/it/src/main/resources/tests/manySimpleProjections.test
@@ -3,7 +3,7 @@
 
   "backends": {
         "marklogic_json":    "ignoreFieldOrder",
-        "mimir":"pending"
+        "mimir":"ignoreFieldOrder"
   },
 
   "data": "zips.data",

--- a/it/src/main/resources/tests/matchCaseInsensitiveRegex.test
+++ b/it/src/main/resources/tests/matchCaseInsensitiveRegex.test
@@ -1,7 +1,7 @@
 {
     "name": "match on case-insensitive string",
     "backends": {
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
     "data": "zips.data",
     "query": "select * from zips where city ~* \"^bOu\"",

--- a/it/src/main/resources/tests/matchRegexPatternWithExpressions.test
+++ b/it/src/main/resources/tests/matchRegexPatternWithExpressions.test
@@ -4,7 +4,7 @@
   "backends": {
         "couchbase": "ignoreFieldOrder",
         "marklogic_json": "ignoreFieldOrder",
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "mongodb_q_3_2":  "pending"
   },
 

--- a/it/src/main/resources/tests/mongodb/distinctStar.test
+++ b/it/src/main/resources/tests/mongodb/distinctStar.test
@@ -1,7 +1,7 @@
 {
     "name": "distinct * (MongoDB)",
     "backends": {
-        "mimir":"pending",
+        "mimir":"skip",
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/mongodb/fakeObjectId.test
+++ b/it/src/main/resources/tests/mongodb/fakeObjectId.test
@@ -1,7 +1,7 @@
 {
     "name": "convert a field to ObjectId",
     "backends": {
-        "mimir":"pending",
+        "mimir":"skip",
         "mongodb_q_3_2": "pending",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/mongodb/temporal/filterOnDate.test
+++ b/it/src/main/resources/tests/mongodb/temporal/filterOnDate.test
@@ -1,7 +1,7 @@
 {
     "name": "filter with date literals",
     "backends": {
-        "mimir":"pending",
+        "mimir":"skip",
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/mongodb/temporal/time.test
+++ b/it/src/main/resources/tests/mongodb/temporal/time.test
@@ -2,7 +2,7 @@
     "name": "filter on time_of_day (MongoDB)",
 
     "backends": {
-        "mimir":"pending",
+        "mimir":"skip",
         "couchbase":         "skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",

--- a/it/src/main/resources/tests/mongodb/temporal/toFromString.test
+++ b/it/src/main/resources/tests/mongodb/temporal/toFromString.test
@@ -1,7 +1,7 @@
 {
     "name": "convert dates to/from strings (MongoDB)",
     "backends": {
-        "mimir":"pending",
+        "mimir":"skip",
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
         "couchbase":         "skip",

--- a/it/src/main/resources/tests/multistageFlatten.test
+++ b/it/src/main/resources/tests/multistageFlatten.test
@@ -1,7 +1,7 @@
 {
     "name": "multi-flatten with fields at various depths",
     "backends": {
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "couchbase": "pending",
         "marklogic_json": "pending",
         "marklogic_xml": "timeout",

--- a/it/src/main/resources/tests/multitypeFlatten.test
+++ b/it/src/main/resources/tests/multitypeFlatten.test
@@ -4,7 +4,7 @@
         "couchbase":         "pending",
         "marklogic_json":    "pending",
         "marklogic_xml":     "timeout",
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "mongodb_q_3_2":     "pending",
         "spark_local":       "pending",
         "spark_hdfs":        "pending"

--- a/it/src/main/resources/tests/negatedRegex.test
+++ b/it/src/main/resources/tests/negatedRegex.test
@@ -2,7 +2,7 @@
     "name": "negate matches in filter and projection",
     "backends": {
         "couchbase": "ignoreFieldOrder",
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
     "data": "largeZips.data",
     "query": "select city, city !~ \"A\" as noA from largeZips where city !~ \"CHI\"",

--- a/it/src/main/resources/tests/null/nullTestExprs.test
+++ b/it/src/main/resources/tests/null/nullTestExprs.test
@@ -2,7 +2,7 @@
     "name": "expressions with `= null` and `is null`",
     "backends": {
         "couchbase": "ignoreFieldOrder",
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "marklogic_json": "ignoreFieldOrder",
         "marklogic_xml":  "ignoreFieldOrder"
     },

--- a/it/src/main/resources/tests/null/nullTestExprsWithMissing.test
+++ b/it/src/main/resources/tests/null/nullTestExprsWithMissing.test
@@ -1,7 +1,7 @@
 {
     "name": "expressions with `= null` and `is null`, with missing fields (pending #465)",
     "backends": {
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
         "mongodb_read_only": "pending",

--- a/it/src/main/resources/tests/null/toFromString.test
+++ b/it/src/main/resources/tests/null/toFromString.test
@@ -2,7 +2,7 @@
     "name": "convert null to/from strings",
     "backends": {
         "marklogic_json": "ignoreFieldOrder",
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
     "data": "nulls.data",
     "query": "select null(name) as n, to_string(val) as s from nulls where name = \"null\"",

--- a/it/src/main/resources/tests/orderedWildcardWithProjection.test
+++ b/it/src/main/resources/tests/orderedWildcardWithProjection.test
@@ -1,7 +1,7 @@
 {
     "name": "wildcard with projection and synthetic field",
     "backends": {
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
     "data": "largeZips.data",
     "query": "select *, pop * 10 as dpop from largeZips order by pop / 10 desc",

--- a/it/src/main/resources/tests/projectCaseInsensitiveRegex.test
+++ b/it/src/main/resources/tests/projectCaseInsensitiveRegex.test
@@ -3,7 +3,7 @@
     "backends": {
         "couchbase": "ignoreFieldOrder",
         "marklogic_json": "ignoreFieldOrder",
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
     "data": "largeZips.data",
     "query": "select city, city ~* \"boU\" as a, city !~* \"Bou\" as b from largeZips",

--- a/it/src/main/resources/tests/projectIndexFromGroup.test
+++ b/it/src/main/resources/tests/projectIndexFromGroup.test
@@ -3,7 +3,7 @@
     "backends": {
         "couchbase": "ignoreFieldOrder",
         "marklogic_json": "ignoreFieldOrder",
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "mongodb_2_6": "ignoreFieldOrder",
         "mongodb_3_0": "ignoreFieldOrder",
         "mongodb_3_2": "ignoreFieldOrder",

--- a/it/src/main/resources/tests/projectIndexFromGroupWithFilter.test
+++ b/it/src/main/resources/tests/projectIndexFromGroupWithFilter.test
@@ -3,7 +3,7 @@
     "backends": {
         "couchbase": "ignoreFieldOrder",
         "marklogic_json": "ignoreFieldOrder",
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "mongodb_2_6": "ignoreFieldOrder",
         "mongodb_3_0": "ignoreFieldOrder",
         "mongodb_3_2": "ignoreFieldOrder",

--- a/it/src/main/resources/tests/projectIndexWithObjectFlatten.test
+++ b/it/src/main/resources/tests/projectIndexWithObjectFlatten.test
@@ -3,7 +3,7 @@
     "backends": {
         "couchbase":         "pending",
         "marklogic_json": "ignoreFieldOrder",
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
     "data": "slamengine_commits.data",
     "query": "select parents[0] as parent, commit{*} from slamengine_commits",

--- a/it/src/main/resources/tests/selectCount.test
+++ b/it/src/main/resources/tests/selectCount.test
@@ -2,7 +2,7 @@
     "name": "select count and another field",
     "backends": {
         "couchbase": "pending",
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "mongodb_q_3_2": "pending"
     },
     "data": "slamengine_commits.data",

--- a/it/src/main/resources/tests/selectTwentyFields.test
+++ b/it/src/main/resources/tests/selectTwentyFields.test
@@ -2,7 +2,7 @@
     "name": "select twenty fields quickly",
     "backends": {
         "marklogic_json": "ignoreFieldOrder",
-        "mimir":"pending"
+        "mimir":"ignoreFieldOrder"
     },
     "data": "largeZips.data",
     "query": "select

--- a/it/src/main/resources/tests/servlet.test
+++ b/it/src/main/resources/tests/servlet.test
@@ -1,7 +1,7 @@
 {
     "name": "servlets with and without init-param (pending #465, #467)",
     "backends": {
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "couchbase":         "pending",
         "marklogic_json":    "pending",
         "marklogic_xml":     "pending",

--- a/it/src/main/resources/tests/simpleDistinct.test
+++ b/it/src/main/resources/tests/simpleDistinct.test
@@ -3,7 +3,7 @@
 
   "backends": {
         "marklogic_json":    "ignoreFieldOrder",
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "mongodb_q_3_2": "pending"
   },
 

--- a/it/src/main/resources/tests/sortByJS.test
+++ b/it/src/main/resources/tests/sortByJS.test
@@ -2,7 +2,7 @@
   "name": "sort by JS expression with filter",
 
   "backends": {
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
   },
 
   "data": "zips.data",

--- a/it/src/main/resources/tests/sortProjectLimit.test
+++ b/it/src/main/resources/tests/sortProjectLimit.test
@@ -2,7 +2,7 @@
     "name": "sort, project, and limit",
 
     "backends": {
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
 
     "data": "zips.data",

--- a/it/src/main/resources/tests/sortWildcardOnExpression.test
+++ b/it/src/main/resources/tests/sortWildcardOnExpression.test
@@ -1,7 +1,7 @@
 {
     "name": "sort wildcard on expression",
     "backends": {
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
     "data": "largeZips.data",
     "query": "select * from largeZips order by pop/10 desc",

--- a/it/src/main/resources/tests/statesByShortestFirstCity.test
+++ b/it/src/main/resources/tests/statesByShortestFirstCity.test
@@ -1,7 +1,7 @@
 {
     "name": "states sorted by the length of name of their first city, alphabetically",
     "backends": {
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "couchbase": "pending"
     },
     "description": "combines an aggregate function (min) with a function implemented in JS (length)",

--- a/it/src/main/resources/tests/temporal/convertTimestamp.test
+++ b/it/src/main/resources/tests/temporal/convertTimestamp.test
@@ -3,7 +3,7 @@
 
   "backends": {
         "couchbase": "ignoreFieldOrder",
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "mongodb_2_6": "ignoreFieldOrder",
         "mongodb_3_0": "ignoreFieldOrder",
         "mongodb_3_2": "ignoreFieldOrder",

--- a/it/src/main/resources/tests/temporal/datePartsConverted.test
+++ b/it/src/main/resources/tests/temporal/datePartsConverted.test
@@ -4,7 +4,7 @@
   "backends": {
         "couchbase": "ignoreFieldOrder",
         "marklogic_json": "ignoreFieldOrder",
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
   },
 
   "data": "../slamengine_commits.data",

--- a/it/src/main/resources/tests/temporal/days.test
+++ b/it/src/main/resources/tests/temporal/days.test
@@ -3,7 +3,7 @@
 
   "backends": {
         "marklogic_json": "ignoreFieldOrder",
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "mongodb_q_3_2": "pending"
   },
 

--- a/it/src/main/resources/tests/temporal/time.test
+++ b/it/src/main/resources/tests/temporal/time.test
@@ -3,7 +3,7 @@
 
     "backends": {
         "couchbase":         "pending",
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
         "mongodb_read_only": "pending",

--- a/it/src/main/resources/tests/temporal/timestampsAndIntervals.test
+++ b/it/src/main/resources/tests/temporal/timestampsAndIntervals.test
@@ -2,7 +2,7 @@
     "name": "timestamp and interval syntax",
 
     "backends": {
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "couchbase":      "pending",
         "marklogic_json": "pending",
         "marklogic_xml":  "pending",

--- a/it/src/main/resources/tests/temporal/toFromString.test
+++ b/it/src/main/resources/tests/temporal/toFromString.test
@@ -3,7 +3,7 @@
     "backends": {
         "couchbase": "ignoreFieldOrder",
         "marklogic_json": "ignoreFieldOrder",
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
         "mongodb_3_2":       "pending",

--- a/it/src/main/resources/tests/trivialGroup.test
+++ b/it/src/main/resources/tests/trivialGroup.test
@@ -2,7 +2,7 @@
     "name": "trivial group by",
     "backends": {
         "couchbase": "ignoreFieldOrder",
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "mongodb_2_6": "ignoreFieldOrder",
         "mongodb_3_0": "ignoreFieldOrder",
         "mongodb_3_2": "ignoreFieldOrder",

--- a/it/src/main/resources/tests/typeOf.test
+++ b/it/src/main/resources/tests/typeOf.test
@@ -1,7 +1,7 @@
 {
     "name": "use type_of function",
     "backends": {
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "couchbase":      "pending",
         "spark_hdfs":     "pending",
         "spark_local":    "pending"

--- a/it/src/main/resources/tests/unifyFlattenedFieldsWithMultipleUses.test
+++ b/it/src/main/resources/tests/unifyFlattenedFieldsWithMultipleUses.test
@@ -1,7 +1,7 @@
 {
     "name": "unify flattened fields with multiple shape-preserving ops.",
     "backends": {
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "couchbase": "pending",
         "marklogic_json": "timeout",
         "marklogic_xml": "timeout",

--- a/it/src/main/resources/tests/unifyFlattenedFieldsWithUnflattened.test
+++ b/it/src/main/resources/tests/unifyFlattenedFieldsWithUnflattened.test
@@ -1,7 +1,7 @@
 {
     "name": "unify flattened fields with unflattened field",
     "backends": {
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "couchbase":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/union.test
+++ b/it/src/main/resources/tests/union.test
@@ -1,7 +1,7 @@
 {
     "name": "union",
     "backends": {
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "couchbase":         "pending",
         "mongodb_q_3_2":     "pending"
     },

--- a/it/src/main/resources/tests/unshiftAggregation.test
+++ b/it/src/main/resources/tests/unshiftAggregation.test
@@ -4,7 +4,7 @@
     "backends": {
         "couchbase":  "pending",
         "marklogic_json": "ignoreFieldOrder",
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "mongodb_2_6": "ignoreFieldOrder",
         "mongodb_3_0": "ignoreFieldOrder",
         "mongodb_3_2": "ignoreFieldOrder",

--- a/it/src/main/resources/tests/wildcardWithExtraProjections.test
+++ b/it/src/main/resources/tests/wildcardWithExtraProjections.test
@@ -2,7 +2,7 @@
   "name": "wildcard with additional projections and filtering",
 
   "backends": {
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
   },
   "data": "zips.data",
   "query": "select *, concat(city, concat(\", \", state)) as city_state, city = \"BOULDER\" as boulderish from zips where city like \"BOULDER%\"",

--- a/it/src/main/resources/tests/wildcardWithSort.test
+++ b/it/src/main/resources/tests/wildcardWithSort.test
@@ -1,7 +1,7 @@
 {
     "name": "wildcard with sort",
     "backends": {
-        "mimir":"pending"
+        "mimir":"pendingIgnoreFieldOrder"
     },
     "data": "zips.data",
     "query": "select * from zips order by pop, city limit 10",

--- a/it/src/main/resources/tests/zipsByCityLength.test
+++ b/it/src/main/resources/tests/zipsByCityLength.test
@@ -3,7 +3,7 @@
     "backends": {
         "couchbase": "ignoreFieldOrder",
         "marklogic_json": "ignoreFieldOrder",
-        "mimir":"pending",
+        "mimir":"pendingIgnoreFieldOrder",
         "mongodb_2_6": "ignoreFieldOrder",
         "mongodb_3_0": "ignoreFieldOrder",
         "mongodb_3_2": "ignoreFieldOrder",

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -150,7 +150,7 @@ abstract class QueryRegressionTest[S[_]](
           BuildInfo.isCIBuild.fold(
             execute.Skipped("(skipped because it times out)"),
             runTest)
-        case Some(TestDirective.Pending) =>
+        case Some(TestDirective.Pending | TestDirective.PendingIgnoreFieldOrder) =>
           if (BuildInfo.coverageEnabled)
             execute.Skipped("(pending example skipped during coverage run)")
           else
@@ -228,14 +228,14 @@ abstract class QueryRegressionTest[S[_]](
         // TODO: Error if a backend ignores field order when the query already does.
         if (exp.ignoreFieldOrder) OrderIgnored
         else exp.backends.get(backendName) match {
-          case Some(TestDirective.IgnoreAllOrder | TestDirective.IgnoreFieldOrder) =>
+          case Some(TestDirective.IgnoreAllOrder | TestDirective.IgnoreFieldOrder | TestDirective.PendingIgnoreFieldOrder) =>
             OrderIgnored
           case _ =>
             OrderPreserved
         },
         if (exp.ignoreResultOrder) OrderIgnored
         else exp.backends.get(backendName) match {
-          case Some(TestDirective.IgnoreAllOrder | TestDirective.IgnoreResultOrder) =>
+          case Some(TestDirective.IgnoreAllOrder | TestDirective.IgnoreResultOrder | TestDirective.PendingIgnoreFieldOrder) =>
             OrderIgnored
           case _ =>
             OrderPreserved
@@ -250,7 +250,7 @@ abstract class QueryRegressionTest[S[_]](
           case x => x
         }.handle {
           case e: java.util.concurrent.TimeoutException => execute.Pending(s"times out: ${e.getMessage}")
-          case e => execute.Failure(s"Errored with “${e.getMessage}”, you should change the “timeout” status to “pending”.") 
+          case e => execute.Failure(s"Errored with “${e.getMessage}”, you should change the “timeout” status to “pending”.")
         }
       case _ => result.handle {
         case e: java.util.concurrent.TimeoutException =>

--- a/it/src/test/scala/quasar/regression/TestDirective.scala
+++ b/it/src/test/scala/quasar/regression/TestDirective.scala
@@ -23,24 +23,26 @@ import argonaut._, Argonaut._
 sealed abstract class TestDirective
 
 object TestDirective {
-  final case object Skip              extends TestDirective
-  final case object SkipCI            extends TestDirective
-  final case object Timeout           extends TestDirective
-  final case object Pending           extends TestDirective
-  final case object IgnoreAllOrder    extends TestDirective
-  final case object IgnoreFieldOrder  extends TestDirective
+  final case object Skip extends TestDirective
+  final case object SkipCI extends TestDirective
+  final case object Timeout extends TestDirective
+  final case object Pending extends TestDirective
+  final case object PendingIgnoreFieldOrder extends TestDirective
+  final case object IgnoreAllOrder extends TestDirective
+  final case object IgnoreFieldOrder extends TestDirective
   final case object IgnoreResultOrder extends TestDirective
 
   import DecodeResult.{ok, fail}
 
   implicit val TestDirectiveDecodeJson: DecodeJson[TestDirective] =
     DecodeJson(c => c.as[String].flatMap {
-      case "skip"              => ok(Skip)
-      case "skipCI"            => ok(SkipCI)
-      case "timeout"           => ok(Timeout)
-      case "pending"           => ok(Pending)
-      case "ignoreAllOrder"    => ok(IgnoreAllOrder)
-      case "ignoreFieldOrder"  => ok(IgnoreFieldOrder)
+      case "skip" => ok(Skip)
+      case "skipCI" => ok(SkipCI)
+      case "timeout" => ok(Timeout)
+      case "pending" => ok(Pending)
+      case "pendingIgnoreFieldOrder" => ok(PendingIgnoreFieldOrder)
+      case "ignoreAllOrder" => ok(IgnoreAllOrder)
+      case "ignoreFieldOrder" => ok(IgnoreFieldOrder)
       case "ignoreResultOrder" => ok(IgnoreResultOrder)
       case str => fail("\"" + str + "\" is not a valid backend directive.", c.history)
     })


### PR DESCRIPTION
Fixes #2512 
Fixes #2481

This involved some considerable hackery inside of NIHDB.  Basically, `Date` works in terms of `Instant`, while `RValue` (i.e. mimir) works in terms `ZonedDateTime`.  So we're handling this right now by parsing the instant and then assigning it to the UTC timezone.  This is most definitely not correct, but it'll sort of work for now.  Long-term, we should fix the impedance mismatch between mimir and `Data`.