### PR TITLE
Use the 'ephemeralForTest' storage engine for MongoDB 3.2+

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,14 +24,14 @@ services:
   quasar_mongodb_3_2:
     container_name: quasar_mongodb_3_2
     image: mongo:3.2
-    command: ["mongod", "--smallfiles"]
+    command: ["mongod", "--smallfiles", "--storageEngine", "ephemeralForTest"]
     ports:
       - "27021:27017"
 
   quasar_mongodb_3_4:
     container_name: quasar_mongodb_3_4
     image: mongo:3.4
-    command: ["mongod", "--smallfiles"]
+    command: ["mongod", "--smallfiles", "--storageEngine", "ephemeralForTest"]
     ports:
       - "27022:27017"
 


### PR DESCRIPTION
Enables the `ephemeralForTest` storage engine for MongoDB 3.2+ to speed up regression tests.

Locally, this reduced the time to run the regression suite by about 40%.