### PR TITLE
Implement Within function in Mimir

### DIFF
--- a/frontend/src/test/scala/quasar/std/StdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/StdLibSpec.scala
@@ -1352,5 +1352,49 @@ abstract class StdLibSpec extends Qspec {
         "returns metadata associated with a value" >> pending("Requires EJson.")
       }
     }
+
+    "SetLib" >> {
+      import SetLib._
+
+      "Within" >> {
+        "0 in [1, 2, 3]" >> {
+          binary(Within(_, _).embed, Data.Int(0), Data.Arr(List(Data.Int(1), Data.Int(2), Data.Int(3))), Data.False)
+        }
+
+        "1 in [1, 2, 3]" >> {
+          binary(Within(_, _).embed, Data.Int(1), Data.Arr(List(Data.Int(1), Data.Int(2), Data.Int(3))), Data.True)
+        }
+
+        "0 in []" >> {
+          binary(Within(_, _).embed, Data.Int(0), Data.Arr(Nil), Data.False)
+        }
+
+        "[0] in [[1], 2, {a:3}, [0]]" >> {
+          binary(
+            Within(_, _).embed,
+            Data.Arr(List(Data.Int(0))),
+            Data.Arr(
+              List(
+                Data.Arr(List(Data.Int(1))),
+                Data.Int(2),
+                Data.Obj(ListMap("a" -> Data.Int(3))),
+                Data.Arr(List(Data.Int(0))))),
+            Data.True)
+        }
+
+        "[0, 1] in [[1], 2, {a:3}, [0, 1]]" >> {
+          binary(
+            Within(_, _).embed,
+            Data.Arr(List(Data.Int(0), Data.Int(1))),
+            Data.Arr(
+              List(
+                Data.Arr(List(Data.Int(1))),
+                Data.Int(2),
+                Data.Obj(ListMap("a" -> Data.Int(3))),
+                Data.Arr(List(Data.Int(0), Data.Int(1))))),
+            Data.True)
+        }
+      }
+    }
   }
 }

--- a/it/src/main/resources/tests/filterComplement.test
+++ b/it/src/main/resources/tests/filterComplement.test
@@ -1,8 +1,5 @@
 {
     "name": "filter on list complement",
-    "backends": {
-        "mimir":"pending"
-    },
     "data": "zips.data",
     "query": "select count(*) as cnt from zips where state not in (\"AZ\", \"CO\")",
     "predicate": "exactly",

--- a/it/src/main/resources/tests/filterMembership.test
+++ b/it/src/main/resources/tests/filterMembership.test
@@ -1,8 +1,5 @@
 {
     "name": "filter on list membership",
-    "backends": {
-        "mimir":"pendingIgnoreFieldOrder"
-    },
     "data": "zips.data",
     "query": "select count(*) as cnt from zips where state in (\"AZ\", \"CO\")",
     "predicate": "exactly",

--- a/it/src/main/resources/tests/filterOnContains.test
+++ b/it/src/main/resources/tests/filterOnContains.test
@@ -1,7 +1,7 @@
 {
     "name": "filter on contains",
     "backends": {
-        "mimir":"pendingIgnoreFieldOrder"
+        "mimir":"ignoreFieldOrder"
     },
     "data": "zips.data",
     "query": "select * from zips where 43.058514 in loc[_]",

--- a/it/src/test/scala/quasar/physical/marklogic/qscript/MarkLogicStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/marklogic/qscript/MarkLogicStdLibSpec.scala
@@ -52,6 +52,8 @@ abstract class MarkLogicStdLibSpec[F[_]: Monad: QNameGenerator: PrologW: MonadPl
       case (Embed(CoEnv(\/-(MFC(MapFuncsCore.Lte(_,_))))), Data.Date(_), Data.Timestamp(_)) => pending
       case (Embed(CoEnv(\/-(MFC(MapFuncsCore.Gt(_,_))))), Data.Date(_), Data.Timestamp(_)) => pending
       case (Embed(CoEnv(\/-(MFC(MapFuncsCore.Gte(_,_))))), Data.Date(_), Data.Timestamp(_)) => pending
+      case (Embed(CoEnv(\/-(MFC(MapFuncsCore.Within(_,_))))), _, _) => pending
+
       case _ => run
     }
 

--- a/it/src/test/scala/quasar/physical/mimir/MimirStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mimir/MimirStdLibSpec.scala
@@ -116,7 +116,6 @@ class MimirStdLibSpec extends StdLibSpec with PrecogCake {
     case MapFuncsCore.Now() => notImplemented.left
     case MapFuncsCore.TypeOf(_) => notImplemented.left
     case MapFuncsCore.Negate(_) => notImplemented.left // TODO this isn't passing because -Long.MinValue == Long.MinValue, so basically a limitation in ColumnarTable
-    case MapFuncsCore.Within(_, _) => notImplemented.left
     // case MapFuncsCore.ToString(Data.Date(_) | Data.Timestamp(_) | Data.Time(_) | Data.Interval(_)) => notImplemented.left
     case MapFuncsCore.ToString(_) => notImplemented.left    // TODO it's implemented but not for everything
     case MapFuncsCore.Meta(_) => notImplemented.left

--- a/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
@@ -51,8 +51,6 @@ class MongoDbExprStdLibSpec extends MongoDbStdLibSpec {
     case (string.Search, _)   => Skipped("compiles to a map/reduce, so can't be run in tests").left
     case (quasar.std.SetLib.Within, _)      => notHandled.left
 
-
-
     case (date.ExtractIsoYear, _) => notHandled.left
     case (date.ExtractWeek, _)    => Skipped("Implemented, but not ISO compliant").left
 

--- a/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
@@ -48,7 +48,9 @@ class MongoDbExprStdLibSpec extends MongoDbStdLibSpec {
     case (string.Integer, _)  => notHandled.left
     case (string.Decimal, _)  => notHandled.left
     case (string.ToString, _) => notHandled.left
-    case (string.Search, _) => Skipped("compiles to a map/reduce, so can't be run in tests").left
+    case (string.Search, _)   => Skipped("compiles to a map/reduce, so can't be run in tests").left
+    case (quasar.std.SetLib.Within, _)      => notHandled.left
+
 
 
     case (date.ExtractIsoYear, _) => notHandled.left

--- a/it/src/test/scala/quasar/physical/mongodb/JsStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/JsStdLibSpec.scala
@@ -41,6 +41,8 @@ class MongoDbJsStdLibSpec extends MongoDbStdLibSpec {
   def shortCircuit[N <: Nat](backend: BackendName, func: GenericFunc[N], args: List[Data]): Result \/ Unit = (func, args) match {
     case (string.Lower, _)   => Pending("TODO").left
     case (string.Upper, _)   => Pending("TODO").left
+    //case (set.Within, _)     => Pending("TODO").left
+
 
     case (string.ToString, Data.Dec(_) :: Nil) =>
       Pending("Dec printing doesn't match precisely").left

--- a/it/src/test/scala/quasar/physical/mongodb/JsStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/JsStdLibSpec.scala
@@ -39,9 +39,9 @@ class MongoDbJsStdLibSpec extends MongoDbStdLibSpec {
 
   /** Identify constructs that are expected not to be implemented in JS. */
   def shortCircuit[N <: Nat](backend: BackendName, func: GenericFunc[N], args: List[Data]): Result \/ Unit = (func, args) match {
-    case (string.Lower, _)   => Pending("TODO").left
-    case (string.Upper, _)   => Pending("TODO").left
-    //case (set.Within, _)     => Pending("TODO").left
+    case (string.Lower, _)              => Pending("TODO").left
+    case (string.Upper, _)              => Pending("TODO").left
+    case (quasar.std.SetLib.Within, _)  => Pending("TODO").left
 
 
     case (string.ToString, Data.Dec(_) :: Nil) =>

--- a/it/src/test/scala/quasar/physical/mongodb/JsStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/JsStdLibSpec.scala
@@ -43,7 +43,6 @@ class MongoDbJsStdLibSpec extends MongoDbStdLibSpec {
     case (string.Upper, _)              => Pending("TODO").left
     case (quasar.std.SetLib.Within, _)  => Pending("TODO").left
 
-
     case (string.ToString, Data.Dec(_) :: Nil) =>
       Pending("Dec printing doesn't match precisely").left
     case (string.ToString, Data.Date(_) :: Nil) =>

--- a/it/src/test/scala/quasar/physical/mongodb/QExprStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/QExprStdLibSpec.scala
@@ -45,6 +45,7 @@ class MongoDbQExprStdLibSpec extends MongoDbQStdLibSpec {
     case (string.Decimal, _)  => notHandled.left
     case (string.ToString, _) => notHandled.left
     case (string.Search, _) => Skipped("compiles to a map/reduce, so can't be run in tests").left
+    case (quasar.std.SetLib.Within, _) => notHandled.left
 
     case (date.ExtractIsoYear, _) => notHandled.left
     case (date.ExtractWeek, _)    => Skipped("Implemented, but not ISO compliant").left

--- a/it/src/test/scala/quasar/physical/mongodb/QJsStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mongodb/QJsStdLibSpec.scala
@@ -35,6 +35,8 @@ import shapeless.Nat
 class MongoDbQJsStdLibSpec extends MongoDbQStdLibSpec {
   /** Identify constructs that are expected not to be implemented in JS. */
   def shortCircuit[N <: Nat](backend: BackendName, func: GenericFunc[N], args: List[Data]): Result \/ Unit = (func, args) match {
+    case (quasar.std.SetLib.Within, _)  => Pending("TODO").left
+
     case (string.ToString, Data.Dec(_) :: Nil) =>
       Skipped("Dec printing doesn't match precisely").left
     case (string.ToString, Data.Date(_) :: Nil) =>
@@ -43,7 +45,6 @@ class MongoDbQJsStdLibSpec extends MongoDbQStdLibSpec {
       Skipped("Interval prints numeric representation").left
     case (string.Search, _) =>
       Skipped("compiles to a map/reduce, so can't be run in tests").left
-
 
     case (math.Power, Data.Number(x) :: Data.Number(y) :: Nil)
         if x == 0 && y < 0 =>

--- a/mimir/src/main/scala/quasar/mimir/MapFuncCorePlanner.scala
+++ b/mimir/src/main/scala/quasar/mimir/MapFuncCorePlanner.scala
@@ -149,7 +149,8 @@ final class MapFuncCorePlanner[T[_[_]]: RecursiveT, F[_]: Applicative]
       case MapFuncsCore.Cond(a1, a2, a3) =>
         (Cond(a1, a2, a3): TransSpec[A]).point[F]
 
-      case MapFuncsCore.Within(a1, a2) => ???
+      case MapFuncsCore.Within(a1, a2) =>
+        (Within(a1, a2): TransSpec[A]).point[F]
 
       case MapFuncsCore.Lower(a1) =>
         toLowerCase.spec(a1).point[F]

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/TransSpecModule.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/TransSpecModule.scala
@@ -119,6 +119,9 @@ trait TransSpecModule extends FNModule {
 
     case class EqualLiteral[+A <: SourceType](left: TransSpec[A], right: CValue, invert: Boolean) extends TransSpec[A]
 
+    // this has to be primitive because of how nutso equality is
+    case class Within[+A <: SourceType](item: TransSpec[A], in: TransSpec[A]) extends TransSpec[A]
+
     // target is the transspec that provides defineedness information. The resulting table will be defined
     // and have the constant value wherever a row provided by the target transspec has at least one member
     // that is not undefined
@@ -205,6 +208,8 @@ trait TransSpecModule extends FNModule {
           case trans.Equal(left, right)                  => trans.Equal(mapSources(left)(f), mapSources(right)(f))
           case trans.EqualLiteral(source, value, invert) => trans.EqualLiteral(mapSources(source)(f), value, invert)
 
+          case trans.Within(item, in) => trans.Within(mapSources(item)(f), mapSources(in)(f))
+
           case trans.Cond(pred, left, right) => trans.Cond(mapSources(pred)(f), mapSources(left)(f), mapSources(right)(f))
         }
       }
@@ -252,6 +257,8 @@ trait TransSpecModule extends FNModule {
 
         case trans.Equal(left, right)                  => trans.Equal(deepMap(left)(f), deepMap(right)(f))
         case trans.EqualLiteral(source, value, invert) => trans.EqualLiteral(deepMap(source)(f), value, invert)
+
+        case trans.Within(item, in)                    => trans.Within(deepMap(item)(f), deepMap(in)(f))
 
         case trans.Cond(pred, left, right) => trans.Cond(deepMap(pred)(f), deepMap(left)(f), deepMap(right)(f))
       }
@@ -360,6 +367,7 @@ trait TransSpecModule extends FNModule {
             case IsType(s, t)            => IsType(normalize(s, undef), t)
             case Equal(f, s)             => Equal(normalize(f, undef), normalize(s, undef))
             case EqualLiteral(f, v, i)   => EqualLiteral(normalize(f, undef), v, i)
+            case Within(item, in)        => Within(normalize(item, undef), normalize(in, undef))
             case Cond(p, l, r)           => Cond(normalize(p, undef), normalize(l, undef), normalize(r, undef))
             case Filter(s, t)            => Filter(normalize(s, undef), normalize(t, undef))
             case FilterDefined(s, df, t) => FilterDefined(normalize(s, undef), normalize(df, undef), t)
@@ -431,6 +439,7 @@ trait TransSpecModule extends FNModule {
           case ConstLiteral(_, s)        => paths(s) + r
           case Equal(f, s)               => paths(f) ++ paths(s) + r
           case EqualLiteral(s, _, _)     => paths(s) + r
+          case Within(item, in)          => paths(item) ++ paths(in) + r
           case Filter(f, p)              => paths(f) ++ paths(p) + r
           case FilterDefined(s, p, _)    => paths(s) ++ paths(p) + r
           case IsType(s, _)              => paths(s) + r

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/ArrayColumn.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/ArrayColumn.scala
@@ -57,7 +57,7 @@ object ArrayHomogeneousArrayColumn {
   }
 }
 
-class ArrayBoolColumn(val defined: BitSet, values: BitSet) extends ArrayColumn[Boolean] with BoolColumn {
+class ArrayBoolColumn(val defined: BitSet, val values: BitSet) extends ArrayColumn[Boolean] with BoolColumn {
   def apply(row: Int) = values(row)
 
   def update(row: Int, value: Boolean) = {

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/TransformSpec.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/TransformSpec.scala
@@ -810,6 +810,10 @@ trait TransformSpec[M[+_]] extends TableModuleTestSupport[M] with SpecificationL
           "a":42
         },
         "in":[[]]
+      },
+      {
+        "item":0,
+        "in":[]
       }
     ]""")
 
@@ -825,6 +829,7 @@ trait TransformSpec[M[+_]] extends TableModuleTestSupport[M] with SpecificationL
 
     val JArray(expected) = JParser.parseUnsafe("""[
       true,
+      false,
       false,
       false
     ]""")

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/table/ColumnarTableModuleSpec.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/table/ColumnarTableModuleSpec.scala
@@ -369,6 +369,10 @@ trait ColumnarTableModuleSpec[M[+_]] extends TestColumnarTableModule[M]
       "perform a equal-literal check" in checkEqualLiteral
       "perform a not-equal-literal check" in checkNotEqualLiteral
 
+      "perform a trivial within check" in checkWithinSelf
+      "perform a trivial negative within check" in checkNotWithin
+      "perform a non-trivial within test" in testNonTrivialWithin
+
       "wrap the results of a transform in an object as the specified field" in checkWrapObject
       "give the identity transform for self-object concatenation" in checkObjectConcatSelf
       "use a right-biased overwrite strategy in object concat conflicts" in checkObjectConcatOverwrite


### PR DESCRIPTION
Fixes #2669 

I had to add `Within` as a first-class `TransSpec`, since it is effectively performing `Equals` repeatedly over each array index.  Since it just delegates to `equalsImpl`, there really isn't a lot of code here.  The trickiest bit is just figuring out which things to materialize and what they look like after you're done.