### PR TITLE
fix PostgreSqlAccessSpec failure in Travis

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -37,10 +37,11 @@ services:
 
   quasar_metastore:
     container_name: quasar_metastore
-    image: postgres:9.6
+    image: postgres:9.6.5-alpine
     privileged: true
     ports:
       - "5432:5432"
+    mem_limit: 1024m
 
   quasar_marklogic_xml:
     container_name: quasar_marklogic_xml


### PR DESCRIPTION
Add mem limit of 1024m and switch to postgres:9.6.5-alpine image on quasar_metastore container. Fixes #2764.