### PR TITLE
A handful of QScript fixes/improvements

### DIFF
--- a/connector/src/main/scala/quasar/qscript/Coalesce.scala
+++ b/connector/src/main/scala/quasar/qscript/Coalesce.scala
@@ -278,11 +278,11 @@ class CoalesceT[T[_[_]]: BirecursiveT: EqualT: ShowT] extends TTypes[T] {
         (implicit QC: QScriptCore :<: OUT)
           : QScriptCore[IT[F]] => Option[QScriptCore[IT[F]]] = {
         case LeftShift(src, struct, id, repair) =>
-          MapFuncCore.extractFilter(struct)(_.some) ∘ { case (f, m) =>
+          MapFuncCore.extractFilter(struct)(_.some) ∘ { case (f, m, _) =>
             LeftShift(FToOut(QC.inj(Filter(src, f))).embed, m, id, repair)
           }
         case Map(src, mf) =>
-          MapFuncCore.extractFilter(mf)(_.some) ∘ { case (f, m) =>
+          MapFuncCore.extractFilter(mf)(_.some) ∘ { case (f, m, _) =>
             Map(FToOut(QC.inj(Filter(src, f))).embed, m)
           }
         case _ => none

--- a/connector/src/main/scala/quasar/qscript/MapFuncCore.scala
+++ b/connector/src/main/scala/quasar/qscript/MapFuncCore.scala
@@ -248,7 +248,7 @@ object MapFuncCore {
   // NB: This _could_ be combined with `rewrite`, but it causes rewriting to
   //     take way too long, so instead we apply it separately afterward.
   /** Pulls conditional `Undefined`s as far up an expression as possible. */
-  def extractGuards[T[_[_]]: BirecursiveT, A]
+  def extractGuards[T[_[_]]: BirecursiveT: EqualT, A: Equal]
       : CoMapFuncR[T, A] => Option[CoMapFuncR[T, A]] =
     _.run.toOption >>= (MFC.unapply) >>= {
       // NB: The last case pulls guards into a wider scope, and we want to avoid
@@ -269,7 +269,7 @@ object MapFuncCore {
         writer.written match {
           case Nil    => none
           case guards =>
-            rollMF[T, A](guards.distinct.foldRight(MFC(writer.value)) {
+            rollMF[T, A](guards.distinctE.foldRight(MFC(writer.value)) {
               case ((e, t), s) =>
                 MFC(Guard(e, t, Free.roll(s), Free.roll(MFC(Undefined[T, FreeMapA[T, A]]()))))
             }).some

--- a/connector/src/main/scala/quasar/qscript/Normalizable.scala
+++ b/connector/src/main/scala/quasar/qscript/Normalizable.scala
@@ -123,39 +123,60 @@ class NormalizableT[T[_[_]]: BirecursiveT : EqualT : ShowT] extends TTypes[T] {
       }
     }))
 
-  private def extractFilterFromThetaJoin[A](tj: ThetaJoin[A])
-      : Option[ThetaJoin[A]] =
-    (MapFuncCore.extractFilter(tj.on) {
+  /** Extracts filter predicates from the join condition, pushing them out
+    * to the branches and eliminates the same predicates from the combiner.
+    */
+  private def extractFilterFromThetaJoin[A](tj: ThetaJoin[A]): Option[ThetaJoin[A]] = {
+    val lFilter = MapFuncCore.extractFilter(tj.on) {
       case LeftSide => SrcHole.some
       case RightSide => none
-    },
-      MapFuncCore.extractFilter(tj.on) {
+    }
+
+    val rFilter = MapFuncCore.extractFilter(tj.on) {
         case LeftSide => none
         case RightSide => SrcHole.some
-      }) match {
-      case (None, None) => none
-      case (Some((lf, on)), _) =>
-        quasar.qscript.ThetaJoin(tj.src, Free.roll(Inject[QScriptCore, QScriptTotal].inj(Filter(tj.lBranch, lf))), tj.rBranch, on, tj.f, tj.combine).some
-      case (_, Some((rf, on))) =>
-        quasar.qscript.ThetaJoin(tj.src, tj.lBranch, Free.roll(Inject[QScriptCore, QScriptTotal].inj(Filter(tj.rBranch, rf))), on, tj.f, tj.combine).some
     }
+
+    def simplifyCombine(f: JoinFunc => Option[JoinFunc]): JoinFunc =
+      tj.combine.transApoT(c => f(c) <\/ c)
+
+    (lFilter, rFilter) match {
+      case (None, None) => none
+
+      case (Some((lf, on, f)), _) =>
+        some(quasar.qscript.ThetaJoin(
+          tj.src,
+          Free.roll(QCT(Filter(tj.lBranch, lf))),
+          tj.rBranch,
+          on,
+          tj.f,
+          simplifyCombine(f)))
+
+      case (_, Some((rf, on, f))) =>
+        some(quasar.qscript.ThetaJoin(
+          tj.src,
+          tj.lBranch,
+          Free.roll(QCT(Filter(tj.rBranch, rf))),
+          on,
+          tj.f,
+          simplifyCombine(f)))
+    }
+  }
 
   def ThetaJoin = make(
     λ[ThetaJoin ~> (Option ∘ ThetaJoin)#λ](tj =>
       (freeTCEq(tj.lBranch), freeTCEq(tj.rBranch), freeMFEq(tj.on), freeMFEq(tj.combine)) match {
-        case (None, None, None, None) => extractFilterFromThetaJoin(tj)
+        case (None, None, None, None) =>
+          extractFilterFromThetaJoin(tj)
 
         case (lBranchNorm, rBranchNorm, onNorm, combineNorm) =>
-          val newTJ =
-            quasar.qscript.ThetaJoin(
-              tj.src,
-              lBranchNorm.getOrElse(tj.lBranch),
-              rBranchNorm.getOrElse(tj.rBranch),
-              onNorm.getOrElse(tj.on),
-              tj.f,
-              combineNorm.getOrElse(tj.combine))
-
-          extractFilterFromThetaJoin(newTJ).getOrElse(newTJ).some
+          some(quasar.qscript.ThetaJoin(
+            tj.src,
+            lBranchNorm.getOrElse(tj.lBranch),
+            rBranchNorm.getOrElse(tj.rBranch),
+            onNorm.getOrElse(tj.on),
+            tj.f,
+            combineNorm.getOrElse(tj.combine)))
       }))
 
   def rebucket(bucket: List[FreeMap]): Option[List[FreeMap]] = {

--- a/connector/src/main/scala/quasar/qscript/package.scala
+++ b/connector/src/main/scala/quasar/qscript/package.scala
@@ -75,6 +75,14 @@ package object qscript {
   type QScriptTotal5[T[_[_]], A] = Coproduct[Const[Read[ADir], ?]        , QScriptTotal6[T, ?], A]
   type QScriptTotal6[T[_[_]], A] = Coproduct[Const[Read[AFile], ?]       , Const[DeadEnd, ?]  , A]
 
+  object QCT {
+    def apply[T[_[_]], A](qc: QScriptCore[T, A]): QScriptTotal[T, A] =
+      Inject[QScriptCore[T, ?], QScriptTotal[T, ?]].inj(qc)
+
+    def unapply[T[_[_]], A](qt: QScriptTotal[T, A]): Option[QScriptCore[T, A]] =
+      Inject[QScriptCore[T, ?], QScriptTotal[T, ?]].prj(qt)
+  }
+
   /** QScript that has not gone through Read conversion. */
   type QScript[T[_[_]], A] =
     (QScriptCore[T, ?] :\: ThetaJoin[T, ?] :/: Const[DeadEnd, ?])#M[A]
@@ -250,6 +258,9 @@ package object qscript {
     val norm = Normalizable.normalizable[T]
 
     (norm.freeMF(l), norm.freeMF(c), norm.freeMF(r), norm.freeMF(r2)) match {
+      case (newL, newC, newR, newR2) if newL ≟ newC && newC ≟ newR && newR ≟ newR2 =>
+        (newL, HoleF, HoleF, HoleF, HoleF)
+
       case (newL, newC, newR, newR2) if newL ≟ newC && newR ≟ newR2 =>
         (StaticArray(List(newL, newR)),
           Free.roll(MFC(ProjectIndex(HoleF[T], IntLit[T, Hole](0)))),

--- a/connector/src/main/scala/quasar/qscript/package.scala
+++ b/connector/src/main/scala/quasar/qscript/package.scala
@@ -190,7 +190,7 @@ package object qscript {
       Free.roll(MFC(ProjectIndex(HoleF[T], IntLit[T, Hole](idx))))
 
     def indexOf(elems: List[FreeMapA[T ,A]], value: FreeMapA[T, A]): Option[Int] =
-      IList.fromList(elems).indexOf(Free.roll(MFC(MakeArray(value))))
+      IList.fromList(elems) indexOf value
 
     indexOf(leftElems, normr).cata(
       idx => (norml, HoleF[T], projectIndex(idx)),

--- a/connector/src/test/scala/quasar/qscript/QScriptHelpers.scala
+++ b/connector/src/test/scala/quasar/qscript/QScriptHelpers.scala
@@ -141,6 +141,9 @@ trait QScriptHelpers extends CompilerHelpers with TTypes[Fix] {
       FreeMapA[A] =
     Free.roll(MFC(MapFuncsCore.Not(value)))
 
+  def UndefinedR[A]: FreeMapA[A] =
+    Free.roll(MFC(MapFuncsCore.Undefined[Fix, FreeMapA[A]]()))
+
   def lpRead(path: String): Fix[LP] =
     lpf.read(unsafeSandboxAbs(posixCodec.parseAbsFile(path).get))
 

--- a/it/src/main/resources/tests/different-flattens.test
+++ b/it/src/main/resources/tests/different-flattens.test
@@ -5,10 +5,6 @@
         "couchbase": "pending",
         "marklogic_json": "pending",
         "marklogic_xml": "pending",
-        "mongodb_2_6": "pending",
-        "mongodb_3_0": "pending",
-        "mongodb_3_2": "pending",
-        "mongodb_3_4": "pending",
         "mongodb_read_only": "pending",
         "spark_hdfs": "pending",
         "spark_local": "pending"

--- a/it/src/main/resources/tests/different-flattens.test
+++ b/it/src/main/resources/tests/different-flattens.test
@@ -3,13 +3,8 @@
     "backends": {
         "mimir":"pendingIgnoreFieldOrder",
         "couchbase": "pending",
-        "marklogic_json": "pending",
-        "marklogic_xml": "pending",
-        "mongodb_read_only": "pending",
-        "spark_hdfs": "pending",
-        "spark_local": "pending"
+        "marklogic_json": "pending"
     },
-    "NB": "marklogic_xml, spark_hdfs and spark_local not on par with master",
     "data": "user_comments.data",
     "query": "select profile from user_comments where (
                 userId                 LIKE \"%Dr%\" OR

--- a/it/src/main/resources/tests/union.test
+++ b/it/src/main/resources/tests/union.test
@@ -2,13 +2,14 @@
     "name": "union",
     "backends": {
         "couchbase":         "pending",
-        "mimir":             "ignoreFieldOrder",
+        "mimir":             "pending",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
         "mongodb_3_2":       "pending",
         "mongodb_3_4":       "pending",
         "mongodb_read_only": "pending"
     },
+    "NB": "The qscript for this query contains some nonsensical structures and the fact that it passes on any connector is based purely on how nonsense-tolerant that connector is, this isn't expected to work in general.",
     "data": "zips.data",
     "query": "select `_id` as zip from zips union select city, state from zips",
     "predicate": "atLeast",


### PR DESCRIPTION
Improves or fixes the following in QScript
* Avoids the use of universal equality in `MapFuncCore.extractGuards`.
* When guards are extracted from a `ThetaJoin` condition into a filter, they are also elided from the combiner.
* Fixed duplicate detection in `concat`.
* Improved equality for `Provenance.Both` by eliding `Nada` and comparing a tree of `Both`s as sets instead of structurally.