### PR TITLE
Add Copy operation to Filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,8 +694,19 @@ Removes all data and views at the specified path. Single files are deleted atomi
 
 ### MOVE /data/fs/[path]
 
-Moves data from one path to another within the same backend. The new path must
-be provided in the `Destination` request header. Single files are moved atomically.
+Moves data from one path to another. Currently, both the source and destination must be within the same backend. The new path is provided in the `Destination` request header. Single files are moved atomically.
+
+A 400 BadRequest is returned if the destination header is missing or if the source and destination are the same.
+A 409 Conflict is returned if a file or directory already exists at the specified destination
+A 201 Created is returned if the operation completed successfully
+
+### COPY /data/fs/[path]
+
+Copy a file or directory in the filesystem. Currently, both the source and destination must be within the same backend. The destination path is provided in the `Destination` request header.
+
+A 400 BadRequest is returned if the destination header is missing or if the source and destination are the same.
+A 409 Conflict is returned if a file or directory already exists at the specified destination
+A 201 Created is returned if the operation completed successfully
 
 ### GET /invoke/fs/[path]
 

--- a/connector/src/main/scala/quasar/connector/BackendModule.scala
+++ b/connector/src/main/scala/quasar/connector/BackendModule.scala
@@ -124,9 +124,9 @@ trait BackendModule {
     }
 
     val mfInter: ManageFile ~> Configured = λ[ManageFile ~> Configured] {
-      case ManageFile.Move(scenario, semantics) =>
-        ManageFileModule.move(scenario, semantics).run.value
-
+      case ManageFile.Move(pathPair, semantics) =>
+        ManageFileModule.move(pathPair, semantics).run.value
+      case ManageFile.Copy(pathPair) => ManageFileModule.copy(pathPair).run.value
       case ManageFile.Delete(path) => ManageFileModule.delete(path).run.value
       case ManageFile.TempFile(near) => ManageFileModule.tempFile(near).run.value
     }
@@ -237,7 +237,8 @@ trait BackendModule {
   trait ManageFileModule {
     import ManageFile._
 
-    def move(scenario: MoveScenario, semantics: MoveSemantics): Backend[Unit]
+    def move(pair: PathPair, semantics: MoveSemantics): Backend[Unit]
+    def copy(pair: PathPair): Backend[Unit]
     def delete(path: APath): Backend[Unit]
     def tempFile(near: APath): Backend[AFile]
   }

--- a/connector/src/main/scala/quasar/fs/Empty.scala
+++ b/connector/src/main/scala/quasar/fs/Empty.scala
@@ -53,6 +53,7 @@ object Empty {
 
   def manageFile[F[_]: Applicative] = λ[ManageFile ~> F] {
     case ManageFile.Move(scn, _) => fsPathNotFound(scn.src)
+    case ManageFile.Copy(pair)   => fsPathNotFound(pair.src)
     case ManageFile.Delete(p)    => fsPathNotFound(p)
     case ManageFile.TempFile(p)  => (refineType(p).swap.valueOr(fileParent) </> file("tmp")).right.point[F]
   }

--- a/connector/src/main/scala/quasar/fs/FileSystemError.scala
+++ b/connector/src/main/scala/quasar/fs/FileSystemError.scala
@@ -63,6 +63,8 @@ object FileSystemError {
     extends FileSystemError
   final case class WriteFailed private (data: Data, reason: String)
     extends FileSystemError
+  final case class UnsupportedOperation(reason: String)
+    extends FileSystemError
 
   val executionFailed = Prism.partial[FileSystemError, (Fix[LogicalPlan], String, JsonObject, Option[PhysicalError])] {
     case ExecutionFailed(lp, rsn, det, cs) => (lp, rsn, det, cs)
@@ -107,6 +109,10 @@ object FileSystemError {
     case WriteFailed(d, r) => (d, r)
   } (WriteFailed.tupled)
 
+  val unsupportedOperation = Prism.partial[FileSystemError, String] {
+    case UnsupportedOperation(reason) => reason
+  } (UnsupportedOperation)
+
   implicit val fileSystemErrorEqual: Equal[FileSystemError] = Equal.equalA
 
   implicit def fileSystemErrorShow: Show[FileSystemError] =
@@ -131,5 +137,7 @@ object FileSystemError {
         s"Failed to write $n data."
       case WriteFailed(d, r) =>
         s"Failed to write datum: reason='$r', datum=${d.shows}"
+      case UnsupportedOperation(reason) =>
+        s"Operation is unsupported because $reason"
     }
 }

--- a/connector/src/main/scala/quasar/fs/transformPaths.scala
+++ b/connector/src/main/scala/quasar/fs/transformPaths.scala
@@ -110,7 +110,7 @@ object transformPaths {
   )(implicit
     S: ManageFile :<: S
   ): S ~> Free[S, ?] = {
-    import ManageFile._, MoveScenario._
+    import ManageFile._, PathPair._
 
     val M = ManageFile.Ops[S]
     val g = λ[ManageFile ~> Free[S, ?]] {
@@ -121,6 +121,12 @@ object transformPaths {
             (src, dst) => fileToFile(inPath(src), inPath(dst))),
           sem
         ).leftMap(transformErrorPath(outPath)).run
+
+      case Copy(pair) =>
+        M.copy(
+          pair.fold(
+            (src, dst) => dirToDir(inPath(src), inPath(dst)),
+            (src, dst) => fileToFile(inPath(src), inPath(dst)))).leftMap(transformErrorPath(outPath)).run
 
       case Delete(p) =>
         M.delete(inPath(p))

--- a/core/src/test/scala/quasar/fs/TraceFS.scala
+++ b/core/src/test/scala/quasar/fs/TraceFS.scala
@@ -94,6 +94,7 @@ object TraceFS {
       WriterT.writer((Vector(mf.render),
         mf match {
           case Move(scenario, semantics) => \/-(())
+          case Copy(pair)                => \/-(())
           case Delete(path)              => \/-(())
           case TempFile(near) =>
             \/-(refineType(near).fold(ι, fileParent) </> file("tmp"))

--- a/core/src/test/scala/quasar/fs/mount/ViewFileSystemSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/ViewFileSystemSpec.scala
@@ -309,7 +309,7 @@ class ViewFileSystemSpec extends quasar.Qspec with TreeMatchers {
   }
 
   "ManageFile.move" should {
-    import ManageFile._, MoveScenario._, MoveSemantics._
+    import ManageFile._, PathPair._, MoveSemantics._
 
     val srcPath = rootDir </> dir("view") </> file("simpleZips")
     val dstPath = rootDir </> dir("foo") </> file("bar")

--- a/couchbase/src/main/scala/quasar/physical/couchbase/fs/managefile.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/fs/managefile.scala
@@ -28,7 +28,7 @@ import pathy.Path._
 import scalaz._, Scalaz._
 
 abstract class managefile {
-  def move(scenario: MoveScenario, semantics: MoveSemantics): Backend[Unit] =
+  def move(scenario: PathPair, semantics: MoveSemantics): Backend[Unit] =
     for {
       ctx       <- MR.asks(_.ctx)
       src       =  docTypeValueFromPath(scenario.src)
@@ -51,6 +51,9 @@ abstract class managefile {
                        where `${ctx.docTypeKey.v}` like "${src.v}%""""
       _         <- ME.unattempt(lift(query(ctx.bucket, qStr)).into[Eff].liftB)
     } yield ()
+
+  def copy(pair: PathPair): Backend[Unit] =
+    ME.raiseError(FileSystemError.unsupportedOperation("Couchbase does not currently support copying"))
 
   def delete(path: APath): Backend[Unit] =
     for {

--- a/marklogic/src/main/scala/quasar/physical/marklogic/MarkLogic.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/MarkLogic.scala
@@ -287,11 +287,14 @@ sealed class MarkLogic protected (readChunkSize: Positive, writeChunkSize: Posit
   object ManageFileModule extends ManageFileModule {
     import ManageFile._
 
-    def move(scenario: MoveScenario, semantics: MoveSemantics): Backend[Unit] =
+    def move(scenario: PathPair, semantics: MoveSemantics): Backend[Unit] =
       scenario match {
-        case MoveScenario.FileToFile(src, dst) => moveFile(src, dst, semantics)
-        case MoveScenario.DirToDir(src, dst)   => moveDir(src, dst, semantics)
+        case PathPair.FileToFile(src, dst) => moveFile(src, dst, semantics)
+        case PathPair.DirToDir(src, dst)   => moveDir(src, dst, semantics)
       }
+
+    def copy(pair: PathPair): Backend[Unit] =
+      unsupportedOperation("Marklogic connector does not currently support copy").raiseError[Backend, Unit]
 
     def delete(path: APath): Backend[Unit] =
       config[Backend] >>= { cfg =>

--- a/mimir/src/main/scala/quasar/mimir/Mimir.scala
+++ b/mimir/src/main/scala/quasar/mimir/Mimir.scala
@@ -991,7 +991,7 @@ object Mimir extends BackendModule with Logging with DefaultAnalyzeModule {
     import ManageFile._
 
     // TODO directory moving and varying semantics
-    def move(scenario: MoveScenario, semantics: MoveSemantics): Backend[Unit] = {
+    def move(scenario: PathPair, semantics: MoveSemantics): Backend[Unit] = {
       scenario.fold(
         d2d = { (from, to) =>
           for {
@@ -1044,6 +1044,9 @@ object Mimir extends BackendModule with Logging with DefaultAnalyzeModule {
           } yield ()
         })
     }
+
+    def copy(pair: PathPair): Backend[Unit] =
+      MonadError_[Backend, FileSystemError].raiseError(unsupportedOperation("Mimir currently does not support copy"))
 
     def delete(path: APath): Backend[Unit] = {
       for {

--- a/mongodb/src/main/scala/quasar/physical/mongodb/MongoDb.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/MongoDb.scala
@@ -261,12 +261,15 @@ object MongoDb
       *   2) Currently, parsing a directory like "/../foo/bar/" as an absolute
       *      dir succeeds, this should probably be changed to fail.
       */
-    def move(scenario: MoveScenario, semantics: MoveSemantics): Backend[Unit] = {
+    def move(scenario: PathPair, semantics: MoveSemantics): Backend[Unit] = {
       val mm: MongoManage[FileSystemError \/ Unit] =
         scenario.fold(moveDir(_, _, semantics), moveFile(_, _, semantics))
           .run.liftM[ManageInT]
       toBackend(mm)
     }
+
+    def copy(pair: PathPair): Backend[Unit] =
+      toBackend(FileSystemError.unsupportedOperation("MongoDb connector does not currently support copying").left[Unit].point[MongoDbIO])
 
     def delete(path: APath): Backend[Unit] = {
       val mm: MongoManage[FileSystemError \/ Unit] =

--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsManageFile.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsManageFile.scala
@@ -22,7 +22,7 @@ import quasar.contrib.scalaz._
 import quasar.contrib.scalaz.eitherT._
 import quasar.effect.MonotonicSeq
 import quasar.fp.free.lift
-import quasar.fs.ManageFile.MoveScenario.{DirToDir, FileToFile}
+import quasar.fs.ManageFile.PathPair.{DirToDir, FileToFile}
 import quasar.fs._
 import quasar.fs.FileSystemError._
 import quasar.fs.PathError._
@@ -77,7 +77,7 @@ trait RdbmsManageFile
         .flatMap(s => lift(createSchema(s).map(_ => s)).into[Eff])
     }
 
-    override def move(scenario: ManageFile.MoveScenario,
+    override def move(scenario: ManageFile.PathPair,
                       semantics: MoveSemantics): Backend[Unit] = {
 
       def moveFile(src: AFile, dst: AFile): M[Unit] = {
@@ -136,6 +136,9 @@ trait RdbmsManageFile
           } yield ()
       }
     }
+
+    def copy(pair: ManageFile.PathPair): Backend[Unit] =
+      ME.raiseError(unsupportedOperation("Rdbms connector does not currently support copying"))
 
     def deleteFile(aFile: AFile): Backend[Unit] = {
       val dbTablePath = TablePath.create(aFile)

--- a/skeleton/src/main/scala/quasar/physical/skeleton/fs/Skeleton.scala
+++ b/skeleton/src/main/scala/quasar/physical/skeleton/fs/Skeleton.scala
@@ -104,7 +104,8 @@ object Skeleton extends BackendModule with DefaultAnalyzeModule {
   object ManageFileModule extends ManageFileModule {
     import ManageFile._
 
-    def move(scenario: MoveScenario, semantics: MoveSemantics): Backend[Unit] = ???
+    def move(scenario: PathPair, semantics: MoveSemantics): Backend[Unit] = ???
+    def copy(pair: PathPair): Backend[Unit] = ???
     def delete(path: APath): Backend[Unit] = ???
     def tempFile(near: APath): Backend[AFile] = ???
   }

--- a/web/src/main/scala/quasar/api/ToApiError.scala
+++ b/web/src/main/scala/quasar/api/ToApiError.scala
@@ -97,7 +97,9 @@ sealed abstract class ToApiErrorInstances extends ToApiErrorInstances0 {
       case QScriptPlanningFailed(e) =>
         e.toApiError
       case UnsupportedOperation(reason) =>
-        apiError(BadRequest, "reason" := reason)
+        fromMsg(
+          BadRequest withReason "Unsupported Operation",
+          reason)
       case UnknownReadHandle(ReadHandle(path, id)) =>
         apiError(
           InternalServerError withReason "Unknown read handle.",

--- a/web/src/main/scala/quasar/api/ToApiError.scala
+++ b/web/src/main/scala/quasar/api/ToApiError.scala
@@ -96,6 +96,8 @@ sealed abstract class ToApiErrorInstances extends ToApiErrorInstances0 {
         e.toApiError :+ ("logicalplan" := lp.render)
       case QScriptPlanningFailed(e) =>
         e.toApiError
+      case UnsupportedOperation(reason) =>
+        apiError(BadRequest, "reason" := reason)
       case UnknownReadHandle(ReadHandle(path, id)) =>
         apiError(
           InternalServerError withReason "Unknown read handle.",

--- a/web/src/main/scala/quasar/api/services/data.scala
+++ b/web/src/main/scala/quasar/api/services/data.scala
@@ -46,7 +46,7 @@ import scalaz.stream.Process
 import scodec.bits.ByteVector
 
 object data {
-  import ManageFile.MoveScenario
+  import ManageFile.PathPair
 
   def service[S[_]](
     implicit
@@ -83,8 +83,20 @@ object data {
         dstStr <- EitherT.fromDisjunction[M.FreeS](
                     requiredHeader(Destination, req) map (_.value))
         dst    <- EitherT.fromDisjunction[M.FreeS](parseDestination(dstStr))
-        scn    <- EitherT.fromDisjunction[M.FreeS](moveScenario(path, dst))
-        _      <- M.move(scn, MoveSemantics.FailIfExists).leftMap(_.toApiError)
+        pair   <- EitherT.fromDisjunction[M.FreeS](pathPair(path, dst, "move"))
+        _      <- EitherT.fromDisjunction[M.FreeS](if (pair.src === pair.dst) sameDst(pair.src).left else ().right)
+        _      <- M.move(pair, MoveSemantics.FailIfExists)
+                    .leftMap(_.toApiError)
+      } yield Created).run)
+
+    case req @ Method.COPY -> AsPath(path) =>
+      respond((for {
+        dstStr <- EitherT.fromDisjunction[M.FreeS](
+                    requiredHeader(Destination, req) map (_.value))
+        dst    <- EitherT.fromDisjunction[M.FreeS](parseDestination(dstStr))
+        pair   <- EitherT.fromDisjunction[M.FreeS](pathPair(path, dst, "copy"))
+        _      <- EitherT.fromDisjunction[M.FreeS](if (pair.src === pair.dst) sameDst(pair.src).left else ().right)
+        _      <- M.copy(pair).leftMap(_.toApiError)
       } yield Created).run)
 
     case DELETE -> AsPath(path) =>
@@ -92,6 +104,11 @@ object data {
   }
 
   ////
+
+  private def sameDst(path: APath) = ApiError.fromMsg(
+    BadRequest withReason "Destination is same path as source",
+    s"Destination is same path as source",
+    "path" := path)
 
   private def download[S[_]](
     format: MessageFormat,
@@ -154,25 +171,24 @@ object data {
     )(dstString)
   }
 
-  private def moveScenario(src: APath, dst: APath): ApiError \/ MoveScenario =
+  private def pathPair(src: APath, dst: APath, operation: String): ApiError \/ PathPair =
     refineType(src).fold(
       srcDir =>
         refineType(dst).swap.bimap(
           df => ApiError.fromMsg(
             BadRequest withReason "Illegal move.",
-            "Cannot move directory into a file",
+            s"Cannot $operation directory into a file",
             "srcPath" := srcDir,
             "dstPath" := df),
-          MoveScenario.dirToDir(srcDir, _)),
+          PathPair.dirToDir(srcDir, _)),
       srcFile =>
         refineType(dst).bimap(
           dd => ApiError.fromMsg(
             BadRequest withReason "Illegal move.",
-            "Cannot move a file into a directory, must specify destination precisely",
+            s"Cannot $operation a file into a directory, must specify destination precisely",
             "srcPath" := srcFile,
             "dstPath" := dd),
-          // TODO: Why not move into directory if dst is a dir?
-          MoveScenario.fileToFile(srcFile, _)))
+          PathPair.fileToFile(srcFile, _)))
 
   // TODO: Streaming
   private def upload[S[_]](

--- a/web/src/test/scala/quasar/api/services/DataServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/DataServiceSpec.scala
@@ -756,13 +756,15 @@ class DataServiceSpec extends quasar.Qspec with FileSystemFixture with Http4s {
         response.as[ApiError].unsafePerformSync must beHeaderMissingError("Destination")
       }
       "be 404 for missing source file" >> prop { (file: AFile, destFile: AFile) =>
-        testMove(
-          from = file,
-          to = destFile,
-          state = emptyMem,
-          status = Status.NotFound,
-          body = (_: ApiError) must beApiErrorLike(pathNotFound(file)),
-          newState = Unchanged)
+        file ≠ destFile ==> {
+          testMove(
+            from = file,
+            to = destFile,
+            state = emptyMem,
+            status = Status.NotFound,
+            body = (_: ApiError) must beApiErrorLike(pathNotFound(file)),
+            newState = Unchanged)
+        }
       }
       "be 400 if attempting to move a dir into a file" >> prop {(fs: NonEmptyDir, file: AFile) =>
         testMove(
@@ -868,13 +870,15 @@ class DataServiceSpec extends quasar.Qspec with FileSystemFixture with Http4s {
         response.as[ApiError].unsafePerformSync must beHeaderMissingError("Destination")
       }
       "be 404 for missing source file" >> prop { (file: AFile, destFile: AFile) =>
-        testCopy(
-          from = file,
-          to = destFile,
-          state = emptyMem,
-          status = Status.NotFound,
-          body = (_: ApiError) must beApiErrorLike(pathNotFound(file)),
-          newState = Unchanged)
+        file ≠ destFile ==> {
+          testCopy(
+            from = file,
+            to = destFile,
+            state = emptyMem,
+            status = Status.NotFound,
+            body = (_: ApiError) must beApiErrorLike(pathNotFound(file)),
+            newState = Unchanged)
+        }
       }
       "be 400 if attempting to copy a dir into a file" >> prop {(fs: NonEmptyDir, file: AFile) =>
         testCopy(


### PR DESCRIPTION
Fixes #2393.

This PR itself does not actually add any useful user-facing functionality because none of the connectors support copying and nor does the views and modules interpreters just yet (There is an implementation for `InMemoryFS` thought so that the web layer can be tested! 😄 ). That said I wanted to open a PR now so that my work doesn't drift as I focus on other things as well as to allow the parallel work of any connector that wants to support copy (i.e. mimir as well as views and modules seem like the important candidates).

I do need to add a section to the README documenting the new HTTP verb before this gets merged though (mostly a reminder for myself) and I am sure there will be a few revisions on the implementation after you guys review it.