### PR TITLE
AppVeyor Configuration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,31 @@
+version: 1.0.{build}
+
+pull_requests:
+  do_not_increment_build_number: true
+
+branches:
+  only:
+  - master
+  - /^backport\/v.*/
+
+skip_tags: true
+
+# TODO add ivy/coursier artifact cache
+cache:
+  - .targets
+  - '%localappdata%/coursier'
+  - ''
+
+environment:
+  JAVA_HOME: 'C:\Program Files\Java\jdk1.8.0'
+  PATH: '%JAVA_HOME%\bin;%PATH%'
+
+# TODO remove target cache here
+# before_build:
+  # - cmd:
+
+build_script:
+  - cmd: .\sbt ++"2.11.8" test:compile
+
+test_script:
+  - cmd: .\sbt ++"2.11.8" test

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,8 @@ skip_tags: true
 
 cache:
   - .targets
+  - project\target
+  - project\project\target
   - '%localappdata%\coursier'
   - 'C:\Users\appveyor\.sbt'
   - 'C:\Users\appveyor\.ivy2'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,9 +23,8 @@ environment:
   JAVA_HOME: 'C:\Program Files\Java\jdk1.8.0'
   PATH: '%JAVA_HOME%\bin;%PATH%'
 
-# TODO remove target cache here
-# before_build:
-  # - cmd:
+before_build:
+  - cmd: 'IF "%APPVEYOR_PULL_REQUEST_NUMBER%"=="" (.\sbt clean)'
 
 build_script:
   - cmd: .\sbt ++"2.11.8" test:compile

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,5 +30,5 @@ build_script:
   - cmd: .\sbt ++"2.11.8" test:compile
 
 test_script:
-  - cmd: 'echo "mimir = "%localappdata%\precog" > it\testing.conf'
+  - cmd: 'echo mimir = "%localappdata%\precog" > it\testing.conf'
   - cmd: '.\sbt ++"2.11.8" it/sideEffectTestFSConfig "testOnly -- xonly" "exclusive:testOnly -- xonly"'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,9 +13,9 @@ skip_tags: true
 cache:
   - .targets
   - '%localappdata%\coursier'
-  - '%HOMEPATH%\.sbt'
-  - '%HOMEPATH%\.ivy2'
-  - '%HOMEPATH%\.coursier'
+  - 'C:\Users\appveyor\.sbt'
+  - 'C:\Users\appveyor\.ivy2'
+  - 'C:\Users\appveyor\.coursier'
 
 environment:
   JAVA_HOME: 'C:\Program Files\Java\jdk1.8.0'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,6 @@ branches:
 
 skip_tags: true
 
-# TODO add ivy/coursier artifact cache
 cache:
   - .targets
   - '%localappdata%\coursier'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,4 +28,5 @@ build_script:
   - cmd: .\sbt ++"2.11.8" test:compile
 
 test_script:
-  - cmd: .\sbt ++"2.11.8" test
+  - cmd: 'echo "mimir = "%localappdata%\precog" > it\testing.conf'
+  - cmd: '.\sbt ++"2.11.8" it/sideEffectTestFSConfig "testOnly -- xonly" "exclusive:testOnly -- xonly"'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,5 +29,5 @@ build_script:
   - cmd: .\sbt ++"2.11.8" test:compile
 
 test_script:
-  - cmd: 'echo mimir = "%localappdata%\precog" > it\testing.conf'
+  - cmd: 'echo mimir = "C:\\Users\\appveyor\\AppData\\Local\\precog" > it\testing.conf'
   - cmd: '.\sbt ++"2.11.8" it/sideEffectTestFSConfig "testOnly -- xonly" "exclusive:testOnly -- xonly"'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,8 +5,8 @@ pull_requests:
 
 branches:
   only:
-  - master
-  - /^backport\/v.*/
+    - master
+    - /^backport\/v.*/
 
 skip_tags: true
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,8 +13,10 @@ skip_tags: true
 # TODO add ivy/coursier artifact cache
 cache:
   - .targets
-  - '%localappdata%/coursier'
-  - ''
+  - '%localappdata%\coursier'
+  - '%HOMEPATH%\.sbt'
+  - '%HOMEPATH%\.ivy2'
+  - '%HOMEPATH%\.coursier'
 
 environment:
   JAVA_HOME: 'C:\Program Files\Java\jdk1.8.0'

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See the instructions below for running and configuring these JARs.
 
 ## Building from Source
 
-**Note**: This requires Java 8 and Bash (Linux, Mac, or Cygwin on Windows).
+**Note**: This requires Java 8 and Bash (Linux, Mac).  Bash is not required on Windows, but the non-SBT infrastructure (e.g. the docker scripts) currently only works on Unix platforms.
 
 ### Build
 
@@ -34,14 +34,13 @@ The following sections explain how to build and run the various subprojects.
 
 #### Basic Compile & Test
 
-To compile the project and run tests, first clone the quasar repo and then execute the following command:
+To compile the project and run tests, first clone the quasar repo and then execute the following command (if on Windows, reverse the slashes):
 
 ```bash
 ./sbt test
 ```
 
-Note: please note that we are not using here a system wide sbt, but our own copy of it (under ./sbt). This is primarily
- done for determinism. In order to have a reproducible build, the helper script needs to be part of the repo.
+Note: please note that we are not using here a system wide sbt, but our own copy of it (under ./sbt). This is primarily done for determinism. In order to have a reproducible build, the helper script needs to be part of the repo.
 
 Running the full test suite can be done using docker containers for various backends:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build status](https://travis-ci.org/quasar-analytics/quasar.svg?branch=master)](https://travis-ci.org/quasar-analytics/quasar)
+[![Travis](https://travis-ci.org/quasar-analytics/quasar.svg?branch=master)](https://travis-ci.org/quasar-analytics/quasar)
+[![AppVeyor](https://ci.appveyor.com/api/projects/status/pr5he90wye6ii8ml/branch/master?svg=true)](https://ci.appveyor.com/project/djspiewak/quasar/branch/master)
 <!-- [![Coverage Status](https://coveralls.io/repos/quasar-analytics/quasar/badge.svg)](https://coveralls.io/r/quasar-analytics/quasar) -->
 [![Latest version](https://index.scala-lang.org/quasar-analytics/quasar/quasar-web/latest.svg)](https://index.scala-lang.org/quasar-analytics/quasar/quasar-web)
 [![Join the chat at https://gitter.im/quasar-analytics/quasar](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/quasar-analytics/quasar?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build status](https://travis-ci.org/quasar-analytics/quasar.svg?branch=master)](https://travis-ci.org/quasar-analytics/quasar)
-[![Coverage Status](https://coveralls.io/repos/quasar-analytics/quasar/badge.svg)](https://coveralls.io/r/quasar-analytics/quasar)
+<!-- [![Coverage Status](https://coveralls.io/repos/quasar-analytics/quasar/badge.svg)](https://coveralls.io/r/quasar-analytics/quasar) -->
 [![Latest version](https://index.scala-lang.org/quasar-analytics/quasar/quasar-web/latest.svg)](https://index.scala-lang.org/quasar-analytics/quasar/quasar-web)
 [![Join the chat at https://gitter.im/quasar-analytics/quasar](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/quasar-analytics/quasar?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@
 [![Latest version](https://index.scala-lang.org/quasar-analytics/quasar/quasar-web/latest.svg)](https://index.scala-lang.org/quasar-analytics/quasar/quasar-web)
 [![Join the chat at https://gitter.im/quasar-analytics/quasar](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/quasar-analytics/quasar?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-# Thanks to Sponsors
-
-YourKit supports open source projects with its full-featured Java Profiler. YourKit, LLC is the creator of <a href="https://www.yourkit.com/java/profiler/index.jsp">YourKit Java Profiler</a> and <a href="https://www.yourkit.com/.net/profiler/index.jsp">YourKit .NET Profiler</a>, innovative and intelligent tools for profiling Java and .NET applications.
-
 # Quasar
 
 Quasar is an open source NoSQL analytics engine that can be used as a library or through a REST API to power advanced analytics across a growing range of data sources and databases, including MongoDB.
@@ -1125,6 +1121,10 @@ This will ensure that your local version is also passing the tests.
 Check to see if the problem you are having is mentioned in the [JIRA issues](https://slamdata.atlassian.net/) and, if it isn't, feel free to create a new issue.
 
 You can also discuss issues on Gitter: [quasar-analytics/quasar](https://gitter.im/quasar-analytics/quasar).
+
+## Thanks to Sponsors
+
+YourKit supports open source projects with its full-featured Java Profiler. YourKit, LLC is the creator of <a href="https://www.yourkit.com/java/profiler/index.jsp">YourKit Java Profiler</a> and <a href="https://www.yourkit.com/.net/profiler/index.jsp">YourKit .NET Profiler</a>, innovative and intelligent tools for profiling Java and .NET applications.
 
 ## Legal
 

--- a/mongoIt/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
+++ b/mongoIt/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
@@ -374,11 +374,11 @@ object MongoDbFileSystemSpec {
     (Functor[Task] compose Functor[IList])
       .map(
         (TestConfig externalFileSystems {
-          case (tpe, uri) =>
+          case (tpe, uri) if tpe.value.startsWith("mongodb") =>
             filesystems.testFileSystem(
               MongoDb.definition.translate(injectFT[Task, filesystems.Eff]).apply(tpe, uri).run)
         }).handleWith[IList[SupportedFs[BackendEffect]]] {
-          case _: TestConfig.UnsupportedFileSystemConfig => Task.now(IList.empty)
+          case _: RuntimeException => Task.now(IList.empty)  // filesystems.scala:39
         }
       )(_.liftIO)
 }

--- a/sbt.bat
+++ b/sbt.bat
@@ -17,7 +17,7 @@ SET CMD_LINE_ARGS=%*
 set NL=^
 
 
-java -Xms512m -Xmx4g -Xss2m -Dfile.encoding=UTF8 -Dline.separator=^%NL%%NL% -jar "%LAUNCHER_PATH%" launch org.scala-sbt:sbt-launch:1.0.2 -- %CMD_LINE_ARGS%
+java -Xms512m -Xmx4g -Xss2m -Dfile.encoding=UTF8 -Djna.nosys=true -Dline.separator=^%NL%%NL% -jar "%LAUNCHER_PATH%" launch org.scala-sbt:sbt-launch:1.0.2 -- %CMD_LINE_ARGS%
 
 IF ERRORLEVEL 1 GOTO error
 GOTO end


### PR DESCRIPTION
Fixes #2799 
Fixes #2900
Fixes #2899 

Fixes a few issues with the Windows `sbt.bat` script and also fixes a couple random bugs that Windows quirks uncovered.  This PR primarily configures AppVeyor to compile, unit test and run the Mimir integration tests.  Caching is enabled along similar rules as Travis.  Both master and backport/ branches will be built, in addition to PRs.

Right now, it seems like fully-cached builds take around 28 minutes, while entirely uncached builds take just over an hour.  No build should be *entirely* uncached, since coursier stuff should be kept around, but it's worth keeping it in mind.  AppVeyor's build limit is 60 minutes, after which the job will be killed.  We're discussing options with them now.

Additionally, and this is the more constraining bit, AppVeyor has a concurrency limit of 1 for OSS projects.  We're looking into getting a paid account which should give us access to higher concurrency, but for the time being, there may be a bit of a queue building up if a lot of PRs are opened at once.

----

As a note regarding Windows stuff in general…  All of the random issues that I fixed to make the build work on Windows were *legitimate* issues.  Most of them were assumptions about the non-existence of backslashes in certain inputs, and one of which was actually a file handle leak that was only caught by file lock bugs.  In other words, if Travis blesses your build but AppVeyor doesn't, chances are very good you have a bug that you didn't realize was there!