### PR TITLE
Reimplement and replace Table#takeRange

### DIFF
--- a/it/src/main/resources/tests/basicAnalyticQuery.test
+++ b/it/src/main/resources/tests/basicAnalyticQuery.test
@@ -3,7 +3,7 @@
     "backends": {
         "couchbase": "ignoreFieldOrder",
         "marklogic_json": "ignoreFieldOrder",
-        "mimir":          "skip",
+        "mimir":          "ignoreFieldOrder",
         "mongodb_q_3_2":  "pending"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/filterSkipLimitCount.test
+++ b/it/src/main/resources/tests/filterSkipLimitCount.test
@@ -1,10 +1,6 @@
 {
     "name": "filter, skip, limit, and count",
 
-    "backends": {
-        "mimir":"skip"
-    },
-
     "data": "zips.data",
 
     "query": "select count(*) as cnt from (select * from zips where city like \"BOU%\" offset 15 limit 10) as x",

--- a/it/src/main/resources/tests/skipCount.test
+++ b/it/src/main/resources/tests/skipCount.test
@@ -1,12 +1,6 @@
 {
     "name": "skip and count",
 
-    "backends": {
-        "mimir":"skip"
-    },
-
-    "NB": "Skipped in mimir due to #2506 offset is slow. Sometimes it passes and sometimes it times out.",
-
     "data": "zips.data",
 
     "query": "select count(*) from (select * from zips offset 10) as x",

--- a/mimir/src/main/scala/quasar/mimir/Mimir.scala
+++ b/mimir/src/main/scala/quasar/mimir/Mimir.scala
@@ -397,10 +397,10 @@ object Mimir extends BackendModule with Logging {
               compacted = fromRepr.table.compact(fromRepr.P.trans.TransSpec1.Id)
               back <- op match {
                 case Take =>
-                  Future.successful(compacted.takeRange(0, number))
+                  Future.successful(compacted.take(number))
 
                 case Drop =>
-                  Future.successful(compacted.takeRange(number, slamdata.Predef.Int.MaxValue.toLong)) // blame precog
+                  Future.successful(compacted.drop(number))
 
                 case Sample =>
                   compacted.sample(number, List(fromRepr.P.trans.TransSpec1.Id)).map(_.head) // the number of Reprs returned equals the number of transspecs

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/TableModule.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/TableModule.scala
@@ -274,7 +274,9 @@ trait TableModule[M[+ _]] extends TransSpecModule {
 
     @deprecated("use drop/take directly")
     def takeRange(startIndex: Long, numberToTake: Long): Table = {
-      if (startIndex <= 0)
+      if (startIndex < 0 || numberToTake < 0)   // it's defined this way, for... reasons
+        Table.empty
+      else if (startIndex == 0)
         take(numberToTake)
       else if (numberToTake == Long.MaxValue)
         drop(startIndex)

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/TableModule.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/TableModule.scala
@@ -272,7 +272,19 @@ trait TableModule[M[+ _]] extends TransSpecModule {
 
     def partitionMerge(partitionBy: TransSpec1)(f: Table => M[Table]): M[Table]
 
-    def takeRange(startIndex: Long, numberToTake: Long): Table
+    @deprecated("use drop/take directly")
+    def takeRange(startIndex: Long, numberToTake: Long): Table = {
+      if (startIndex <= 0)
+        take(numberToTake)
+      else if (numberToTake == Long.MaxValue)
+        drop(startIndex)
+      else
+        drop(startIndex).take(numberToTake)
+    }
+
+    def drop(count: Long): Table
+
+    def take(count: Long): Table
 
     def canonicalize(length: Int, maxLength0: Option[Int] = None): Table
 

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnarTableModule.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnarTableModule.scala
@@ -1689,36 +1689,43 @@ trait ColumnarTableModule[M[+ _]]
       distinct0(SliceTransform.identity(None: Option[Slice]), composeSliceTransform(spec))
     }
 
-    def takeRange(startIndex: Long, numberToTake: Long): Table = {
-      def loop(stream: StreamT[M, Slice], readSoFar: Long): M[StreamT[M, Slice]] = stream.uncons flatMap {
-        // Prior to first needed slice, so skip
-        case Some((head, tail)) if (readSoFar + head.size) < (startIndex + 1) => loop(tail, readSoFar + head.size)
-        // Somewhere in between, need to transition to splitting/reading
-        case Some(_) if readSoFar < (startIndex + 1) => inner(stream, 0, (startIndex - readSoFar).toInt)
-        // Read off the end (we took nothing)
-        case _ => M.point(StreamT.empty[M, Slice])
+    def drop(count: Long): Table = {
+      val slices2 = StreamT.unfoldM[M, StreamT[M, Slice], Option[(StreamT[M, Slice], Long)]](Some((slices, 0L))) {
+        case Some((slices, dropped)) =>
+          slices.uncons map {
+            case Some((slice, tail)) =>
+              if (slice.size <= count - dropped)
+                Some((StreamT.empty[M, Slice], Some((tail, dropped + slice.size))))
+              else
+                Some((slice.drop((count - dropped).toInt) :: tail, None))
+
+            case None => None
+          }
+
+        case None => M.point(None)
       }
 
-      def inner(stream: StreamT[M, Slice], takenSoFar: Long, sliceStartIndex: Int): M[StreamT[M, Slice]] = stream.uncons flatMap {
-        case Some((head, tail)) if takenSoFar < numberToTake => {
-          val needed = head.takeRange(sliceStartIndex, (numberToTake - takenSoFar).toInt)
-          inner(tail, takenSoFar + (head.size - (sliceStartIndex)), 0).map(needed :: _)
-        }
-        case _ => M.point(StreamT.empty[M, Slice])
-      }
-
-      def calcNewSize(current: Long): Long = ((current - startIndex) max 0) min numberToTake
-
-      val newSize = size match {
-        case ExactSize(sz)            => ExactSize(calcNewSize(sz))
-        case EstimateSize(sMin, sMax) => TableSize(calcNewSize(sMin), calcNewSize(sMax))
-        case UnknownSize              => UnknownSize
-        case InfiniteSize             => InfiniteSize
-      }
-
-      Table(StreamT.wrapEffect(loop(slices, 0)), newSize)
+      Table(slices2.flatMap(x => x), size + ExactSize(-count))
     }
 
+    def take(count: Long): Table = {
+      val slices2 = StreamT.unfoldM[M, StreamT[M, Slice], Option[(StreamT[M, Slice], Long)]](Some((slices, 0L))) {
+        case Some((slices, taken)) =>
+          slices.uncons map {
+            case Some((slice, tail)) =>
+              if (slice.size > count - taken)
+                Some((slice :: StreamT.empty[M, Slice], Some(tail, taken + slice.size)))
+              else
+                Some((slice.take((count - taken).toInt) :: StreamT.empty[M, Slice], None))
+
+            case None => None
+          }
+
+        case None => M.point(None)
+      }
+
+      Table(slices2.flatMap(x => x), EstimateSize(0, count))
+    }
     /**
       * In order to call partitionMerge, the table must be sorted according to
       * the values specified by the partitionBy transspec.

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnarTableModule.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnarTableModule.scala
@@ -1713,8 +1713,8 @@ trait ColumnarTableModule[M[+ _]]
         case Some((slices, taken)) =>
           slices.uncons map {
             case Some((slice, tail)) =>
-              if (slice.size > count - taken)
-                Some((slice :: StreamT.empty[M, Slice], Some(tail, taken + slice.size)))
+              if (slice.size <= count - taken)
+                Some((slice :: StreamT.empty[M, Slice], Some((tail, taken + slice.size))))
               else
                 Some((slice.take((count - taken).toInt) :: StreamT.empty[M, Slice], None))
 

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/Slice.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/Slice.scala
@@ -782,9 +782,10 @@ trait Slice { source =>
     (take(idx), drop(idx))
   }
 
-  def take(sz: Int): Slice =
-    if (sz >= source.size) source
-    else {
+  def take(sz: Int): Slice = {
+    if (sz >= source.size) {
+      source
+    } else {
       new Slice {
         val size = sz
         val columns = source.columns lazyMapValues { col =>
@@ -792,10 +793,12 @@ trait Slice { source =>
         }
       }
     }
+  }
 
-  def drop(sz: Int): Slice =
-    if (sz <= 0) source
-    else {
+  def drop(sz: Int): Slice = {
+    if (sz <= 0) {
+      source
+    } else {
       new Slice {
         val size = source.size - sz
         val columns = source.columns lazyMapValues { col =>
@@ -803,6 +806,7 @@ trait Slice { source =>
         }
       }
     }
+  }
 
   def takeRange(startIndex: Int, numberToTake: Int): Slice = {
     val take2 = math.min(this.size, startIndex + numberToTake) - startIndex


### PR DESCRIPTION
Fixes #2506
Depends on #2557 
Affects #2542

Now we have a nice and sane `drop` and `take`, both of which run quite quickly and have the properties you would want.