### PR TITLE
Removed mongo 2.6 and 3.0 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ env:
     - CONNECTOR=marklogic_json
     - CONNECTOR=marklogic_xml
     - CONNECTOR=mimir
-    - CONNECTOR=mongodb_2_6
-    - CONNECTOR=mongodb_3_0
     - CONNECTOR=mongodb_3_2
     - CONNECTOR=mongodb_3_4
     - CONNECTOR=mongodb_read_only


### PR DESCRIPTION
Mongo 2.6 and 3.0 are no longer officially supported by SlamData.  Translation: we no longer CI them.