### PR TITLE
Fixes spark `DeleteField` bug

### DIFF
--- a/it/src/main/resources/tests/orderedWildcardWithProjection.test
+++ b/it/src/main/resources/tests/orderedWildcardWithProjection.test
@@ -5,11 +5,8 @@
         "mongodb_3_0":       "ignoreResultOrder",
         "mongodb_3_2":       "ignoreResultOrder",
         "mongodb_3_4":       "ignoreResultOrder",
-        "mongodb_read_only": "ignoreResultOrder",
-        "spark_hdfs":        "pending",
-        "spark_local":       "pending"
+        "mongodb_read_only": "ignoreResultOrder"
     },
-    "NB": "spark_hdfs and spark_local not on par with master",
     "data": "largeZips.data",
     "query": "select *, pop * 10 as dpop from largeZips order by pop / 10 desc",
     "predicate": "initial",

--- a/it/src/main/resources/tests/sortWildcardOnExpression.test
+++ b/it/src/main/resources/tests/sortWildcardOnExpression.test
@@ -5,11 +5,8 @@
         "mongodb_3_0":       "ignoreResultOrder",
         "mongodb_3_2":       "ignoreResultOrder",
         "mongodb_3_4":       "ignoreResultOrder",
-        "mongodb_read_only": "ignoreResultOrder",
-        "spark_hdfs":        "pending",
-        "spark_local":       "pending"
+        "mongodb_read_only": "ignoreResultOrder"
     },
-    "NB": "spark_hdfs and spark_local not on par with master",
     "data": "largeZips.data",
     "query": "select * from largeZips order by pop/10 desc",
     "predicate": "initial",

--- a/it/src/test/scala/quasar/physical/sparkcore/SparkStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/sparkcore/SparkStdLibSpec.scala
@@ -49,7 +49,6 @@ class SparkStdLibSpec extends StdLibSpec {
     case MFD(Trunc(_))           => TODO
     case MFC(Power(_, _))        => Pending("TODO: handle large value").left
     case MFC(ConcatArrays(_, _)) => Pending("TODO: handle mixed string/array").left
-    case MFC(DeleteField(_, _))  => Pending("TODO: deleting a non-existent field should be the original object, NOT undefined").left
     case _                       => ().right
   }
 

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/CoreMap.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/CoreMap.scala
@@ -336,6 +336,7 @@ object CoreMap extends Serializable {
     }).right
     case DeleteField(fSrc, fField) =>  ((x: A) => (fSrc(x), fField(x)) match {
       case (Data.Obj(m), Data.Str(field)) if m.isDefinedAt(field) => Data.Obj(m - field)
+      case (obj @ Data.Obj(_), _) => obj
       case _ => undefined
     }).right
     case Range(fFrom, fTo) => ((x: A) => (fFrom(x), fTo(x)) match {


### PR DESCRIPTION
Fixes #2691 

Fixes deleting a nonexistent field in spark. Previously if a field was nonexistent the result would be undefined. Now if a field is nonexistent, the original object is returned.