### PR TITLE
Add a 'compile' command to the repl

### DIFF
--- a/connector/src/main/scala/quasar/qscript/DiscoverPath.scala
+++ b/connector/src/main/scala/quasar/qscript/DiscoverPath.scala
@@ -51,6 +51,15 @@ object DiscoverPath extends DiscoverPathInstances {
 
   type ListContents[M[_]] = ADir => M[Set[PathSegment]]
 
+  object ListContents {
+    def static[F[_]: Foldable, M[_]: Applicative](paths: F[APath]): ListContents[M] = {
+      def segment(d: ADir): APath => Set[PathSegment] =
+        _.relativeTo(d).flatMap(firstSegmentName).toSet
+
+      dir => paths.foldMap(segment(dir)).point[M]
+    }
+  }
+
   def apply[T[_[_]], IN[_], OUT[_]](implicit ev: DiscoverPath.Aux[T, IN, OUT]) =
     ev
 

--- a/repl/src/main/scala/quasar/repl/Command.scala
+++ b/repl/src/main/scala/quasar/repl/Command.scala
@@ -30,6 +30,7 @@ object Command {
   private val CdPattern           = "(?i)cd(?: +(.+))?".r
   private val NamedExprPattern    = "(?i)([^ :]+) *<- *(.+)".r
   private val ExplainPattern      = "(?i)explain +(.+)".r
+  private val CompilePattern      = "(?i)compile +(.+)".r
   private val SchemaPattern       = "(?i)schema +(.+)".r
   private val LsPattern           = "(?i)ls(?: +(.+))?".r
   private val SavePattern         = "(?i)save +([\\S]+) (.+)".r
@@ -48,6 +49,7 @@ object Command {
   final case class Cd(dir: XDir) extends Command
   final case class Select(name: Option[String], query: Query) extends Command
   final case class Explain(query: Query) extends Command
+  final case class Compile(query: Query) extends Command
   final case class Schema(query: Query) extends Command
   final case class Ls(dir: Option[XDir]) extends Command
   final case class Save(path: XFile, value: String) extends Command
@@ -67,6 +69,7 @@ object Command {
       case CdPattern(_)                  => Cd(rootDir.right)
       case NamedExprPattern(name, query) => Select(Some(name), Query(query))
       case ExplainPattern(query)         => Explain(Query(query))
+      case CompilePattern(query)         => Compile(Query(query))
       case SchemaPattern(query)          => Schema(Query(query))
       case LsPattern(XDir(d))            => Ls(d.some)
       case LsPattern(_)                  => Ls(none)

--- a/repl/src/main/scala/quasar/repl/Command.scala
+++ b/repl/src/main/scala/quasar/repl/Command.scala
@@ -76,10 +76,9 @@ object Command {
       case SavePattern(XFile(f), value)  => Save(f, value)
       case AppendPattern(XFile(f), value) => Append(f, value)
       case DeletePattern(XFile(f))       => Delete(f)
-      case DebugPattern(code)            =>
-        Debug(DebugLevel.fromInt(code.toInt).getOrElse(DebugLevel.Normal))
+      case DebugPattern(code)            => Debug(DebugLevel.int.unapply(code.toInt) | DebugLevel.Normal)
       case SummaryCountPattern(rows)     => SummaryCount(rows.toInt)
-      case FormatPattern(format)         => Format(OutputFormat.fromString(format).getOrElse(OutputFormat.Table))
+      case FormatPattern(format)         => Format(OutputFormat.fromString(format) | OutputFormat.Table)
       case HelpPattern()                 => Help
       case SetVarPattern(name, value)    => SetVar(name, value)
       case UnsetVarPattern(name)         => UnsetVar(name)

--- a/repl/src/main/scala/quasar/repl/DebugLevel.scala
+++ b/repl/src/main/scala/quasar/repl/DebugLevel.scala
@@ -18,16 +18,27 @@ package quasar.repl
 
 import slamdata.Predef._
 
+import monocle.Prism
+import scalaz._, Scalaz._
+
 sealed abstract class DebugLevel
+
 object DebugLevel {
   final case object Silent extends DebugLevel
   final case object Normal extends DebugLevel
   final case object Verbose extends DebugLevel
 
-  def fromInt(code: Int): Option[DebugLevel] = code match {
-    case 0 => Some(Silent)
-    case 1 => Some(Normal)
-    case 2 => Some(Verbose)
-    case _ => None
-  }
+  val int: Prism[Int, DebugLevel] =
+    Prism.partial[Int, DebugLevel] {
+      case 0 => Silent
+      case 1 => Normal
+      case 2 => Verbose
+    } {
+      case Silent  => 0
+      case Normal  => 1
+      case Verbose => 2
+    }
+
+  implicit val equal: Equal[DebugLevel] =
+    Equal.equalBy(int(_))
 }


### PR DESCRIPTION
Differs from `explain` in that `compile` does not require a backend, useful for debugging LP -> QScript issues.