### PR TITLE
WIP 2502 mongo now

### DIFF
--- a/it/src/main/resources/tests/temporal/nowComparison.test
+++ b/it/src/main/resources/tests/temporal/nowComparison.test
@@ -1,0 +1,24 @@
+{
+  "name": "use now function (comparison)",
+
+  "backends": {
+  },
+
+  "data": "../days.data",
+
+  "query": "select now() > ts as past, ts > now() as future from `../days`",
+
+  "predicate": "exactly",
+
+  "expected": [
+    { "past": true, "future": false },
+    { "past": true, "future": false },
+    { "past": true, "future": false },
+    { "past": true, "future": false },
+    { "past": true, "future": false },
+    { "past": true, "future": false },
+    { "past": true, "future": false },
+    { "past": true, "future": false },
+    { "past": true, "future": false }
+  ]
+}

--- a/it/src/main/resources/tests/temporal/nowSubtract.test
+++ b/it/src/main/resources/tests/temporal/nowSubtract.test
@@ -1,0 +1,24 @@
+{
+  "name": "use now function (subtract)",
+
+  "backends": {
+  },
+
+  "data": "../days.data",
+
+  "query": "select now() - ts > 0 as past, ts - now() > 0 as future from `../days`",
+
+  "predicate": "exactly",
+
+  "expected": [
+    { "past": true, "future": false },
+    { "past": true, "future": false },
+    { "past": true, "future": false },
+    { "past": true, "future": false },
+    { "past": true, "future": false },
+    { "past": true, "future": false },
+    { "past": true, "future": false },
+    { "past": true, "future": false },
+    { "past": true, "future": false }
+  ]
+}

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/FuncHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/FuncHandler.scala
@@ -196,7 +196,7 @@ object FuncHandler {
 
               case ToTimestamp(a1) =>
                $add($literal(Bson.Date(0)), a1)
-
+              case Now() => $now()
               case Between(a1, a2, a3)   => $and($lte(a2, a1), $lte(a1, a3))
               // TODO: With type info, we could reduce the number of comparisons necessary.
               case TypeOf(a1) =>


### PR DESCRIPTION
A not so ideal implementation of `now()` in agg. pipeline.

Just putting this up for discussion. 

There _is_ a `bson` representation that is a backend managed `now()` - `Bson.JavaScript(Js.New(Js.Call(Js.Ident("Date"), List())))` - but its usage is quite limited. E.g. `select fieldA, now() from tableA` does not work, nor does `select ts - now(), now() - ts from days` 

I also tried using `$let` tricks such as below, but this has the same limitations.

```
val jsNewDate = Bson.JavaScript(quasar.javascript.Js.New(quasar.javascript.Js.Call(quasar.javascript.Js.Ident("Date"), List())))
Bson.Doc("$let" -> Bson.Doc(
       "vars" -> Bson.Doc("now" -> jsNewDate),
       "in"   -> Bson.Text("$$now"))
)
```

I see another backend-managed `now` solution that _may_ work, but it's a long shot. Not sure if it's worth trying... In a nutshell: we can try **writing** (ugh) `now()` via https://docs.mongodb.com/manual/reference/operator/update/currentDate/ and then looking up that value.

Alternatively, we can calculate `now` from quasar and then pass that to mongo, but this has the problem of clock skew. Anyway, this PR does that in a quick and dirty way (with some additional problems that 1) it's not referential transparent 2) may be different for each occurrence of `now()`). 
I am hoping someone sees a way that doesn't involve too much refactoring to provide this value for `now` once, so that we can solve issue 1) and 2) (adding some kind of evaluation context maybe?).