### PR TITLE
Change planner signature

### DIFF
--- a/effect/src/main/scala/quasar/effect/Capture.scala
+++ b/effect/src/main/scala/quasar/effect/Capture.scala
@@ -25,7 +25,7 @@ import scalaz.syntax.monad._
   *
   * Cribbed from [doobie](http://github.com/tpolecat/doobie)
   */
-trait Capture[F[_]] {
+trait Capture[F[_]] extends Serializable {
   /** Captures the effect of producing `A`, including any exceptions that may
     * be thrown.
     */

--- a/effect/src/main/scala/quasar/effect/Capture.scala
+++ b/effect/src/main/scala/quasar/effect/Capture.scala
@@ -78,11 +78,11 @@ private[effect] class TaskCapture extends Capture[Task] with Serializable {
 }
 
 private[effect] class TransCapture[F[_]: Monad: Capture, T[_[_], _]: MonadTrans]
-  extends Capture[T[F, ?]] {
+  extends Capture[T[F, ?]] with Serializable{
   def capture[A](a: => A) = Capture[F].capture(a).liftM[T]
 }
 
 private[effect] class FreeCapture[F[_], S[_]](implicit F: Capture[F], I: F :<: S)
-  extends Capture[Free[S, ?]] {
+  extends Capture[Free[S, ?]] with Serializable {
   def capture[A](a: => A) = Free.liftF(I(F.capture(a)))
 }

--- a/effect/src/main/scala/quasar/effect/Capture.scala
+++ b/effect/src/main/scala/quasar/effect/Capture.scala
@@ -73,7 +73,7 @@ sealed abstract class CaptureInstances0 {
     new TransCapture[F, WriterT[?[_], W, ?]]
 }
 
-private[effect] class TaskCapture extends Capture[Task] {
+private[effect] class TaskCapture extends Capture[Task] with Serializable {
   def capture[A](a: => A) = Task.delay(a)
 }
 

--- a/it/src/main/resources/tests/multistageFlatten.test
+++ b/it/src/main/resources/tests/multistageFlatten.test
@@ -6,8 +6,8 @@
         "marklogic_json": "pending",
         "marklogic_xml": "timeout",
         "mongodb_q_3_2": "pending",
-        "spark_local": "timeout",
-        "spark_hdfs": "timeout"
+        "spark_local": "pending",
+        "spark_hdfs": "pending"
     },
     "data": "nested_foo.data",
     "query": "select * from nested_foo where (

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/EquiJoinPlanner.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/EquiJoinPlanner.scala
@@ -21,7 +21,6 @@ import quasar.common.JoinType
 import quasar.contrib.pathy.AFile
 import quasar.fp._, ski._
 import quasar.qscript._
-import quasar.effect.Capture
 
 import scala.math.{Ordering => SOrdering}, SOrdering.Implicits._
 
@@ -32,13 +31,13 @@ import matryoshka.implicits._
 import matryoshka.patterns._
 import scalaz._, Scalaz._
 
-class EquiJoinPlanner[T[_[_]]: BirecursiveT: ShowT, M[_]:Capture:Monad] extends Planner[EquiJoin[T, ?], M] {
+class EquiJoinPlanner[T[_[_]]: BirecursiveT: ShowT, M[_]:Monad] extends Planner[EquiJoin[T, ?], M] {
 
   import Planner.{SparkState, SparkStateT}
 
-  def plan(fromFile: AFile => M[RDD[Data]]): AlgebraM[SparkState[M, ?], EquiJoin[T, ?], RDD[Data]] = {
+  def plan(fromFile: AFile => M[RDD[Data]], first: RDD[Data] => M[Data]): AlgebraM[SparkState[M, ?], EquiJoin[T, ?], RDD[Data]] = {
     case EquiJoin(src, lBranch, rBranch, lKey, rKey, jt, combine) =>
-      val algebraM = Planner[QScriptTotal[T, ?], M].plan(fromFile)
+      val algebraM = Planner[QScriptTotal[T, ?], M].plan(fromFile, first)
       val srcState = src.point[SparkState[M, ?]]
 
       def genKey(kf: FreeMap[T]): SparkState[M, Data => Data] =

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/EquiJoinPlanner.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/EquiJoinPlanner.scala
@@ -25,7 +25,6 @@ import quasar.effect.Capture
 
 import scala.math.{Ordering => SOrdering}, SOrdering.Implicits._
 
-import org.apache.spark._
 import org.apache.spark.rdd._
 import matryoshka.{Hole => _, _}
 import matryoshka.data._
@@ -37,7 +36,7 @@ class EquiJoinPlanner[T[_[_]]: BirecursiveT: ShowT, M[_]:Capture:Monad] extends 
 
   import Planner.{SparkState, SparkStateT}
 
-  def plan(fromFile: (SparkContext, AFile) => M[RDD[Data]]): AlgebraM[SparkState[M, ?], EquiJoin[T, ?], RDD[Data]] = {
+  def plan(fromFile: AFile => M[RDD[Data]]): AlgebraM[SparkState[M, ?], EquiJoin[T, ?], RDD[Data]] = {
     case EquiJoin(src, lBranch, rBranch, lKey, rKey, jt, combine) =>
       val algebraM = Planner[QScriptTotal[T, ?], M].plan(fromFile)
       val srcState = src.point[SparkState[M, ?]]

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/Planner.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/Planner.scala
@@ -20,43 +20,43 @@ import slamdata.Predef._
 import quasar._, quasar.Planner._
 import quasar.contrib.pathy.{AFile, ADir}
 import quasar.qscript._
-import quasar.effect.Capture
 
 import org.apache.spark._
 import org.apache.spark.rdd._
 import matryoshka.{Hole => _, _}
 import scalaz._, Scalaz._
 
+
 trait Planner[F[_], M[_]] extends Serializable {
-  def plan(fromFile: AFile => M[RDD[Data]]): AlgebraM[Planner.SparkState[M, ?], F, RDD[Data]]
+  def plan(fromFile: AFile => M[RDD[Data]], first: RDD[Data] => M[Data]): AlgebraM[Planner.SparkState[M, ?], F, RDD[Data]]
 }
 
 object Planner {
 
-  def apply[F[_],M[_]:Capture](implicit P: Planner[F, M]): Planner[F, M] = P
+  def apply[F[_],M[_]:Monad](implicit P: Planner[F, M]): Planner[F, M] = P
 
   type SparkState[M[_], A] = StateT[EitherT[M, PlannerError, ?], SparkContext, A]
   type SparkStateT[F[_], A] = StateT[F, SparkContext, A]
 
-  implicit def deadEnd[M[_]:Capture:Monad]: Planner[Const[DeadEnd, ?], M] = unreachable("deadEnd")
-  implicit def read[A, M[_]:Capture:Monad]: Planner[Const[Read[A], ?], M] = unreachable("read")
-  implicit def shiftedReadPath[M[_]:Capture:Monad]: Planner[Const[ShiftedRead[ADir], ?], M] = unreachable("shifted read of a dir")
-  implicit def projectBucket[T[_[_]], M[_]:Capture:Monad]: Planner[ProjectBucket[T, ?], M] = unreachable("projectBucket")
-  implicit def thetaJoin[T[_[_]], M[_]:Capture:Monad]: Planner[ThetaJoin[T, ?], M] = unreachable("thetajoin")
-  implicit def shiftedread[M[_]:Capture:Monad]: Planner[Const[ShiftedRead[AFile], ?], M] = new ShiftedReadPlanner[M]
-  implicit def qscriptCore[T[_[_]]: BirecursiveT: ShowT, M[_]:Capture:Monad]: Planner[QScriptCore[T, ?], M] = new QScriptCorePlanner[T, M]
-  implicit def equiJoin[T[_[_]]: BirecursiveT: ShowT, M[_]:Capture:Monad]: Planner[EquiJoin[T, ?], M] = new EquiJoinPlanner[T, M]
+  implicit def deadEnd[M[_]:Monad]: Planner[Const[DeadEnd, ?], M] = unreachable("deadEnd")
+  implicit def read[A, M[_]:Monad]: Planner[Const[Read[A], ?], M] = unreachable("read")
+  implicit def shiftedReadPath[M[_]:Monad]: Planner[Const[ShiftedRead[ADir], ?], M] = unreachable("shifted read of a dir")
+  implicit def projectBucket[T[_[_]], M[_]:Monad]: Planner[ProjectBucket[T, ?], M] = unreachable("projectBucket")
+  implicit def thetaJoin[T[_[_]], M[_]:Monad]: Planner[ThetaJoin[T, ?], M] = unreachable("thetajoin")
+  implicit def shiftedread[M[_]:Monad]: Planner[Const[ShiftedRead[AFile], ?], M] = new ShiftedReadPlanner[M]
+  implicit def qscriptCore[T[_[_]]: BirecursiveT: ShowT, M[_]:Monad]: Planner[QScriptCore[T, ?], M] = new QScriptCorePlanner[T, M]
+  implicit def equiJoin[T[_[_]]: BirecursiveT: ShowT, M[_]:Monad]: Planner[EquiJoin[T, ?], M] = new EquiJoinPlanner[T, M]
 
-  implicit def coproduct[F[_], G[_], M[_]:Capture](
+  implicit def coproduct[F[_], G[_], M[_]:Monad](
     implicit F: Planner[F, M], G: Planner[G, M]):
       Planner[Coproduct[F, G, ?], M] =
     new Planner[Coproduct[F, G, ?], M] {
-      def plan(fromFile: AFile => M[RDD[Data]]): AlgebraM[SparkState[M, ?], Coproduct[F, G, ?], RDD[Data]] = _.run.fold(F.plan(fromFile), G.plan(fromFile))
+      def plan(fromFile: AFile => M[RDD[Data]], first: RDD[Data] => M[Data]): AlgebraM[SparkState[M, ?], Coproduct[F, G, ?], RDD[Data]] = _.run.fold(F.plan(fromFile, first), G.plan(fromFile, first))
     }
 
-  private def unreachable[F[_], M[_]:Capture:Monad](what: String): Planner[F, M] =
+  private def unreachable[F[_], M[_]:Monad](what: String): Planner[F, M] =
     new Planner[F, M] {
-      def plan(fromFile: AFile => M[RDD[Data]]): AlgebraM[SparkState[M, ?], F, RDD[Data]] =
+      def plan(fromFile: AFile => M[RDD[Data]], first: RDD[Data] => M[Data]): AlgebraM[SparkState[M, ?], F, RDD[Data]] =
         _ =>  StateT((sc: SparkContext) => {
           EitherT(InternalError.fromMsg(s"unreachable $what").left[(SparkContext, RDD[Data])].point[M])
         })

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/QScriptCorePlanner.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/QScriptCorePlanner.scala
@@ -74,7 +74,7 @@ class QScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, M[_]:Capture:Monad]
 
 
   private def filterOut(
-    fromFile: (SparkContext, AFile) => M[RDD[Data]],
+    fromFile: AFile => M[RDD[Data]],
     src: RDD[Data],
     from: FreeQS[T],
     count: FreeQS[T],
@@ -136,7 +136,7 @@ class QScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, M[_]:Capture:Monad]
 
   }
 
-  def plan(fromFile: (SparkContext, AFile) => M[RDD[Data]]): AlgebraM[SparkState[M, ?], QScriptCore[T, ?], RDD[Data]] = {
+  def plan(fromFile: AFile => M[RDD[Data]]): AlgebraM[SparkState[M, ?], QScriptCore[T, ?], RDD[Data]] = {
     case qscript.Map(src, f) =>
       StateT((sc: SparkContext) =>
         EitherT(CoreMap.changeFreeMap(f).map(df => (sc, src.map(df))).point[M]))

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/ShiftedReadPlanner.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/ShiftedReadPlanner.scala
@@ -26,14 +26,14 @@ import org.apache.spark._
 import org.apache.spark.rdd._
 import scalaz._, Scalaz._
 
-class ShiftedReadPlanner[M[_]:Monad] extends Planner[Const[ShiftedRead[AFile], ?], M] {
+class ShiftedReadPlanner[S[_]] extends Planner[Const[ShiftedRead[AFile], ?], S] {
 
   import Planner.SparkState
 
   def plan(
-    fromFile: AFile => M[RDD[Data]],
-    first: RDD[Data] => M[Data]
-  ): AlgebraM[SparkState[M, ?], Const[ShiftedRead[AFile], ?], RDD[Data]] =
+    fromFile: AFile => Free[S, RDD[Data]],
+    first: RDD[Data] => Free[S, Data]
+  ): AlgebraM[SparkState[S, ?], Const[ShiftedRead[AFile], ?], RDD[Data]] =
     (qs: Const[ShiftedRead[AFile], RDD[Data]]) => {
       StateT((sc: SparkContext) => {
         val filePath = qs.getConst.path

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/ShiftedReadPlanner.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/ShiftedReadPlanner.scala
@@ -28,13 +28,13 @@ import scalaz._, Scalaz._
 
 class ShiftedReadPlanner[M[_]:Capture:Monad] extends Planner[Const[ShiftedRead[AFile], ?], M] {
 
-  def plan(fromFile: (SparkContext, AFile) => M[RDD[Data]]) =
+  def plan(fromFile: AFile => M[RDD[Data]]) =
     (qs: Const[ShiftedRead[AFile], RDD[Data]]) => {
       StateT((sc: SparkContext) => {
         val filePath = qs.getConst.path
         val idStatus = qs.getConst.idStatus
 
-        EitherT(fromFile(sc, filePath).map { rdd =>
+        EitherT(fromFile(filePath).map { rdd =>
           (sc,
             idStatus match {
               case IdOnly => rdd.zipWithIndex.map[Data](p => Data.Int(p._2))

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/ShiftedReadPlanner.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/ShiftedReadPlanner.scala
@@ -25,11 +25,10 @@ import quasar.effect.Capture
 import org.apache.spark._
 import org.apache.spark.rdd._
 import scalaz._, Scalaz._
-import scalaz.concurrent.Task
 
-class ShiftedReadPlanner[M[_]:Capture] extends Planner[Const[ShiftedRead[AFile], ?], M] {
+class ShiftedReadPlanner[M[_]:Capture:Monad] extends Planner[Const[ShiftedRead[AFile], ?], M] {
 
-  def plan(fromFile: (SparkContext, AFile) => Task[RDD[Data]]) =
+  def plan(fromFile: (SparkContext, AFile) => M[RDD[Data]]) =
     (qs: Const[ShiftedRead[AFile], RDD[Data]]) => {
       StateT((sc: SparkContext) => {
         val filePath = qs.getConst.path

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/ShiftedReadPlanner.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/ShiftedReadPlanner.scala
@@ -20,13 +20,14 @@ import slamdata.Predef._
 import quasar._, quasar.Planner._
 import quasar.contrib.pathy.AFile
 import quasar.qscript._
+import quasar.effect.Capture
 
 import org.apache.spark._
 import org.apache.spark.rdd._
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 
-object ShiftedReadPlanner extends Planner[Const[ShiftedRead[AFile], ?]] {
+class ShiftedReadPlanner[M[_]:Capture] extends Planner[Const[ShiftedRead[AFile], ?], M] {
 
   def plan(fromFile: (SparkContext, AFile) => Task[RDD[Data]]) =
     (qs: Const[ShiftedRead[AFile], RDD[Data]]) => {

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/cassandra/package.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/cassandra/package.scala
@@ -119,7 +119,7 @@ package object cassandra {
 
   private def fsInterpret: SparkFSConf => (FileSystem ~> Free[Eff, ?]) =
     (sparkFsConf: SparkFSConf) => interpretFileSystem(
-      corequeryfile.chrooted[Eff](queryfile.input, FsType, sparkFsConf.prefix),
+      corequeryfile.chrooted[Eff](FsType, sparkFsConf.prefix),
       corereadfile.chrooted(sparkFsConf.prefix),
       writefile.chrooted[Eff](sparkFsConf.prefix),
       managefile.chrooted[Eff](sparkFsConf.prefix))

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/cassandra/queryfile.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/cassandra/queryfile.scala
@@ -17,22 +17,17 @@
 package quasar.physical.sparkcore.fs.cassandra
 
 import slamdata.Predef._
-import quasar.effect._
 import quasar.fp.free._
-import quasar.fp.ski._
 import quasar.contrib.pathy._
 import quasar.fs.FileSystemError
 import quasar.fs.FileSystemErrT
 import quasar.{Data, DataCodec}
-import quasar.physical.sparkcore.fs.queryfile.Input
 import quasar.physical.sparkcore.fs.SparkConnectorDetails, SparkConnectorDetails._
 import quasar.fs._,
   FileSystemError._, 
   PathError._
 
-import org.apache.spark.SparkContext
 import org.apache.spark.rdd._
-import com.datastax.spark.connector._
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 import pathy.Path._
@@ -41,14 +36,6 @@ import pathy.Path._
 object queryfile {
 
   import common._
-
-  def fromFile(sc: SparkContext, file: AFile): Task[RDD[Data]] = Task.delay {
-    sc.cassandraTable[String](keyspace(fileParent(file)), tableName(file))
-      .select("data")
-      .map{ raw =>
-        DataCodec.parse(raw)(DataCodec.Precise).fold(error => Data.NA, ι)
-      }
-  }
 
   def rddFrom[S[_]](f: AFile)(implicit
     cass: CassandraDDL.Ops[S]
@@ -107,13 +94,6 @@ object queryfile {
   }
 
   def readChunkSize: Int = 5000
-
-  def input[S[_]](implicit
-    cass: CassandraDDL.Ops[S],
-    read: Read.Ops[SparkContext, S],
-    S0: Task :<: S
-  ): Input[S] =
-    Input(fromFile _)
 
   def detailsInterpreter[S[_]](implicit
     cass: CassandraDDL.Ops[S],

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/elastic/package.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/elastic/package.scala
@@ -172,7 +172,7 @@ package object elastic {
 
     type FreeEff[A]  = Free[Eff, A]
     interpretFileSystem(
-      corequeryfile.interpreter[Eff](queryfile.input[Eff], FsType),
+      corequeryfile.interpreter[Eff](FsType),
       corereadfile.interpret[Eff],
       writefile.interpreter[Eff],
       managefile.interpreter[Eff])

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/elastic/queryfile.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/elastic/queryfile.scala
@@ -18,7 +18,6 @@ package quasar.physical.sparkcore.fs.elastic
 
 import slamdata.Predef._
 import quasar.{Data, DataCodec}
-import quasar.physical.sparkcore.fs.queryfile.Input
 import quasar.contrib.pathy._
 import quasar.fs.FileSystemError
 import quasar.fs.FileSystemErrT
@@ -39,7 +38,7 @@ object queryfile {
 
   private def parseIndex(adir: ADir) = posixCodec.unsafePrintPath(adir).replace("/", "") // TODO_ES handle invalid paths
 
-  def fromFile(sc: SparkContext, file: AFile): Task[RDD[Data]] = Task.delay {
+  private def fromFile(sc: SparkContext, file: AFile): Task[RDD[Data]] = Task.delay {
     sc
       .esJsonRDD(file2ES(file).shows)
       .map(_._2)
@@ -95,12 +94,6 @@ object queryfile {
   }
 
   def readChunkSize: Int = 5000
-
-  def input[S[_]](implicit
-    s0: Task :<: S,
-    elastic: ElasticCall :<: S
-  ): Input[S] =
-    Input[S](fromFile _)
 
   def detailsInterpreter[S[_]](implicit
     read: Read.Ops[SparkContext, S],

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/hdfs/package.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/hdfs/package.scala
@@ -191,7 +191,7 @@ package object hdfs {
     val fileSystem = generateHdfsFS(sparkFsConf)
 
     interpretFileSystem(
-      corequeryfile.chrooted[Eff](queryfile.input(fileSystem), FsType, sparkFsConf.prefix),
+      corequeryfile.chrooted[Eff](FsType, sparkFsConf.prefix),
       corereadfile.chrooted(sparkFsConf.prefix),
       writefile.chrooted[Eff](sparkFsConf.prefix, fileSystem),
       managefile.chrooted[Eff](sparkFsConf.prefix, fileSystem))

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/hdfs/queryfile.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/hdfs/queryfile.scala
@@ -18,7 +18,6 @@ package quasar.physical.sparkcore.fs.hdfs
 
 import slamdata.Predef._
 import quasar.{Data, DataCodec}
-import quasar.physical.sparkcore.fs.queryfile.Input
 import quasar.contrib.pathy._
 import quasar.contrib.pathy._
 import quasar.effect.Capture
@@ -39,7 +38,6 @@ import org.apache.hadoop.fs.FileSystem
 import org.apache.hadoop.util.Progressable
 import pathy.Path._
 import scalaz._, Scalaz._
-import scalaz.concurrent.Task
 import org.apache.spark._
 import org.apache.spark.rdd._
 
@@ -49,18 +47,7 @@ class queryfile[F[_]:Capture:Bind](fileSystem: F[FileSystem]) {
     new Path(posixCodec.unsafePrintPath(apath))
   }
 
-  def fromFile(sc: SparkContext, file: AFile): F[RDD[Data]] = for {
-    hdfs <- fileSystem
-    pathStr <- Capture[F].capture {
-      val pathStr = posixCodec.unsafePrintPath(file)
-      val host = hdfs.getUri().getHost()
-      val port = hdfs.getUri().getPort()
-      s"hdfs://$host:$port$pathStr"
-    }
-    rdd <- fetchRdd(sc, pathStr)
-  } yield rdd
-
-  def fetchRdd[F[_]:Capture](sc: SparkContext, pathStr: String): F[RDD[Data]] = Capture[F].capture {
+  private def fetchRdd[F[_]:Capture](sc: SparkContext, pathStr: String): F[RDD[Data]] = Capture[F].capture {
     import ParquetRDD._
     // TODO add magic number support to distinguish
     if(pathStr.endsWith(".parquet"))
@@ -138,9 +125,4 @@ object queryfile {
         case RDDFrom(f)          => qf.rddFrom(f)(hdfsPathStr)
       }
     }
-
-  def input[S[_]](fileSystem: Task[FileSystem])(implicit s0: Task :<: S): Input[S] = {
-    val qf = new queryfile[Task](fileSystem)
-    Input[S](qf.fromFile _)
-  }
 }

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/local/package.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/local/package.scala
@@ -102,7 +102,7 @@ package object local {
 
   def fsInterpret: SparkFSConf => (FileSystem ~> Free[Eff, ?]) =
     (fsConf: SparkFSConf) => interpretFileSystem(
-      corequeryfile.chrooted[Eff](queryfile.input, FsType, fsConf.prefix),
+      corequeryfile.chrooted[Eff](FsType, fsConf.prefix),
       corereadfile.chrooted(fsConf.prefix),
       writefile.chrooted[Eff](fsConf.prefix),
       managefile.chrooted[Eff](fsConf.prefix))

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/queryfile.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/queryfile.scala
@@ -101,7 +101,7 @@ object queryfile {
     read: Read.Ops[SparkContext, S]
   ): Free[S, EitherT[Writer[PhaseResults, ?], FileSystemError, ExecutionPlan]] = {
 
-    val total = scala.Predef.implicitly[Planner[SparkQScript]]
+    val total = scala.Predef.implicitly[Planner[SparkQScript, Task]]
 
     read.asks { sc =>
       val sparkStuff: Task[PlannerError \/ RDD[Data]] =
@@ -127,7 +127,7 @@ object queryfile {
     details: SparkConnectorDetails.Ops[S]
   ): Free[S, EitherT[Writer[PhaseResults, ?], FileSystemError, AFile]] = {
 
-    val total = scala.Predef.implicitly[Planner[SparkQScript]]
+    val total = scala.Predef.implicitly[Planner[SparkQScript, Task]]
 
     read.asks { sc =>
       val sparkStuff: Free[S, PlannerError \/ RDD[Data]] =
@@ -150,7 +150,7 @@ object queryfile {
       ms: MonotonicSeq.Ops[S]
   ): Free[S, EitherT[Writer[PhaseResults, ?], FileSystemError, QueryFile.ResultHandle]] = {
 
-    val total = scala.Predef.implicitly[Planner[SparkQScript]]
+    val total = scala.Predef.implicitly[Planner[SparkQScript, Task]]
 
     val open: Free[S, PlannerError \/ (QueryFile.ResultHandle, RDD[Data])] = (for {
       h <- EitherT(ms.next map (QueryFile.ResultHandle(_).right[PlannerError]))

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/queryfile.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/queryfile.scala
@@ -108,7 +108,7 @@ object queryfile {
     details: SparkConnectorDetails.Ops[S]
   ): Free[S, EitherT[Writer[PhaseResults, ?], FileSystemError, ExecutionPlan]] = {
 
-    val total = scala.Predef.implicitly[Planner[SparkQScript, Free[S, ?]]]
+    val total = scala.Predef.implicitly[Planner[SparkQScript, S]]
 
     read.asks { sc =>
       val sparkStuff: Free[S, PlannerError \/ RDD[Data]] =
@@ -132,7 +132,7 @@ object queryfile {
     details: SparkConnectorDetails.Ops[S]
   ): Free[S, EitherT[Writer[PhaseResults, ?], FileSystemError, AFile]] = {
 
-    val total = scala.Predef.implicitly[Planner[SparkQScript, Free[S, ?]]]
+    val total = scala.Predef.implicitly[Planner[SparkQScript, S]]
 
     read.asks { sc =>
       val sparkStuff: Free[S, PlannerError \/ RDD[Data]] =
@@ -156,7 +156,7 @@ object queryfile {
     details: SparkConnectorDetails.Ops[S]
   ): Free[S, EitherT[Writer[PhaseResults, ?], FileSystemError, QueryFile.ResultHandle]] = {
 
-    val total = scala.Predef.implicitly[Planner[SparkQScript, Free[S, ?]]]
+    val total = scala.Predef.implicitly[Planner[SparkQScript, S]]
 
     val open: Free[S, PlannerError \/ (QueryFile.ResultHandle, RDD[Data])] = (for {
       h <- EitherT(ms.next map (QueryFile.ResultHandle(_).right[PlannerError]))

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/queryfile.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/queryfile.scala
@@ -42,22 +42,18 @@ import scalaz.concurrent.Task
 
 object queryfile {
 
-  final case class Input[S[_]](
-    fromFile: (SparkContext, AFile) => Task[RDD[Data]]
-  )
-
   type SparkContextRead[A] = effect.Read[SparkContext, A]
 
-  def chrooted[S[_]](input: Input[S], fsType: FileSystemType, prefix: ADir)(implicit
+  def chrooted[S[_]](fsType: FileSystemType, prefix: ADir)(implicit
     s0: Task :<: S,
     s1: SparkContextRead :<: S,
     s2: MonotonicSeq :<: S,
     s3: KeyValueStore[QueryFile.ResultHandle, RddState, ?] :<: S,
     s4: SparkConnectorDetails :<: S
   ): QueryFile ~> Free[S, ?] =
-    flatMapSNT(interpreter(input, fsType)) compose chroot.queryFile[QueryFile](prefix)
+    flatMapSNT(interpreter(fsType)) compose chroot.queryFile[QueryFile](prefix)
 
-  def interpreter[S[_]](input: Input[S], fsType: FileSystemType)(implicit
+  def interpreter[S[_]](fsType: FileSystemType)(implicit
     s0: Task :<: S,
     s1: SparkContextRead :<: S,
     s2: MonotonicSeq :<: S,
@@ -78,13 +74,13 @@ object queryfile {
         case QueryFile.FileExists(f) => details.fileExists(f)
         case QueryFile.ListContents(dir) => details.listContents(dir).run
         case QueryFile.ExecutePlan(lp: Fix[LogicalPlan], out: AFile) =>
-          qsToProgram(qs => executePlan(input, qs, out, lp), lp)
+          qsToProgram(qs => executePlan(qs, out, lp), lp)
         case QueryFile.EvaluatePlan(lp: Fix[LogicalPlan]) =>
-          qsToProgram(qs => evaluatePlan(input, qs, lp), lp)
+          qsToProgram(qs => evaluatePlan(qs, lp), lp)
         case QueryFile.More(h) => more(h)
         case QueryFile.Close(h) => close(h)
         case QueryFile.Explain(lp: Fix[LogicalPlan]) =>
-          qsToProgram(qs => explainPlan(input, fsType, qs, lp), lp)
+          qsToProgram(qs => explainPlan(fsType, qs, lp), lp)
       }
     }}
 
@@ -96,42 +92,45 @@ object queryfile {
 
   // TODO unify explainPlan, executePlan & evaluatePlan
   // This might be more complicated then it looks at first glance
-  private def explainPlan[S[_]](input: Input[S], fsType: FileSystemType, qs: Fix[SparkQScript], lp: Fix[LogicalPlan]) (implicit
+  private def explainPlan[S[_]](fsType: FileSystemType, qs: Fix[SparkQScript], lp: Fix[LogicalPlan]) (implicit
     s0: Task :<: S,
-    read: Read.Ops[SparkContext, S]
+    read: Read.Ops[SparkContext, S],
+    details: SparkConnectorDetails.Ops[S]
   ): Free[S, EitherT[Writer[PhaseResults, ?], FileSystemError, ExecutionPlan]] = {
 
-    val total = scala.Predef.implicitly[Planner[SparkQScript, Task]]
+    val total = scala.Predef.implicitly[Planner[SparkQScript, Free[S, ?]]]
+
+    val temp = (sc: SparkContext, afile: AFile) => details.rddFrom(afile)
 
     read.asks { sc =>
-      val sparkStuff: Task[PlannerError \/ RDD[Data]] =
-        qs.cataM(total.plan(input.fromFile)).eval(sc).run
+      val sparkStuff: Free[S, PlannerError \/ RDD[Data]] =
+        qs.cataM(total.plan(temp)).eval(sc).run
 
-      injectFT.apply {
-        sparkStuff.flatMap(mrdd => mrdd.bitraverse[(Task ∘ Writer[PhaseResults, ?])#λ, FileSystemError, ExecutionPlan](
-          planningFailed(lp, _).point[Writer[PhaseResults, ?]].point[Task],
+        sparkStuff.flatMap(mrdd => mrdd.bitraverse[(Free[S, ?] ∘ Writer[PhaseResults, ?])#λ, FileSystemError, ExecutionPlan](
+          planningFailed(lp, _).point[Writer[PhaseResults, ?]].point[Free[S, ?]],
           rdd => {
             val rddDebug = rdd.toDebugString
             val inputs   = qs.cata(ExtractPath[SparkQScript, APath].extractPath[DList])
-            Task.delay(Writer(
+            lift(Task.delay(Writer(
               Vector(PhaseResult.detail("RDD", rddDebug)),
-              ExecutionPlan(fsType, rddDebug, ISet fromFoldable inputs)))
+              ExecutionPlan(fsType, rddDebug, ISet fromFoldable inputs)))).into[S]
           })).map(EitherT(_))
-      }
     }.join
   }
 
-  private def executePlan[S[_]](input: Input[S], qs: Fix[SparkQScript], out: AFile, lp: Fix[LogicalPlan]) (implicit
+  private def executePlan[S[_]](qs: Fix[SparkQScript], out: AFile, lp: Fix[LogicalPlan]) (implicit
     s0: Task :<: S,
     read: effect.Read.Ops[SparkContext, S],
     details: SparkConnectorDetails.Ops[S]
   ): Free[S, EitherT[Writer[PhaseResults, ?], FileSystemError, AFile]] = {
 
-    val total = scala.Predef.implicitly[Planner[SparkQScript, Task]]
+    val total = scala.Predef.implicitly[Planner[SparkQScript, Free[S, ?]]]
+
+    val temp = (sc: SparkContext, afile: AFile) => details.rddFrom(afile)
 
     read.asks { sc =>
       val sparkStuff: Free[S, PlannerError \/ RDD[Data]] =
-        lift(qs.cataM(total.plan(input.fromFile)).eval(sc).run).into[S]
+        qs.cataM(total.plan(temp)).eval(sc).run
 
       sparkStuff >>= (mrdd => mrdd.bitraverse[(Free[S, ?] ∘ Writer[PhaseResults, ?])#λ, FileSystemError, AFile](
         planningFailed(lp, _).point[Writer[PhaseResults, ?]].point[Free[S, ?]],
@@ -143,19 +142,22 @@ object queryfile {
   // TODO for Q4.2016  - unify it with ReadFile
   final case class RddState(maybeRDD: Option[RDD[(Data, Long)]], pointer: Int)
 
-  private def evaluatePlan[S[_]](input: Input[S], qs: Fix[SparkQScript], lp: Fix[LogicalPlan])(implicit
-      s0: Task :<: S,
-      kvs: KeyValueStore.Ops[QueryFile.ResultHandle, RddState, S],
-      read: Read.Ops[SparkContext, S],
-      ms: MonotonicSeq.Ops[S]
+  private def evaluatePlan[S[_]](qs: Fix[SparkQScript], lp: Fix[LogicalPlan])(implicit
+    s0: Task :<: S,
+    kvs: KeyValueStore.Ops[QueryFile.ResultHandle, RddState, S],
+    read: Read.Ops[SparkContext, S],
+    ms: MonotonicSeq.Ops[S],
+    details: SparkConnectorDetails.Ops[S]
   ): Free[S, EitherT[Writer[PhaseResults, ?], FileSystemError, QueryFile.ResultHandle]] = {
 
-    val total = scala.Predef.implicitly[Planner[SparkQScript, Task]]
+    val total = scala.Predef.implicitly[Planner[SparkQScript, Free[S, ?]]]
+
+    val temp = (sc: SparkContext, afile: AFile) => details.rddFrom(afile)
 
     val open: Free[S, PlannerError \/ (QueryFile.ResultHandle, RDD[Data])] = (for {
       h <- EitherT(ms.next map (QueryFile.ResultHandle(_).right[PlannerError]))
       rdd <- EitherT(read.asks { sc =>
-        lift(qs.cataM(total.plan(input.fromFile)).eval(sc).run).into[S]
+        qs.cataM(total.plan(temp)).eval(sc).run
       }.join)
       _ <- kvs.put(h, RddState(rdd.zipWithIndex.persist.some, 0)).liftM[PlannerErrT]
     } yield (h, rdd)).run

--- a/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/PlannerSpec.scala
+++ b/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/PlannerSpec.scala
@@ -49,9 +49,9 @@ class PlannerSpec
 
   sequential
 
-  val equi = Planner.equiJoin[Fix]
-  val sr = Planner.shiftedread
-  val qscore = Planner.qscriptCore[Fix]
+  val equi = Planner.equiJoin[Fix, Task]
+  val sr = Planner.shiftedread[Task]
+  val qscore = Planner.qscriptCore[Fix, Task]
 
   val data = List(
     Data.Obj(ListMap(("age" -> Data.Int(24)), "height" -> Data.Dec(1.56), "country" -> Data.Str("Poland"))),

--- a/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/PlannerSpec.scala
+++ b/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/PlannerSpec.scala
@@ -96,8 +96,8 @@ class PlannerSpec
               "name" -> Data.Str("tom"),
               "age" -> Data.Int(28)
             )
-        val fromFile: (SparkContext, AFile) => Task[RDD[Data]] =
-          (sc: SparkContext, file: AFile) => Task.delay {
+        val fromFile: AFile => Task[RDD[Data]] =
+          (file: AFile) => Task.delay {
             sc.parallelize(List(Data.Obj(input)))
           }
         val compile: AlgebraM[SparkState[Task, ?], Const[ShiftedRead[AFile], ?], RDD[Data]] = sr.plan(fromFile)
@@ -116,7 +116,7 @@ class PlannerSpec
     "core" should {
       "map" in {
         withSpark { sc =>
-          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF)
+          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
           val src: RDD[Data] = sc.parallelize(data)
 
           def func: FreeMap = ProjectFieldR(HoleF, StrLit("country"))
@@ -138,7 +138,7 @@ class PlannerSpec
 
       "sort" in {
         withSpark { sc =>
-          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF)
+          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
           val src: RDD[Data] = sc.parallelize(data)
 
           def bucket = ProjectFieldR(HoleF, StrLit("country"))
@@ -163,7 +163,7 @@ class PlannerSpec
       "reduce" should {
         "calculate count" in {
           withSpark( sc => {
-            val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF)
+            val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
             val src: RDD[Data] = sc.parallelize(data)
 
             def bucket: FreeMap = ProjectFieldR(HoleF, StrLit("country"))
@@ -182,7 +182,7 @@ class PlannerSpec
 
         "calculate sum" in {
           withSpark { sc =>
-            val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF)
+            val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
             val src: RDD[Data] = sc.parallelize(data)
 
             def bucket: FreeMap = ProjectFieldR(HoleF, StrLit("country"))
@@ -201,7 +201,7 @@ class PlannerSpec
 
         "extract bucket" in {
           withSpark { sc =>
-            val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF)
+            val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
             val src: RDD[Data] = sc.parallelize(data)
 
             def bucket: FreeMap = ProjectFieldR(HoleF, StrLit("country"))
@@ -222,7 +222,7 @@ class PlannerSpec
         //        not sure how to check the result
         // "calculate arbitrary" in {
         //   withSpark { sc =>
-        //     val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF)
+        //     val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
         //     val src: RDD[Data] = sc.parallelize(data)
 
         //     def bucket: FreeMap = ProjectFieldR(HoleF, StrLit("country"))
@@ -241,7 +241,7 @@ class PlannerSpec
 
         "calculate max" in {
           withSpark { sc =>
-            val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF)
+            val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
             val src: RDD[Data] = sc.parallelize(data)
 
             def bucket: FreeMap = ProjectFieldR(HoleF, StrLit("country"))
@@ -261,7 +261,7 @@ class PlannerSpec
         "for avg" should {
           "calculate int values" in {
             withSpark { sc =>
-              val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF)
+              val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
 
               val src: RDD[Data] = sc.parallelize(List(
                 Data.Obj(ListMap() + ("age" -> Data.Int(24)) + ("country" -> Data.Str("Poland"))),
@@ -286,7 +286,7 @@ class PlannerSpec
 
           "calculate dec values" in {
             withSpark { sc =>
-              val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF)
+              val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
 
               val src: RDD[Data] = sc.parallelize(List(
                 Data.Obj(ListMap(("height" -> Data.Dec(1.56)),("country" -> Data.Str("Poland")))),
@@ -311,7 +311,7 @@ class PlannerSpec
           "bugfix: calculate even if Data.Dec has BigDecimal with precision 0" in {
             withSpark { sc =>
               // given avg height is 10.(3)
-              val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF)
+              val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
               val src: RDD[Data] = sc.parallelize(List(
                 Data.Obj(ListMap(("height" -> Data.Dec(BigDecimal(3,MathContext.UNLIMITED))),("country" -> Data.Str("Poland")))),
                 Data.Obj(ListMap(("height" -> Data.Dec(BigDecimal(4,MathContext.UNLIMITED))),("country" -> Data.Str("Poland")))),
@@ -333,7 +333,7 @@ class PlannerSpec
 
       "filter" in {
         withSpark { sc =>
-          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF)
+          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
           val src: RDD[Data] = sc.parallelize(data)
 
           def func: FreeMap = Free.roll(MFC(Lt(ProjectFieldR(HoleF, StrLit("age")), IntLit(24))))
@@ -355,7 +355,7 @@ class PlannerSpec
 
       "take" in {
         withSpark { sc =>
-          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF)
+          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
           val src: RDD[Data] = sc.parallelize(data)
 
           def from: FreeQS = Free.point(SrcHole)
@@ -379,7 +379,7 @@ class PlannerSpec
 
       "drop" in {
         withSpark { sc =>
-          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF)
+          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
           val src: RDD[Data] = sc.parallelize(data)
 
           def from: FreeQS = Free.point(SrcHole)
@@ -403,7 +403,7 @@ class PlannerSpec
 
       "union" in {
         withSpark { sc =>
-          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF)
+          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
           val src: RDD[Data] = sc.parallelize(data)
 
           def func(country: String): FreeMap =
@@ -429,7 +429,7 @@ class PlannerSpec
 
       "leftshift" in {
         withSpark { sc =>
-          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF)
+          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
           val src: RDD[Data] = sc.parallelize(data2)
 
           def struct: FreeMap = ProjectFieldR(HoleF, StrLit("countries"))
@@ -456,7 +456,7 @@ class PlannerSpec
       "inner" in {
 
         withSpark { sc =>
-          val compile: AlgebraM[SparkState[Task, ?], EquiJoin, RDD[Data]] = equi.plan(emptyFF)
+          val compile: AlgebraM[SparkState[Task, ?], EquiJoin, RDD[Data]] = equi.plan(emptyFF(sc))
           val src: RDD[Data] = sc.parallelize(data3)
 
           def func(country: String): FreeMap =
@@ -486,7 +486,7 @@ class PlannerSpec
       "leftOuter" in {
 
         withSpark { sc =>
-          val compile: AlgebraM[SparkState[Task, ?], EquiJoin, RDD[Data]] = equi.plan(emptyFF)
+          val compile: AlgebraM[SparkState[Task, ?], EquiJoin, RDD[Data]] = equi.plan(emptyFF(sc))
           val src: RDD[Data] = sc.parallelize(data3)
 
           def func(country: String): FreeMap =
@@ -521,7 +521,7 @@ class PlannerSpec
       "rightOuter" in {
 
         withSpark { sc =>
-          val compile: AlgebraM[SparkState[Task, ?], EquiJoin, RDD[Data]] = equi.plan(emptyFF)
+          val compile: AlgebraM[SparkState[Task, ?], EquiJoin, RDD[Data]] = equi.plan(emptyFF(sc))
 
           val src: RDD[Data] = sc.parallelize(data4)
 
@@ -556,7 +556,7 @@ class PlannerSpec
 
       "fullOuter" in {
         withSpark { sc =>
-          val compile: AlgebraM[SparkState[Task, ?], EquiJoin, RDD[Data]] = equi.plan(emptyFF)
+          val compile: AlgebraM[SparkState[Task, ?], EquiJoin, RDD[Data]] = equi.plan(emptyFF(sc))
           val src: RDD[Data] = sc.parallelize(data5)
 
           def func(country: String): FreeMap =
@@ -605,8 +605,8 @@ class PlannerSpec
   private def constFreeQS(v: Int): FreeQS =
     Free.roll(QCT.inj(quasar.qscript.Map(Free.roll(QCT.inj(Unreferenced())), IntLit(v))))
 
-  private val emptyFF: (SparkContext, AFile) => Task[RDD[Data]] =
-    (sc: SparkContext, file: AFile) => Task.delay {
+  private def emptyFF(sc: SparkContext): AFile => Task[RDD[Data]] =
+    (file: AFile) => Task.delay {
       sc.parallelize(List())
     }
 }

--- a/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/PlannerSpec.scala
+++ b/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/PlannerSpec.scala
@@ -100,7 +100,8 @@ class PlannerSpec
           (file: AFile) => Task.delay {
             sc.parallelize(List(Data.Obj(input)))
           }
-        val compile: AlgebraM[SparkState[Task, ?], Const[ShiftedRead[AFile], ?], RDD[Data]] = sr.plan(fromFile)
+        val compile: AlgebraM[SparkState[Task, ?], Const[ShiftedRead[AFile], ?], RDD[Data]] =
+          sr.plan(fromFile, first)
         val afile: AFile = rootDir </> dir("Users") </> dir("rabbit") </> file("test.json")
 
         val program: SparkState[Task, RDD[Data]] = compile(Const(ShiftedRead(afile, ExcludeId)))
@@ -116,7 +117,7 @@ class PlannerSpec
     "core" should {
       "map" in {
         withSpark { sc =>
-          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
+          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc), first)
           val src: RDD[Data] = sc.parallelize(data)
 
           def func: FreeMap = ProjectFieldR(HoleF, StrLit("country"))
@@ -138,7 +139,7 @@ class PlannerSpec
 
       "sort" in {
         withSpark { sc =>
-          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
+          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc), first)
           val src: RDD[Data] = sc.parallelize(data)
 
           def bucket = ProjectFieldR(HoleF, StrLit("country"))
@@ -163,7 +164,7 @@ class PlannerSpec
       "reduce" should {
         "calculate count" in {
           withSpark( sc => {
-            val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
+            val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc), first)
             val src: RDD[Data] = sc.parallelize(data)
 
             def bucket: FreeMap = ProjectFieldR(HoleF, StrLit("country"))
@@ -182,7 +183,7 @@ class PlannerSpec
 
         "calculate sum" in {
           withSpark { sc =>
-            val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
+            val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc), first)
             val src: RDD[Data] = sc.parallelize(data)
 
             def bucket: FreeMap = ProjectFieldR(HoleF, StrLit("country"))
@@ -201,7 +202,7 @@ class PlannerSpec
 
         "extract bucket" in {
           withSpark { sc =>
-            val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
+            val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc), first)
             val src: RDD[Data] = sc.parallelize(data)
 
             def bucket: FreeMap = ProjectFieldR(HoleF, StrLit("country"))
@@ -222,7 +223,7 @@ class PlannerSpec
         //        not sure how to check the result
         // "calculate arbitrary" in {
         //   withSpark { sc =>
-        //     val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
+        //     val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc), first)
         //     val src: RDD[Data] = sc.parallelize(data)
 
         //     def bucket: FreeMap = ProjectFieldR(HoleF, StrLit("country"))
@@ -241,7 +242,7 @@ class PlannerSpec
 
         "calculate max" in {
           withSpark { sc =>
-            val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
+            val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc), first)
             val src: RDD[Data] = sc.parallelize(data)
 
             def bucket: FreeMap = ProjectFieldR(HoleF, StrLit("country"))
@@ -261,7 +262,7 @@ class PlannerSpec
         "for avg" should {
           "calculate int values" in {
             withSpark { sc =>
-              val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
+              val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc), first)
 
               val src: RDD[Data] = sc.parallelize(List(
                 Data.Obj(ListMap() + ("age" -> Data.Int(24)) + ("country" -> Data.Str("Poland"))),
@@ -286,7 +287,7 @@ class PlannerSpec
 
           "calculate dec values" in {
             withSpark { sc =>
-              val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
+              val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc), first)
 
               val src: RDD[Data] = sc.parallelize(List(
                 Data.Obj(ListMap(("height" -> Data.Dec(1.56)),("country" -> Data.Str("Poland")))),
@@ -311,7 +312,7 @@ class PlannerSpec
           "bugfix: calculate even if Data.Dec has BigDecimal with precision 0" in {
             withSpark { sc =>
               // given avg height is 10.(3)
-              val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
+              val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc), first)
               val src: RDD[Data] = sc.parallelize(List(
                 Data.Obj(ListMap(("height" -> Data.Dec(BigDecimal(3,MathContext.UNLIMITED))),("country" -> Data.Str("Poland")))),
                 Data.Obj(ListMap(("height" -> Data.Dec(BigDecimal(4,MathContext.UNLIMITED))),("country" -> Data.Str("Poland")))),
@@ -333,7 +334,7 @@ class PlannerSpec
 
       "filter" in {
         withSpark { sc =>
-          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
+          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc), first)
           val src: RDD[Data] = sc.parallelize(data)
 
           def func: FreeMap = Free.roll(MFC(Lt(ProjectFieldR(HoleF, StrLit("age")), IntLit(24))))
@@ -355,7 +356,7 @@ class PlannerSpec
 
       "take" in {
         withSpark { sc =>
-          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
+          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc), first)
           val src: RDD[Data] = sc.parallelize(data)
 
           def from: FreeQS = Free.point(SrcHole)
@@ -379,7 +380,7 @@ class PlannerSpec
 
       "drop" in {
         withSpark { sc =>
-          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
+          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc), first)
           val src: RDD[Data] = sc.parallelize(data)
 
           def from: FreeQS = Free.point(SrcHole)
@@ -403,7 +404,7 @@ class PlannerSpec
 
       "union" in {
         withSpark { sc =>
-          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
+          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc), first)
           val src: RDD[Data] = sc.parallelize(data)
 
           def func(country: String): FreeMap =
@@ -429,7 +430,7 @@ class PlannerSpec
 
       "leftshift" in {
         withSpark { sc =>
-          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc))
+          val compile: AlgebraM[SparkState[Task, ?], QScriptCore, RDD[Data]] = qscore.plan(emptyFF(sc), first)
           val src: RDD[Data] = sc.parallelize(data2)
 
           def struct: FreeMap = ProjectFieldR(HoleF, StrLit("countries"))
@@ -456,7 +457,7 @@ class PlannerSpec
       "inner" in {
 
         withSpark { sc =>
-          val compile: AlgebraM[SparkState[Task, ?], EquiJoin, RDD[Data]] = equi.plan(emptyFF(sc))
+          val compile: AlgebraM[SparkState[Task, ?], EquiJoin, RDD[Data]] = equi.plan(emptyFF(sc), first)
           val src: RDD[Data] = sc.parallelize(data3)
 
           def func(country: String): FreeMap =
@@ -486,7 +487,7 @@ class PlannerSpec
       "leftOuter" in {
 
         withSpark { sc =>
-          val compile: AlgebraM[SparkState[Task, ?], EquiJoin, RDD[Data]] = equi.plan(emptyFF(sc))
+          val compile: AlgebraM[SparkState[Task, ?], EquiJoin, RDD[Data]] = equi.plan(emptyFF(sc), first)
           val src: RDD[Data] = sc.parallelize(data3)
 
           def func(country: String): FreeMap =
@@ -521,7 +522,7 @@ class PlannerSpec
       "rightOuter" in {
 
         withSpark { sc =>
-          val compile: AlgebraM[SparkState[Task, ?], EquiJoin, RDD[Data]] = equi.plan(emptyFF(sc))
+          val compile: AlgebraM[SparkState[Task, ?], EquiJoin, RDD[Data]] = equi.plan(emptyFF(sc), first)
 
           val src: RDD[Data] = sc.parallelize(data4)
 
@@ -556,7 +557,7 @@ class PlannerSpec
 
       "fullOuter" in {
         withSpark { sc =>
-          val compile: AlgebraM[SparkState[Task, ?], EquiJoin, RDD[Data]] = equi.plan(emptyFF(sc))
+          val compile: AlgebraM[SparkState[Task, ?], EquiJoin, RDD[Data]] = equi.plan(emptyFF(sc), first)
           val src: RDD[Data] = sc.parallelize(data5)
 
           def func(country: String): FreeMap =
@@ -609,4 +610,8 @@ class PlannerSpec
     (file: AFile) => Task.delay {
       sc.parallelize(List())
     }
+
+  private def first: RDD[Data] => Task[Data] = (rdd: RDD[Data]) => Task.delay {
+    rdd.first
+  }
 }


### PR DESCRIPTION
Finally closes https://github.com/quasar-analytics/quasar/issues/1634

It happily:

1. removes QueryFile.Input completely 
2. ~~makes sparkcore Planner more generic - it can be used with any `M` as long as it is `Monad` and `Capture`~~