### PR TITLE
Metastore endpoint now obscures postgres password on GET request

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,9 +839,9 @@ Removes any configured port, reverting to the default (20223) and restarting, as
 
 ### GET /metastore
 
-Retrieve the connection information of the current metastore in use
+Retrieve the connection information of the current metastore in use. In the case where the current metastore is a postgres database, the password will be obscured for security reasons.
 
-An example response:
+A few example responses:
 
 ```json
 {
@@ -850,6 +850,18 @@ An example response:
     }
 }
 
+```
+
+```json
+{
+    "postgresql": {
+      "host": "localhost",
+      "port": 8087,
+      "database": "slamdata_db",
+      "userName": "slamdata",
+      "password": "****"
+    }
+}
 ```
 
 ### PUT /metastore

--- a/core/src/main/scala/quasar/db/DbConnectionConfig.scala
+++ b/core/src/main/scala/quasar/db/DbConnectionConfig.scala
@@ -46,16 +46,22 @@ object DbConnectionConfig {
   }
 
   implicit val encodeJson: EncodeJson[DbConnectionConfig] =
+    encodeJsonImpl(false)
+
+  val secureEncodeJson: EncodeJson[DbConnectionConfig] =
+    encodeJsonImpl(true)
+
+  def encodeJsonImpl(secure: Boolean): EncodeJson[DbConnectionConfig] =
     EncodeJson {
       case H2(file) => Json("h2" -> Json("location" := file))
       case PostgreSql(host, database, userName, password, parameters) =>
         Json("postgresql" -> (
           ("host"       :=? host.map(_.name)) ->?:
-          ("port"       :=? host.flatMap(_.port)) ->?:
-          ("database"   :=? database) ->?:
-          ("userName"   :=  userName) ->:
-          ("password"   :=  password) ->:
-          ("parameters" :=? parameters.nonEmpty.option(parameters)) ->?:
+            ("port"       :=? host.flatMap(_.port)) ->?:
+            ("database"   :=? database) ->?:
+            ("userName"   :=  userName) ->:
+            ("password"   :=  (if (secure) "****" else password))   ->:
+            ("parameters" :=? parameters.nonEmpty.option(parameters)) ->?:
             jEmptyObject))
     }
 

--- a/web/src/main/scala/quasar/api/services/metastore.scala
+++ b/web/src/main/scala/quasar/api/services/metastore.scala
@@ -35,7 +35,7 @@ object metastore {
 
     QHttpService {
       case GET -> Root =>
-        respond(meta.get.map(_.asJson))
+        respond(meta.get.map(_.asJson(DbConnectionConfig.secureEncodeJson)))
       case req @ PUT -> Root =>
         val initialize = req.params.keys.toList.contains("initialize")
         respondT((for {


### PR DESCRIPTION
Fixes an issue that was reported in Slamdata Backend