### PR TITLE
Special-case equality on literals

### DIFF
--- a/it/src/main/resources/tests/joins/crossJoinWithOneSidedConditions.test
+++ b/it/src/main/resources/tests/joins/crossJoinWithOneSidedConditions.test
@@ -4,10 +4,10 @@
     "backends": {
         "couchbase":         "pending",
         "marklogic_json":    "ignoreFieldOrder",
-        "mimir":             "pendingIgnoreFieldOrder"
+        "mimir":             "skip"
     },
 
-    "NB": "#1587: Disabled in couchbase due to lack of general join.",
+    "NB": "#1587: Disabled in couchbase due to lack of general join; disabled in mimir because it takes forever",
 
     "data": ["../largeZips.data", "../zips.data"],
 

--- a/mimir/src/main/scala/quasar/mimir/MapFuncCorePlanner.scala
+++ b/mimir/src/main/scala/quasar/mimir/MapFuncCorePlanner.scala
@@ -120,10 +120,25 @@ final class MapFuncCorePlanner[T[_[_]]: RecursiveT, F[_]: Applicative]
 
       case MapFuncsCore.Not(a1) =>
         Unary.Comp.spec(a1).point[F]
+
+      case MapFuncsCore.Eq(a1, ConstLiteral(literal, _)) =>
+        (EqualLiteral[A](a1, literal, false): TransSpec[A]).point[F]
+
+      case MapFuncsCore.Eq(ConstLiteral(literal, _), a2) =>
+        (EqualLiteral[A](a2, literal, false): TransSpec[A]).point[F]
+
       case MapFuncsCore.Eq(a1, a2) =>
         (Equal[A](a1, a2): TransSpec[A]).point[F]
+
+      case MapFuncsCore.Neq(a1, ConstLiteral(literal, _)) =>
+        (EqualLiteral[A](a1, literal, true): TransSpec[A]).point[F]
+
+      case MapFuncsCore.Neq(ConstLiteral(literal, _), a2) =>
+        (EqualLiteral[A](a2, literal, true): TransSpec[A]).point[F]
+
       case MapFuncsCore.Neq(a1, a2) =>
         Unary.Comp.spec(Equal[A](a1, a2)).point[F]
+
       case MapFuncsCore.Lt(a1, a2) =>
         Infix.Lt.spec(a1, a2).point[F]
       case MapFuncsCore.Lte(a1, a2) =>


### PR DESCRIPTION
Row-level equality is a very expensive check for columnar stores like mimir.  It's an order of magnitude *less* expensive when one side or the other of the equality is a simple constant.

Fixes #2675