### PR TITLE
Implements Sort in mimir

### DIFF
--- a/it/src/main/resources/tests/filterOnFieldComparison.test
+++ b/it/src/main/resources/tests/filterOnFieldComparison.test
@@ -1,7 +1,7 @@
 {
     "name": "filter on field comparison",
     "backends": {
-        "mimir":"pendingIgnoreFieldOrder"
+        "mimir":"ignoreFieldOrder"
     },
     "data": "zips.data",
     "query": "select * from zips where pop < loc[1] order by `_id` limit 10",

--- a/it/src/main/resources/tests/joins/orderJoinByAlias.test
+++ b/it/src/main/resources/tests/joins/orderJoinByAlias.test
@@ -5,7 +5,7 @@
         "couchbase":         "pending",
         "marklogic_json":    "timeout",
         "marklogic_xml":     "timeout",
-        "mimir":"pendingIgnoreFieldOrder",
+        "mimir":"ignoreFieldOrder",
         "mongodb_q_3_2":     "pending"
     },
 

--- a/it/src/main/resources/tests/joins/orderJoinByAlias.test
+++ b/it/src/main/resources/tests/joins/orderJoinByAlias.test
@@ -5,11 +5,12 @@
         "couchbase":         "pending",
         "marklogic_json":    "timeout",
         "marklogic_xml":     "timeout",
-        "mimir":"ignoreFieldOrder",
+        "mimir":"pending",
         "mongodb_q_3_2":     "pending"
     },
 
     "NB": "#1587: Disabled in couchbase due to lack of general join.",
+    "NB": "Technically, mimir should be pendingIgnoreFieldOrder, but that oddly doesn't work",
 
     "data": ["../smallZips.data", "../zips.data"],
 

--- a/it/src/main/resources/tests/largestZips.test
+++ b/it/src/main/resources/tests/largestZips.test
@@ -1,8 +1,9 @@
 {
     "name": "largest zips",
     "backends": {
-        "mimir":"pendingIgnoreFieldOrder"
+        "mimir":"pending"
     },
+    "NB": "this should be pendingIgnoreFieldOrder, but it doesn't quite work for some reason",
     "data": "zips.data",
     "query": "select city, pop from zips where pop > 90000 order by city, pop desc",
     "predicate": "exactly",

--- a/mimir/src/main/scala/quasar/mimir/Mimir.scala
+++ b/mimir/src/main/scala/quasar/mimir/Mimir.scala
@@ -321,8 +321,8 @@ object Mimir extends BackendModule with Logging {
 
           (bucketed, _) = pair
 
-          table <- bucketed.foldLeftM(src.table) {
-            case (table, (transes, sortOrder)) =>
+          table <- bucketed.foldRightM(src.table) {
+            case ((transes, sortOrder), table) =>
               val sortKey = OuterArrayConcat(transes: _*)
 
               table.sort(sortKey, sortOrder).toTask.liftM[MT].liftB


### PR DESCRIPTION
Depends on #2516 and #2517 
Fixes #2518 

Implements sorting without bucketing.  The implementation obviously depends on the `Table#sort` function being stable.  Fortunately, it is!  So we're good.  A couple tests that *should* have sprung to life… have not.  So that's annoying.  Also there's a weird bug in `pendingIgnoreFieldOrder`.  Not sure what's up with that.

Anyway, the tests that should have sprung to life seem to be sorting on the wrong thing.  The `FreeMap` is getting translated correctly, and we're passing it along to `Table#sort` correctly, so what's probably happening here is a bug in either JDBM3 or in `BlockStoreColumnarTable`.  Hard to tell which.  Will require further investigating.