### PR TITLE
Subquery grouped count

### DIFF
--- a/it/src/main/resources/tests/flattenGroupedObject.test
+++ b/it/src/main/resources/tests/flattenGroupedObject.test
@@ -1,7 +1,7 @@
 {
     "name": "flatten a grouped object with filter",
     "backends": {
-        "mimir":"pendingIgnoreFieldOrder",
+        "mimir":             "ignoreFieldOrder",
         "couchbase":         "pending",
         "marklogic_json":    "pending",
         "mongodb_q_3_2":     "pending",

--- a/it/src/main/resources/tests/groupByArray.test
+++ b/it/src/main/resources/tests/groupByArray.test
@@ -1,7 +1,6 @@
 {
     "name": "group by array",
     "backends": {
-        "mimir":"pending",
         "mongodb_q_3_2": "pending"
     },
     "data": "slamengine_commits.data",

--- a/it/src/main/resources/tests/unsupportedTests.test
+++ b/it/src/main/resources/tests/unsupportedTests.test
@@ -2,7 +2,6 @@
     "name": "show tests that likely have a bug prior to the connector",
     "backends": {
         "couchbase":         "pending",
-        "mimir":             "pending",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
         "mongodb_3_2":       "pending",

--- a/mimir/src/main/scala/quasar/mimir/Mimir.scala
+++ b/mimir/src/main/scala/quasar/mimir/Mimir.scala
@@ -518,7 +518,7 @@ object Mimir extends BackendModule with Logging {
 
     lazy val planEquiJoin: AlgebraM[Backend, EquiJoin[T, ?], Repr] = {
       case qscript.EquiJoin(src, lbranch, rbranch, lkey, rkey, tpe, combine) =>
-        import src.P.trans._, scalaz.syntax.std.option._, scalaz.std.option._, scalaz.syntax.show._
+        import src.P.trans._, scalaz.syntax.std.option._
         def rephrase2(projection: TransSpec2, rootL: TransSpec1, rootR: TransSpec1): Option[SortOrdering[TransSpec1]] = {
           val leftRephrase = TransSpec.rephrase(projection, SourceLeft, rootL).fold(Set.empty[TransSpec1])(Set(_))
           val rightRephrase = TransSpec.rephrase(projection, SourceRight, rootR).fold(Set.empty[TransSpec1])(Set(_))

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/TableModule.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/TableModule.scala
@@ -270,7 +270,7 @@ trait TableModule[M[+ _]] extends TransSpecModule {
       */
     def groupByN(groupKeys: Seq[TransSpec1], valueSpec: TransSpec1, sortOrder: DesiredSortOrder = SortAscending, unique: Boolean = false): M[Seq[Table]]
 
-    def partitionMerge(partitionBy: TransSpec1)(f: Table => M[Table]): M[Table]
+    def partitionMerge(partitionBy: TransSpec1, keepKey: Boolean = false)(f: Table => M[Table]): M[Table]
 
     @deprecated("use drop/take directly")
     def takeRange(startIndex: Long, numberToTake: Long): Table = {


### PR DESCRIPTION
Fixes #2656

This is a really big fix, because the web frontend relies on queries of this form to determine whether or not it should show results.  So very frequently, even when the query itself would run, the subquery form would not, meaning that the frontend would just not display results (e.g. [here](https://github.com/slamdata/slamdata/issues/2099)).

I'm assigning @alissapajer to review this, both because she knows the `Reduce` stuff better than anyone else, and also because this has a notable impact on mimir in next-major, where `ReduceIndex` is encoded differently.  Specifically, there is a TODO comment on next-major which can be eliminated and implemented from this work.