### PR TITLE
Use sbt version 1.0.0.

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.2
+sbt.version=1.0.0


### PR DESCRIPTION
`~` is dysfunctional with sbt version 1.0.2. Pressing enter does not return the sbt prompt, every 10 seconds it returns success as if changes were made, and we get `[error] Caused by: java.io.IOException: error=23, Too many open files in system`.

`~` is also dysfunctional with sbt version 1.0.1:
```
[error] Error occurred obtaining files to watch.  Terminating continuous execution...
[error] java.lang.NullPointerException
```
So we will use 1.0.0.