### PR TITLE
Fix bug in compactReduction where we didn't shift indices properly.

### DIFF
--- a/it/src/main/resources/tests/demo/timeSeriesAggregation.test
+++ b/it/src/main/resources/tests/demo/timeSeriesAggregation.test
@@ -1,10 +1,8 @@
 {
     "name": "time series aggregation",
     "backends": {
-        "couchbase": "pending",
-        "mimir":"pendingIgnoreFieldOrder",
-        "spark_hdfs": "pending",
-        "spark_local": "pending"
+        "couchbase": "ignoreFieldOrder",
+        "mimir":"pendingIgnoreFieldOrder"
     },
     "data": "smalltimeseries.data",
     "query": "
@@ -12,8 +10,7 @@
         FROM smalltimeseries
         GROUP BY sensor, dt
         ORDER BY sensor ASC, dt ASC",
-    "NB": "The query is ordered, but not uniquely, so we have to use containsExactly instead of equalsExactly.
-           Couchbase, spark_hdfs and spark_local not on par with master",
+    "NB": "The query is ordered, but not uniquely, so we have to use containsExactly instead of equalsExactly.",
     "predicate": "exactly",
     "ignoreResultOrder": true,
     "expected": [


### PR DESCRIPTION
Fixes #2571 
Fixes #2531

In `compactReduction` we were not remapping the indices of new reducers found according to how many reducers had previously been duplicates.