### PR TITLE
[Fix #2485] Keep track of sort order in Mimir Repr

### DIFF
--- a/mimir/src/main/scala/quasar/mimir/Mimir.scala
+++ b/mimir/src/main/scala/quasar/mimir/Mimir.scala
@@ -61,6 +61,10 @@ import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
+import quasar.yggdrasil.TableModule.{DesiredSortOrder, SortAscending}
+
+import scalaz.Leibniz.===
+
 object Mimir extends BackendModule with Logging {
   import FileSystemError._
   import PathError._
@@ -77,48 +81,76 @@ object Mimir extends BackendModule with Logging {
 
   private type Cake = Precog with Singleton
 
+  // EquiJoin results are sorted by both keys at the same time, so we need to keep track of both
+  final case class SortOrdering[TS1](sortKeys: Set[TS1], sortOrder: DesiredSortOrder, unique: Boolean) {
+    def sort(src: Cake)(table: src.Table)(implicit ev: TS1 === src.trans.TransSpec1): Future[src.Table] =
+      if (sortKeys.isEmpty) Future.successful(table)
+      else table.sort(ev(sortKeys.head), sortOrder, unique)
+  }
+
+  final case class SortRepr[TS1](bucket: Option[TS1], orderings: List[SortOrdering[TS1]])
+
   trait Repr {
     type P <: Cake
 
+    // Scala is afraid to infer this but it must be valid,
+    // because Cake <: Singleton
+    val sing: Leibniz[⊥, Cake, P, P.type]
+
     val P: P
     val table: P.Table
+    val lastSort: Option[SortRepr[P.trans.TransSpec1]]
 
-    /**
-     * Given a term which is a type derived from the generic cake,
-     * produce the equivalent term which is typed specific to the
-     * cake in this repr.  For example:
-     *
-     * {{{
-     * val transM: M[Cake#trans#TransSpec1] = cake.flatMap(_.trans.Single.Value)
-     *
-     * def foo(repr: Repr) = for {
-     *   trans <- repr.unsafeCoerce[λ[`P <: Cake` => P.trans.TransSpec1]](transM).liftM[MT]
-     * } yield repr.table.transform(trans)
-     * }}}
-     */
-    def unsafeCoerce[F[_ <: Cake]](term: F[Cake]): Task[F[P]] =
-      Task.delay(term.asInstanceOf[F[P]])
+    // these casts can't crash, because `Precog` is final.
+    // however they're unsafe because they could lead to sharing cakes
+    // between state threads.
+    def unsafeMerge(other: Repr): Repr.Aux[Repr.this.P.type] =
+      other.asInstanceOf[Repr.Aux[Repr.this.P.type]]
 
-    def unsafeMerge(other: Repr): Task[Repr { type P = Repr.this.P.type }] =
-      Task.delay(other.asInstanceOf[Repr { type P = Repr.this.P.type }])
+    def unsafeMergeTable(other: Repr#P#Table): Repr.this.P.Table =
+      other.asInstanceOf[Repr.this.P.Table]
 
-    def map(f: P.Table => P.Table): Repr { type P = Repr.this.P.type } =
+    // this is totally safe because `Precog` is final *and* `TransSpec` can't reference cake state.
+    def mergeTS1(other: or.P.trans.TransSpec1 forSome { val or: Repr }): Repr.this.P.trans.TransSpec1 =
+      other.asInstanceOf[Repr.this.P.trans.TransSpec1]
+
+    def map(f: P.Table => P.Table): Repr.Aux[Repr.this.P.type] =
       Repr(P)(f(table))
   }
 
   object Repr {
-    def apply(P0: Precog)(table0: P0.Table): Repr { type P = P0.type } =
+    type Aux[P0 <: Cake] = Repr { type P = P0 }
+
+    def apply(P0: Precog)(table0: P0.Table): Repr.Aux[P0.type] =
       new Repr {
         type P = P0.type
 
-        val P: P = P0
+        val sing: Leibniz[P, P, P, P] = Leibniz.refl[P]
+
+        val P: P0.type = P0
         val table: P.Table = table0
+        val lastSort: Option[SortRepr[P0.trans.TransSpec1]] = None
+      }
+
+    def withSort(P0: Precog)(table0: P0.Table)(lastSort0: Option[SortRepr[P0.trans.TransSpec1]]): Repr.Aux[P0.type] =
+      new Repr {
+        type P = P0.type
+
+        val sing: Leibniz[P, P, P, P] = Leibniz.refl[P]
+
+        val P: P0.type = P0
+        val table: P.Table = table0
+        val lastSort: Option[SortRepr[P0.trans.TransSpec1]] = lastSort0
       }
 
     def meld[F[_]: Monad](fn: DepFn1[Cake, λ[`P <: Cake` => F[P#Table]]])(
       implicit
         F: MonadReader_[F, Cake]): F[Repr] =
       F.ask.flatMap(cake => fn(cake).map(table => Repr(cake)(table)))
+
+    // witness that all cakes have a singleton type for P
+    def single[P0 <: Cake](src: Repr.Aux[P0]): Repr.Aux[src.P.type] =
+      src.sing.subst[Repr.Aux](src)
   }
 
   private type MT[F[_], A] = Kleisli[F, Cake, A]
@@ -145,6 +177,32 @@ object Mimir extends BackendModule with Logging {
     } yield (λ[M ~> Task](_.run(cake)), cake.shutdown.toTask)
 
     t.liftM[BackendDef.DefErrT]
+  }
+
+  def needToSort(p: Precog)(oldSort: SortRepr[p.trans.TransSpec1], newSort: SortRepr[p.trans.TransSpec1]): Boolean = {
+    (oldSort.orderings.length != newSort.orderings.length || oldSort.bucket != newSort.bucket) || {
+      def requiresSort(oldOrdering: SortOrdering[p.trans.TransSpec1], newOrdering: SortOrdering[p.trans.TransSpec1]) =
+        (oldOrdering.sortKeys & newOrdering.sortKeys).nonEmpty ||
+          (oldOrdering.sortOrder != newOrdering.sortOrder) ||
+          (oldOrdering.unique && !newOrdering.unique)
+      (oldSort.bucket != newSort.bucket) || {
+        val allOrderings = oldSort.orderings.zip(newSort.orderings)
+        allOrderings.exists { case (o, n) => requiresSort(o, n) }
+      }
+    }
+  }
+
+  // sort by one dimension
+  def sortT[P0 <: Cake](c: Repr.Aux[P0])(table: c.P.Table, sortKey: c.P.trans.TransSpec1,
+                                                 sortOrder: DesiredSortOrder = SortAscending, unique: Boolean = false): Task[Repr.Aux[c.P.type]] = {
+    val newRepr =
+      SortRepr[c.P.trans.TransSpec1](bucket = None, orderings = SortOrdering(Set(sortKey), sortOrder, unique) :: Nil)
+    if (c.lastSort.fold(true)(needToSort(c.P)(_, newSort = newRepr)))
+      table.sort(sortKey, sortOrder, unique).toTask.map(sorted =>
+        Repr.withSort(c.P)(sorted)(Some(newRepr))
+      )
+    else
+      Task.now(Repr.withSort(c.P)(table)(Some(newRepr)))
   }
 
   val Type = FileSystemType("mimir")
@@ -189,9 +247,21 @@ object Mimir extends BackendModule with Logging {
 
     lazy val planQScriptCore: AlgebraM[Backend, QScriptCore[T, ?], Repr] = {
       case qscript.Map(src, f) =>
+        import src.P.trans._
         for {
           trans <- interpretMapFunc[Backend](src.P)(f)
-        } yield Repr(src.P)(src.table.transform(trans))
+          newSort = for {
+            lastSort <- src.lastSort
+            newBucket = lastSort.bucket.flatMap(TransSpec.rephrase(_, Source, trans))
+            newOrderings <- lastSort.orderings.traverse{ord =>
+              val rephrasedSortKeys = ord.sortKeys.flatMap(TransSpec.rephrase(_, Source, trans))
+              // can't guarantee uniqueness is preserved by all functions,
+              // but maybe it's worth keeping track of that
+              if (rephrasedSortKeys.isEmpty) None
+              else Some(SortOrdering(rephrasedSortKeys, ord.sortOrder, unique = false))
+            }
+          } yield SortRepr(newBucket, newOrderings)
+        } yield Repr.withSort(src.P)(src.table.transform(trans))(newSort)
 
       case qscript.Reduce(src, bucket, reducers, repair) =>
         import src.P.trans._
@@ -210,8 +280,10 @@ object Mimir extends BackendModule with Logging {
 
             transformed = src.table.transform(trans)
 
-            sorted <- transformed.sort(TransSpec1.Id, unique = true).toTask.liftM[MT].liftB
-          } yield Repr(src.P)(sorted)
+            sorted <- sortT[src.P.type](Repr.single[src.P](src))(transformed,
+              TransSpec1.Id,
+              unique = true).liftM[MT].liftB
+          } yield sorted
         } else {
           def extractReduction(red: ReduceFunc[FreeMap[T]])
               : (Library.Reduction, FreeMap[T]) = red match {
@@ -281,7 +353,8 @@ object Mimir extends BackendModule with Logging {
                 for {
                   bucketTrans <- interpretMapFunc[Backend](src.P)(bucket)
 
-                  prepared <- src.table.sort(bucketTrans).toTask.liftM[MT].liftB
+                  prepared <- sortT[src.P.type](Repr.single[src.P](src))(src.table, bucketTrans)
+                    .liftM[MT].liftB.map(r => src.unsafeMergeTable(r.table))
                   table <- prepared.partitionMerge(bucketTrans)(reduceAll).toTask.liftM[MT].liftB
                 } yield table
               }
@@ -348,41 +421,53 @@ object Mimir extends BackendModule with Logging {
 
           (sorts, _) = pair
 
-          table <- {
-            def sortAll(table: src.P.Table): Future[src.P.Table] = {
-              sorts.foldRightM(table) {
-                case ((transes, sortOrder), table) =>
-                  val sortKey = OuterArrayConcat(transes.map(WrapArray(_)): _*)
+          tableAndSort <- {
+            val sortOrderings = sorts.foldRight(List.empty[SortOrdering[TransSpec1]]) {
+              case ((transes, sortOrder), a) =>
+                val sortKey = OuterArrayConcat(transes.map(WrapArray(_)): _*)
+                SortOrdering[TransSpec1](Set(sortKey), sortOrder, unique = false) :: a
+            }
 
-                  table.sort(sortKey, sortOrder)
+            def sortAll(table: src.P.Table): Future[src.P.Table] = {
+              sortOrderings.foldRightM(table) {
+                case (ordering, table) =>
+                  ordering.sort(src.P)(table)
               }
             }
 
-            if (bucket === MapFuncsCore.NullLit()) {
-              sortAll(src.table).toTask.liftM[MT].liftB
-            } else {
-              for {
-                bucketTrans <- interpretMapFunc[Backend](src.P)(bucket)
-
-                prepared <- src.table.sort(bucketTrans).toTask.liftM[MT].liftB
-                table <- prepared.partitionMerge(bucketTrans)(sortAll).toTask.liftM[MT].liftB
-              } yield table
-            }
+            for {
+              bucketNotNullTrans <- Some(bucket)
+                .filterNot(_ === MapFuncsCore.NullLit())
+                .traverse(interpretMapFunc[Backend](src.P))
+              newSort = SortRepr(bucketNotNullTrans, sortOrderings)
+              sortedTable <- if (src.lastSort.fold(true)(last => needToSort(Repr.single[src.P](src).P)(last, newSort))) {
+                bucketNotNullTrans.fold(sortAll(src.table).toTask.liftM[MT].liftB) { bucketTrans =>
+                  for {
+                    prepared <- sortT[src.P.type](Repr.single[src.P](src))(src.table, bucketTrans)
+                      .liftM[MT].liftB.map(r => src.unsafeMergeTable(r.table))
+                    table <- prepared.partitionMerge(bucketTrans)(sortAll).toTask.liftM[MT].liftB
+                  } yield table
+                }
+              } else {
+                src.table.point[Backend]
+              }
+            } yield (sortedTable, newSort)
           }
-        } yield Repr(src.P)(table)
+          (table, sort) = tableAndSort
+        } yield Repr.withSort(src.P)(table)(Some(sort))
 
       case qscript.Filter(src, f) =>
         import src.P.trans._
 
         for {
           trans <- interpretMapFunc[Backend](src.P)(f)
-        } yield Repr(src.P)(src.table.transform(Filter(TransSpec1.Id, trans)))
+        } yield Repr.withSort(src.P)(src.table.transform(Filter(TransSpec1.Id, trans)))(src.lastSort)
 
       case qscript.Union(src, lBranch, rBranch) =>
         for {
          leftRepr <- lBranch.cataM(interpretM(κ(src.point[Backend]), planQST))
          rightRepr <- rBranch.cataM(interpretM(κ(src.point[Backend]), planQST))
-         rightCoerced <- leftRepr.unsafeMerge(rightRepr).liftM[MT].liftB
+         rightCoerced = leftRepr.unsafeMerge(rightRepr)
         } yield Repr(leftRepr.P)(leftRepr.table.concat(rightCoerced.table))
 
       case qscript.Subset(src, from, op, count) =>
@@ -395,6 +480,7 @@ object Mimir extends BackendModule with Logging {
               nums = vals collect { case n: JNum => n.toLong.toInt } // TODO error if we get something strange
               number = nums.head
               compacted = fromRepr.table.compact(fromRepr.P.trans.TransSpec1.Id)
+              retainsOrder = op != Sample
               back <- op match {
                 case Take =>
                   Future.successful(compacted.take(number))
@@ -405,7 +491,9 @@ object Mimir extends BackendModule with Logging {
                 case Sample =>
                   compacted.sample(number, List(fromRepr.P.trans.TransSpec1.Id)).map(_.head) // the number of Reprs returned equals the number of transspecs
               }
-            } yield Repr(fromRepr.P)(back)
+            } yield
+              if (retainsOrder) Repr.withSort(fromRepr.P)(back)(fromRepr.lastSort)
+              else Repr(fromRepr.P)(back)
 
             result.toTask.liftM[MT].liftB
           }
@@ -421,16 +509,23 @@ object Mimir extends BackendModule with Logging {
 
     lazy val planEquiJoin: AlgebraM[Backend, EquiJoin[T, ?], Repr] = {
       case qscript.EquiJoin(src, lbranch, rbranch, lkey, rkey, tpe, combine) =>
-        import src.P.trans._
+        import src.P.trans._, scalaz.syntax.std.option._, scalaz.std.option._, scalaz.syntax.show._
+        def rephrase2(projection: TransSpec2, rootL: TransSpec1, rootR: TransSpec1): Option[SortOrdering[TransSpec1]] = {
+          val leftRephrase = TransSpec.rephrase(projection, SourceLeft, rootL).fold(Set.empty[TransSpec1])(Set(_))
+          val rightRephrase = TransSpec.rephrase(projection, SourceRight, rootR).fold(Set.empty[TransSpec1])(Set(_))
+          val bothRephrased = leftRephrase ++ rightRephrase
+          if (bothRephrased.isEmpty) None
+          else SortOrdering(bothRephrased, SortAscending, unique = false).some
+        }
 
         for {
           leftRepr <- lbranch.cataM(interpretM(κ(src.point[Backend]), planQST))
           rightRepr <- rbranch.cataM(interpretM(κ(src.point[Backend]), planQST))
 
-          lmerged <- src.unsafeMerge(leftRepr).liftM[MT].liftB
+          lmerged = src.unsafeMerge(leftRepr)
           ltable = lmerged.table
 
-          rmerged <- src.unsafeMerge(rightRepr).liftM[MT].liftB
+          rmerged = src.unsafeMerge(rightRepr)
           rtable = rmerged.table
 
           transLKey <- interpretMapFunc[Backend](src.P)(lkey)
@@ -445,16 +540,18 @@ object Mimir extends BackendModule with Logging {
               mapFuncPlanner[Backend].plan(src.P)[Source2](TransSpec2.LeftId)))    // TODO weirdly left-biases things like constants
 
           // identify full-cross and avoid cogroup
-          result <- if (transLKey == transRKey && transLKey == ConstLiteral(CEmptyArray, TransSpec1.Id)) {
+          resultAndSort <- if (transLKey == transRKey && transLKey == ConstLiteral(CEmptyArray, TransSpec1.Id)) {
             log.trace("EQUIJOIN: full-cross detected!")
-
-            rtable.cross(ltable)(transMiddle).point[Backend]
+            val crossWithSort = (rtable.cross(ltable)(transMiddle), src.unsafeMerge(leftRepr).lastSort)
+            crossWithSort.point[Backend]
           } else {
             log.trace("EQUIJOIN: not a full-cross; sorting and cogrouping")
 
             for {
-              lsorted <- ltable.sort(transLKey).toTask.liftM[MT].liftB
-              rsorted <- rtable.sort(transRKey).toTask.liftM[MT].liftB
+              lsorted <- sortT[leftRepr.P.type](Repr.single[leftRepr.P](leftRepr))(leftRepr.table, leftRepr.mergeTS1(transLKey))
+                .liftM[MT].liftB.map(r => src.unsafeMergeTable(r.table))
+              rsorted <- sortT[rightRepr.P.type](Repr.single[rightRepr.P](rightRepr))(rightRepr.table, rightRepr.mergeTS1(transRKey))
+                .liftM[MT].liftB.map(r => src.unsafeMergeTable(r.table))
 
               transLeft <- tpe match {
                 case JoinType.LeftOuter | JoinType.FullOuter =>
@@ -483,9 +580,13 @@ object Mimir extends BackendModule with Logging {
                 case JoinType.Inner | JoinType.LeftOuter =>
                   TransSpec1.Undef.point[Backend]
               }
-            } yield lsorted.cogroup(transLKey, transRKey, rsorted)(transLeft, transRight, transMiddle)
+              newSortOrder = rephrase2(transMiddle, transLKey, transRKey)
+            } yield
+              (lsorted.cogroup(transLKey, transRKey, rsorted)(transLeft, transRight, transMiddle),
+                newSortOrder.map(order => SortRepr(None, order :: Nil)))
           }
-        } yield Repr(src.P)(result)
+          (result, newSort) = resultAndSort
+        } yield Repr.withSort(src.P)(result)(newSort)
     }
 
     lazy val planShiftedRead: AlgebraM[Backend, Const[ShiftedRead[AFile], ?], Repr] = {

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/FNModule.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/FNModule.scala
@@ -42,6 +42,7 @@ trait FNDummyModule extends FNModule {
   import table.CFId
   type F1 = table.CF1
   type F2 = table.CF2
+  type FN = table.CFN
 
   implicit def liftF1(f: F1) = new F1Like {
     def compose(f1: F1) = f compose f1

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/TransSpecModule.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/TransSpecModule.scala
@@ -131,6 +131,7 @@ trait TransSpecModule extends FNModule {
     type TransSpec1 = TransSpec[Source1]
 
     object TransSpec {
+
       import CPath._
 
       def concatChildren[A <: SourceType](tree: CPathTree[Int], leaf: TransSpec[A] = Leaf(Source)): TransSpec[A] = {
@@ -176,7 +177,7 @@ trait TransSpecModule extends FNModule {
           case trans.Map1(source, f1)      => trans.Map1(mapSources(source)(f), f1)
           case trans.DeepMap1(source, f1)  => trans.DeepMap1(mapSources(source)(f), f1)
           case trans.Map2(left, right, f2) => trans.Map2(mapSources(left)(f), mapSources(right)(f), f2)
-          case trans.MapN(contents, f1) => trans.MapN(mapSources(contents)(f), f1)
+          case trans.MapN(contents, f1)    => trans.MapN(mapSources(contents)(f), f1)
 
           case trans.OuterObjectConcat(objects @ _ *) => trans.OuterObjectConcat(objects.map(mapSources(_)(f)): _*)
           case trans.InnerObjectConcat(objects @ _ *) => trans.InnerObjectConcat(objects.map(mapSources(_)(f)): _*)
@@ -211,7 +212,7 @@ trait TransSpecModule extends FNModule {
       def deepMap[A <: SourceType](spec: TransSpec[A])(f: PartialFunction[TransSpec[A], TransSpec[A]]): TransSpec[A] = spec match {
         case x if f isDefinedAt x => f(x)
 
-        case x @ Leaf(source)                  => x
+        case x @ Leaf(_)                       => x
         case trans.ConstLiteral(value, target) => trans.ConstLiteral(value, deepMap(target)(f))
 
         case trans.Filter(source, pred) => trans.Filter(deepMap(source)(f), deepMap(pred)(f))
@@ -253,6 +254,274 @@ trait TransSpecModule extends FNModule {
         case trans.EqualLiteral(source, value, invert) => trans.EqualLiteral(deepMap(source)(f), value, invert)
 
         case trans.Cond(pred, left, right) => trans.Cond(deepMap(pred)(f), deepMap(left)(f), deepMap(right)(f))
+      }
+
+      // reduce the TransSpec to a "normal form", in which nested *Concats are flattened into
+      // single vararg calls and statically-known *DerefStatics are performed
+      def normalize[A <: SourceType](ts: TransSpec[A], undef: TransSpec[A]): TransSpec[A] = {
+        import scalaz.syntax.std.option._, scalaz.std.option._
+        def flattenOuterArrayConcats[A <: SourceType](proj: TransSpec[A]): Option[List[TransSpec[A]]] = proj match {
+          case OuterArrayConcat(ls@_*) =>
+            Some(ls.toList.flatMap(a => flattenOuterArrayConcats(a).getOrElse(a :: Nil)))
+          case _ => None
+        }
+        def flattenOuterObjectConcats[A <: SourceType](proj: TransSpec[A]): Option[List[TransSpec[A]]] = proj match {
+          case OuterObjectConcat(ls@_*) =>
+            Some(ls.toList.flatMap(a => flattenOuterObjectConcats(a).getOrElse(a :: Nil)))
+          case _ => None
+        }
+        def flattenInnerArrayConcats[A <: SourceType](proj: TransSpec[A]): Option[List[TransSpec[A]]] = proj match {
+          case InnerArrayConcat(ls@_*) =>
+            Some(ls.toList.flatMap(a => flattenInnerArrayConcats(a).getOrElse(a :: Nil)))
+          case _ => None
+        }
+        def flattenInnerObjectConcats[A <: SourceType](proj: TransSpec[A]): Option[List[TransSpec[A]]] = proj match {
+          case InnerObjectConcat(ls@_*) =>
+            Some(ls.toList.flatMap(a => flattenInnerObjectConcats(a).getOrElse(a :: Nil)))
+          case _ => None
+        }
+        @inline def flattenedOuterArrayConcatNormalized: Option[TransSpec[A]] =
+          flattenOuterArrayConcats(ts).map(ks => OuterArrayConcat(ks.map(normalize(_, undef)): _*))
+        @inline def flattenedOuterObjectConcatNormalized: Option[TransSpec[A]] =
+          flattenOuterObjectConcats(ts).map(ks => OuterObjectConcat(ks.map(normalize(_, undef)): _*))
+        @inline def flattenedInnerArrayConcatNormalized: Option[TransSpec[A]] =
+          flattenInnerArrayConcats(ts).map(ks => InnerArrayConcat(ks.map(normalize(_, undef)): _*))
+        @inline def flattenedInnerObjectConcatNormalized: Option[TransSpec[A]] =
+          flattenInnerObjectConcats(ts).map(ks => InnerObjectConcat(ks.map(normalize(_, undef)): _*))
+        flattenedOuterArrayConcatNormalized
+          .orElse(flattenedOuterObjectConcatNormalized)
+          .orElse(flattenedInnerArrayConcatNormalized)
+          .orElse(flattenedInnerObjectConcatNormalized)
+          .getOrElse[TransSpec[A]] {
+          ts match {
+            case WrapArray(t) => WrapArray(normalize(t, undef))
+            case WrapObject(t, f) => WrapObject(normalize(t, undef), f)
+            case WrapObjectDynamic(t, f) => WrapObjectDynamic(normalize(t, undef), normalize(f, undef))
+            case ConstLiteral(t, f) => ConstLiteral(t, normalize(f, undef))
+            case DerefArrayStatic(t, f@CPathIndex(i)) => normalize[A](t, undef) match {
+              case n@OuterArrayConcat(ks@_*) =>
+                if (ks.length < (i + 1) && ks.forall(_.isInstanceOf[WrapArray[_]])) undef
+                else ks.foldLeft((0.some, none[TransSpec[A]])) {
+                  case ((Some(a), b), WrapArray(nt)) =>
+                    ((a + 1).some, if (a == i) normalize(nt, undef).some else b)
+                  case ((_, b), _) => (none, b)
+                }._2.getOrElse(DerefArrayStatic(n, f))
+              case WrapArray(k) =>
+                if (i == 0) k else undef
+              case `undef` => undef
+              case n@_ => DerefArrayStatic(n, f)
+            }
+            case DerefObjectStatic(t, f@CPathField(k)) => normalize[A](t, undef) match {
+              // ks is reversed before being folded, because keys are overriden
+              // by operands on the right, not the left
+              case n@OuterObjectConcat(ks@_*) => ks.reverse.foldRight(undef) {
+                case (WrapObject(s, k2), o) => if (k == k2) normalize(s, undef) else o
+                case _ => DerefObjectStatic(n, f)
+              }
+              case WrapObject(s, `k`) => normalize(s, undef)
+              case WrapObject(_, _) => undef
+              case `undef` => undef
+              case n@_ => DerefObjectStatic(n, f)
+            }
+            case DerefMetadataStatic(t, f) =>
+              DerefMetadataStatic(normalize[A](t, undef), f)
+            case DerefObjectDynamic(s, f) =>
+              normalize(s, undef) match {
+                case `undef` => undef
+                case sn => normalize(f, undef) match {
+                  case `undef` => undef
+                  case fn => DerefObjectDynamic(sn, fn)
+                }
+              }
+            case DerefArrayDynamic(s, f) =>
+              normalize(s, undef) match {
+                case `undef` => undef
+                case sn => normalize(f, undef) match {
+                  case `undef` => undef
+                  case fn => DerefArrayDynamic(sn, fn)
+                }
+              }
+            case IsType(s, t) => IsType(normalize(s, undef), t)
+            case Equal(f, s) => Equal(normalize(f, undef), normalize(s, undef))
+            case EqualLiteral(f, v, i) => EqualLiteral(normalize(f, undef), v, i)
+            case Cond(p, l, r) => Cond(normalize(p, undef), normalize(l, undef), normalize(r, undef))
+            case Filter(s, t) => Filter(normalize(s, undef), normalize(t, undef))
+            case FilterDefined(s, df, t) => FilterDefined(normalize(s, undef), normalize(df, undef), t)
+            case Typed(s, t) => Typed(normalize(s, undef), t)
+            case TypedSubsumes(s, t) => TypedSubsumes(normalize(s, undef), t)
+            case Map1(s, fun) => Map1(normalize(s, undef), fun)
+            case DeepMap1(s, fun) => DeepMap1(normalize(s, undef), fun)
+            case Map2(s, f, fun) => Map2(normalize(s, undef), normalize(f, undef), fun)
+            case MapN(s, fun) => MapN(normalize(s, undef), fun)
+            case ArraySwap(s, i) => ArraySwap(normalize(s, undef), i)
+            case _ => ts
+          }
+        }
+      }
+
+      // rephrase(p, r)(p(a)) --> r(a), if this is possible.
+      // rephrase(p, r) "pulls back" r from p.
+
+      // selectors:
+      // rephrase(.a.b, .a.b.c)(x) --> x.c
+      // ==> rephrase(.a.b, .a.b.c)(x.a.b) --> x.a.b.c
+
+      // rephrase(.[0], .[0].[1])(x) --> [[undef] ++ [x]].[0].[1]
+      // ==> rephrase(.[0], .[0].[1])(x.[0]) --> x.[0].[1]
+
+      // rephrase({k: f}, f)(x) --> x.k
+      // ==> rephrase({k: f}, f)({k: f(x))) --> f(x)
+
+      // arrays:
+      // rephrase([a] ++ [b] ++ [c] ++ [d], a)(x) --> x.[0]
+      // rephrase([a] ++ [b] ++ ([c] ++ [d], d)(x) --> x.[3]
+
+      // constants:
+      // rephrase(1, f) --> none
+      // rephrase(f, 1) --> 1
+
+      def rephrase[A <: SourceType](projection: TransSpec[A], rootSource: A,
+                                    root: TransSpec1): Option[TransSpec1] = {
+        import scalaz.syntax.std.option._, scalaz.std.option._
+        // every iteration of peelInvert returns:
+        // - a change in the current index inside a nested *ArrayConcat, or None if the index information has been lost
+        //   (e.g., by concatting with Leaf(Source))
+        // - a change in the set of keys known to be inside a nested *ObjectConcat, or None if the key information has been lost
+        //   (e.g., by concatting with Leaf(Source))
+        // - a map of substitutions, which maps from subtrees of `root` that have been found in `projection`
+        //   to the accumulated inverse of the TransSpec layers seen inside `projection` upwards of that point
+        final case class PeelState(delta: Option[Int], keys: Option[Set[String]], substitutions: Map[TransSpec1, TransSpec1])
+
+        val rootWithSourceReplaced = TransSpec.mapSources(root)(_ => rootSource)
+
+        // find all paths (subtrees) through a `TransSpec[A]`
+        // note we don't need to include `r` in the set of paths when `r` is a `WrapArray`, `WrapObject`, or `*Concat`,
+        // because actually substituting that subtree messes up the index handling while traversing `projection`.
+        def paths(r: TransSpec[A]): Set[TransSpec[A]] = r match {
+          case OuterArrayConcat(rs@_*) => rs.flatMap(paths).toSet
+          case InnerArrayConcat(rs@_*) => rs.flatMap(paths).toSet
+          case OuterObjectConcat(rs@_*) => rs.flatMap(paths).toSet
+          case InnerObjectConcat(rs@_*) => rs.flatMap(paths).toSet
+          case WrapArray(s) => paths(s)
+          case WrapObject(s, _) => paths(s)
+          case DerefObjectStatic(s, _) => paths(s) + r
+          case DerefObjectDynamic(f, s) => paths(f) ++ paths(s) + r
+          case DerefArrayStatic(s, _) => paths(s) + r
+          case DerefArrayDynamic(f, s) => paths(f) ++ paths(s) + r
+          case DerefMetadataStatic(s, _) => paths(s) + r
+          case ArraySwap(s, _) => paths(s)
+          case Cond(f, s, _) => paths(f) ++ paths(s) + r
+          case ConstLiteral(_, s) => paths(s) + r
+          case Equal(f, s) => paths(f) ++ paths(s) + r
+          case EqualLiteral(s, _, _) => paths(s) + r
+          case Filter(f, p) => paths(f) ++ paths(p) + r
+          case FilterDefined(s, p, _) => paths(s) ++ paths(p) + r
+          case IsType(s, _) => paths(s) + r
+          case Map1(s, _) => paths(s) + r
+          case Map2(f, s, _) => paths(f) ++ paths(s) + r
+          case MapN(s, _) => paths(s) + r
+          case DeepMap1(s, _) => paths(s) + r
+          case MapWith(s, _) => paths(s) + r
+          case ObjectDelete(s, _) => paths(s) + r
+          case Scan(s, _) => paths(s) + r
+          case Typed(s, _) => paths(s) + r
+          case TypedSubsumes(s, _) => paths(s) + r
+          case WrapObjectDynamic(f, s) => paths(f) ++ paths(s) + r
+          case Leaf(`rootSource`) => Set(r)
+          case Leaf(_) => sys.error("impossible")
+        }
+
+        // find all subtrees of `root`, so that they can be substituted with inverses of the
+        // outer layers of `projection` from inside `root` when they're encountered inside `projection`.
+        val allRootPaths = paths(rootWithSourceReplaced)
+
+        // peels layers off of `projection`, building up the inverses of every layer and substituting those layers for common
+        // occurrences of subtrees of `root` inside `projection` when they're reached.
+        def peelInvert(projection: TransSpec[A], currentIndex: Int, keys: Set[String], inverseLayers: TransSpec1 => TransSpec1): PeelState = {
+
+          // folds over every branch in a *ArrayConcat, from the *left*, collecting substitutions.
+          // the state carried along consists of:
+          // a) the index into the array formed by the *ArrayConcat (and outer *ArrayConcats, because it's passed into peelInvert)
+          // b) the Option[TransSpec1] returned by the first successfully rephrased branch of the *ArrayConcat.
+          // If the index returned by any rephrase call is none before a branch is successfully rephrased,
+          // we have insufficient information to continue searching for a successful branch,
+          // so we have to halt and return none. Otherwise, the first successfully rephrased branch is returned.
+          def arrayConcat(rs: Seq[TransSpec[A]]) = {
+            val (delta, substsOut) = rs.foldLeft((0.some, Map.empty[TransSpec1, TransSpec1])) {
+              case ((Some(i), substs), ts) =>
+                val PeelState(newDelta, _, newSubsts) = peelInvert(ts, currentIndex = currentIndex + i, keys = Set.empty, inverseLayers)
+                (newDelta.map(_ + i), newSubsts ++ substs)
+              case ((None, substs), _) => (none, substs)
+            }
+            PeelState(delta, Set.empty[String].some, substsOut)
+          }
+
+          // folds over every branch in a *ObjectConcat, from the *right*, collecting substitutions.
+          // the state carried along consists of:
+          // a) the set of keys which have been observed in the *ObjectConcat (and outer *ObjectConcats, because it's passed into peelInvert)
+          // b) the Option[TransSpec1] returned by the first successfully rephrased branch of the *ObjectConcat.
+          // if the set of keys returned by any rephrase call is none before a branch is successfully rephrased,
+          // we have insufficient information to continue searching for a successful branch,
+          // so we have to halt and return none. Otherwise, the first successfully rephrased branch is returned.
+          def objectConcat(rs: Seq[TransSpec[A]]) = {
+            val (resultKeys, out) = rs.foldRight((Set.empty[String].some, Map.empty[TransSpec1, TransSpec1])) {
+              case (ts, (Some(ks), substs)) =>
+                val PeelState(_, newKeys, newSubsts) = peelInvert(ts, currentIndex = 0, keys = keys ++ ks, inverseLayers)
+                (newKeys.map(_ ++ ks), newSubsts ++ substs)
+              case (_, (None, substs)) => (none, substs)
+            }
+            PeelState(0.some, resultKeys, out)
+          }
+
+          projection match {
+            // if the key has already been spotted (to the right in a nested *ObjectConcat of this WrapObject),
+            // the object resulting from the *ObjectConcat has had this WrapObject call's result overriden.
+            // so this branch's value is inaccessible, so we return none.
+            case WrapObject(s, k) =>
+              if (keys(k)) PeelState(none, Set.empty[String].some, Map.empty)
+              else {
+                val out = peelInvert(s, currentIndex = 0, Set.empty, inverseLayers andThen (DerefObjectStatic(_, CPathField(k))))
+                PeelState(out.delta, Set(k).some, out.substitutions)
+              }
+            // encountering a WrapArray inside a *ArrayConcat requires shifting the index by 1.
+            // however inside the WrapArray, the index is reset to 0.
+            case WrapArray(s) =>
+              PeelState(1.some, none,
+                peelInvert(s, currentIndex = 0, Set.empty, inverseLayers andThen (DerefArrayStatic(_, CPathIndex(currentIndex)))).substitutions)
+            case OuterArrayConcat(rs@_*) =>
+              arrayConcat(rs)
+            case InnerArrayConcat(rs@_*) =>
+              arrayConcat(rs)
+            case OuterObjectConcat(rs@_*) =>
+              objectConcat(rs)
+            case InnerObjectConcat(rs@_*) =>
+              objectConcat(rs)
+            case ArraySwap(s, i) =>
+              peelInvert(s, currentIndex = 0, Set.empty, inverseLayers andThen (ArraySwap(_, i)))
+            // this branch of `projection` is a subtree of `root`, so we can substitute it with the inverted layers of
+            // `projection` we've encountered so far.
+            case rootSubtree if allRootPaths(rootSubtree) =>
+              val rootSubtreeAsTransSpec1 =
+                if (rootSource == Source) rootSubtree.asInstanceOf[TransSpec1]
+                else TransSpec.mapSources(rootSubtree)(_ => Source)
+              PeelState(0.some, Set.empty[String].some, Map(rootSubtreeAsTransSpec1 -> inverseLayers(Leaf(Source))))
+            // this won't be Leaf(rootSource), because that would be a subtree of root
+            case Leaf(_) => PeelState(none, none, Map.empty)
+            case _ => PeelState(none, none, Map.empty)
+          }
+        }
+        val peelSubstitutions =
+          peelInvert(projection, currentIndex = 0, keys = Set.empty, inverseLayers = identity[TransSpec1]).substitutions
+        if (peelSubstitutions.isEmpty) {
+          // there wasn't even an occurrence of `Leaf(rootSource)` in `projection`,
+          // so `projection` has definitely destroyed the information necessary to get back to root
+          none
+        } else {
+          // deepMap takes care of running substitutions over the largest subtrees first
+          val substitutedRoot = TransSpec.deepMap(root)(peelSubstitutions)
+          // normalize the output, so that equivalent sort orders are more likely to be comparable
+          normalize(substitutedRoot, TransSpec1.Undef).some
+        }
       }
     }
 

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/TransSpecModuleSpec.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/TransSpecModuleSpec.scala
@@ -16,8 +16,11 @@
 
 package quasar.yggdrasil
 
+import org.specs2.execute.Result
 import quasar.precog.common._
 import quasar.precog.TestSupport._
+import quasar.yggdrasil.bytecode.JNumberT
+import quasar.yggdrasil.table.{CF1, CF2, CFN}
 
 trait TransSpecModuleSpec extends TransSpecModule with FNDummyModule with SpecificationLike {
   import trans._
@@ -49,6 +52,370 @@ trait TransSpecModuleSpec extends TransSpecModule with FNDummyModule with Specif
 
       result mustEqual expected
     }
+  }
+
+  "rephrase" should {
+    import scalaz.syntax.std.option._
+    def rephraseTest[A <: SourceType](projection: TransSpec[A], rootSource: A, root: TransSpec1, expected: Option[TransSpec1]): Result = {
+      TransSpec.rephrase(projection, rootSource, root) mustEqual expected
+    }
+
+    "invert a single-key prefix" in rephraseTest(
+      // rephrase(.a, .a.b) --> .b
+      projection = DerefObjectStatic(
+        Leaf(Source),
+        CPathField("a")),
+      root = DerefObjectStatic(DerefObjectStatic(
+        Leaf(Source),
+        CPathField("a")), CPathField("b")),
+      rootSource = Source,
+      expected = DerefObjectStatic(Leaf(Source), CPathField("b")).some
+    )
+
+    "invert a multiple-key prefix" in rephraseTest(
+      // rephrase(.a.b, .a.b.c) --> .c
+      projection = DerefObjectStatic(DerefObjectStatic(
+        Leaf(Source), CPathField("a")), CPathField("b")),
+      root = DerefObjectStatic(DerefObjectStatic(DerefObjectStatic(
+        Leaf(Source), CPathField("a")), CPathField("b")), CPathField("c")),
+      rootSource = Source,
+      expected = DerefObjectStatic(Leaf(Source), CPathField("c")).some
+    )
+
+    "strip a single-index prefix" in rephraseTest(
+      // rephrase(.[0], .[0].[1]) --> .[1]
+      projection = DerefArrayStatic(
+        Leaf(Source), CPathIndex(0)),
+      root = DerefArrayStatic(DerefArrayStatic(
+        Leaf(Source), CPathIndex(0)), CPathIndex(1)),
+      rootSource = Source,
+      expected = DerefArrayStatic(Leaf(Source), CPathIndex(1)).some
+    )
+
+    "strip a multiple-index prefix" in rephraseTest(
+      // rephrase(.[0].[1], .[0].[1].[2]) --> .[2]
+      projection = DerefArrayStatic(DerefArrayStatic(Leaf(Source), CPathIndex(0)), CPathIndex(1)),
+      root = DerefArrayStatic(DerefArrayStatic(DerefArrayStatic(
+        Leaf(Source), CPathIndex(0)), CPathIndex(1)), CPathIndex(2)),
+      rootSource = Source,
+      expected = DerefArrayStatic(Leaf(Source), CPathIndex(2)).some
+    )
+
+    "strip WrapObject" in rephraseTest(
+      // rephrase({key: .}, .) --> .key
+      projection = WrapObject(Leaf(Source), "key"),
+      root = Leaf(Source),
+      rootSource = Source,
+      expected = DerefObjectStatic(Leaf(Source), CPathField("key")).some
+    )
+
+    "strip WrapArray" in rephraseTest(
+      // rephrase([.], .) --> .[0]
+      projection = WrapArray(Leaf(Source)),
+      root = Leaf(Source),
+      rootSource = Source,
+      expected = DerefArrayStatic(Leaf(Source), CPathIndex(0)).some
+    )
+
+    "strip ArraySwap" in rephraseTest(
+      // rephrase(swap(., x), .) --> swap(., x)
+      projection = ArraySwap(Leaf(Source), 1),
+      root = Leaf(Source),
+      rootSource = Source,
+      expected = ArraySwap(Leaf(Source), 1).some
+    )
+
+    "strip OuterArrayConcat" in rephraseTest(
+      // rephrase([.] ++ [], .) --> .[0]
+      projection = OuterArrayConcat(WrapArray(Leaf(Source))),
+      root = Leaf(Source),
+      rootSource = Source,
+      expected = DerefArrayStatic(Leaf(Source), CPathIndex(0)).some
+    )
+
+    "strip OuterArrayConcat with two args" in rephraseTest(
+      // rephrase([.], .) -> .[0]
+      projection = OuterArrayConcat(WrapArray(Leaf(SourceLeft)), WrapArray(Leaf(SourceRight))),
+      root = Leaf(Source),
+      rootSource = SourceRight,
+      expected = DerefArrayStatic(Leaf(Source), CPathIndex(1)).some
+    )
+
+    "strip OuterArrayConcat with nested InnerArrayConcat" in rephraseTest(
+      // rephrase(([._1] ++ [._1]) ++ [._2], _2, .) -> .[2]
+      projection = OuterArrayConcat(InnerArrayConcat(WrapArray(Leaf(SourceLeft)), WrapArray(Leaf(SourceLeft))), WrapArray(Leaf(SourceRight))),
+      root = Leaf(Source),
+      rootSource = SourceRight,
+      expected = DerefArrayStatic(Leaf(Source), CPathIndex(2)).some
+    )
+
+    "strip OuterObjectConcat with two args with the same key, with the second returning none" in rephraseTest(
+      // rephrase({k: ._1} ++ {k: ._2}, _1, .) -> none
+      projection = OuterObjectConcat(WrapObject(Leaf(SourceLeft), "k"), WrapObject(Leaf(SourceRight), "k")),
+      root = Leaf(Source),
+      rootSource = SourceLeft,
+      expected = None
+    )
+
+    "strip OuterObjectConcat with two args with the same key, with the first returning none" in rephraseTest(
+      // rephrase({k: ._1} ++ {k: ._2}, _2, .) -> .k
+      projection = OuterObjectConcat(WrapObject(Leaf(SourceLeft), "k"), WrapObject(Leaf(SourceRight), "k")),
+      root = Leaf(Source),
+      rootSource = SourceRight,
+      expected = DerefObjectStatic(Leaf(Source), CPathField("k")).some
+    )
+
+    "strip OuterObjectConcat with two args with different keys chooses the last" in rephraseTest(
+      // rephrase({k1: .} ++ {k2: .}, .) -> .k2
+      projection = OuterObjectConcat(WrapObject(Leaf(Source), "k1"), WrapObject(Leaf(Source), "k2")),
+      root = Leaf(Source),
+      rootSource = Source,
+      expected = DerefObjectStatic(Leaf(Source), CPathField("k2")).some
+    )
+
+    "strip OuterObjectConcat nested with InnerObjectConcat with two args with different keys chooses the last" in rephraseTest(
+      // rephrase({k1: .} ++ {k2: .}, .) --> .k2
+      projection = OuterObjectConcat(WrapObject(Leaf(Source), "k1"), InnerObjectConcat(WrapObject(Leaf(Source), "k2"))),
+      root = Leaf(Source),
+      rootSource = Source,
+      expected = DerefObjectStatic(Leaf(Source), CPathField("k2")).some
+    )
+
+    "return none when the projection doesn't mention rootSource" in rephraseTest(
+      // rephrase(._1, _2, .) --> none
+      projection = Leaf(SourceLeft),
+      root = Leaf(Source),
+      rootSource = SourceRight,
+      expected = None
+    )
+
+    "strip prefixes with the same target as root" in rephraseTest(
+      // rephrase(._1.a, .a.b) --> .b
+      projection = DerefObjectStatic(Leaf(SourceLeft), CPathField("a")),
+      root = DerefObjectStatic(DerefObjectStatic(
+        Leaf(Source), CPathField("a")), CPathField("b")),
+      rootSource = SourceLeft,
+      expected = DerefObjectStatic(Leaf(Source), CPathField("b")).some
+    )
+
+    "deal with single OuterArrayConcat" in rephraseTest(
+      // rephrase([.key] ++ [1], .key) --> .[0]
+      projection = OuterArrayConcat(
+        WrapArray(DerefObjectStatic(Leaf(Source), CPathField("key"))),
+        WrapArray(ConstLiteral(CLong(1), Leaf(Source)))
+      ),
+      root = DerefObjectStatic(Leaf(Source), CPathField("key")),
+      rootSource = Source,
+      expected = DerefArrayStatic(Leaf(Source), CPathIndex(0)).some
+    )
+
+    "deal with nested OuterArrayConcat" in rephraseTest(
+      // rephrase([.key] ++ [1], .key) --> .[0]
+      projection = OuterArrayConcat(
+        WrapArray(DerefObjectStatic(Leaf(Source), CPathField("key"))),
+        OuterArrayConcat(WrapArray(ConstLiteral(CLong(1), Leaf(Source))))
+      ),
+      root = DerefObjectStatic(Leaf(Source), CPathField("key")),
+      rootSource = Source,
+      expected = DerefArrayStatic(Leaf(Source), CPathIndex(0)).some
+    )
+
+    "swap positions in OuterArrayConcat" in rephraseTest(
+      // rephrase([.y] ++ [.x], [.x] ++ [.y]) --> [.[1]] ++ [.[0]]
+      projection = OuterArrayConcat(
+        WrapArray(DerefObjectStatic(Leaf(Source), CPathField("y"))),
+        WrapArray(DerefObjectStatic(Leaf(Source), CPathField("x")))
+      ),
+      root = OuterArrayConcat(
+        WrapArray(DerefObjectStatic(Leaf(Source), CPathField("x"))),
+        WrapArray(DerefObjectStatic(Leaf(Source), CPathField("y")))
+      ),
+      rootSource = Source,
+      expected = OuterArrayConcat(
+        WrapArray(DerefArrayStatic(Leaf(Source), CPathIndex(1))),
+        WrapArray(DerefArrayStatic(Leaf(Source), CPathIndex(0)))
+      ).some
+    )
+
+    "remap keys in OuterObjectConcat" in rephraseTest(
+      // rephrase({k2: .x} ++ {k1: .y}, {k1: .x} ++ {k2: .y}) --> {k1: .k2} ++ {k2: .k1}
+      projection = OuterObjectConcat(
+        WrapObject(DerefObjectStatic(Leaf(Source), CPathField("x")), "k2"),
+        WrapObject(DerefObjectStatic(Leaf(Source), CPathField("y")), "k1")
+      ),
+      root = OuterObjectConcat(
+        WrapObject(DerefObjectStatic(Leaf(Source), CPathField("x")), "k1"),
+        WrapObject(DerefObjectStatic(Leaf(Source), CPathField("y")), "k2")
+      ),
+      rootSource = Source,
+      expected = OuterObjectConcat(
+        WrapObject(DerefObjectStatic(Leaf(Source), CPathField("k2")), "k1"),
+        WrapObject(DerefObjectStatic(Leaf(Source), CPathField("k1")), "k2")
+      ).some
+    )
+
+    "duplicate subtrees of root in projection" in rephraseTest(
+      // rephrase(.x, [.x.y] ++ [.x]) --> [.y] ++ [.]
+      projection = DerefObjectStatic(Leaf(Source), CPathField("x")),
+      root = OuterArrayConcat(
+        WrapArray(DerefObjectStatic(DerefObjectStatic(Leaf(Source), CPathField("x")), CPathField("y"))),
+        WrapArray(DerefObjectStatic(Leaf(Source), CPathField("x")))
+      ),
+      rootSource = Source,
+      expected = OuterArrayConcat(
+        WrapArray(DerefObjectStatic(Leaf(Source), CPathField("y"))),
+        WrapArray(Leaf(Source))
+      ).some
+    )
+
+    "select cars.name, cars2.name from cars join cars2 on cars.name = cars2.name order by cars.name" in {
+      // real example
+      // rephrase([[._1] ++ [._1]] ++ [[._2] ++ [._2]], _1, [.name]) --> .[0].[0].name
+      // rephrase([[._1] ++ [._1]] ++ [[._2] ++ [._2]], _2, [.name]) --> .[1].[0].name
+      val leftKey = WrapArray(DerefObjectStatic(Leaf(Source), CPathField("name")))
+      val rightKey = WrapArray(DerefObjectStatic(Leaf(Source), CPathField("name")))
+      val repair = OuterArrayConcat(
+        WrapArray(OuterArrayConcat(WrapArray(Leaf(SourceLeft)), WrapArray(Leaf(SourceLeft)))),
+        WrapArray(OuterArrayConcat(WrapArray(Leaf(SourceRight)), WrapArray(Leaf(SourceRight))))
+      )
+      val expectedLeft = Some(
+        WrapArray(DerefObjectStatic(DerefArrayStatic(DerefArrayStatic(Leaf(Source), CPathIndex(0)), CPathIndex(0)), CPathField("name")))
+      )
+      val expectedRight = Some(
+        WrapArray(DerefObjectStatic(DerefArrayStatic(DerefArrayStatic(Leaf(Source), CPathIndex(1)), CPathIndex(0)), CPathField("name")))
+      )
+      val resultLeft = TransSpec.rephrase(repair, SourceLeft, leftKey)
+      val resultRight = TransSpec.rephrase(repair, SourceRight, rightKey)
+      resultLeft mustEqual expectedLeft
+      resultRight mustEqual expectedRight
+    }
+  }
+
+  "normalize" should {
+    import scalaz.Scalaz.ToFoldableOps, scalaz.std.list._
+    def testNormalize1(in: TransSpec1, expected: TransSpec1): Result =
+      TransSpec.normalize(in, TransSpec1.Undef) mustEqual expected
+    def testNormalize1PE(ins: List[TransSpec1], expected: TransSpec1): Result =
+      testNormalize1P(ins.map(_ -> expected))
+    def testNormalize1P(inAndExpecteds: List[(TransSpec1, TransSpec1)]): Result =
+      inAndExpecteds.foldMap { case (i, e) => testNormalize1(in = i, expected = e) }
+    def testNormalize2(in: TransSpec2, expected: TransSpec2): Result =
+      TransSpec.normalize(in, TransSpec2.Undef) mustEqual expected
+
+    "reduce {k: .}.k to ." in testNormalize1(
+      in = DerefObjectStatic(WrapObject(Leaf(Source), "k"), CPathField("k")),
+      expected = Leaf(Source)
+    )
+
+    "reduce (. ++ {k: .}).k to ." in testNormalize1(
+      in = DerefObjectStatic(OuterObjectConcat(Leaf(Source), WrapObject(Leaf(Source), "k")), CPathField("k")),
+      expected = Leaf(Source)
+    )
+
+    "do not reduce (. ++ {k: .}).k" in {
+      val in = DerefObjectStatic(OuterObjectConcat(WrapObject(Leaf(Source), "k"), Leaf(Source)), CPathField("k"))
+      testNormalize1(in = in, expected = in)
+    }
+
+    "reduce ([.] ++ .).[0] to ." in testNormalize1(
+      in = DerefArrayStatic(OuterArrayConcat(WrapArray(Leaf(Source)), Leaf(Source)), CPathIndex(0)),
+      expected = Leaf(Source)
+    )
+
+    "reduce ([._1] ++ [._2]).[1] to ._2" in testNormalize2(
+      in = DerefArrayStatic(OuterArrayConcat(WrapArray(Leaf(SourceLeft)), WrapArray(Leaf(SourceRight))), CPathIndex(1)),
+      expected = Leaf(SourceRight)
+    )
+
+    "do not reduce (. ++ [.]).[0] to ." in testNormalize1(
+      in = DerefArrayStatic(OuterArrayConcat(Leaf(Source), WrapArray(Leaf(Source))), CPathIndex(0)),
+      expected = DerefArrayStatic(OuterArrayConcat(Leaf(Source), WrapArray(Leaf(Source))), CPathIndex(0))
+    )
+
+    "flatten nested OuterArrayConcat" in testNormalize1(
+      in = OuterArrayConcat(Leaf(Source), OuterArrayConcat(Leaf(Source), OuterArrayConcat(Leaf(Source)))),
+      expected = OuterArrayConcat(Leaf(Source), Leaf(Source), Leaf(Source))
+    )
+
+    "reduce [.].[1] to undefined" in testNormalize1(
+      in = DerefArrayStatic(OuterArrayConcat(WrapArray(Leaf(Source))), CPathIndex(1)),
+      expected = TransSpec1.Undef
+    )
+
+    "recursively reduce {k1: {k2: {k3: .}}}.k1.k2.k3 to ." in testNormalize1(
+      in =
+        DerefObjectStatic(
+          DerefObjectStatic(
+            DerefObjectStatic(
+              WrapObject(WrapObject(WrapObject(Leaf(Source), "k3"), "k2"), "k1"),
+              CPathField("k1")),
+            CPathField("k2")),
+          CPathField("k3")
+        ),
+      expected = Leaf(Source)
+    )
+
+    "recursively reduce {k1: {k2: {k3: .}.k3}.k2}.k1 to ." in testNormalize1(
+      in = DerefObjectStatic(WrapObject(
+        DerefObjectStatic(WrapObject(
+          DerefObjectStatic(WrapObject(
+            Leaf(Source), "k3"), CPathField("k3")),
+          "k2"), CPathField("k2")),
+        "k1"), CPathField("k1")
+      ),
+      expected = Leaf(Source)
+    )
+
+    "reduce undef.[i], undef.k to undef" in testNormalize1PE(
+      ins = DerefArrayStatic(
+        TransSpec1.Undef, CPathIndex(0)
+      ) :: DerefObjectStatic(
+        TransSpec1.Undef, CPathField("k")
+      ) :: DerefArrayDynamic(
+        TransSpec1.Undef, Leaf(Source)
+      ) :: DerefObjectDynamic(
+        TransSpec1.Undef, Leaf(Source)
+      ) :: Nil,
+      expected = TransSpec1.Undef
+    )
+
+    "reduce .(undef) and .[(undef)] to undef" in testNormalize1PE(
+      ins = DerefArrayDynamic(
+        Leaf(Source), TransSpec1.Undef
+      ) :: DerefObjectDynamic(
+        Leaf(Source), TransSpec1.Undef
+      ) :: Nil,
+      expected = TransSpec1.Undef
+    )
+
+    "normalizations must pass through all branches which are preserved" in {
+      val transformers = List[TransSpec1 => TransSpec1](
+        DerefArrayStatic(_, CPathIndex(1)), DerefObjectStatic(_, CPathField("k")),
+        DerefMetadataStatic(_, CPathMeta("m")),
+        t => DerefArrayDynamic(t, t), t => DerefObjectDynamic(t, t),
+        WrapArray(_), WrapObject(_, "k"),
+        t => WrapObjectDynamic(t, t),
+        t => OuterObjectConcat(t, t), t => InnerObjectConcat(t, t),
+        t => OuterArrayConcat(t, t), t => InnerArrayConcat(t, t),
+        IsType(_, JNumberT),
+        ConstLiteral(CLong(1L), _),
+        t => Equal(t, t), EqualLiteral(_, CLong(1L), invert = false),
+        t => Filter(t, t),
+        t => Cond(t, t, t),
+        t => FilterDefined(t, t, TransSpecModule.AllDefined),
+        Typed(_, JNumberT),
+        TypedSubsumes(_, JNumberT),
+        ArraySwap(_, 1),
+        Map1(_, CF1("id")(Some(_))),
+        DeepMap1(_, CF1("id")(Some(_))),
+        t => Map2(t, t, CF2("id")((c, _) => Some(c))),
+        MapN(_, CFN("id")(_.headOption))
+      )
+      testNormalize1P(transformers.map(f =>
+        f(DerefArrayStatic(WrapArray(Leaf(Source)), CPathIndex(0))) -> f(Leaf(Source))
+      ))
+    }
+
   }
 }
 


### PR DESCRIPTION
Keeps track of the current sort order in Mimir to avoid sorting the same data the same way repeatedly.