### PR TITLE
Backend module qanalysis

### DIFF
--- a/connector/src/main/scala/quasar/connector/BackendModule.scala
+++ b/connector/src/main/scala/quasar/connector/BackendModule.scala
@@ -19,7 +19,6 @@ package connector
 
 import slamdata.Predef._
 import quasar.Data
-import quasar.Data._int
 import quasar.common._
 import quasar.contrib.pathy._
 import quasar.contrib.matryoshka._
@@ -27,17 +26,14 @@ import quasar.contrib.scalaz._, eitherT._
 import quasar.fp._
 import quasar.fp.free._
 import quasar.fp.numeric.{Natural, Positive}
-import quasar.frontend.logicalplan.{Read => LPRead, LogicalPlan}
+import quasar.frontend.logicalplan.LogicalPlan
 import quasar.fs._
 import quasar.fs.mount._
-import quasar.fs.PathError.invalidPath
-import quasar.qscript._, analysis._
-import quasar.std.StdLib.agg
+import quasar.qscript._
 
 import matryoshka.{Hole => _, _}
 import matryoshka.data._
 import matryoshka.implicits._
-import pathy.Path.{file, peel, file1}
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 
@@ -52,9 +48,7 @@ trait BackendModule {
   type BackendT[F[_], A]    = FileSystemErrT[PhaseResultT[ConfiguredT[F, ?], ?], A]
   type Backend[A]           = BackendT[M, A]
 
-  private final implicit def _CardinalityQSM: Cardinality[QSM[Fix, ?]] = CardinalityQSM
-  private final implicit def _CostQSM: Cost[QSM[Fix, ?]] = CostQSM
-  private final implicit def _TraverseQSM[T[_[_]]] = TraverseQSM[T]
+  private final implicit def _FunctorQSM[T[_[_]]] = FunctorQSM[T]
   private final implicit def _DelayRenderTreeQSM[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT]: Delay[RenderTree, QSM[T, ?]] = DelayRenderTreeQSM
   private final implicit def _ExtractPathQSM[T[_[_]]: RecursiveT]: ExtractPath[QSM[T, ?], APath] = ExtractPathQSM
   private final implicit def _QSCoreInject[T[_[_]]] = QSCoreInject[T]
@@ -84,37 +78,13 @@ trait BackendModule {
         (runM compose runCfg compose runFs, close)
     }
 
-  def pathCard: APath => Backend[Int] = (apath: APath) => {
-    val afile: Option[AFile] = peel(apath).map {
-      case (dirPath, \/-(fileName)) => dirPath </> file1(fileName)
-      case (dirPath, -\/(dirName))  => dirPath </> file(dirName.value)
-    }
-
-    def lpFromPath[LP](p: FPath)(implicit LP: Corecursive.Aux[LP, LogicalPlan]): LP =
-      LP.embed(agg.Count(LP.embed(LPRead(p))))
-
-    def first(plan: Fix[LogicalPlan]): Backend[Option[Data]] = for {
-      pp <- lpToRepr[Fix](plan)
-      h  <- QueryFileModule.evaluatePlan(pp.repr)
-      vs <- QueryFileModule.more(h)
-      _  <- QueryFileModule.close(h).liftB
-    } yield vs.headOption
-
-    val lp: Backend[Fix[LogicalPlan]] =
-      EitherT.fromDisjunction(afile.map(p => lpFromPath[Fix[LogicalPlan]](p)) \/> FileSystemError.pathErr(invalidPath(apath, "Cardinality unsupported")))
-
-    (lp >>= (first _)) map (_.flatMap(d => _int.getOption(d).map(_.toInt)) | 0)
-  }
 
   private final def analyzeInterpreter: Analyze ~> Configured = {
     val lc: DiscoverPath.ListContents[Backend] =
       QueryFileModule.listContents(_)
 
     λ[Analyze ~> Configured]({
-      case Analyze.QueryCost(lp) => (for {
-        qs <- lpToQScript[Fix, Backend](lp, lc)
-        c  <- qs.zygoM(CardinalityQSM.calculate[Backend](pathCard), CostQSM.evaluate[Backend](pathCard))
-      } yield c).run.value
+      case Analyze.QueryCost(lp) => 10.right[FileSystemError].point[Configured]
     })
   }
 
@@ -212,9 +182,7 @@ trait BackendModule {
   type Repr
   type M[A]
 
-  def CardinalityQSM: Cardinality[QSM[Fix, ?]]
-  def CostQSM: Cost[QSM[Fix, ?]]
-  def TraverseQSM[T[_[_]]]: Traverse[QSM[T, ?]]
+  def FunctorQSM[T[_[_]]]: Functor[QSM[T, ?]]
   def DelayRenderTreeQSM[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT]: Delay[RenderTree, QSM[T, ?]]
   def ExtractPathQSM[T[_[_]]: RecursiveT]: ExtractPath[QSM[T, ?], APath]
   def QSCoreInject[T[_[_]]]: QScriptCore[T, ?] :<: QSM[T, ?]
@@ -275,6 +243,13 @@ trait BackendModule {
   }
 
   def ManageFileModule: ManageFileModule
+
+  trait AnalyzeModule {
+
+    def queryCost(qs: Fix[QSM[Fix, ?]]): Backend[Int]
+  }
+
+  def AnalyzeModule: AnalyzeModule
 }
 
 object BackendModule {

--- a/connector/src/main/scala/quasar/connector/DefaultAnalyzeModule.scala
+++ b/connector/src/main/scala/quasar/connector/DefaultAnalyzeModule.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.connector
+
+import slamdata.Predef._
+import quasar.Data
+import quasar.Data._int
+import quasar.contrib.pathy._
+import quasar.frontend.logicalplan.{Read => LPRead, LogicalPlan}
+import quasar.fs._
+import quasar.fs.PathError.invalidPath
+import quasar.qscript._, analysis._
+import quasar.std.StdLib.agg
+
+import pathy.Path.{file, peel, file1}
+import matryoshka.{Hole => _, _}
+import matryoshka.data._
+import matryoshka.implicits._
+import scalaz._, Scalaz._
+
+trait DefaultAnalyzeModule { self: BackendModule =>
+
+  private final implicit def _CardinalityQSM: Cardinality[QSM[Fix, ?]] = CardinalityQSM
+  private final implicit def _CostQSM: Cost[QSM[Fix, ?]] = CostQSM
+  private final implicit def _TraverseQSM[T[_[_]]] = TraverseQSM[T]
+  private final implicit def _MonadM = MonadM
+
+  def CardinalityQSM: Cardinality[QSM[Fix, ?]]
+  def CostQSM: Cost[QSM[Fix, ?]]
+  def TraverseQSM[T[_[_]]]: Traverse[QSM[T, ?]]
+
+  object AnalyzeModule extends AnalyzeModule {
+
+    // TODO[scalaz]: Shadow the scalaz.Monad.monadMTMAB SI-2712 workaround
+    import EitherT.eitherTMonad
+
+    private def pathCard: APath => Backend[Int] = (apath: APath) => {
+      val afile: Option[AFile] = peel(apath).map {
+        case (dirPath, \/-(fileName)) => dirPath </> file1(fileName)
+        case (dirPath, -\/(dirName))  => dirPath </> file(dirName.value)
+      }
+
+      def lpFromPath[LP](p: FPath)(implicit LP: Corecursive.Aux[LP, LogicalPlan]): LP =
+        LP.embed(agg.Count(LP.embed(LPRead(p))))
+
+      def first(plan: Fix[LogicalPlan]): Backend[Option[Data]] = for {
+        pp <- lpToRepr[Fix](plan)
+        h  <- QueryFileModule.evaluatePlan(pp.repr)
+        vs <- QueryFileModule.more(h)
+        _  <- QueryFileModule.close(h).liftB
+      } yield vs.headOption
+
+      val lp: Backend[Fix[LogicalPlan]] =
+        EitherT.fromDisjunction(afile.map(p => lpFromPath[Fix[LogicalPlan]](p)) \/> FileSystemError.pathErr(invalidPath(apath, "Cardinality unsupported")))
+
+      (lp >>= (first _)) map (_.flatMap(d => _int.getOption(d).map(_.toInt)) | 0)
+    }
+
+    def queryCost(qs: Fix[QSM[Fix, ?]]): Backend[Int] =
+      qs.zygoM(CardinalityQSM.calculate[Backend](pathCard), CostQSM.evaluate[Backend](pathCard))
+  }
+  
+}

--- a/couchbase/src/main/scala/quasar/physical/couchbase/Couchbase.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/Couchbase.scala
@@ -19,7 +19,7 @@ package quasar.physical.couchbase
 import slamdata.Predef._
 import quasar._
 import quasar.common.{Int => _, Map => _, _}, PhaseResult.detail
-import quasar.connector.BackendModule
+import quasar.connector.{DefaultAnalyzeModule, BackendModule}
 import quasar.contrib.pathy._
 import quasar.contrib.scalaz._, eitherT._
 import quasar.effect.{KeyValueStore, MonotonicSeq}
@@ -41,7 +41,7 @@ import matryoshka.implicits._
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 
-trait Couchbase extends BackendModule {
+trait Couchbase extends BackendModule with DefaultAnalyzeModule {
   type Eff[A] = (
     Task                                       :\:
     MonotonicSeq                               :\:
@@ -70,6 +70,7 @@ trait Couchbase extends BackendModule {
   def CardinalityQSM: Cardinality[QSM[Fix, ?]] = Cardinality[QSM[Fix, ?]]
   def CostQSM: Cost[QSM[Fix, ?]] = Cost[QSM[Fix, ?]]
   def TraverseQSM[T[_[_]]] = Traverse[QSM[T, ?]]
+  def FunctorQSM[T[_[_]]] = Functor[QSM[T, ?]]
   def DelayRenderTreeQSM[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] =
     implicitly[Delay[RenderTree, QSM[T, ?]]]
   def ExtractPathQSM[T[_[_]]: RecursiveT] = ExtractPath[QSM[T, ?], APath]

--- a/couchbase/src/main/scala/quasar/physical/couchbase/Couchbase.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/Couchbase.scala
@@ -31,6 +31,7 @@ import quasar.physical.couchbase.common._
 import quasar.physical.couchbase.planner.Planner
 import quasar.Planner.PlannerError
 import quasar.qscript.{Map => _, _}
+import quasar.qscript.analysis._
 
 import scala.Predef.implicitly
 
@@ -63,7 +64,12 @@ trait Couchbase extends BackendModule {
 
   val jsonTranscoder = new JsonTranscoder
 
-  def FunctorQSM[T[_[_]]] = Functor[QSM[T, ?]]
+  import Cost._
+  import Cardinality._
+
+  def CardinalityQSM: Cardinality[QSM[Fix, ?]] = Cardinality[QSM[Fix, ?]]
+  def CostQSM: Cost[QSM[Fix, ?]] = Cost[QSM[Fix, ?]]
+  def TraverseQSM[T[_[_]]] = Traverse[QSM[T, ?]]
   def DelayRenderTreeQSM[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] =
     implicitly[Delay[RenderTree, QSM[T, ?]]]
   def ExtractPathQSM[T[_[_]]: RecursiveT] = ExtractPath[QSM[T, ?], APath]

--- a/marklogic/src/main/scala/quasar/physical/marklogic/MarkLogic.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/MarkLogic.scala
@@ -56,6 +56,7 @@ import scalaz.stream.Process
 
 sealed class MarkLogic protected (readChunkSize: Positive, writeChunkSize: Positive)
     extends BackendModule
+    with DefaultAnalyzeModule
     with ManagedQueryFile[XccDataStream]
     with ManagedWriteFile[AFile]
     with ManagedReadFile[XccDataStream]
@@ -83,6 +84,7 @@ sealed class MarkLogic protected (readChunkSize: Positive, writeChunkSize: Posit
     Cost[QSM[Fix, ?]]
   }
   def TraverseQSM[T[_[_]]] = Traverse[QSM[T, ?]]
+  def FunctorQSM[T[_[_]]] = Functor[QSM[T, ?]]
   def DelayRenderTreeQSM[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] = implicitly[Delay[RenderTree, QSM[T, ?]]]
   def ExtractPathQSM[T[_[_]]: RecursiveT] = ExtractPath[QSM[T, ?], APath]
   def QSCoreInject[T[_[_]]] = implicitly[QScriptCore[T, ?] :<: QSM[T, ?]]

--- a/marklogic/src/main/scala/quasar/physical/marklogic/MarkLogic.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/MarkLogic.scala
@@ -41,11 +41,13 @@ import quasar.physical.marklogic.xcc._, Xcc.ops._
 import quasar.physical.marklogic.xquery._
 import quasar.physical.marklogic.xquery.syntax._
 import quasar.qscript.{Read => QRead, _}
+import quasar.qscript.analysis._
 
 import scala.Predef.implicitly
 
 import eu.timepit.refined.auto._
 import matryoshka._
+import matryoshka.data._
 import matryoshka.implicits._
 import pathy.Path._
 import scalaz._, Scalaz._
@@ -72,7 +74,15 @@ sealed class MarkLogic protected (readChunkSize: Positive, writeChunkSize: Posit
     ::\::[QScriptCore[T, ?]](::\::[ThetaJoin[T, ?]](::/::[T, Const[ShiftedRead[ADir], ?], Const[QRead[AFile], ?]]))
 
   // BackendModule
-  def FunctorQSM[T[_[_]]] = Functor[QSM[T, ?]]
+  def CardinalityQSM: Cardinality[QSM[Fix, ?]] = {
+    import Cardinality._
+    Cardinality[QSM[Fix, ?]]
+  }
+  def CostQSM: Cost[QSM[Fix, ?]] = {
+    import Cost._
+    Cost[QSM[Fix, ?]]
+  }
+  def TraverseQSM[T[_[_]]] = Traverse[QSM[T, ?]]
   def DelayRenderTreeQSM[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] = implicitly[Delay[RenderTree, QSM[T, ?]]]
   def ExtractPathQSM[T[_[_]]: RecursiveT] = ExtractPath[QSM[T, ?], APath]
   def QSCoreInject[T[_[_]]] = implicitly[QScriptCore[T, ?] :<: QSM[T, ?]]

--- a/mimir/src/main/scala/quasar/mimir/Mimir.scala
+++ b/mimir/src/main/scala/quasar/mimir/Mimir.scala
@@ -66,7 +66,7 @@ import quasar.yggdrasil.TableModule.{DesiredSortOrder, SortAscending}
 
 import scalaz.Leibniz.===
 
-object Mimir extends BackendModule with Logging {
+object Mimir extends BackendModule with Logging with DefaultAnalyzeModule {
   import FileSystemError._
   import PathError._
   import Precog.startTask
@@ -167,6 +167,7 @@ object Mimir extends BackendModule with Logging {
 
   def CardinalityQSM: Cardinality[QSM[Fix, ?]] = Cardinality[QSM[Fix, ?]]
   def CostQSM: Cost[QSM[Fix, ?]] = Cost[QSM[Fix, ?]]
+  def FunctorQSM[T[_[_]]] = Functor[QSM[T, ?]]
   def TraverseQSM[T[_[_]]] = Traverse[QSM[T, ?]]
   def DelayRenderTreeQSM[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] = implicitly[Delay[RenderTree, QSM[T, ?]]]
   def ExtractPathQSM[T[_[_]]: RecursiveT] = ExtractPath[QSM[T, ?], APath]

--- a/mimir/src/main/scala/quasar/mimir/Mimir.scala
+++ b/mimir/src/main/scala/quasar/mimir/Mimir.scala
@@ -29,6 +29,7 @@ import quasar.fp.ski.κ
 import quasar.fs._
 import quasar.fs.mount._
 import quasar.qscript._
+import quasar.qscript.analysis._
 
 import quasar.blueeyes.json.{JNum, JValue}
 import quasar.precog.common.{ColumnRef, CPath, CPathField, CPathIndex, Path}
@@ -161,7 +162,12 @@ object Mimir extends BackendModule with Logging {
 
   def cake[F[_]](implicit F: MonadReader_[F, Cake]): F[Cake] = F.ask
 
-  def FunctorQSM[T[_[_]]] = Functor[QSM[T, ?]]
+  import Cost._
+  import Cardinality._
+
+  def CardinalityQSM: Cardinality[QSM[Fix, ?]] = Cardinality[QSM[Fix, ?]]
+  def CostQSM: Cost[QSM[Fix, ?]] = Cost[QSM[Fix, ?]]
+  def TraverseQSM[T[_[_]]] = Traverse[QSM[T, ?]]
   def DelayRenderTreeQSM[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] = implicitly[Delay[RenderTree, QSM[T, ?]]]
   def ExtractPathQSM[T[_[_]]: RecursiveT] = ExtractPath[QSM[T, ?], APath]
   def QSCoreInject[T[_[_]]] = implicitly[QScriptCore[T, ?] :<: QSM[T, ?]]

--- a/mongodb/src/main/scala/quasar/physical/mongodb/MongoDb.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/MongoDb.scala
@@ -43,7 +43,8 @@ import scala.Predef.implicitly
 object MongoDb
     extends BackendModule
     with ManagedReadFile[BsonCursor]
-    with ManagedWriteFile[Collection] {
+    with ManagedWriteFile[Collection]
+    with DefaultAnalyzeModule {
 
   type QS[T[_[_]]] = fs.MongoQScriptCP[T]
 
@@ -60,6 +61,7 @@ object MongoDb
   def CardinalityQSM: Cardinality[QSM[Fix, ?]] = Cardinality[QSM[Fix, ?]]
   def CostQSM: Cost[QSM[Fix, ?]] = Cost[QSM[Fix, ?]]
   def TraverseQSM[T[_[_]]] = Traverse[QSM[T, ?]]
+  def FunctorQSM[T[_[_]]] = Functor[QSM[T, ?]]
   def DelayRenderTreeQSM[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] = implicitly[Delay[RenderTree, QSM[T, ?]]]
   def ExtractPathQSM[T[_[_]]: RecursiveT] = ExtractPath[QSM[T, ?], APath]
   def QSCoreInject[T[_[_]]] = implicitly[QScriptCore[T, ?] :<: QSM[T, ?]]

--- a/mongodb/src/main/scala/quasar/physical/mongodb/MongoDb.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/MongoDb.scala
@@ -31,9 +31,11 @@ import quasar.fs.mount._
 import quasar.physical.mongodb.fs.bsoncursor._
 import quasar.physical.mongodb.workflow._
 import quasar.qscript._
+import quasar.qscript.analysis._
 
 import java.time.Instant
 import matryoshka._
+import matryoshka.data._
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 import scala.Predef.implicitly
@@ -52,7 +54,12 @@ object MongoDb
 
   type M[A] = fs.MongoM[A]
 
-  def FunctorQSM[T[_[_]]] = Functor[QSM[T, ?]]
+  import Cost._
+  import Cardinality._
+
+  def CardinalityQSM: Cardinality[QSM[Fix, ?]] = Cardinality[QSM[Fix, ?]]
+  def CostQSM: Cost[QSM[Fix, ?]] = Cost[QSM[Fix, ?]]
+  def TraverseQSM[T[_[_]]] = Traverse[QSM[T, ?]]
   def DelayRenderTreeQSM[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] = implicitly[Delay[RenderTree, QSM[T, ?]]]
   def ExtractPathQSM[T[_[_]]: RecursiveT] = ExtractPath[QSM[T, ?], APath]
   def QSCoreInject[T[_[_]]] = implicitly[QScriptCore[T, ?] :<: QSM[T, ?]]

--- a/rdbms/src/main/scala/quasar/physical/rdbms/Rdbms.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/Rdbms.scala
@@ -17,7 +17,7 @@
 package quasar.physical.rdbms
 
 import slamdata.Predef._
-import quasar.connector.BackendModule
+import quasar.connector.{DefaultAnalyzeModule, BackendModule}
 import quasar.contrib.pathy.{AFile, APath}
 import quasar.contrib.scalaz.MonadReader_
 import quasar.effect.uuid.GenUUID
@@ -46,7 +46,7 @@ import scalaz._
 import Scalaz._
 import scalaz.concurrent.Task
 
-trait Rdbms extends BackendModule with RdbmsReadFile with RdbmsWriteFile with RdbmsManageFile with RdbmsQueryFile with Interpreter {
+trait Rdbms extends BackendModule with RdbmsReadFile with RdbmsWriteFile with RdbmsManageFile with RdbmsQueryFile with Interpreter with DefaultAnalyzeModule {
 
   type Eff[A] = (
       ConnectionIO :\:
@@ -71,6 +71,7 @@ trait Rdbms extends BackendModule with RdbmsReadFile with RdbmsWriteFile with Rd
 
   def CardinalityQSM: Cardinality[QSM[Fix, ?]] = Cardinality[QSM[Fix, ?]]
   def CostQSM: Cost[QSM[Fix, ?]] = Cost[QSM[Fix, ?]]
+  def FunctorQSM[T[_[_]]] = Functor[QSM[T, ?]]
   def TraverseQSM[T[_[_]]] = Traverse[QSM[T, ?]]
   def DelayRenderTreeQSM[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] =
     implicitly[Delay[RenderTree, QSM[T, ?]]]

--- a/rdbms/src/main/scala/quasar/physical/rdbms/Rdbms.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/Rdbms.scala
@@ -34,11 +34,13 @@ import quasar.fs.WriteFile.WriteHandle
 import quasar.physical.rdbms.common.{Config, TablePath}
 import quasar.physical.rdbms.jdbc.JdbcConnectionInfo
 import quasar.{RenderTree, RenderTreeT, fp}
+import quasar.qscript.analysis._
 
 import scala.Predef.implicitly
 import doobie.hikari.hikaritransactor.HikariTransactor
 import doobie.imports.ConnectionIO
 import matryoshka.{BirecursiveT, Delay, EqualT, RecursiveT, ShowT}
+import matryoshka.data._
 
 import scalaz._
 import Scalaz._
@@ -64,7 +66,12 @@ trait Rdbms extends BackendModule with RdbmsReadFile with RdbmsWriteFile with Rd
     val liftB: Backend[A] = lift(m).into[Eff].liftB
   }
 
-  def FunctorQSM[T[_[_]]] = Functor[QSM[T, ?]]
+  import Cost._
+  import Cardinality._
+
+  def CardinalityQSM: Cardinality[QSM[Fix, ?]] = Cardinality[QSM[Fix, ?]]
+  def CostQSM: Cost[QSM[Fix, ?]] = Cost[QSM[Fix, ?]]
+  def TraverseQSM[T[_[_]]] = Traverse[QSM[T, ?]]
   def DelayRenderTreeQSM[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] =
     implicitly[Delay[RenderTree, QSM[T, ?]]]
   def ExtractPathQSM[T[_[_]]: RecursiveT]                               = ExtractPath[QSM[T, ?], APath]

--- a/skeleton/src/main/scala/quasar/physical/skeleton/fs/Skeleton.scala
+++ b/skeleton/src/main/scala/quasar/physical/skeleton/fs/Skeleton.scala
@@ -25,8 +25,10 @@ import quasar.fp.numeric._
 import quasar.fs._
 import quasar.fs.mount._
 import quasar.qscript._
+import quasar.qscript.analysis._
 
 import matryoshka._
+import matryoshka.data._
 import scalaz._
 import scalaz.concurrent.Task
 import scala.Predef.implicitly
@@ -43,7 +45,12 @@ object Skeleton extends BackendModule {
   type Repr = Unit
   type M[A] = Nothing
 
-  def FunctorQSM[T[_[_]]] = Functor[QSM[T, ?]]
+  import Cost._
+  import Cardinality._
+
+  def CardinalityQSM: Cardinality[QSM[Fix, ?]] = Cardinality[QSM[Fix, ?]]
+  def CostQSM: Cost[QSM[Fix, ?]] = Cost[QSM[Fix, ?]]
+  def TraverseQSM[T[_[_]]] = Traverse[QSM[T, ?]]
   def DelayRenderTreeQSM[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] = implicitly[Delay[RenderTree, QSM[T, ?]]]
   def ExtractPathQSM[T[_[_]]: RecursiveT] = ExtractPath[QSM[T, ?], APath]
   def QSCoreInject[T[_[_]]] = implicitly[QScriptCore[T, ?] :<: QSM[T, ?]]

--- a/skeleton/src/main/scala/quasar/physical/skeleton/fs/Skeleton.scala
+++ b/skeleton/src/main/scala/quasar/physical/skeleton/fs/Skeleton.scala
@@ -33,7 +33,7 @@ import scalaz._
 import scalaz.concurrent.Task
 import scala.Predef.implicitly
 
-object Skeleton extends BackendModule {
+object Skeleton extends BackendModule with DefaultAnalyzeModule {
 
   // default QS subset; change if you're cool/weird/unique!
   type QS[T[_[_]]] = QScriptCore[T, ?] :\: EquiJoin[T, ?] :/: Const[ShiftedRead[AFile], ?]
@@ -50,6 +50,7 @@ object Skeleton extends BackendModule {
 
   def CardinalityQSM: Cardinality[QSM[Fix, ?]] = Cardinality[QSM[Fix, ?]]
   def CostQSM: Cost[QSM[Fix, ?]] = Cost[QSM[Fix, ?]]
+  def FunctorQSM[T[_[_]]] = Functor[QSM[T, ?]]
   def TraverseQSM[T[_[_]]] = Traverse[QSM[T, ?]]
   def DelayRenderTreeQSM[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] = implicitly[Delay[RenderTree, QSM[T, ?]]]
   def ExtractPathQSM[T[_[_]]: RecursiveT] = ExtractPath[QSM[T, ?], APath]

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/sparkcore.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/sparkcore.scala
@@ -18,7 +18,7 @@ package quasar.physical.sparkcore.fs
 
 import slamdata.Predef._
 import quasar._
-import quasar.connector.BackendModule
+import quasar.connector.{DefaultAnalyzeModule, BackendModule}
 import quasar.contrib.scalaz._
 import quasar.contrib.pathy._
 import quasar.common._
@@ -43,7 +43,7 @@ import scalaz.concurrent.Task
 
 final case class SparkCursor(rdd: Option[RDD[(Data, Long)]], pointer: Int)
 
-trait SparkCore extends BackendModule {
+trait SparkCore extends BackendModule with DefaultAnalyzeModule {
 
   // TODO[scalaz]: Shadow the scalaz.Monad.monadMTMAB SI-2712 workaround
   import EitherT.eitherTMonad
@@ -96,6 +96,7 @@ trait SparkCore extends BackendModule {
 
   def CardinalityQSM: Cardinality[QSM[Fix, ?]] = Cardinality[QSM[Fix, ?]]
   def CostQSM: Cost[QSM[Fix, ?]] = Cost[QSM[Fix, ?]]
+  def FunctorQSM[T[_[_]]] = Functor[QSM[T, ?]]
   def TraverseQSM[T[_[_]]] = Traverse[QSM[T, ?]]
   def DelayRenderTreeQSM[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] =
     implicitly[Delay[RenderTree, QSM[T, ?]]]

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/sparkcore.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/sparkcore.scala
@@ -27,6 +27,7 @@ import quasar.fs._, FileSystemError._
 import quasar.fs.mount._, BackendDef._
 import quasar.effect._
 import quasar.qscript.{Read => _, _}
+import quasar.qscript.analysis._
 
 import java.lang.Thread
 import scala.Predef.implicitly
@@ -35,6 +36,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkContext
 import pathy.Path._
 import matryoshka._
+import matryoshka.data._
 import matryoshka.implicits._
 import scalaz.{Failure => _, _}, Scalaz._
 import scalaz.concurrent.Task
@@ -89,7 +91,12 @@ trait SparkCore extends BackendModule {
   def qfKvsOps: KeyValueStore.Ops[QueryFile.ResultHandle, SparkCursor, Eff] =
     KeyValueStore.Ops[QueryFile.ResultHandle, SparkCursor, Eff]
 
-  def FunctorQSM[T[_[_]]] = Functor[QSM[T, ?]]
+  import Cost._
+  import Cardinality._
+
+  def CardinalityQSM: Cardinality[QSM[Fix, ?]] = Cardinality[QSM[Fix, ?]]
+  def CostQSM: Cost[QSM[Fix, ?]] = Cost[QSM[Fix, ?]]
+  def TraverseQSM[T[_[_]]] = Traverse[QSM[T, ?]]
   def DelayRenderTreeQSM[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] =
     implicitly[Delay[RenderTree, QSM[T, ?]]]
   def ExtractPathQSM[T[_[_]]: RecursiveT] = ExtractPath[QSM[T, ?], APath]


### PR DESCRIPTION
This fixes https://github.com/quasar-analytics/quasar/issues/2213

In general we provide proper implementation for `  private final def analyzeInterpreter: Analyze ~> Configured` in `BackendModule`.

Connectors should provide two methods:
```
  def CardinalityQSM: Cardinality[QSM[Fix, ?]]
  def CostQSM: Cost[QSM[Fix, ?]]
```
For both `Cost` and `Cardinality` there are "generic", default implementations available (under `Cost._` and `Cardinality._`) that connectors can used - and this is what they actually do right now. But at some point they should provide their own implementation (especially for the `Cost` typeclass as it can take more connecotr specific information into consideration)

There is also a method called `pathCard` that provides default implementation to calculate `APath` cardinality (it basically runs `select count(*) from apath`) but connectors can (and should if they can) provide their own, more efficient version of this method.


Regarding the code, I tried to make this

```
  def CardinalityQSM: Cardinality[QSM[Fix, ?]] = Cardinality[QSM[Fix, ?]]
  def CostQSM: Cost[QSM[Fix, ?]] = Cost[QSM[Fix, ?]]
```

a bit more polymorphic (not fixing on the `Fix` - pun not intended), but I failed. Compiler was just not happy about it. But maybe since this method will only be used with `Fix` it is not such a big of a problem?

