### PR TITLE
Working windows build

### DIFF
--- a/sbt.bat
+++ b/sbt.bat
@@ -1,0 +1,29 @@
+@REM https://github.com/xerial/sbt-pack/blob/master/src/main/templates/launch-bat.mustache
+@REM would be worth getting more inspiration from
+
+@echo off
+
+SET ERROR_CODE=0
+
+SET LAUNCHER_PATH=%localappdata%/coursier
+
+IF NOT EXIST "%LAUNCHER_PATH%" (
+  bitsadmin /transfer "DownloadCoursierLauncher" https://github.com/coursier/coursier/raw/master/coursier "%LAUNCHER_PATH%"
+)
+
+SET CMD_LINE_ARGS=%*
+
+java -Xms512m -Xmx4g -Xss2m -Dfile.encoding=UTF8 -jar "%LAUNCHER_PATH%" launch org.scala-sbt:sbt-launch:1.0.2 %CMD_LINE_ARGS%
+
+IF ERRORLEVEL 1 GOTO error
+GOTO end
+
+:error
+SET ERROR_CODE=1
+
+:end
+SET LAUNCHER_PATH=
+SET CMD_LINE_ARGS=
+
+EXIT /B %ERROR_CODE%
+

--- a/sbt.bat
+++ b/sbt.bat
@@ -13,7 +13,11 @@ IF NOT EXIST "%LAUNCHER_PATH%" (
 
 SET CMD_LINE_ARGS=%*
 
-java -Xms512m -Xmx4g -Xss2m -Dfile.encoding=UTF8 -jar "%LAUNCHER_PATH%" launch org.scala-sbt:sbt-launch:1.0.2 %CMD_LINE_ARGS%
+@REM this is the hackiest thing ever. don't delete the extra newline here!
+set NL=^
+
+
+java -Xms512m -Xmx4g -Xss2m -Dfile.encoding=UTF8 -Dline.separator=^%NL%%NL% -jar "%LAUNCHER_PATH%" launch org.scala-sbt:sbt-launch:1.0.2 %CMD_LINE_ARGS%
 
 IF ERRORLEVEL 1 GOTO error
 GOTO end

--- a/sbt.bat
+++ b/sbt.bat
@@ -17,7 +17,7 @@ SET CMD_LINE_ARGS=%*
 set NL=^
 
 
-java -Xms512m -Xmx4g -Xss2m -Dfile.encoding=UTF8 -Dline.separator=^%NL%%NL% -jar "%LAUNCHER_PATH%" launch org.scala-sbt:sbt-launch:1.0.2 %CMD_LINE_ARGS%
+java -Xms512m -Xmx4g -Xss2m -Dfile.encoding=UTF8 -Dline.separator=^%NL%%NL% -jar "%LAUNCHER_PATH%" launch org.scala-sbt:sbt-launch:1.0.2 -- %CMD_LINE_ARGS%
 
 IF ERRORLEVEL 1 GOTO error
 GOTO end


### PR DESCRIPTION
Fixes #2815 
Fixes #2819 

I can now checkout and build quasar on windows and the only dependency is the JDK.  The `sbt.bat` script will bootstrap and run SBT, similar to how the `sbt` script does.  We should be able to use this when we setup AppVeyor (to address #2799).