### PR TITLE
Spark details algebra - queryfile.Input / def fileExists

### DIFF
--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/SparkConnectorDetails.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/SparkConnectorDetails.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.sparkcore.fs
+
+import slamdata.Predef._
+import quasar.contrib.pathy._
+import quasar.fp.free._
+
+import scalaz._
+
+trait SparkConnectorDetails[A]
+final case class FileExists(afile: AFile) extends SparkConnectorDetails[Boolean]
+
+object SparkConnectorDetails {
+
+  class Ops[S[_]](implicit S: SparkConnectorDetails :<: S) {
+    def fileExists(afile: AFile): Free[S, Boolean] =
+      lift(FileExists(afile)).into[S]
+  }
+
+  object Ops {
+    implicit def apply[S[_]](implicit S: SparkConnectorDetails :<: S): Ops[S] =
+      new Ops[S]
+  }
+
+
+}

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/elastic/package.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/elastic/package.scala
@@ -105,9 +105,8 @@ package object elastic {
     val definition: SparkContext => Free[S, SparkFSDef[Eff, S]] =
       (sc: SparkContext) => lift((TaskRef(0L) |@| TaskRef(Map.empty[ResultHandle, RddState]) |@| TaskRef(Map.empty[ReadHandle, SparkCursor]) |@| TaskRef(Map.empty[WriteHandle, writefile.WriteCursor])) {
         (genState, rddStates, readCursors, writeCursors) => {
-
           val interpreter: Eff ~> S =
-            (queryfile.detailsInterpreter[ElasticCall, Task](ElasticCall.interpreter) andThen injectNT[Task, S]) :+:
+            (queryfile.detailsInterpreter[ElasticCall] andThen foldMapNT(ElasticCall.interpreter) andThen injectNT[Task, S]) :+:
             (KeyValueStore.impl.fromTaskRef[WriteHandle, writefile.WriteCursor](writeCursors) andThen injectNT[Task, S])  :+:
             (KeyValueStore.impl.fromTaskRef[ReadHandle, SparkCursor](readCursors) andThen injectNT[Task, S]) :+:
             (KeyValueStore.impl.fromTaskRef[ResultHandle, RddState](rddStates) andThen injectNT[Task, S]) :+:

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/elastic/queryfile.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/elastic/queryfile.scala
@@ -92,13 +92,12 @@ object queryfile {
   ): Input[S] =
     Input[S](fromFile _, store[S] _, (f: AFile) => false.point[Free[S, ?]], listContents[S] _, readChunkSize _)
 
-  def detailsInterpreter[S[_], G[_] : Monad](int: S ~> G)(implicit
+  def detailsInterpreter[S[_]](implicit
     E: ElasticCall.Ops[S]
-  ): SparkConnectorDetails ~> G =
-    new (SparkConnectorDetails ~> G) {
-      def apply[A](from: SparkConnectorDetails[A]) = from match {
-        case FileExists(f) => E.typeExists(file2ES(f)).foldMap(int)
-      }
+  ): SparkConnectorDetails ~> Free[S, ?] = new (SparkConnectorDetails ~> Free[S, ?]) {
+    def apply[A](from: SparkConnectorDetails[A]) = from match {
+      case FileExists(f) => E.typeExists(file2ES(f))
     }
+  }
 
 }

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/hdfs/package.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/hdfs/package.scala
@@ -152,10 +152,8 @@ package object hdfs {
       // TODO better names!
       (genState, rddStates, sparkCursors, writeCursors) =>
 
-      def detailsInterpreter: SparkConnectorDetails ~> Task = ???
-
       val interpreter: Eff ~> S =
-        (detailsInterpreter andThen injectNT[Task, S]) :+:
+        (queryfile.detailsInterpreter(generateHdfsFS(sfsc), injectNT[Task, Task]) andThen injectNT[Task, S]) :+:
         (MonotonicSeq.fromTaskRef(genState) andThen injectNT[Task, S]) :+:
       injectNT[PhysErr, S] :+:
       injectNT[Task, S]  :+:
@@ -163,7 +161,6 @@ package object hdfs {
       (KeyValueStore.impl.fromTaskRef[ReadHandle, SparkCursor](sparkCursors) andThen injectNT[Task, S]) :+:
       (KeyValueStore.impl.fromTaskRef[ResultHandle, RddState](rddStates) andThen injectNT[Task, S]) :+:
       (Read.constant[Task, SparkContext](sc) andThen injectNT[Task, S])
-
 
       SparkFSDef(mapSNT[Eff, S](interpreter), lift(Task.delay(sc.stop())).into[S])
     }).into[S]

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/hdfs/package.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/hdfs/package.scala
@@ -153,7 +153,7 @@ package object hdfs {
       (genState, rddStates, sparkCursors, writeCursors) =>
 
       val interpreter: Eff ~> S =
-        (queryfile.detailsInterpreter(generateHdfsFS(sfsc), injectNT[Task, Task]) andThen injectNT[Task, S]) :+:
+        (queryfile.detailsInterpreter(generateHdfsFS(sfsc)) andThen injectNT[Task, S]) :+:
         (MonotonicSeq.fromTaskRef(genState) andThen injectNT[Task, S]) :+:
       injectNT[PhysErr, S] :+:
       injectNT[Task, S]  :+:

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/hdfs/queryfile.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/hdfs/queryfile.scala
@@ -27,6 +27,7 @@ import quasar.fs.PathError._
 import quasar.fp.free._
 import quasar.contrib.pathy._
 import quasar.physical.sparkcore.fs.{SparkConnectorDetails, FileExists}
+import quasar.effect.Capture
 
 import java.io.BufferedWriter
 import java.io.OutputStreamWriter
@@ -41,15 +42,15 @@ import scalaz.concurrent.Task
 import org.apache.spark._
 import org.apache.spark.rdd._
 
-class queryfile(fileSystem: Task[FileSystem]) {
+class queryfile[F[_]:Capture:Bind](fileSystem: F[FileSystem]) {
 
-  private def toPath(apath: APath): Task[Path] = Task.delay {
+  private def toPath(apath: APath): F[Path] = Capture[F].capture {
     new Path(posixCodec.unsafePrintPath(apath))
   }
 
-  def fromFile(sc: SparkContext, file: AFile): Task[RDD[Data]] = for {
+  def fromFile(sc: SparkContext, file: AFile): F[RDD[Data]] = for {
     hdfs <- fileSystem
-    pathStr <- Task.delay {
+    pathStr <- Capture[F].capture {
       val pathStr = posixCodec.unsafePrintPath(file)
       val host = hdfs.getUri().getHost()
       val port = hdfs.getUri().getPort()
@@ -58,9 +59,7 @@ class queryfile(fileSystem: Task[FileSystem]) {
     rdd <- readfile.fetchRdd(sc, pathStr)
   } yield rdd
 
-  def store[S[_]](rdd: RDD[Data], out: AFile)(implicit
-    S: Task :<: S
-  ): Free[S, Unit] = lift(for {
+  def store(rdd: RDD[Data], out: AFile): F[Unit] = for {
     path <- toPath(out)
     hdfs <- fileSystem
   } yield {
@@ -75,22 +74,18 @@ class queryfile(fileSystem: Task[FileSystem]) {
     })
     bw.close()
     hdfs.close()
-  }).into[S]
+  }
 
-  def fileExists[S[_]](f: AFile)(implicit
-    S: Task :<: S
-  ): Free[S, Boolean] = lift(for {
+  def fileExists(f: AFile): F[Boolean] = for {
     path <- toPath(f)
     hdfs <- fileSystem
   } yield {
     val exists = hdfs.exists(path)
     hdfs.close()
     exists
-  }).into[S]
+  }
 
-  def listContents[S[_]](d: ADir)(implicit
-    S: Task :<: S
-  ): FileSystemErrT[Free[S, ?], Set[PathSegment]] = EitherT(lift(for {
+  def listContents(d: ADir): FileSystemErrT[F, Set[PathSegment]] = EitherT(for {
     path <- toPath(d)
     hdfs <- fileSystem
   } yield {
@@ -102,28 +97,31 @@ class queryfile(fileSystem: Task[FileSystem]) {
     } else pathErr(pathNotFound(d)).left[Set[PathSegment]]
     hdfs.close
     result
-  }).into[S])
+  })
 
   def readChunkSize: Int = 5000
-
-  def input[S[_]](implicit s0: Task :<: S): Input[S] =
-    Input[S](fromFile _, store[S] _, fileExists[S] _, listContents[S] _, readChunkSize _)
-
 
 }
 
 object queryfile {
 
-  def detailsInterpreter[S[_], G[_] : Monad](fileSystem: Task[FileSystem], int: S ~> G)(implicit
-    S: Task :<: S
-  ): SparkConnectorDetails ~> G =
-    new (SparkConnectorDetails ~> G) {
-      val qf = new queryfile(fileSystem)
+  def detailsInterpreter[F[_]:Capture:Bind](fileSystem: F[FileSystem]): SparkConnectorDetails ~> F =
+    new (SparkConnectorDetails ~> F) {
+      val qf = new queryfile[F](fileSystem)
 
       def apply[A](from: SparkConnectorDetails[A]) = from match {
-        case FileExists(f) => qf.fileExists(f).foldMap(int)
+        case FileExists(f) => qf.fileExists(f)
       }
     }
 
-  def input[S[_]](fileSystem: Task[FileSystem])(implicit s0: Task :<: S): Input[S] = new queryfile(fileSystem).input
+  def input[S[_]](fileSystem: Task[FileSystem])(implicit s0: Task :<: S): Input[S] = {
+    val qf = new queryfile[Task](fileSystem)
+    Input[S](
+      qf.fromFile _,
+      (rdd, out) => lift(qf.store(rdd, out)).into[S],
+      f => lift(qf.fileExists(f)).into[S],
+      d => EitherT(lift(qf.listContents(d).run).into[S]),
+      qf.readChunkSize _
+    )
+  }
 }

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/local/package.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/local/package.scala
@@ -79,7 +79,7 @@ package object local {
       (genState, rddStates, sparkCursors, printWriters) =>
 
       val interpreter: Eff ~> S =
-        (queryfile.detailsInterpreter(injectNT[Task, Task]) andThen injectNT[Task, S]) :+:
+      (queryfile.detailsInterpreter[Task] andThen injectNT[Task, S]) :+:
       (MonotonicSeq.fromTaskRef(genState) andThen injectNT[Task, S]) :+:
       injectNT[PhysErr, S] :+:
       injectNT[Task, S]  :+:

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/local/package.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/local/package.scala
@@ -78,10 +78,8 @@ package object local {
       ) {
       (genState, rddStates, sparkCursors, printWriters) =>
 
-      def detailsInterpreter: SparkConnectorDetails ~> Task = ???
-
       val interpreter: Eff ~> S =
-        (detailsInterpreter andThen injectNT[Task, S]) :+:
+        (queryfile.detailsInterpreter(injectNT[Task, Task]) andThen injectNT[Task, S]) :+:
       (MonotonicSeq.fromTaskRef(genState) andThen injectNT[Task, S]) :+:
       injectNT[PhysErr, S] :+:
       injectNT[Task, S]  :+:

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/local/queryfile.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/local/queryfile.scala
@@ -25,6 +25,7 @@ import quasar.fs.FileSystemError._
 import quasar.contrib.pathy._
 import quasar.fp.ski._
 import quasar.fp.free._
+import quasar.effect.Capture
 import quasar.physical.sparkcore.fs.{SparkConnectorDetails, FileExists}
 
 import java.io.{File, PrintWriter, FileOutputStream}
@@ -51,11 +52,9 @@ object queryfile {
     pw.close()
   }).into[S]
 
-  def fileExists[S[_]](f: AFile)(implicit
-    S: Task :<: S
-  ): Free[S, Boolean] = lift(Task.delay {
-    Files.exists(Paths.get(posixCodec.unsafePrintPath(f)))
-  }).into[S]
+  def fileExists[F[_]:Capture](f: AFile): F[Boolean] = Capture[F].capture {
+      Files.exists(Paths.get(posixCodec.unsafePrintPath(f)))
+  }
 
   def listContents[S[_]](d: ADir)(implicit
     S: Task :<: S
@@ -79,15 +78,14 @@ object queryfile {
 
   def input[S[_]](implicit
     S: Task :<: S
-  ): Input[S] = Input[S](fromFile _, store[S] _, fileExists[S] _, listContents[S] _, readChunkSize _)
+  ): Input[S] = Input[S](fromFile _, store[S] _, fileExists[Free[S, ?]] _, listContents[S] _, readChunkSize _)
 
-  def detailsInterpreter[S[_], G[_] : Monad](int: S ~> G)(implicit
-    S: Task :<: S
-  ): SparkConnectorDetails ~> G =
-    new (SparkConnectorDetails ~> G) {
+  def detailsInterpreter[F[_] : Capture]: SparkConnectorDetails ~> F =
+    new (SparkConnectorDetails ~> F) {
       def apply[A](from: SparkConnectorDetails[A]) = from match {
-        case FileExists(f) => fileExists[S](f).foldMap(int)
+        case FileExists(f) => fileExists[F](f)
       }
     }
+
 
 }


### PR DESCRIPTION
This is first PR to https://github.com/quasar-analytics/quasar/issues/1634

Here we try to eliminate `queryfile.Input` / `fileExists` method and replace it with algebra (SparkConnectorDetails) to which connectors have to provide interpreter.

Before I continue with any other functions from `queryfile.Input` I want to have this reviewed - confirmation that my approach is the right one.