### PR TITLE
Moved blocking console read off of the main(!!) thread pool

### DIFF
--- a/web/src/main/scala/quasar/server/PortChangingServer.scala
+++ b/web/src/main/scala/quasar/server/PortChangingServer.scala
@@ -43,8 +43,9 @@ final case class PortChangingServer(servers: Process[Task, (http4s.server.Server
   def shutdownOnUserInput: Task[Unit] = for {
     _ <- stdout("Press Enter to stop.")
     // TODO this ignores errors all over the place
-    _ <- Task.delay(Task.fork(waitForInput)(PortChangingServer.AwaitingPool).unsafePerformAsync(_ => shutdownImpl.unsafePerformAsync(_ => ())))
     _ <- servers.run
+    _ <- Task.fork(waitForInput)(PortChangingServer.AwaitingPool)
+    _ <- shutdownImpl
   } yield ()
 
   def shutdown: Task[Unit] =


### PR DESCRIPTION
Fixes #2693

Like I said, we need to be very very careful of this sort of stuff.  The `fork` here was doing exactly nothing, since it was keeping the action sequenced onto the main pool, resulting in eating a thread.  The fact that this is only failing with Mongo 2.6 is also suspicious, and suggests that the mongo driver is using blocking IO and we're not thread shifting it.  We need to take a hard look at how all of this stuff is working right now, because it's tremendously easy for us to paint ourselves into terrible corners without realizing it except in specific circumstances.