### PR TITLE
Implement bucketed sorting and reduction in mimir

### DIFF
--- a/it/src/main/resources/tests/filterOnFieldComparison.test
+++ b/it/src/main/resources/tests/filterOnFieldComparison.test
@@ -1,7 +1,7 @@
 {
     "name": "filter on field comparison",
     "backends": {
-        "mimir":"pendingIgnoreFieldOrder"
+        "mimir":"ignoreFieldOrder"
     },
     "data": "zips.data",
     "query": "select * from zips where pop < loc[1] order by `_id` limit 10",

--- a/it/src/main/resources/tests/groupAndFilterWithNoUnreduced.test
+++ b/it/src/main/resources/tests/groupAndFilterWithNoUnreduced.test
@@ -1,10 +1,6 @@
 {
     "name": "explicitly grouped, with only reduced projections, and a filter",
 
-    "backends": {
-        "mimir":"pending"
-    },
-
     "data": "zips.data",
 
     "query": "select count(*) as cnt from zips where pop < 5 group by pop",

--- a/it/src/main/resources/tests/joins/orderJoinByAlias.test
+++ b/it/src/main/resources/tests/joins/orderJoinByAlias.test
@@ -5,7 +5,7 @@
         "couchbase":         "pending",
         "marklogic_json":    "timeout",
         "marklogic_xml":     "timeout",
-        "mimir":"pendingIgnoreFieldOrder",
+        "mimir":"ignoreFieldOrder",
         "mongodb_q_3_2":     "pending"
     },
 

--- a/it/src/main/resources/tests/joins/orderJoinByAlias.test
+++ b/it/src/main/resources/tests/joins/orderJoinByAlias.test
@@ -5,11 +5,12 @@
         "couchbase":         "pending",
         "marklogic_json":    "timeout",
         "marklogic_xml":     "timeout",
-        "mimir":"ignoreFieldOrder",
+        "mimir":"pending",
         "mongodb_q_3_2":     "pending"
     },
 
     "NB": "#1587: Disabled in couchbase due to lack of general join.",
+    "NB": "Technically, mimir should be pendingIgnoreFieldOrder, but that oddly doesn't work",
 
     "data": ["../smallZips.data", "../zips.data"],
 

--- a/it/src/main/resources/tests/largestZips.test
+++ b/it/src/main/resources/tests/largestZips.test
@@ -1,8 +1,9 @@
 {
     "name": "largest zips",
     "backends": {
-        "mimir":"pendingIgnoreFieldOrder"
+        "mimir":"pending"
     },
+    "NB": "this should be pendingIgnoreFieldOrder, but it doesn't quite work for some reason",
     "data": "zips.data",
     "query": "select city, pop from zips where pop > 90000 order by city, pop desc",
     "predicate": "exactly",

--- a/mimir/src/main/scala/quasar/mimir/Mimir.scala
+++ b/mimir/src/main/scala/quasar/mimir/Mimir.scala
@@ -321,8 +321,8 @@ object Mimir extends BackendModule with Logging {
 
           (bucketed, _) = pair
 
-          table <- bucketed.foldLeftM(src.table) {
-            case (table, (transes, sortOrder)) =>
+          table <- bucketed.foldRightM(src.table) {
+            case ((transes, sortOrder), table) =>
               val sortKey = OuterArrayConcat(transes: _*)
 
               table.sort(sortKey, sortOrder).toTask.liftM[MT].liftB


### PR DESCRIPTION
Depends on #2519, which itself depends on #2516 and #2517
Fixes #1991 
Fixes #1990 
Fixes #2266 

Bucketing turned out to be way easier than expected.  Basically, `partitionMerge` does exactly what we want.  Note for future: we should eliminate `groupByN` and simplify the implementation into `sort`, since we don't actually need its full generality (grouping in SQL^2 is considerably weaker than in Quirrel).  We have to explicitly sort on the bucket key, similar to the issue we have equijoin, but this should be made much nicer with #2485.