### PR TITLE
Handle errors in linking a bit more gracefully

### DIFF
--- a/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/POSIX.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/POSIX.scala
@@ -44,10 +44,10 @@ object POSIX {
   def mkDir[S[_]](target: ADir)(implicit S: POSIXOp :<: S): Free[S, Unit] =
     Free.liftF(S.inj(MkDir(target)))
 
-  def linkDir[S[_]](src: ADir, target: ADir)(implicit S: POSIXOp :<: S): Free[S, Unit] =
+  def linkDir[S[_]](src: ADir, target: ADir)(implicit S: POSIXOp :<: S): Free[S, Boolean] =
     Free.liftF(S.inj(LinkDir(src, target)))
 
-  def linkFile[S[_]](src: AFile, target: AFile)(implicit S: POSIXOp :<: S): Free[S, Unit] =
+  def linkFile[S[_]](src: AFile, target: AFile)(implicit S: POSIXOp :<: S): Free[S, Boolean] =
     Free.liftF(S.inj(LinkFile(src, target)))
 
   def move[S[_]](src: AFile, target: AFile)(implicit S: POSIXOp :<: S): Free[S, Unit] =

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/POSIXOp.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/POSIXOp.scala
@@ -36,8 +36,9 @@ object POSIXOp {
   final case class Ls(target: ADir) extends POSIXOp[List[RPath]]
 
   final case class MkDir(target: ADir) extends POSIXOp[Unit]
-  final case class LinkDir(src: ADir, target: ADir) extends POSIXOp[Unit]
-  final case class LinkFile(src: AFile, target: AFile) extends POSIXOp[Unit]
+
+  final case class LinkDir(src: ADir, target: ADir) extends POSIXOp[Boolean]
+  final case class LinkFile(src: AFile, target: AFile) extends POSIXOp[Boolean]
 
   final case class Move(src: AFile, target: AFile) extends POSIXOp[Unit]
   final case class Exists(target: APath) extends POSIXOp[Boolean]

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/RealPOSIX.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/RealPOSIX.scala
@@ -33,7 +33,7 @@ import scalaz.syntax.traverse._
 
 import scodec.bits.ByteVector
 
-import java.io.File
+import java.io.{File, IOException}
 import java.nio.file.{Files, StandardCopyOption}
 import java.util.UUID
 
@@ -90,9 +90,13 @@ object RealPOSIX {
           val ptarget = canonicalize(target).toPath()
 
           Task delay {
-            Files.createSymbolicLink(ptarget, psrc)
+            try {
+              Files.createSymbolicLink(ptarget, psrc)
 
-            ()
+              true
+            } catch {
+              case _: IOException => false
+            }
           }
 
         case LinkFile(src, target) =>
@@ -100,9 +104,13 @@ object RealPOSIX {
           val ptarget = canonicalize(target).toPath()
 
           Task delay {
-            Files.createSymbolicLink(ptarget, psrc)
+            try {
+              Files.createSymbolicLink(ptarget, psrc)
 
-            ()
+              true
+            } catch {
+              case _: IOException => false
+            }
           }
 
         case Move(src, target) =>

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/vfs/FreeVFSSpecs.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/vfs/FreeVFSSpecs.scala
@@ -1030,11 +1030,13 @@ object FreeVFSSpecs extends Specification {
           }
       }
 
-      _ <- H.pattern[Unit] {
+      _ <- H.pattern[Boolean] {
         case CPL(LinkDir(from, to)) =>
           Task delay {
             from mustEqual (baseDir </> Path.dir(uuid.toString))
             to mustEqual (baseDir </> Path.dir("HEAD"))
+
+            true
           }
       }
     } yield ()

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/vfs/VersionLogSpecs.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/vfs/VersionLogSpecs.scala
@@ -277,11 +277,13 @@ object VersionLogSpecs extends Specification {
             }
         }
 
-        _ <- HWT.pattern[Unit] {
+        _ <- HWT.pattern[Boolean] {
           case CPL(LinkDir(from, to)) =>
             Task delay {
               from mustEqual (BaseDir </> Path.dir(v.value.toString))
               to mustEqual (BaseDir </> Path.dir("HEAD"))
+
+              true
             }
         }
       } yield ()


### PR DESCRIPTION
Fixes #2765 (I believe…)

Windows was failing because creating symlinks on windows… fails.  So now we handle those errors and return `false`, which the VFS in turn ignores because it doesn't really care whether or not the symlink is *actually* created.