### PR TITLE
Enable distinct test with correct expectation.

### DIFF
--- a/it/src/main/resources/tests/citiesByLargestZip.test
+++ b/it/src/main/resources/tests/citiesByLargestZip.test
@@ -2,23 +2,12 @@
     "name": "cities with largest individual zip codes",
     "backends": {
         "couchbase":      "pending",
-        "marklogic_json": "pending",
-        "marklogic_xml":  "pending",
-        "mimir":          "pending",
         "mongodb_2_6":    "pending",
         "mongodb_3_0":    "pending",
         "mongodb_3_2":    "pending",
         "mongodb_3_4":    "pending",
-        "mongodb_read_only": "pending",
-        "spark_hdfs":     "pending",
-        "spark_local":    "pending"
+        "mongodb_read_only": "pending"
     },
-    "NB": "Skipped for all connectors due to reduce/sort ordering bug.
-           Bug is fixed on @sellout's new mongo branch, but the fix breaks old mongo.
-
-           This is tricky because the sort key does not appear in the result.
-           The result can be verified by running a similar query with
-          `select city, pop`.",
 
     "data": "zips.data",
 
@@ -26,9 +15,9 @@
 
     "predicate": "exactly",
 
-    "expected": ["CHICAGO",
-                 "BROOKLYN",
-                 "NEW YORK",
-                 "BELL GARDENS",
-                 "LOS ANGELES"]
+    "expected": [{ "city": "CHICAGO" },
+                 { "city": "BROOKLYN" },
+                 { "city": "NEW YORK" },
+                 { "city": "BELL GARDENS" },
+                 { "city": "LOS ANGELES" }]
 }


### PR DESCRIPTION
I don't know why this integration test expectation got changed. This is the commit it got changed in https://github.com/quasar-analytics/quasar/commit/518dc93b61b337da23bbbd35237d60ec7578325e. SQL semantics along with the other integration tests confirm that the new expectation (which is also the expectation on master) is the one we want.