### PR TITLE
fix unzipped file suffix

### DIFF
--- a/web/src/main/scala/quasar/api/services/package.scala
+++ b/web/src/main/scala/quasar/api/services/package.scala
@@ -17,10 +17,12 @@
 package quasar.api
 
 import slamdata.Predef._
+import quasar.api.MessageFormat.{Csv, JsonContentType}
 import quasar.Data
 import quasar.contrib.argonaut._
 import quasar.effect.Failure
 import quasar.ejson.{EJson, JsonCodec}
+import quasar.fp.ski._
 import quasar.fp.numeric._
 import quasar.contrib.pathy.AFile
 
@@ -84,8 +86,12 @@ package object services {
   ): QResponse[S] = {
     val headers: List[Header] = `Content-Type`(MediaType.`application/zip`) :: 
       (format.disposition.toList: List[Header])
-    val p = format.encode(data).map(str => ByteVector.view(str.getBytes(StandardCharsets.UTF_8))) 
-    val f = currentDir[Sandboxed] </> file1[Sandboxed](fileName(filePath)) 
+    val p = format.encode(data).map(str => ByteVector.view(str.getBytes(StandardCharsets.UTF_8)))
+    val suffix = format match {
+          case JsonContentType(_, _, _) => "json"
+          case Csv(_, _) => "csv"
+        }
+    val f = currentDir[Sandboxed] </> file1[Sandboxed](fileName(filePath).changeExtension(κ(suffix))) 
     val z = Zip.zipFiles(Map(f -> p))
     QResponse.headers.modify(_ ++ headers)(QResponse.streaming(z))
   }

--- a/web/src/test/scala/quasar/api/services/DataServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/DataServiceSpec.scala
@@ -333,6 +333,8 @@ class DataServiceSpec extends quasar.Qspec with FileSystemFixture with Http4s {
             val response = service(fileSystemWithSampleFile(data))(request).unsafePerformSync
             val zipfile = response.as[ByteVector].unsafePerformSync
             val zipMagicByte: ByteVector = hex"504b" // zip file magic byte
+
+            Zip.unzipFiles(response.body).run.unsafePerformSync.map(_.keys) must_=== \/-(Set(currentDir </> file("foo.json")))
             zipfile.take(2) must_=== zipMagicByte
             response.headers.get(`Content-Disposition`.name) must_=== Some(disposition)
             response.contentType must_=== Some(`Content-Type`(MediaType.`application/zip`))
@@ -349,6 +351,8 @@ class DataServiceSpec extends quasar.Qspec with FileSystemFixture with Http4s {
             val response = service(fileSystemWithSampleFile(data))(request).unsafePerformSync
             val zipfile = response.as[ByteVector].unsafePerformSync
             val zipMagicByte: ByteVector = hex"504b" // zip file magic byte
+
+            Zip.unzipFiles(response.body).run.unsafePerformSync.map(_.keys) must_=== \/-(Set(currentDir </> file("foo.csv")))
             zipfile.take(2) must_=== zipMagicByte
             response.headers.get(`Content-Disposition`.name) must_=== Some(disposition)
             response.contentType must_=== Some(`Content-Type`(MediaType.`application/zip`))
@@ -361,6 +365,8 @@ class DataServiceSpec extends quasar.Qspec with FileSystemFixture with Http4s {
             val response = service(fileSystemWithSampleFile(data))(request).unsafePerformSync
             val zipfile = response.as[ByteVector].unsafePerformSync
             val zipMagicByte: ByteVector = hex"504b" // zip file magic byte
+
+            Zip.unzipFiles(response.body).run.unsafePerformSync.map(_.keys) must_=== \/-(Set(currentDir </> file("foo.json")))
             zipfile.take(2) must_=== zipMagicByte
             response.contentType must_=== Some(`Content-Type`(MediaType.`application/zip`))
             response.status must_=== Status.Ok


### PR DESCRIPTION
Unzipping a file produces a file with suffix equal to the data format requested. Fixes #2144.