### PR TITLE
Avoid synthetic sort key for flattened field appearing in projection

### DIFF
--- a/it/src/main/resources/tests/unifyFlattenedFieldsWithUnflattened.test
+++ b/it/src/main/resources/tests/unifyFlattenedFieldsWithUnflattened.test
@@ -2,6 +2,7 @@
     "name": "unify flattened fields with unflattened field",
     "backends": {
         "couchbase": "pending",
+        "mimir": "ignoreFieldOrder",
         "mongodb_2_6": "ignoreResultOrder",
         "mongodb_3_0": "ignoreResultOrder",
         "mongodb_read_only": "ignoreResultOrder"

--- a/it/src/main/resources/tests/unifyFlattenedFieldsWithUnflattened.test
+++ b/it/src/main/resources/tests/unifyFlattenedFieldsWithUnflattened.test
@@ -4,8 +4,6 @@
         "couchbase": "pending",
         "mongodb_2_6": "ignoreResultOrder",
         "mongodb_3_0": "ignoreResultOrder",
-        "mongodb_3_2": "ignoreResultOrder",
-        "mongodb_3_4": "ignoreResultOrder",
         "mongodb_read_only": "ignoreResultOrder"
     },
     "data": "zips.data",


### PR DESCRIPTION
This fixes an issue in the `projectSortKeys` analysis where projecting and sorting by the same flattened value would unnecessarily result in a synthetic sort key. 

Fixes #2712.