### PR TITLE
Speed up mimir flatten tests 

### DIFF
--- a/blueeyes/src/main/scala/quasar/blueeyes/Perf.scala
+++ b/blueeyes/src/main/scala/quasar/blueeyes/Perf.scala
@@ -78,14 +78,14 @@ object yggConfig {
 
   def hashJoins         = true
   def sortBufferSize    = 1000
-  def maxSliceSize: Int = 10
+  def maxSliceSize: Int = 20000
 
   // This is a slice size that we'd like our slices to be at least as large as.
   def minIdealSliceSize: Int = maxSliceSize / 4
 
   // This is what we consider a "small" slice. This may affect points where
   // we take proactive measures to prevent problems caused by small slices.
-  def smallSliceSize: Int = 3
+  def smallSliceSize: Int = 50
 
   def maxSaneCrossSize: Long = 2400000000L // 2.4 billion
 }

--- a/it/src/main/resources/tests/trivialGroup.test
+++ b/it/src/main/resources/tests/trivialGroup.test
@@ -2,7 +2,7 @@
     "name": "trivial group by",
     "backends": {
         "couchbase": "ignoreFieldOrder",
-        "mimir":"ignoreFieldOrder",
+        "mimir": "timeout",
         "mongodb_2_6": "ignoreFieldOrder",
         "mongodb_3_0": "ignoreFieldOrder",
         "mongodb_3_2": "ignoreFieldOrder",


### PR DESCRIPTION
Increase `maxSliceSize` and `smallSliceSize` values in `yggConfig`. Fixes #2521.