### PR TITLE
Eliminate MongoDB value wrapping

### DIFF
--- a/connector/src/main/scala/quasar/fs/QueryFile.scala
+++ b/connector/src/main/scala/quasar/fs/QueryFile.scala
@@ -95,7 +95,7 @@ object QueryFile {
     val rewrite = new Rewrite[T]
 
     val normUntilFixpoint: T[QS] => Option[T[QS]] = tqs => {
-      val next = tqs.transAna[T[QS]](rewrite.normalize)
+      val next = tqs.transAna[T[QS]](rewrite.normalizeTJ)
       (next =/= tqs) option next
     }
 
@@ -137,7 +137,7 @@ object QueryFile {
     val rewrite = new Rewrite[T]
 
     val qs =
-      convertAndNormalize[T, QScriptInternal[T, ?]](lp)(rewrite.normalize)
+      convertAndNormalize[T, QScriptInternal[T, ?]](lp)(rewrite.normalizeTJ)
         .leftMap(FileSystemError.planningFailed(lp.convertTo[Fix[LogicalPlan]], _)) ∘
         simplifyAndNormalize[T, QScriptInternal[T, ?], QS]
 
@@ -179,7 +179,7 @@ object QueryFile {
             Injectable.coproduct(Injectable.inject[Const[Read[ADir], ?], QScriptTotal[T, ?]],
               Injectable.inject[Const[Read[AFile], ?], QScriptTotal[T, ?]]))))
 
-    convertAndNormalize[T, QScriptInternal[T, ?]](lp)(rewrite.normalize)
+    convertAndNormalize[T, QScriptInternal[T, ?]](lp)(rewrite.normalizeTJ)
       .fold(
         perr => merr.raiseError(FileSystemError.planningFailed(lp.convertTo[Fix[LogicalPlan]], perr)),
         _.point[M])

--- a/connector/src/main/scala/quasar/qscript/Normalizable.scala
+++ b/connector/src/main/scala/quasar/qscript/Normalizable.scala
@@ -74,8 +74,9 @@ class NormalizableT[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends T
   import Normalizable._
   lazy val rewrite = new Rewrite[T]
 
+  // FIXME: Should this be a version that also normalizes EquiJoin
   def freeTC(free: FreeQS): FreeQS =
-    free.transCata[FreeQS](liftCo(rewrite.normalizeCoEnv[QScriptTotal]))
+    free.transCata[FreeQS](liftCo(rewrite.normalizeTJCoEnv[QScriptTotal]))
 
   def freeTCEq(free: FreeQS): Option[FreeQS] = {
     val freeNormalized = freeTC(free)

--- a/connector/src/main/scala/quasar/qscript/Rewrite.scala
+++ b/connector/src/main/scala/quasar/qscript/Rewrite.scala
@@ -124,13 +124,10 @@ class Rewrite[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TTypes[
   //       • coalesceMaps ⇒ no `Map(Map(???, ???), ???)`
   //       • coalesceMapJoin ⇒ no `Map(ThetaJoin(???, …), ???)`
 
-  def elideNopQC[F[_]: Functor, G[_]: Functor]
-    (FtoG: F ~> G)
-    (implicit QC: QScriptCore :<: F)
-      : QScriptCore[T[G]] => G[T[G]] = {
-    case Filter(Embed(src), BoolLit(true)) => src
-    case Map(Embed(src), mf) if mf ≟ HoleF => src
-    case x                                 => FtoG(QC.inj(x))
+  def elideNopQC[F[_]: Functor]: QScriptCore[T[F]] => Option[F[T[F]]] = {
+    case Filter(Embed(src), BoolLit(true)) => some(src)
+    case Map(Embed(src), mf) if mf ≟ HoleF => some(src)
+    case _                                 => none
   }
 
   type Remap[A] = JoinFunc => Option[FreeMapA[A]]
@@ -401,17 +398,16 @@ class Rewrite[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TTypes[
     case _                                 => None
   }
 
-  def compactLeftShift[F[_]: Functor, G[_]: Functor]
-    (FToG: PrismNT[G, F])
-    (implicit QC: QScriptCore :<: F)
-      : QScriptCore[T[G]] => Option[F[T[G]]] = {
+  def compactLeftShift[F[_]: Functor]
+      (QCToG: PrismNT[F, QScriptCore])
+      : QScriptCore[T[F]] => Option[F[T[F]]] = {
     case qs @ LeftShift(Embed(src), struct, ExcludeId, joinFunc) =>
-      (FToG.get(src) >>= QC.prj, struct.resume) match {
+      (QCToG.get(src), struct.resume) match {
         // LeftShift(Map(_, MakeArray(_)), Hole, ExcludeId, _)
         case (Some(Map(innerSrc, fm)), \/-(SrcHole)) =>
           fm.resume match {
             case -\/(MFC(MakeArray(value))) =>
-              QC.inj(Map(innerSrc, joinFunc >>= {
+              QCToG(Map(innerSrc, joinFunc >>= {
                 case LeftSide => fm
                 case RightSide => value
               })).some
@@ -419,7 +415,7 @@ class Rewrite[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TTypes[
           }
         // LeftShift(_, MakeArray(_), ExcludeId, _)
         case (_, -\/(MFC(MakeArray(value)))) =>
-          QC.inj(Map(src.embed, joinFunc >>= {
+          QCToG(Map(src.embed, joinFunc >>= {
             case LeftSide => HoleF
             case RightSide => value
           })).some
@@ -496,24 +492,40 @@ class Rewrite[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TTypes[
   // - normalize mapfunc
   private def applyNormalizations[F[_]: Traverse: Normalizable, G[_]: Traverse](
     prism: PrismNT[G, F],
-    rebase: FreeQS => T[G] => Option[T[G]])(
+    rebase: FreeQS => T[G] => Option[T[G]],
+    normalizeJoins: F[T[G]] => Option[G[T[G]]])(
     implicit C: Coalesce.Aux[T, F, F],
              QC: QScriptCore :<: F,
-             TJ: ThetaJoin :<: F,
              FI: Injectable.Aux[F, QScriptTotal]):
-      F[T[G]] => G[T[G]] =
-    (repeatedly(Normalizable[F].normalizeF(_: F[T[G]])) _) ⋙
-      liftFG(injectRepeatedly(elideNopJoin[F, T[G]](rebase))) ⋙
-      liftFF(repeatedly(compactQC(_: QScriptCore[T[G]]))) ⋙
-      liftFG(injectRepeatedly(compactLeftShift[F, G](prism).apply(_: QScriptCore[T[G]]))) ⋙
-      liftFF(repeatedly(applyTransforms(
-        uniqueBuckets(_: QScriptCore[T[G]]),
-        compactReductions(_: QScriptCore[T[G]])))) ⋙
-      repeatedly(C.coalesceQCNormalize[G](prism)) ⋙
-      liftFG(injectRepeatedly(C.coalesceTJNormalize[G](prism.get))) ⋙
-      (fa => QC.prj(fa).fold(prism.reverseGet(fa))(elideNopQC[F, G](prism.reverseGet)))
+      F[T[G]] => G[T[G]] = {
+
+    val qcPrism = PrismNT.inject[QScriptCore, F] compose prism
+
+    ftf => repeatedly(applyTransforms(
+      liftFFTrans(prism)(Normalizable[F].normalizeF(_: F[T[G]])),
+      liftFFTrans(qcPrism)(compactQC(_: QScriptCore[T[G]])),
+      liftFGTrans(qcPrism)(compactLeftShift[G](qcPrism)),
+      liftFFTrans(qcPrism)(uniqueBuckets(_: QScriptCore[T[G]])),
+      liftFFTrans(qcPrism)(compactReductions(_: QScriptCore[T[G]])),
+      liftFFTrans(prism)(C.coalesceQC[G](prism)),
+      liftFGTrans(prism)(normalizeJoins),
+      liftFGTrans(qcPrism)(elideNopQC[G])
+    ))(prism(ftf))
+  }
 
   private def normalizeWithBijection[F[_]: Traverse: Normalizable, G[_]: Traverse, A](
+    bij: Bijection[A, T[G]])(
+    prism: PrismNT[G, F],
+    rebase: FreeQS => T[G] => Option[T[G]],
+    normalizeJoins: F[T[G]] => Option[G[T[G]]])(
+    implicit C:  Coalesce.Aux[T, F, F],
+             QC: QScriptCore :<: F,
+             FI: Injectable.Aux[F, QScriptTotal]):
+      F[A] => G[A] =
+    fa => applyNormalizations[F, G](prism, rebase, normalizeJoins)
+      .apply(fa ∘ bij.toK.run) ∘ bij.fromK.run
+
+  private def normalizeTJBijection[F[_]: Traverse: Normalizable, G[_]: Traverse, A](
     bij: Bijection[A, T[G]])(
     prism: PrismNT[G, F],
     rebase: FreeQS => T[G] => Option[T[G]])(
@@ -521,9 +533,14 @@ class Rewrite[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TTypes[
              QC: QScriptCore :<: F,
              TJ: ThetaJoin :<: F,
              FI: Injectable.Aux[F, QScriptTotal]):
-      F[A] => G[A] =
-    fa => applyNormalizations[F, G](prism, rebase)
-      .apply(fa ∘ bij.toK.run) ∘ bij.fromK.run
+      F[A] => G[A] = {
+
+    val normTJ = applyTransforms(
+      liftFFTrans(prism)(C.coalesceTJ[G](prism.get)),
+      liftFFTrans(prism)((fa: F[T[G]]) => TJ.prj(fa).flatMap(elideNopJoin[F, T[G]](rebase))))
+
+    normalizeWithBijection[F, G, A](bij)(prism, rebase, normTJ compose (prism apply _))
+  }
 
   def normalize[F[_]: Traverse: Normalizable](
     implicit C:  Coalesce.Aux[T, F, F],
@@ -531,7 +548,7 @@ class Rewrite[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TTypes[
              TJ: ThetaJoin :<: F,
              FI: Injectable.Aux[F, QScriptTotal]):
       F[T[F]] => F[T[F]] =
-    normalizeWithBijection[F, F, T[F]](bijectionId)(idPrism, rebaseT)
+    normalizeTJBijection[F, F, T[F]](bijectionId)(idPrism, rebaseT)
 
   def normalizeCoEnv[F[_]: Traverse: Normalizable](
     implicit C:  Coalesce.Aux[T, F, F],
@@ -539,7 +556,7 @@ class Rewrite[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TTypes[
              TJ: ThetaJoin :<: F,
              FI: Injectable.Aux[F, QScriptTotal]):
       F[Free[F, Hole]] => CoEnv[Hole, F, Free[F, Hole]] =
-    normalizeWithBijection[F, CoEnv[Hole, F, ?], Free[F, Hole]](coenvBijection)(coenvPrism, rebaseTCo)
+    normalizeTJBijection[F, CoEnv[Hole, F, ?], Free[F, Hole]](coenvBijection)(coenvPrism, rebaseTCo)
 
   /** A backend-or-mount-specific `f` is provided, that allows us to rewrite
     * [[Root]] (and projections, etc.) into [[Read]], so then we can handle

--- a/connector/src/main/scala/quasar/qscript/Rewrite.scala
+++ b/connector/src/main/scala/quasar/qscript/Rewrite.scala
@@ -80,7 +80,7 @@ class Rewrite[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TTypes[
               N: Normalizable[G])
       : T[F] => T[G] = {
     _.codyna(
-      normalize[G] >>>
+      normalizeTJ[G] >>>
       liftFG(injectRepeatedly(C.coalesceSRNormalize[G, ADir](idPrism))) >>>
       liftFG(injectRepeatedly(C.coalesceSRNormalize[G, AFile](idPrism))) >>>
       (_.embed),
@@ -98,7 +98,7 @@ class Rewrite[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TTypes[
     N: Normalizable[G]
   ): T[F] => T[G] =
     _.codyna(
-      normalize[G] >>>
+      normalizeTJ[G] >>>
       liftFG(injectRepeatedly(C.coalesceSRNormalize[G, ADir](idPrism))) >>>
       (_.embed),
       ((_: T[F]).project) >>> (S.shiftReadDir(idPrism.reverseGet)(_)))
@@ -542,7 +542,7 @@ class Rewrite[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TTypes[
     normalizeWithBijection[F, G, A](bij)(prism, rebase, normTJ compose (prism apply _))
   }
 
-  def normalize[F[_]: Traverse: Normalizable](
+  def normalizeTJ[F[_]: Traverse: Normalizable](
     implicit C:  Coalesce.Aux[T, F, F],
              QC: QScriptCore :<: F,
              TJ: ThetaJoin :<: F,
@@ -550,7 +550,7 @@ class Rewrite[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TTypes[
       F[T[F]] => F[T[F]] =
     normalizeTJBijection[F, F, T[F]](bijectionId)(idPrism, rebaseT)
 
-  def normalizeCoEnv[F[_]: Traverse: Normalizable](
+  def normalizeTJCoEnv[F[_]: Traverse: Normalizable](
     implicit C:  Coalesce.Aux[T, F, F],
              QC: QScriptCore :<: F,
              TJ: ThetaJoin :<: F,

--- a/connector/src/main/scala/quasar/qscript/Rewrite.scala
+++ b/connector/src/main/scala/quasar/qscript/Rewrite.scala
@@ -399,15 +399,15 @@ class Rewrite[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TTypes[
   }
 
   def compactLeftShift[F[_]: Functor]
-      (QCToG: PrismNT[F, QScriptCore])
+      (QCToF: PrismNT[F, QScriptCore])
       : QScriptCore[T[F]] => Option[F[T[F]]] = {
     case qs @ LeftShift(Embed(src), struct, ExcludeId, joinFunc) =>
-      (QCToG.get(src), struct.resume) match {
+      (QCToF.get(src), struct.resume) match {
         // LeftShift(Map(_, MakeArray(_)), Hole, ExcludeId, _)
         case (Some(Map(innerSrc, fm)), \/-(SrcHole)) =>
           fm.resume match {
             case -\/(MFC(MakeArray(value))) =>
-              QCToG(Map(innerSrc, joinFunc >>= {
+              QCToF(Map(innerSrc, joinFunc >>= {
                 case LeftSide => fm
                 case RightSide => value
               })).some
@@ -415,7 +415,7 @@ class Rewrite[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TTypes[
           }
         // LeftShift(_, MakeArray(_), ExcludeId, _)
         case (_, -\/(MFC(MakeArray(value)))) =>
-          QCToG(Map(src.embed, joinFunc >>= {
+          QCToF(Map(src.embed, joinFunc >>= {
             case LeftSide => HoleF
             case RightSide => value
           })).some

--- a/connector/src/main/scala/quasar/qscript/Transform.scala
+++ b/connector/src/main/scala/quasar/qscript/Transform.scala
@@ -622,7 +622,7 @@ class Transform
 
       val reifiedCondition: F[T[F]] =
         QC.inj(reifyResult(func.ann, func.value)).embed
-          .transCata[T[F]](rewrite.normalize).project
+          .transCata[T[F]](rewrite.normalizeTJ).project
 
       reifiedCondition match {
         case QC(Map(_, mf)) if mf.count ≟ 0 =>

--- a/connector/src/main/scala/quasar/qscript/package.scala
+++ b/connector/src/main/scala/quasar/qscript/package.scala
@@ -226,6 +226,7 @@ package object qscript {
 
   def rebase[M[_]: Bind, A](in: M[A], field: M[A]): M[A] = in >> field
 
+  // FIXME: Should this also normalize EquiJoins?
   def rebaseBranch[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT](
     br: FreeQS[T],
     fm: FreeMap[T]
@@ -234,7 +235,7 @@ package object qscript {
 
     (br >> Free.roll(Inject[QScriptCore[T, ?], QScriptTotal[T, ?]].inj(
       Map(Free.point[QScriptTotal[T, ?], Hole](SrcHole), fm))))
-      .transCata[FreeQS[T]](liftCo(rewrite.normalizeCoEnv[QScriptTotal[T, ?]]))
+      .transCata[FreeQS[T]](liftCo(rewrite.normalizeTJCoEnv[QScriptTotal[T, ?]]))
   }
 
   def rebaseT[T[_[_]]: BirecursiveT, F[_]: Traverse](

--- a/connector/src/test/scala/quasar/qscript/Rewrite.scala
+++ b/connector/src/test/scala/quasar/qscript/Rewrite.scala
@@ -48,8 +48,8 @@ class QScriptRewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptH
     expr.transCata[Fix[QST]](SimplifyJoin[Fix, QS, QST].simplifyJoin(idPrism.reverseGet))
 
   def compactLeftShiftExpr(expr: Fix[QS]): Fix[QS] =
-    expr.transCata[Fix[QS]](
-      liftFG(injectRepeatedly(rewrite.compactLeftShift[QS, QS](idPrism).apply(_: QScriptCore[Fix[QS]]))))
+    expr.transCata[Fix[QS]](liftFG(injectRepeatedly(
+      rewrite.compactLeftShift[QS](PrismNT.inject).apply(_: QScriptCore[Fix[QS]]))))
 
   def includeToExcludeExpr(expr: Fix[QST]): Fix[QST] =
     expr.transCata[Fix[QST]](
@@ -72,9 +72,8 @@ class QScriptRewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptH
   "rewriter" should {
     "elide a no-op map in a constant boolean" in {
       val query = lpf.constant(Data.Bool(true))
-      val run: QSI[Fix[QSI]] => QSI[Fix[QSI]] = {
-        fa => QCI.prj(fa).fold(fa)(rewrite.elideNopQC(idPrism[QSI].reverseGet))
-      }
+      val run: QSI[Fix[QSI]] => QSI[Fix[QSI]] =
+        repeatedly((fa: QSI[Fix[QSI]]) => QCI.prj(fa) >>= rewrite.elideNopQC[QSI])
 
       QueryFile.convertAndNormalize[Fix, QSI](query)(run).toOption must
         equal(chain(

--- a/connector/src/test/scala/quasar/qscript/Rewrite.scala
+++ b/connector/src/test/scala/quasar/qscript/Rewrite.scala
@@ -42,7 +42,7 @@ class QScriptRewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptH
     expr.transCata[Fix[QS]](orOriginal(Normalizable[QS].normalizeF(_: QS[Fix[QS]])))
 
   def normalizeExpr(expr: Fix[QS]): Fix[QS] =
-    expr.transCata[Fix[QS]](rewrite.normalize[QS])
+    expr.transCata[Fix[QS]](rewrite.normalizeTJ[QS])
 
   def simplifyJoinExpr(expr: Fix[QS]): Fix[QST] =
     expr.transCata[Fix[QST]](SimplifyJoin[Fix, QS, QST].simplifyJoin(idPrism.reverseGet))
@@ -148,7 +148,7 @@ class QScriptRewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptH
                 ProjectFieldR(HoleF, StrLit("l")),
                 StrLit("lon")))))
 
-      Coalesce[Fix, QST, QST].coalesceTJ(idPrism[QST].get).apply(exp).map(rewrite.normalize[QST]) must
+      Coalesce[Fix, QST, QST].coalesceTJ(idPrism[QST].get).apply(exp).map(rewrite.normalizeTJ[QST]) must
       equal(
         TJT.inj(ThetaJoin(
           QCT.inj(Unreferenced[Fix, Fix[QST]]()).embed,

--- a/connector/src/test/scala/quasar/qscript/ShiftReadSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/ShiftReadSpec.scala
@@ -44,7 +44,7 @@ class ShiftReadSpec extends quasar.Qspec with QScriptHelpers with TreeMatchers {
 
       val newQScript =
         qScript.codyna(
-          rewrite.normalize[QST] >>> (_.embed),
+          rewrite.normalizeTJ[QST] >>> (_.embed),
           ((_: Fix[QS]).project) >>> (ShiftRead[Fix, QS, QST].shiftRead(idPrism.reverseGet)(_)))
 
       newQScript must
@@ -60,7 +60,7 @@ class ShiftReadSpec extends quasar.Qspec with QScriptHelpers with TreeMatchers {
           lpf.constant(Data.Str("0")),
           agg.Count(lpRead("/foo/bar")).embed).embed).map(
         _.codyna(
-          rewrite.normalize[QST] >>> (_.embed),
+          rewrite.normalizeTJ[QST] >>> (_.embed),
           ((_: Fix[QS]).project) >>> (ShiftRead[Fix, QS, QST].shiftRead(idPrism.reverseGet)(_)))) must
       beTreeEqual(chain(
         SRTF.inj(Const[ShiftedRead[AFile], Fix[QST]](

--- a/foundation/src/main/scala/quasar/fp/package.scala
+++ b/foundation/src/main/scala/quasar/fp/package.scala
@@ -175,10 +175,18 @@ package object fp
       G[A] => M[G[A]] =
     ftf => F.prj(ftf).fold(ftf.point[M])(orig)
 
+  def liftFGTrans[F[_], G[_], A](prism: PrismNT[G, F])(f: F[A] => Option[G[A]])
+      : G[A] => Option[G[A]] =
+    ga => prism.get(ga).flatMap(f)
+
 
   def liftFF[F[_], G[_], A](orig: F[A] => F[A])(implicit F: F :<: G):
       G[A] => G[A] =
     ftf => F.prj(ftf).fold(ftf)(orig.andThen(F.inj))
+
+  def liftFFTrans[F[_], G[_], A](prism: PrismNT[G, F])(f: F[A] => Option[F[A]])
+      : G[A] => Option[G[A]] =
+    ga => prism.get(ga).flatMap(f).map(prism.reverseGet(_))
 
   def liftR[T[_[_]]: BirecursiveT, F[_]: Traverse, G[_]: Traverse](orig: T[F] => T[F])(implicit F: F:<: G):
       T[G] => T[G] =

--- a/foundation/src/test/scala/quasar/QuasarSpecification.scala
+++ b/foundation/src/test/scala/quasar/QuasarSpecification.scala
@@ -36,6 +36,7 @@ trait QuasarSpecification extends AnyRef
         with org.specs2.matcher.ShouldExpectations
         with org.specs2.matcher.MatchResultCombinators
         with org.specs2.matcher.ValueChecks
+        with org.specs2.matcher.MatcherZipOperators
         with org.specs2.execute.PendingUntilFixed
         with org.specs2.ScalaCheck
         with org.specs2.scalaz.ScalazMatchers

--- a/it/src/main/resources/tests/citiesByLargestZip.test
+++ b/it/src/main/resources/tests/citiesByLargestZip.test
@@ -5,8 +5,6 @@
         "mimir":             "pending",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
-        "mongodb_3_2":       "pending",
-        "mongodb_3_4":       "pending",
         "mongodb_read_only": "pending"
     },
 

--- a/it/src/main/resources/tests/matchRegexPattern.test
+++ b/it/src/main/resources/tests/matchRegexPattern.test
@@ -1,5 +1,7 @@
 {
     "name": "match regex pattern",
+    "backends": {
+    },
     "data": "zips.data",
     "query": "select city from zips where city ~ \"OULD.{0,2} CIT\"",
     "predicate": "exactly",

--- a/it/src/main/resources/tests/typeOf.test
+++ b/it/src/main/resources/tests/typeOf.test
@@ -5,19 +5,24 @@
         "mimir":"pendingIgnoreFieldOrder",
         "spark_hdfs":     "pending",
         "spark_local":    "pending",
-	"spark_cassandra": "pending"
+        "spark_cassandra": "pending"
     },
     "data": "nested_foo.data",
-    "query": "select foo, type_of(foo) as type from nested_foo",
+    "query": "select foo ?? \"nope\" as foo, type_of(foo ?? 42) as type from nested_foo",
+    "NB": "The test suite doesn't handle empty objects well.",
     "predicate": "exactly",
     "ignoreResultOrder": true,
-    "FIXME": "There should be three `{ }`, but they are rewritten away",
-    "expected": [{ "foo": "zap",                            "type": "array" },
-                 { "foo": [15, [{ "baz": ["quux"] }]],      "type": "array" },
-                 { "foo": ["15z", [{ "baz": ["qx"] }]],     "type": "array" },
-                 { "foo": [18, ["meh", { "baz": ["qx"] }]], "type": "array" },
-                 { "foo": [16, [{ "baz": "mooooo" }]],      "type": "array" },
-                 { "foo": { "bar": 15, "baz": ["qx"] },     "type": "map"   },
-                 { "foo": { "bar": "a15", "baz": ["qx"] },  "type": "map"   },
-                 { "foo": [17, [{ "baz": ["qx"] }]],        "type": "array" }]
+    "expected": [
+      { "foo": "nope",                           "type": "number" },
+      { "foo": "nope",                           "type": "number" },
+      { "foo": "nope",                           "type": "number" },
+      { "foo": "zap",                            "type": "array"  },
+      { "foo": [15, [{ "baz": ["quux"] }]],      "type": "array"  },
+      { "foo": ["15z", [{ "baz": ["qx"] }]],     "type": "array"  },
+      { "foo": [18, ["meh", { "baz": ["qx"] }]], "type": "array"  },
+      { "foo": [16, [{ "baz": "mooooo" }]],      "type": "array"  },
+      { "foo": { "bar": 15, "baz": ["qx"] },     "type": "map"    },
+      { "foo": { "bar": "a15", "baz": ["qx"] },  "type": "map"    },
+      { "foo": [17, [{ "baz": ["qx"] }]],        "type": "array"  }
+    ]
 }

--- a/it/src/main/resources/tests/typeOf.test
+++ b/it/src/main/resources/tests/typeOf.test
@@ -1,10 +1,14 @@
 {
     "name": "use type_of function",
     "backends": {
-        "couchbase":      "pending",
-        "mimir":"pendingIgnoreFieldOrder",
-        "spark_hdfs":     "pending",
-        "spark_local":    "pending",
+        "couchbase":       "pending",
+        "mimir":           "pendingIgnoreFieldOrder",
+        "mongodb_2_6":     "pending",
+        "mongodb_3_0":     "pending",
+        "mongodb_3_2":     "pending",
+        "mongodb_3_4":     "pending",
+        "spark_hdfs":      "pending",
+        "spark_local":     "pending",
         "spark_cassandra": "pending"
     },
     "data": "nested_foo.data",
@@ -13,16 +17,16 @@
     "predicate": "exactly",
     "ignoreResultOrder": true,
     "expected": [
-      { "foo": "nope",                           "type": "number" },
-      { "foo": "nope",                           "type": "number" },
-      { "foo": "nope",                           "type": "number" },
-      { "foo": "zap",                            "type": "array"  },
-      { "foo": [15, [{ "baz": ["quux"] }]],      "type": "array"  },
-      { "foo": ["15z", [{ "baz": ["qx"] }]],     "type": "array"  },
-      { "foo": [18, ["meh", { "baz": ["qx"] }]], "type": "array"  },
-      { "foo": [16, [{ "baz": "mooooo" }]],      "type": "array"  },
-      { "foo": { "bar": 15, "baz": ["qx"] },     "type": "map"    },
-      { "foo": { "bar": "a15", "baz": ["qx"] },  "type": "map"    },
-      { "foo": [17, [{ "baz": ["qx"] }]],        "type": "array"  }
+      { "foo": "nope",                           "type": "integer" },
+      { "foo": "nope",                           "type": "integer" },
+      { "foo": "nope",                           "type": "integer" },
+      { "foo": "zap",                            "type": "array"   },
+      { "foo": [15, [{ "baz": ["quux"] }]],      "type": "array"   },
+      { "foo": ["15z", [{ "baz": ["qx"] }]],     "type": "array"   },
+      { "foo": [18, ["meh", { "baz": ["qx"] }]], "type": "array"   },
+      { "foo": [16, [{ "baz": "mooooo" }]],      "type": "array"   },
+      { "foo": { "bar": 15, "baz": ["qx"] },     "type": "map"     },
+      { "foo": { "bar": "a15", "baz": ["qx"] },  "type": "map"     },
+      { "foo": [17, [{ "baz": ["qx"] }]],        "type": "array"   }
     ]
 }

--- a/it/src/main/resources/tests/typeOf.test
+++ b/it/src/main/resources/tests/typeOf.test
@@ -1,15 +1,15 @@
 {
     "name": "use type_of function",
     "backends": {
-        "couchbase":       "pending",
-        "mimir":           "pendingIgnoreFieldOrder",
-        "mongodb_2_6":     "pending",
-        "mongodb_3_0":     "pending",
-        "mongodb_3_2":     "pending",
-        "mongodb_3_4":     "pending",
-        "spark_hdfs":      "pending",
-        "spark_local":     "pending",
-        "spark_cassandra": "pending"
+        "couchbase":         "pending",
+        "mimir":             "pendingIgnoreFieldOrder",
+        "mongodb_2_6":       "pending",
+        "mongodb_3_0":       "pending",
+        "mongodb_3_2":       "pending",
+        "mongodb_3_4":       "pending",
+        "mongodb_read_only": "pending",
+        "spark_hdfs":        "pending",
+        "spark_cassandra":   "pending"
     },
     "data": "nested_foo.data",
     "query": "select foo ?? \"nope\" as foo, type_of(foo ?? 42) as type from nested_foo",

--- a/it/src/main/resources/tests/undefinedJsInExpr.test
+++ b/it/src/main/resources/tests/undefinedJsInExpr.test
@@ -2,16 +2,10 @@
     "name": "propagate undefined and null in JS",
     "backends": {
         "couchbase":         "pending",
-        "mongodb_2_6":       "pending",
-        "mongodb_3_0":       "pending",
-        "mongodb_3_2":       "pending",
-        "mongodb_3_4":       "pending",
-        "mongodb_read_only": "pending"
+        "mimir":             "pending"
     },
     "data": "zips.data",
     "query": "select distinct length(meh) as meh_len, meh.mep, length(meh.mep) as mep_len from zips",
     "predicate": "exactly",
-    "ignoreResultOrder": true,
-    "FIXME": "There should be a `{ }`, but it is rewritten away",
-    "expected": []
+    "expected": [{}]
 }

--- a/it/src/test/scala/quasar/fs/ManageFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/ManageFilesSpec.scala
@@ -58,7 +58,7 @@ class ManageFilesSpec extends FileSystemTest[BackendEffect](allFsUT.map(_ filter
                   .map(_.right[Data])
 
         runLogT(run, p).map(_.toVector.separate)
-          .runEither must beRight((oneDoc, Vector(false)))
+          .runEither must beRight((oneDoc, Vector(false)).zip(completelySubsume(_), equal(_)))
       }
 
       "moving a file to an existing path using FailIfExists semantics should fail with PathExists" >> {
@@ -87,7 +87,7 @@ class ManageFilesSpec extends FileSystemTest[BackendEffect](allFsUT.map(_ filter
                   .map(_.right[Data])
 
         runLogT(run, p).map(_.toVector.separate)
-          .runEither must beRight((oneDoc, Vector(false)))
+          .runEither must beRight((oneDoc, Vector(false)).zip(completelySubsume(_), equal(_)))
       }
 
       "moving a file that doesn't exist to a file that does should fail with src NotFound" >> {
@@ -178,8 +178,8 @@ class ManageFilesSpec extends FileSystemTest[BackendEffect](allFsUT.map(_ filter
           write.saveThese(uf3, thirdDoc)   *>
           manage.moveDir(src, dst, MoveSemantics.FailIfExists)
 
-        (runT(run)(setupAndMove).runOption must beNone) and
-        (runLogT(run, read.scanAll(dst </> file("one"))).runEither must beRight(oneDoc)) and
+        (runT(run)(setupAndMove).runOption must beNone)                                                     and
+        (runLogT(run, read.scanAll(dst </> file("one"))).runEither must beRight(completelySubsume(oneDoc))) and
         (run(query.fileExists(src </> file("one"))).unsafePerformSync must beFalse)
       }
 
@@ -207,7 +207,7 @@ class ManageFilesSpec extends FileSystemTest[BackendEffect](allFsUT.map(_ filter
 
         (execT(run, p).runOption must beNone)                                       and
         (runLogT(run, read.scanAll(f1)).runEither must beRight(Vector.empty[Data])) and
-        (runLogT(run, read.scanAll(f2)).runEither must beRight(anotherDoc))
+        (runLogT(run, read.scanAll(f2)).runEither must beRight(completelySubsume(anotherDoc)))
       }
 
       "deleting a directory deletes all files therein" >> {
@@ -241,7 +241,7 @@ class ManageFilesSpec extends FileSystemTest[BackendEffect](allFsUT.map(_ filter
                   manage.delete(tf).liftM[Process].drain
                 }
 
-        runLogT(run, p).runEither must beRight(anotherDoc)
+        runLogT(run, p).runEither must beRight(completelySubsume(anotherDoc))
       }
 
       "write/read from temp dir near non existing" >> {
@@ -253,7 +253,7 @@ class ManageFilesSpec extends FileSystemTest[BackendEffect](allFsUT.map(_ filter
                   manage.delete(tf).liftM[Process].drain
                 }
 
-        runLogT(run, p).runEither must beRight(anotherDoc)
+        runLogT(run, p).runEither must beRight(completelySubsume(anotherDoc))
       }
 
       "temp file should be generated in hint directory" >> prop { rdir: RDir =>

--- a/it/src/test/scala/quasar/fs/QueryFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/QueryFilesSpec.scala
@@ -78,8 +78,8 @@ class QueryFilesSpec extends FileSystemTest[BackendEffect](FileSystemTest.allFsU
         val e = EitherT((query.execute(aToc, c) *> query.execute(bToc, c).void).run.value)
         val p = e.liftM[Process].drain ++ read.scanAll(c)
 
-        runLogT(fs.testInterpM, p).runEither must beRight(containTheSameElementsAs(Vector[Data](
-          Data.Obj("c" -> Data._int(2)))))
+        runLogT(fs.testInterpM, p).runEither must
+          beRight(completelySubsume(Vector[Data](Data.Obj("c" -> Data._int(2)))))
       } }
 
       "listing directory returns immediate child nodes" >> {

--- a/it/src/test/scala/quasar/fs/ReadFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/ReadFilesSpec.scala
@@ -64,8 +64,6 @@ class ReadFilesSpec extends FileSystemTest[BackendEffect](FileSystemTest.allFsUT
   def deleteForReading(run: Run): FsTask[Unit] =
     runT(run)(manage.delete(readsPrefix))
 
-  implicit val setDataEq = Equal.equalA[Set[Data]]
-
   fileSystemShould { (fs, _) =>
     implicit val run = fs.testInterpM
 
@@ -99,8 +97,7 @@ class ReadFilesSpec extends FileSystemTest[BackendEffect](FileSystemTest.allFsUT
 
       "scan with offset zero and no limit reads entire file" >> {
         val r = runLogT(run, read.scan(smallFile.file, 0L, None))
-
-        r.run_\/.map(_.toSet) must_= smallFile.data.toSet.right
+        r.runEither must beRight(completelySubsume(smallFile.data))
       }
 
       "scan with offset = |file| and no limit yields no data" >> {
@@ -125,7 +122,7 @@ class ReadFilesSpec extends FileSystemTest[BackendEffect](FileSystemTest.allFsUT
 
           val d = rFull.map(_.drop(k))
 
-          (rFull.map(_.toSet) must_= smallFile.data.toSet.right) and
+          (rFull.toEither must beRight(completelySubsume(smallFile.data))) and
           (r must_= d)
         }.set(minTestsOk = 10)
       }
@@ -139,7 +136,7 @@ class ReadFilesSpec extends FileSystemTest[BackendEffect](FileSystemTest.allFsUT
 
           val d = rFull.map(_.take(j.value))
 
-          (rFull.map(_.toSet) must_= smallFile.data.toSet.right) and
+          (rFull.toEither must beRight(completelySubsume(smallFile.data))) and
           (r must_= d)
         }.set(minTestsOk = 10)
       }
@@ -154,7 +151,7 @@ class ReadFilesSpec extends FileSystemTest[BackendEffect](FileSystemTest.allFsUT
 
           val d = rFull.map(_.drop(k).take(j.value))
 
-          (rFull.map(_.toSet) must_= smallFile.data.toSet.right) and
+          (rFull.toEither must beRight(completelySubsume(smallFile.data))) and
           (r must_= d)
         }.set(minTestsOk = 5)
       }
@@ -168,8 +165,8 @@ class ReadFilesSpec extends FileSystemTest[BackendEffect](FileSystemTest.allFsUT
 
           val d = rFull.map(_.take(j.value))
 
-          (j.value must beGreaterThan(smallFile.data.length))    and
-          (rFull.map(_.toSet) must_= smallFile.data.toSet.right) and
+          (j.value must beGreaterThan(smallFile.data.length))              and
+          (rFull.toEither must beRight(completelySubsume(smallFile.data))) and
           (r must_= d)
         }.set(minTestsOk = 10)
       }

--- a/it/src/test/scala/quasar/fs/WriteFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/WriteFilesSpec.scala
@@ -75,7 +75,7 @@ class WriteFilesSpec extends FileSystemTest[BackendEffect](
         val f = writesPrefix </> file("saveone")
         val p = write.append(f, oneDoc.toProcess).drain ++ read.scanAll(f)
 
-        runLogT(run, p).runEither must beRight(oneDoc)
+        runLogT(run, p).runEither must beRight(completelySubsume(oneDoc))
       }
 
       "append two files, one in subdir of the other's parent, should succeed" >> {

--- a/it/src/test/scala/quasar/regression/ExpectedResult.scala
+++ b/it/src/test/scala/quasar/regression/ExpectedResult.scala
@@ -17,7 +17,6 @@
 package quasar.regression
 
 import slamdata.Predef._
-import quasar.BackendName
 
 import argonaut._, Json._
 
@@ -27,4 +26,4 @@ case class ExpectedResult(
   ignoredFields:     List[JsonField],
   ignoreFieldOrder:  Boolean,
   ignoreResultOrder: Boolean,
-  backends:          Map[BackendName, TestDirective])
+  backends:          Directives)

--- a/it/src/test/scala/quasar/regression/Predicate.scala
+++ b/it/src/test/scala/quasar/regression/Predicate.scala
@@ -158,12 +158,7 @@ object Predicate {
 
     // Removes the element at `idx` from `as`.
     private def deleteAt[A](idx: Int, as: Vector[A]): Vector[A] =
-      if (idx < 0)
-        as
-      else {
-        val (l, r) = as splitAt (idx + 1)
-        l.dropRight(1) ++ r
-      }
+      as.patch(idx, Nil, 1)
   }
 
   /** Must START WITH the elements, in order. */

--- a/it/src/test/scala/quasar/regression/TestDirective.scala
+++ b/it/src/test/scala/quasar/regression/TestDirective.scala
@@ -19,6 +19,7 @@ package quasar.regression
 import slamdata.Predef._
 
 import argonaut._, Argonaut._
+import scalaz.Equal
 
 sealed abstract class TestDirective
 
@@ -46,4 +47,7 @@ object TestDirective {
       case "ignoreResultOrder" => ok(IgnoreResultOrder)
       case str => fail("\"" + str + "\" is not a valid backend directive.", c.history)
     })
+
+  implicit val equal: Equal[TestDirective] =
+    Equal.equalA
 }

--- a/it/src/test/scala/quasar/regression/package.scala
+++ b/it/src/test/scala/quasar/regression/package.scala
@@ -30,6 +30,8 @@ import scalaz.syntax.apply._
 package object regression {
   import quasar.fs.mount.hierarchical.MountedResultH
 
+  type Directives = Map[BackendName, NonEmptyList[TestDirective]]
+
   type BackendEffectIO[A] = Coproduct[Task, BackendEffect, A]
 
   type HfsIO0[A] = Coproduct[MountedResultH, Task, A]

--- a/mongoIt/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
+++ b/mongoIt/src/test/scala/quasar/physical/mongodb/ExprStdLibSpec.scala
@@ -95,7 +95,7 @@ class MongoDbExprStdLibSpec extends MongoDbStdLibSpec {
   ) =
     WorkflowBuilder.build[PlannerError \/ ?, WF](
       WorkflowBuilder.DocBuilder(WorkflowBuilder.Ops[WF].read(coll),
-        ListMap(BsonField.Name("value") -> \&/-(expr))))
+        ListMap(QuasarSigilName -> \&/-(expr))))
       .leftMap(qscriptPlanningFailed.reverseGet(_))
 
   def compile(queryModel: MongoQueryModel, coll: Collection, mf: FreeMap[Fix]
@@ -107,22 +107,22 @@ class MongoDbExprStdLibSpec extends MongoDbStdLibSpec {
       case MongoQueryModel.`3.4` =>
         (MongoDbPlanner.getExpr[Fix, PlanStdT, Expr3_4](
           FuncHandler.handle3_4(bsonVersion), StaticHandler.v3_2)(mf).run(runAt) >>= (build[Workflow3_2F](_, coll)))
-          .map(wf => (Crystallize[Workflow3_2F].crystallize(wf).inject[WorkflowF], BsonField.Name("value")))
+          .map(wf => (Crystallize[Workflow3_2F].crystallize(wf).inject[WorkflowF], QuasarSigilName))
 
       case MongoQueryModel.`3.2` =>
         (MongoDbPlanner.getExpr[Fix, PlanStdT, Expr3_2](
           FuncHandler.handle3_2(bsonVersion), StaticHandler.v3_2)(mf).run(runAt) >>= (build[Workflow3_2F](_, coll)))
-          .map(wf => (Crystallize[Workflow3_2F].crystallize(wf).inject[WorkflowF], BsonField.Name("value")))
+          .map(wf => (Crystallize[Workflow3_2F].crystallize(wf).inject[WorkflowF], QuasarSigilName))
 
       case MongoQueryModel.`3.0` =>
         (MongoDbPlanner.getExpr[Fix, PlanStdT, Expr3_0](
           FuncHandler.handle3_0(bsonVersion), StaticHandler.v2_6)(mf).run(runAt) >>= (build[Workflow2_6F](_, coll)))
-          .map(wf => (Crystallize[Workflow2_6F].crystallize(wf).inject[WorkflowF], BsonField.Name("value")))
+          .map(wf => (Crystallize[Workflow2_6F].crystallize(wf).inject[WorkflowF], QuasarSigilName))
 
       case _                     =>
         (MongoDbPlanner.getExpr[Fix, PlanStdT, Expr2_6](
           FuncHandler.handle2_6(bsonVersion), StaticHandler.v2_6)(mf).run(runAt) >>= (build[Workflow2_6F](_, coll)))
-          .map(wf => (Crystallize[Workflow2_6F].crystallize(wf).inject[WorkflowF], BsonField.Name("value")))
+          .map(wf => (Crystallize[Workflow2_6F].crystallize(wf).inject[WorkflowF], QuasarSigilName))
 
     }
   }

--- a/mongoIt/src/test/scala/quasar/physical/mongodb/MongoDbStdLibSpec.scala
+++ b/mongoIt/src/test/scala/quasar/physical/mongodb/MongoDbStdLibSpec.scala
@@ -98,17 +98,8 @@ abstract class MongoDbStdLibSpec extends StdLibSpec {
       prg((0 until args.length).toList.map(idx => lpf.free(Symbol("arg" + idx))))
         .cataM[Result \/ ?, Unit](shortCircuitLP(args)).swap.toOption
 
-    final case class SingleResultCheckedMatcher(check: ValueCheck[Data]) extends OptionLikeCheckedMatcher[List, Data, Data](
-      "a single result",
-      {
-        case Data.Obj(m) :: Nil =>
-          m.toList match {
-            case (_, v) :: Nil => v.some
-            case _             => None
-          }
-        case _ => None
-      },
-      check)
+    final case class SingleResultCheckedMatcher(check: ValueCheck[Data])
+        extends OptionLikeCheckedMatcher[List, Data, Data]("a single result", _.headOption, check)
 
     def beSingleResult(t: ValueCheck[Data]) = SingleResultCheckedMatcher(t)
 

--- a/mongoIt/src/test/scala/quasar/physical/mongodb/MongoDbStdLibSpec.scala
+++ b/mongoIt/src/test/scala/quasar/physical/mongodb/MongoDbStdLibSpec.scala
@@ -99,7 +99,13 @@ abstract class MongoDbStdLibSpec extends StdLibSpec {
         .cataM[Result \/ ?, Unit](shortCircuitLP(args)).swap.toOption
 
     final case class SingleResultCheckedMatcher(check: ValueCheck[Data])
-        extends OptionLikeCheckedMatcher[List, Data, Data]("a single result", _.headOption, check)
+        extends OptionLikeCheckedMatcher[List, Data, Data](
+          "a single result",
+          {
+            case v :: Nil => Some(v)
+            case _        => None
+          },
+          check)
 
     def beSingleResult(t: ValueCheck[Data]) = SingleResultCheckedMatcher(t)
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/MongoDb.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/MongoDb.scala
@@ -29,16 +29,19 @@ import quasar.fp.ski.κ
 import quasar.fs._
 import quasar.fs.mount._
 import quasar.physical.mongodb.fs.bsoncursor._
+import quasar.physical.mongodb.mongoiterable._
 import quasar.physical.mongodb.workflow._
 import quasar.qscript._
 import quasar.qscript.analysis._
 
 import java.time.Instant
+import scala.Predef.implicitly
+
 import matryoshka._
 import matryoshka.data._
+import org.bson.BsonValue
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
-import scala.Predef.implicitly
 
 object MongoDb
     extends BackendModule
@@ -196,7 +199,7 @@ object MongoDb
         iter <- MongoDbIO.find(coll)
         iter2 =  iter.skip(offset.value.toInt)
         iter3 = limit.map(l => iter2.limit(l.value.toInt)).getOrElse(iter2)
-        cur  <- MongoDbIO.async(iter3.batchCursor)
+        cur  <- MongoDbIO.async(iter3.widen[BsonValue].batchCursor)
       } yield cur
 
     def readCursor(f: AFile, offset: Natural, limit: Option[Positive])

--- a/mongodb/src/main/scala/quasar/physical/mongodb/MongoDbIO.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/MongoDbIO.scala
@@ -143,6 +143,10 @@ object MongoDbIO {
   def ensureCollection(c: Collection): MongoDbIO[Unit] =
     collectionExists(c).ifM(().point[MongoDbIO], createCollection(c))
 
+  /** Returns the first document in the collection. */
+  def first(coll: Collection): OptionT[MongoDbIO, BsonDocument] =
+    OptionT(find(coll) >>= (c => async(c.limit(1).first) map (Option(_))))
+
   /** Returns the name of the first database where an insert to the collection
     * having the given name succeeds.
     */

--- a/mongodb/src/main/scala/quasar/physical/mongodb/MongoDbIOWorkflowExecutor.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/MongoDbIOWorkflowExecutor.scala
@@ -103,7 +103,7 @@ private[mongodb] final class MongoDbIOWorkflowExecutor
   protected def mapReduceCursor(src: Collection, mr: MapReduce) = {
     // NB: MapReduce results look like { _id: <reduce key>, value: <reduced value> }
     def unwrap(doc: BsonDocument): BsonValue =
-      doc.get("value", doc)
+      doc.get(sigil.Value, doc)
 
     toCursor(MongoDbIO.mapReduceIterable(src, mr).map(Functor[MongoIterable].map(_)(unwrap)))
   }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/bsonvalue.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/bsonvalue.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package quasar.physical.mongodb.fs
+package quasar.physical.mongodb
 
 import quasar.fp.ski.ι
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/fs/bsoncursor.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/fs/bsoncursor.scala
@@ -16,21 +16,24 @@
 
 package quasar.physical.mongodb.fs
 
-import slamdata.Predef.{Boolean, Vector}
+import slamdata.Predef._
 import quasar.Data
 import quasar.fs.DataCursor
 import quasar.physical.mongodb._
-import quasar.physical.mongodb.workflow.WrapperSigilLabel
+import quasar.physical.mongodb.workflow.{ExprLabel, WrapperSigilLabel}
 
 import scala.Option
 import scala.collection.JavaConverters._
 
 import org.bson.BsonValue
+import scalaz.Kleisli
 import scalaz.concurrent.Task
 import scalaz.syntax.compose._
 import scalaz.syntax.monad._
+import scalaz.syntax.plus._
 import scalaz.syntax.std.option._
 import scalaz.std.function._
+import scalaz.std.option._
 import scalaz.std.vector._
 
 object bsoncursor {
@@ -51,11 +54,20 @@ object bsoncursor {
 
       ////
 
+      /** Returns the value of the named field or `None` if the input isn't
+        * a document or the field doesn't exist.
+        */
+      def fieldValue(name: String): BsonValue => Option[BsonValue] =
+        v => bsonvalue.document.getOption(v).flatMap(d => Option(d.get(name)))
+
+      val sigilValue: BsonValue => Option[BsonValue] =
+        fieldValue(WrapperSigilLabel)
+
+      val mapReduceSigilValue: BsonValue => Option[BsonValue] =
+        Kleisli(sigilValue) <==< fieldValue(ExprLabel)
+
       val elideSigil: BsonValue => BsonValue =
-        v => bsonvalue.document
-          .getOption(v)
-          .flatMap(d => Option(d.get(WrapperSigilLabel)))
-          .getOrElse(v)
+        v => (sigilValue(v) <+> mapReduceSigilValue(v)) | v
 
       val toData: BsonValue => Data =
         (BsonCodec.toData _) <<< Bson.fromRepr <<< elideSigil

--- a/mongodb/src/main/scala/quasar/physical/mongodb/fs/bsoncursor.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/fs/bsoncursor.scala
@@ -51,7 +51,7 @@ object bsoncursor {
       ////
 
       val toData: BsonValue => Data =
-        (BsonCodec.toData _) <<< Bson.fromRepr <<< sigil.elideQusarSigil
+        (BsonCodec.toData _) <<< Bson.fromRepr <<< sigil.elideQuasarSigil
 
       def isClosed(cursor: BsonCursor): MongoDbIO[Boolean] =
         MongoDbIO.liftTask(Task.delay(cursor.isClosed))

--- a/mongodb/src/main/scala/quasar/physical/mongodb/fs/bsonvalue.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/fs/bsonvalue.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.mongodb.fs
+
+import quasar.fp.ski.ι
+
+import monocle.Prism
+import org.bson.{BsonValue, BsonDocument}
+
+object bsonvalue {
+  val document: Prism[BsonValue, BsonDocument] =
+    Prism.partial[BsonValue, BsonDocument] {
+      case doc: BsonDocument => doc
+    } (ι)
+}

--- a/mongodb/src/main/scala/quasar/physical/mongodb/mongoiterable.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/mongoiterable.scala
@@ -16,11 +16,18 @@
 
 package quasar.physical.mongodb
 
+import scala.annotation.unchecked.uncheckedVariance
+
 import com.mongodb.async.client.MongoIterable
 import com.mongodb.{Function => MFunction}
-import scalaz._
+import scalaz._, Liskov.<~<
 
 object mongoiterable {
+  final implicit class MongoIterableOps[A](val self: MongoIterable[A]) extends scala.AnyVal {
+    def widen[B](implicit ev: A <~< B): MongoIterable[B] =
+      ev.subst[λ[`-X` => MongoIterable[X @uncheckedVariance] <~< MongoIterable[B]]](Liskov.refl)(self)
+  }
+
   implicit val mongoIterableFunctor: Functor[MongoIterable] =
     new Functor[MongoIterable] {
       def map[A, B](ma: MongoIterable[A])(f: A => B) = {

--- a/mongodb/src/main/scala/quasar/physical/mongodb/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/package.scala
@@ -23,11 +23,11 @@ import quasar.fs.PhysicalError
 import quasar.namegen._
 
 import com.mongodb.async.AsyncBatchCursor
-import org.bson.BsonDocument
+import org.bson.BsonValue
 import scalaz._
 
 package object mongodb {
-  type BsonCursor         = AsyncBatchCursor[BsonDocument]
+  type BsonCursor         = AsyncBatchCursor[BsonValue]
 
   type MongoErrT[F[_], A] = EitherT[F, PhysicalError, A]
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/JsFuncHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/JsFuncHandler.scala
@@ -359,7 +359,9 @@ object JsFuncHandler {
                       If(Call(select(ident("Array"), "isArray"), List(v)),
                         Literal(Js.Str("array")),
                         Literal(Js.Str("map")))),
-                    ident("typ")))
+                    If(BinOp(jscore.Eq, ident("typ"), Literal(Js.Str("string"))),
+                      Literal(Js.Str("array")),
+                      ident("typ"))))
 
               case Cond(i, t, e) => If(i, t, e)
             }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/elideQuasarSigil.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/elideQuasarSigil.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.mongodb.planner
+
+import slamdata.Predef.{Map => _, _}
+import quasar.contrib.pathy.AFile
+import quasar.fs.{FileSystemError, MonadFsErr}
+import quasar.physical.mongodb.{sigil, Collection}
+import quasar.qscript._
+
+import matryoshka._
+import matryoshka.implicits._
+import org.bson.BsonDocument
+import scalaz._, Scalaz._
+
+/** A QScript transformation that, given a function to retrieve a document
+  * from a collection, inserts projections around any `ShiftedRead`s of
+  * collections having documents wrapped in the Quasar sigil, eliding them
+  * from the query.
+  */
+object elideQuasarSigil {
+  import FileSystemError.pathErr
+  import MapFuncsCore._
+
+  def apply[T[_[_]]: CorecursiveT, F[_]: Functor, M[_]: Monad: MonadFsErr]
+      (anyDoc: Collection => OptionT[M, BsonDocument])
+      (implicit
+        SR: Const[ShiftedRead[AFile], ?] :<: F,
+        QC: QScriptCore[T, ?] :<: F)
+      : F[T[F]] => M[F[T[F]]] = {
+
+    case sr @ SR(Const(ShiftedRead(f, IdOnly))) =>
+      sr.point[M]
+
+    case sr @ SR(Const(ShiftedRead(f, idStatus))) =>
+      (collection[M](f).liftM[OptionT] >>= anyDoc).run
+        .map(_.flatMap(getValue[T]).fold(sr) { fm =>
+          QC(Map(sr.embed, elideSigil[T](idStatus, fm)))
+        })
+
+    case other => other.point[M]
+  }
+
+  ////
+
+  private def collection[M[_]: Monad: MonadFsErr](f: AFile): M[Collection] =
+    Collection.fromFile(f).fold(
+      e => MonadFsErr[M].raiseError(pathErr(e)),
+      _.point[M])
+
+  private def elideSigil[T[_[_]]: CorecursiveT](idStatus: IdStatus, prj: FreeMap[T]): FreeMap[T] =
+    idStatus match {
+      case IdOnly    => HoleF
+      case ExcludeId => prj
+      case IncludeId =>
+        MapFuncCore.StaticArray(List(
+          Free.roll(MFC(ProjectIndex(HoleF, IntLit(0)))),
+          prj >> Free.roll(MFC(ProjectIndex(HoleF, IntLit(1))))))
+    }
+
+  private def getValue[T[_[_]]: CorecursiveT](doc: BsonDocument): Option[FreeMap[T]] =
+    if (sigil.mapReduceQuasarSigilExists(doc))
+      Some(sigil.projectMapReduceQuasarValue[T])
+    else if (sigil.quasarSigilExists(doc))
+      Some(sigil.projectQuasarValue[T])
+    else
+      None
+}

--- a/mongodb/src/main/scala/quasar/physical/mongodb/sigil.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/sigil.scala
@@ -34,7 +34,7 @@ object sigil {
   /** Quasar-specific sigil, used to construct a singleton result object under
     * the following conditions:
     *
-    * 1. Emitting a document value in aggregation when `$replaceRoot` is not available.
+    * 1. Emitting a document value in aggregation when `$replaceRoot` is not applicable.
     *
     * 2. Emitting a value in aggregation when its type is unknown.
     *

--- a/mongodb/src/main/scala/quasar/physical/mongodb/sigil.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/sigil.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.mongodb
+
+import slamdata.Predef._
+import quasar.qscript._
+
+import matryoshka._
+import org.bson.BsonValue
+import scalaz.{Free, Kleisli}
+import scalaz.std.option._
+import scalaz.syntax.bind._
+import scalaz.syntax.plus._
+import scalaz.syntax.std.option._
+
+/** MongoDB Document keys posessing special meaning. */
+object sigil {
+  import MapFuncsCore._
+
+  /** Quasar-specific sigil, used to construct a singleton result object under
+    * the following conditions:
+    *
+    * 1. Emitting a document value in aggregation when `$replaceRoot` is not available.
+    *
+    * 2. Emitting a value in aggregation when its type is unknown.
+    *
+    * 3. Emitting map-reduce results as the final stage of a query.
+    *
+    * NB: This can end up in data at rest due to write-back queries or caching, thus
+    *     we must always support eliding this particular name when reading or
+    *     querying data, even if the "primary" sigil name is changed.
+    */
+  val Quasar = "__quasar_mongodb_sigil"
+
+  /** MapReduce result expression key. */
+  val Value = "value"
+
+  /** MapReduce result identity key. */
+  val Id = "_id"
+
+
+  // Sigils in BsonValues
+
+  /** Returns the value under any Quasar sigil or the input if not found. */
+  def elideQusarSigil: BsonValue => BsonValue =
+    v => (quasarValue(v) <+> mapReduceQuasarValue(v)) | v
+
+  /** The value under the MapReduce value field, if found. */
+  def mapReduceValue: BsonValue => Option[BsonValue] =
+    fieldValue(Value)
+
+  /** The value under the Quasar sigil in a MapReduce result, if found. */
+  def mapReduceQuasarValue: BsonValue => Option[BsonValue] =
+    Kleisli(quasarValue) <==< mapReduceValue
+
+  /** Whether the given `BsonValue` contains the Quasar sigil nested in a MapReduce result. */
+  def mapReduceQuasarSigilExists: BsonValue => Boolean =
+    mapReduceValue andThen (_ exists quasarSigilExists)
+
+  /** Whether the given `BsonValue` contains the Quasar sigil. */
+  def quasarSigilExists: BsonValue => Boolean =
+    bsonvalue.document.exist(_ containsKey Quasar)
+
+  /** The value under the Quasar sigil, if found. */
+  def quasarValue: BsonValue => Option[BsonValue] =
+    fieldValue(Quasar)
+
+
+  // Sigils in QScript
+
+  /** Projects the Quasar sigil. */
+  def projectQuasarValue[T[_[_]]: CorecursiveT]: FreeMap[T] =
+    projectField(Quasar)
+
+  /** Projects the Quasar sigil in a MapReduce result. */
+  def projectMapReduceQuasarValue[T[_[_]]: CorecursiveT]: FreeMap[T] =
+    projectQuasarValue[T] >> projectField(Value)
+
+  ////
+
+  /** Returns the value of the named field or `None` if the input isn't
+    * a document or the field doesn't exist.
+    */
+  private def fieldValue(name: String): BsonValue => Option[BsonValue] =
+    v => bsonvalue.document.getOption(v).flatMap(d => Option(d.get(name)))
+
+  private def projectField[T[_[_]]: CorecursiveT](f: String): FreeMap[T] =
+    Free.roll(MFC(ProjectField(HoleF, StrLit(f))))
+}

--- a/mongodb/src/main/scala/quasar/physical/mongodb/sigil.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/sigil.scala
@@ -56,7 +56,7 @@ object sigil {
   // Sigils in BsonValues
 
   /** Returns the value under any Quasar sigil or the input if not found. */
-  def elideQusarSigil: BsonValue => BsonValue =
+  def elideQuasarSigil: BsonValue => BsonValue =
     v => (quasarValue(v) <+> mapReduceQuasarValue(v)) | v
 
   /** The value under the MapReduce value field, if found. */

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflow/WorkflowOpCore.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflow/WorkflowOpCore.scala
@@ -159,7 +159,7 @@ object $project {
     : FixOp[F] =
     $project[F](
       shape,
-      shape.get(IdName).fold[IdHandling](IgnoreId)(κ(IncludeId)))
+      shape.get(IdName).fold[IdHandling](ExcludeId)(κ(IncludeId)))
 }
 
 final case class $RedactF[A](src: A, value: Fix[ExprOp])

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflow/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflow/package.scala
@@ -75,31 +75,16 @@ package object workflow {
       Inject[WorkflowOpCoreF, WorkflowF].prj(p.op)
   }
 
-  /** Quasar-specific sigil, used to construct a singleton result object under
-    * the following conditions:
-    *
-    * 1. Emitting a document value in aggregation when `$replaceRoot` is not available.
-    *
-    * 2. Emitting a value in aggregation when its type is unknown.
-    *
-    * 3. Emitting map-reduce results as the final stage of a query.
-    *
-    * NB: This can end up in data at rest due to write-back queries or caching, thus
-    *     we must always support eliding this particular name when reading or
-    *     querying data, even if the "primary" sigil name is changed.
-    */
-  val WrapperSigilLabel = "__quasar_mongodb_wrapper"
-  val WrapperSigilName  = BsonField.Name(WrapperSigilLabel)
-  val WrapperSigilVar   = DocVar.ROOT(WrapperSigilName)
+  /** Quasar result sigil. */
+  val QuasarSigilName  = BsonField.Name(sigil.Quasar)
+  val QuasarSigilVar   = DocVar.ROOT(QuasarSigilName)
 
   /** MapReduce result expression key. */
-  val ExprLabel  = "value"
-  val ExprName   = BsonField.Name(ExprLabel)
+  val ExprName   = BsonField.Name(sigil.Value)
   val ExprVar    = DocVar.ROOT(ExprName)
 
   /** MapReduce result identity key. */
-  val IdLabel  = "_id"
-  val IdName   = BsonField.Name(IdLabel)
+  val IdName   = BsonField.Name(sigil.Id)
   val IdVar    = DocVar.ROOT(IdName)
 
   // NB: it's only safe to emit "core" expr ops here, but we always use the
@@ -705,7 +690,7 @@ package object workflow {
           $simpleMap[F](
             NonEmptyList(MapExpr(jscore.JsFn(
               finalValue,
-              jscore.obj(WrapperSigilLabel -> jscore.Ident(finalValue))))),
+              jscore.obj(sigil.Quasar -> jscore.Ident(finalValue))))),
             ListMap()).apply(mr)
 
         case other => other

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflow/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflow/package.scala
@@ -627,7 +627,7 @@ package object workflow {
           deleteUnusedFields(reorderOps(simplifyGroup[F](op)))
 
         def fixShape(wf: Fix[F]) =
-          simpleShape(wf).fold(wf) { n =>
+          simpleShape(wf).fold(finished) { n =>
             $project[F](Reshape(n.strengthR($include().right).toListMap)).apply(finished)
           }
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflow/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflow/package.scala
@@ -637,62 +637,81 @@ package object workflow {
       // NB: We don’t convert a $ProjectF after a map/reduce op because it could
       //     affect the final shape unnecessarily.
       def crystallize(op: Fix[F]) = {
-        @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
-        def unwindSrc(uw: $UnwindF[Fix[F]]): F[Fix[F]] =
-          uw.src.project match {
-            case I(uw1 @ $UnwindF(_, _)) => unwindSrc(uw1)
-            case src => src
-          }
-
-        val crystallizeƒ: F[Fix[F]] => F[Fix[F]] = {
-          case I(mr: MapReduceF[Fix[F]]) => mr.singleSource.src.project match {
-            case I(uw @ $UnwindF(_, _)) if IsPipeline.unapply(unwindSrc(uw)).isEmpty =>
-              mr.singleSource.fmap(ι, I).reparentW(I.inj(uw.flatmapop).embed).project
-            case _                        => I.inj(mr)
-          }
-          case I($FoldLeftF(head, tail)) =>
-            I.inj($FoldLeftF[Fix[F]](
-              chain(head,
-                $project[F](
-                  Reshape(ListMap(ExprName -> \/-($$ROOT))),
-                  IncludeId)),
-              tail.map(x => x.project match {
-                case I($ReduceF(_, _, _)) => x
-                case _ => chain(x, $reduce[F]($ReduceF.reduceFoldLeft, ListMap()))
-              })))
-          case I(g @ $GroupF(src, grouped, by)) =>
-            // We can't use arrays directly inside accumulators because of
-            // https://jira.mongodb.org/browse/SERVER-23839
-            // so let's wrap arrays in a let
-            I($GroupF(src, wrapArrayLitExprInLet(grouped), by))
-
-          case op => op
-        }
 
         val finished =
           deleteUnusedFields(reorderOps(simplifyGroup[F](op)))
 
         def fixShape(wf: Fix[F]) =
-          simpleShape(wf).fold(
-            finished)(
-            n => $project[F](Reshape(n.map(_ -> \/-($include())).toListMap)).apply(finished))
+          simpleShape(wf).fold(wf) { n =>
+            $project[F](Reshape(n.strengthR($include().right).toListMap)).apply(finished)
+          }
 
         @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
         def promoteKnownShape(wf: Fix[F]): Fix[F] = wf.project match {
-          case I($SimpleMapF(_, _, _))   => fixShape(wf)
-          case IsShapePreserving(sp) => promoteKnownShape(sp.src)
-          case _                     => finished
+          case I($SimpleMapF(_, _, _)) => fixShape(wf)
+          case IsShapePreserving(sp)   => promoteKnownShape(sp.src)
+          case _                       => finished
         }
 
-        // FIXME: This _may_ be causing the failure.
         Crystallized(
-          promoteKnownShape(finished).transHylo(Coalesce[F].coalesce, crystallizeƒ)
-            // TODO: this can coalesce more cases, but hasn’t been done thus far
-            //       and requires rewriting many tests in a much less readable
-            //       way.
-            // .cata[Workflow](x => coalesce(uncleanƒ(x).project))
-        )
+          wrapFinalMapReduceValue(
+            promoteKnownShape(finished)
+              .transHylo(Coalesce[F].coalesce, crystallizeƒ)))
       }
+
+      val crystallizeƒ: F[Fix[F]] => F[Fix[F]] = {
+        case I(mr: MapReduceF[Fix[F]]) => mr.singleSource.src.project match {
+          case I(uw @ $UnwindF(_, _)) if IsPipeline.unapply(unwindSrc(uw)).isEmpty =>
+            mr.singleSource.fmap(ι, I).reparentW(I.inj(uw.flatmapop).embed).project
+          case _                        => I.inj(mr)
+        }
+        case I($FoldLeftF(head, tail)) =>
+          I.inj($FoldLeftF[Fix[F]](
+            chain(head,
+              $project[F](
+                Reshape(ListMap(ExprName -> \/-($$ROOT))),
+                IncludeId)),
+            tail.map(x => x.project match {
+              case I($ReduceF(_, _, _)) => x
+              case _ => chain(x, $reduce[F]($ReduceF.reduceFoldLeft, ListMap()))
+            })))
+        case I(g @ $GroupF(src, grouped, by)) =>
+          // We can't use arrays directly inside accumulators because of
+          // https://jira.mongodb.org/browse/SERVER-23839
+          // so let's wrap arrays in a let
+          I($GroupF(src, wrapArrayLitExprInLet(grouped), by))
+
+        case op => op
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
+      def unwindSrc(uw: $UnwindF[Fix[F]]): F[Fix[F]] =
+        uw.src.project match {
+          case I(uw1 @ $UnwindF(_, _)) => unwindSrc(uw1)
+          case src => src
+        }
+
+      /** Wraps the result of a map-reduce in the Sigil, if it is the last
+        * stage in the workflow, so it may be identified and unwrapped
+        * when reading and querying.
+        *
+        * TODO: This doesn't appear to be necessary when returning "inline"
+        *       map-reduce results, but we don't have enough information to
+        *       know if this is the case here. It may be worth refactoring
+        *       to be a transformation on WorkflowTask.
+        */
+      val wrapFinalMapReduceValue: Fix[F] => Fix[F] = {
+        case mr @ Embed(I(_: MapReduceF[Fix[F]])) =>
+          $simpleMap[F](
+            NonEmptyList(MapExpr(jscore.JsFn(
+              finalValue,
+              jscore.obj(WrapperSigilLabel -> jscore.Ident(finalValue))))),
+            ListMap()).apply(mr)
+
+        case other => other
+      }
+
+      val finalValue = jscore.Name("__finalVal")
     }
 
   implicit def workflowRenderTree[T[_[_]]: RecursiveT, F[_]: Traverse: Classify](implicit ev0: WorkflowOpCoreF :<: F, ev1: RenderTree[F[Unit]]): RenderTree[T[F]] =

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
@@ -558,13 +558,16 @@ object WorkflowBuilder {
     (implicit ev: WorkflowOpCoreF :<: F)
     : (Fix[F], Base) = {
     (base, struct) match {
-      case (Field(ExprName), None) => (graph, Field(ExprName))
-      case (_,       None)         =>
+      case (Field(WrapperSigilName), None) =>
+        (graph, Field(WrapperSigilName))
+
+      case (_, None) =>
         (chain(graph,
-          $project[F](Reshape(ListMap(ExprName -> \/-($var(base.toDocVar)))),
+          $project[F](Reshape(ListMap(WrapperSigilName -> \/-($var(base.toDocVar)))),
             ExcludeId)),
-          Field(ExprName))
-      case (_,       Some(fields)) =>
+          Field(WrapperSigilName))
+
+      case (_, Some(fields)) =>
         (chain(graph,
           $project[F](
             Reshape(fields.map(name =>

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflowbuilder.scala
@@ -558,14 +558,14 @@ object WorkflowBuilder {
     (implicit ev: WorkflowOpCoreF :<: F)
     : (Fix[F], Base) = {
     (base, struct) match {
-      case (Field(WrapperSigilName), None) =>
-        (graph, Field(WrapperSigilName))
+      case (Field(QuasarSigilName), None) =>
+        (graph, Field(QuasarSigilName))
 
       case (_, None) =>
         (chain(graph,
-          $project[F](Reshape(ListMap(WrapperSigilName -> \/-($var(base.toDocVar)))),
+          $project[F](Reshape(ListMap(QuasarSigilName -> \/-($var(base.toDocVar)))),
             ExcludeId)),
-          Field(WrapperSigilName))
+          Field(QuasarSigilName))
 
       case (_, Some(fields)) =>
         (chain(graph,

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflowtask/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflowtask/package.scala
@@ -84,12 +84,12 @@ package object workflowtask {
                   ExcludeId).pipeline)))
 
         case None =>
-          (WrapperSigilVar,
+          (QuasarSigilVar,
             PipelineTask(
               src,
               pipeline :+
                 PipelineOp($ProjectF((),
-                  Reshape[ExprOp](ListMap(WrapperSigilName -> $var(base).right)),
+                  Reshape[ExprOp](ListMap(QuasarSigilName -> $var(base).right)),
                   ExcludeId).pipeline)))
       }
     case _ => (base, task)

--- a/mongodb/src/main/scala/quasar/physical/mongodb/workflowtask/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/workflowtask/package.scala
@@ -84,12 +84,12 @@ package object workflowtask {
                   ExcludeId).pipeline)))
 
         case None =>
-          (ExprVar,
+          (WrapperSigilVar,
             PipelineTask(
               src,
               pipeline :+
                 PipelineOp($ProjectF((),
-                  Reshape[ExprOp](ListMap(ExprName -> $var(base).right)),
+                  Reshape[ExprOp](ListMap(WrapperSigilName -> $var(base).right)),
                   ExcludeId).pipeline)))
       }
     case _ => (base, task)

--- a/mongodb/src/test/resources/planner/collect_unaggregated_fields_into_single_doc_when_grouping.txt
+++ b/mongodb/src/test/resources/planner/collect_unaggregated_fields_into_single_doc_when_grouping.txt
@@ -69,12 +69,12 @@ Chain
 ├─ $UnwindF(DocField(BsonField.Name("left")))
 ╰─ $SimpleMapF
    ├─ Map
-   │  ╰─ Let(__val)
-   │     ├─ JsCore([_.left, _.right])
-   │     ╰─ SpliceObjects
-   │        ├─ SpliceObjects
-   │        │  ├─ JsCore(__val[0][1])
-   │        │  ╰─ JsCore(__val[0][2])
-   │        ╰─ Obj
-   │           ╰─ Key(2: __val[1])
+   │  ╰─ Obj
+   │     ╰─ Key(__quasar_mongodb_sigil)
+   │        ╰─ SpliceObjects
+   │           ├─ SpliceObjects
+   │           │  ├─ JsCore(_.left[1])
+   │           │  ╰─ JsCore(_.left[2])
+   │           ╰─ Obj
+   │              ╰─ Key(2: _.right)
    ╰─ Scope(Map())

--- a/mongodb/src/test/resources/planner/group_by_flattened_field.txt
+++ b/mongodb/src/test/resources/planner/group_by_flattened_field.txt
@@ -17,7 +17,7 @@ Chain
 │  │  │  ╰─ Scope(Map())
 │  │  ├─ $ProjectF
 │  │  │  ├─ Name("0" -> { "$arrayElemAt": ["$$ROOT", { "$literal": NumberInt("3") }] })
-│  │  │  ╰─ IgnoreId
+│  │  │  ╰─ ExcludeId
 │  │  ├─ $SimpleMapF
 │  │  │  ├─ Flatten
 │  │  │  │  ╰─ JsCore(_["0"])
@@ -183,7 +183,7 @@ Chain
 │     │  │         },
 │     │  │         { "$literal": undefined }]
 │     │  │     })
-│     │  ╰─ IgnoreId
+│     │  ╰─ ExcludeId
 │     ├─ $SimpleMapF
 │     │  ├─ Flatten
 │     │  │  ╰─ JsCore(_.f)
@@ -225,4 +225,4 @@ Chain
 ╰─ $ProjectF
    ├─ Name("0" -> { "$arrayElemAt": ["$left", { "$literal": NumberInt("1") }] })
    ├─ Name("1" -> { "$arrayElemAt": ["$right", { "$literal": NumberInt("1") }] })
-   ╰─ IgnoreId
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_3-way_equi-join_($lookup).txt
+++ b/mongodb/src/test/resources/planner/plan_3-way_equi-join_($lookup).txt
@@ -6,7 +6,7 @@ Chain
 │  │  │  ├─ Name("0" -> { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] })
 │  │  │  ├─ Name("1" -> { "$literal": true })
 │  │  │  ├─ Name("src" -> ["$_id", "$$ROOT"])
-│  │  │  ╰─ IgnoreId
+│  │  │  ╰─ ExcludeId
 │  │  ├─ $MatchF
 │  │  │  ╰─ And
 │  │  │     ├─ Doc
@@ -39,7 +39,7 @@ Chain
 │     │  │  │  ├─ Name("0" -> { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] })
 │     │  │  │  ├─ Name("1" -> { "$literal": true })
 │     │  │  │  ├─ Name("src" -> ["$_id", "$$ROOT"])
-│     │  │  │  ╰─ IgnoreId
+│     │  │  │  ╰─ ExcludeId
 │     │  │  ├─ $MatchF
 │     │  │  │  ╰─ And
 │     │  │  │     ├─ Doc
@@ -70,7 +70,7 @@ Chain
 │     │     │  ├─ Name("0" -> { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] })
 │     │     │  ├─ Name("1" -> { "$literal": true })
 │     │     │  ├─ Name("src" -> ["$_id", "$$ROOT"])
-│     │     │  ╰─ IgnoreId
+│     │     │  ╰─ ExcludeId
 │     │     ├─ $MatchF
 │     │     │  ╰─ And
 │     │     │     ├─ Doc
@@ -111,7 +111,7 @@ Chain
 │     │  │     })
 │     │  ├─ Name("1" -> { "$literal": true })
 │     │  ├─ Name("src" -> "$$ROOT")
-│     │  ╰─ IgnoreId
+│     │  ╰─ ExcludeId
 │     ├─ $MatchF
 │     │  ╰─ And
 │     │     ├─ Doc
@@ -181,4 +181,4 @@ Chain
    ├─ Name("name" -> true)
    ├─ Name("address" -> true)
    ├─ Name("zip" -> true)
-   ╰─ IgnoreId
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_3-way_right_equi-join_(map-reduce).txt
+++ b/mongodb/src/test/resources/planner/plan_3-way_right_equi-join_(map-reduce).txt
@@ -153,7 +153,7 @@ Chain
 │  │         "$left"]
 │  │     })
 │  ├─ Name("right" -> "$right")
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $UnwindF(DocField(BsonField.Name("right")))
 ├─ $UnwindF(DocField(BsonField.Name("left")))
 ├─ $SimpleMapF
@@ -197,4 +197,4 @@ Chain
    ├─ Name("name" -> true)
    ├─ Name("address" -> true)
    ├─ Name("zip" -> true)
-   ╰─ IgnoreId
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_Sort_expression_(and_extra_project).txt
+++ b/mongodb/src/test/resources/planner/plan_Sort_expression_(and_extra_project).txt
@@ -14,5 +14,5 @@ Chain
 ├─ $SortF
 │  ╰─ SortKey(0 -> Ascending)
 ╰─ $ProjectF
-   ├─ Name("value" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
+   ├─ Name("__quasar_mongodb_sigil" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_aggregation_on_grouped_field.txt
+++ b/mongodb/src/test/resources/planner/plan_aggregation_on_grouped_field.txt
@@ -1,8 +1,12 @@
 Chain
 ├─ $ReadF(db; zips)
-╰─ $GroupF
-   ├─ Grouped
-   │  ├─ Name("city" -> { "$first": "$city" })
-   │  ╰─ Name("1" -> { "$sum": { "$literal": NumberInt("1") } })
-   ╰─ By
-      ╰─ Name("0" -> ["$city"])
+├─ $GroupF
+│  ├─ Grouped
+│  │  ├─ Name("f0" -> { "$first": "$city" })
+│  │  ╰─ Name("f1" -> { "$sum": { "$literal": NumberInt("1") } })
+│  ╰─ By
+│     ╰─ Name("0" -> ["$city"])
+╰─ $ProjectF
+   ├─ Name("city" -> "$f0")
+   ├─ Name("1" -> "$f1")
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_array_concat.txt
+++ b/mongodb/src/test/resources/planner/plan_array_concat.txt
@@ -1,7 +1,7 @@
 Chain
 ├─ $ReadF(db; zips)
 ╰─ $ProjectF
-   ├─ Name("value" -> {
+   ├─ Name("__quasar_mongodb_sigil" -> {
    │       "$cond": [
    │         {
    │           "$or": [

--- a/mongodb/src/test/resources/planner/plan_array_concat_with_filter.txt
+++ b/mongodb/src/test/resources/planner/plan_array_concat_with_filter.txt
@@ -5,5 +5,6 @@ Chain
 │     ╰─ Expr($city -> Eq(Text(BOULDER)))
 ╰─ $SimpleMapF
    ├─ Map
-   │  ╰─ JsCore((Array.isArray(_.loc) || isString(_.loc)) ? (Array.isArray(_.loc) || Array.isArray([_.pop])) ? _.loc.concat([_.pop]) : _.loc + [_.pop] : undefined)
+   │  ╰─ Obj
+   │     ╰─ Key(__quasar_mongodb_sigil: (Array.isArray(_.loc) || isString(_.loc)) ? (Array.isArray(_.loc) || Array.isArray([_.pop])) ? _.loc.concat([_.pop]) : _.loc + [_.pop] : undefined)
    ╰─ Scope(Map())

--- a/mongodb/src/test/resources/planner/plan_array_flatten.txt
+++ b/mongodb/src/test/resources/planner/plan_array_flatten.txt
@@ -11,11 +11,11 @@ Chain
 │  │         "$loc",
 │  │         { "$literal": undefined }]
 │  │     })
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $SimpleMapF
 │  ├─ Flatten
 │  │  ╰─ JsCore(_["0"])
 │  ╰─ Scope(Map())
 ╰─ $ProjectF
-   ├─ Name("value" -> "$0")
+   ├─ Name("__quasar_mongodb_sigil" -> "$0")
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_array_flatten_with_unflattened_field.txt
+++ b/mongodb/src/test/resources/planner/plan_array_flatten_with_unflattened_field.txt
@@ -30,10 +30,12 @@ Chain
    ├─ Flatten
    │  ╰─ JsCore(_.f)
    ├─ Map
-   │  ╰─ SpliceObjects
-   │     ├─ SpliceObjects
-   │     │  ├─ JsCore(_.s[0])
-   │     │  ╰─ JsCore(_.s[1])
-   │     ╰─ Obj
-   │        ╰─ Key(coord: _.f)
+   │  ╰─ Obj
+   │     ╰─ Key(__quasar_mongodb_sigil)
+   │        ╰─ SpliceObjects
+   │           ├─ SpliceObjects
+   │           │  ├─ JsCore(_.s[0])
+   │           │  ╰─ JsCore(_.s[1])
+   │           ╰─ Obj
+   │              ╰─ Key(coord: _.f)
    ╰─ Scope(Map())

--- a/mongodb/src/test/resources/planner/plan_combination_of_two_distinct_sets.txt
+++ b/mongodb/src/test/resources/planner/plan_combination_of_two_distinct_sets.txt
@@ -9,7 +9,7 @@ Chain
 │  ╰─ By
 │     ╰─ Name("0" -> "$$ROOT")
 ╰─ $ProjectF
-   ├─ Name("value" -> {
+   ├─ Name("__quasar_mongodb_sigil" -> {
    │       "$cond": [
    │         {
    │           "$and": [

--- a/mongodb/src/test/resources/planner/plan_complex_group_by_with_sorting_and_limiting.txt
+++ b/mongodb/src/test/resources/planner/plan_complex_group_by_with_sorting_and_limiting.txt
@@ -35,9 +35,9 @@ Chain
 │  │         { "$literal": NumberInt("2") }]
 │  │     })
 │  ├─ Name("src" -> "$$ROOT")
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $SortF
 │  ╰─ SortKey(0 -> Ascending)
 ╰─ $ProjectF
-   ├─ Name("value" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
+   ├─ Name("__quasar_mongodb_sigil" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_count_and_field_when_grouped.txt
+++ b/mongodb/src/test/resources/planner/plan_count_and_field_when_grouped.txt
@@ -1,8 +1,12 @@
 Chain
 ├─ $ReadF(db; zips)
-╰─ $GroupF
-   ├─ Grouped
-   │  ├─ Name("cnt" -> { "$sum": { "$literal": NumberInt("1") } })
-   │  ╰─ Name("city" -> { "$first": "$city" })
-   ╰─ By
-      ╰─ Name("0" -> ["$city"])
+├─ $GroupF
+│  ├─ Grouped
+│  │  ├─ Name("f0" -> { "$sum": { "$literal": NumberInt("1") } })
+│  │  ╰─ Name("f1" -> { "$first": "$city" })
+│  ╰─ By
+│     ╰─ Name("0" -> ["$city"])
+╰─ $ProjectF
+   ├─ Name("cnt" -> "$f0")
+   ├─ Name("city" -> "$f1")
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_count_and_js_expr.txt
+++ b/mongodb/src/test/resources/planner/plan_count_and_js_expr.txt
@@ -60,7 +60,7 @@ Chain
 ├─ $UnwindF(DocField(BsonField.Name("right")))
 ├─ $UnwindF(DocField(BsonField.Name("left")))
 ╰─ $ProjectF
-   ├─ Name("cnt" -> { "$arrayElemAt": [["$left", "$right"], { "$literal": NumberInt("0") }] })
+   ├─ Name("cnt" -> "$left")
    ├─ Name("1" -> {
    │       "$cond": [
    │         {
@@ -68,33 +68,15 @@ Chain
    │             {
    │               "$lte": [
    │                 { "$literal": "" },
-   │                 {
-   │                   "$arrayElemAt": [
-   │                     {
-   │                       "$arrayElemAt": [["$left", "$right"], { "$literal": NumberInt("1") }]
-   │                     },
-   │                     { "$literal": NumberInt("1") }]
-   │                 }]
+   │                 { "$arrayElemAt": ["$right", { "$literal": NumberInt("1") }] }]
    │             },
    │             {
    │               "$lt": [
-   │                 {
-   │                   "$arrayElemAt": [
-   │                     {
-   │                       "$arrayElemAt": [["$left", "$right"], { "$literal": NumberInt("1") }]
-   │                     },
-   │                     { "$literal": NumberInt("1") }]
-   │                 },
+   │                 { "$arrayElemAt": ["$right", { "$literal": NumberInt("1") }] },
    │                 { "$literal": {  } }]
    │             }]
    │         },
-   │         {
-   │           "$arrayElemAt": [
-   │             {
-   │               "$arrayElemAt": [["$left", "$right"], { "$literal": NumberInt("1") }]
-   │             },
-   │             { "$literal": NumberInt("2") }]
-   │         },
+   │         { "$arrayElemAt": ["$right", { "$literal": NumberInt("2") }] },
    │         { "$literal": undefined }]
    │     })
-   ╰─ IgnoreId
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_count_of_$lookup.txt
+++ b/mongodb/src/test/resources/planner/plan_count_of_$lookup.txt
@@ -8,7 +8,7 @@ Chain
 │  │  │  │  │  ├─ Name("0" -> { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] })
 │  │  │  │  │  ├─ Name("1" -> { "$literal": true })
 │  │  │  │  │  ├─ Name("src" -> ["$_id", "$$ROOT"])
-│  │  │  │  │  ╰─ IgnoreId
+│  │  │  │  │  ╰─ ExcludeId
 │  │  │  │  ├─ $MatchF
 │  │  │  │  │  ╰─ And
 │  │  │  │  │     ├─ Doc
@@ -39,7 +39,7 @@ Chain
 │  │  │     │  ├─ Name("0" -> { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] })
 │  │  │     │  ├─ Name("1" -> { "$literal": true })
 │  │  │     │  ├─ Name("src" -> ["$_id", "$$ROOT"])
-│  │  │     │  ╰─ IgnoreId
+│  │  │     │  ╰─ ExcludeId
 │  │  │     ├─ $MatchF
 │  │  │     │  ╰─ And
 │  │  │     │     ├─ Doc
@@ -158,7 +158,7 @@ Chain
 │     │  │  │  ├─ Name("0" -> { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] })
 │     │  │  │  ├─ Name("1" -> { "$literal": true })
 │     │  │  │  ├─ Name("src" -> ["$_id", "$$ROOT"])
-│     │  │  │  ╰─ IgnoreId
+│     │  │  │  ╰─ ExcludeId
 │     │  │  ├─ $MatchF
 │     │  │  │  ╰─ And
 │     │  │  │     ├─ Doc
@@ -189,7 +189,7 @@ Chain
 │     │     │  ├─ Name("0" -> { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] })
 │     │     │  ├─ Name("1" -> { "$literal": true })
 │     │     │  ├─ Name("src" -> ["$_id", "$$ROOT"])
-│     │     │  ╰─ IgnoreId
+│     │     │  ╰─ ExcludeId
 │     │     ├─ $MatchF
 │     │     │  ╰─ And
 │     │     │     ├─ Doc

--- a/mongodb/src/test/resources/planner/plan_distinct_as_expression.txt
+++ b/mongodb/src/test/resources/planner/plan_distinct_as_expression.txt
@@ -16,5 +16,5 @@ Chain
 │  │  ╰─ Name("f0" -> { "$sum": { "$literal": NumberInt("1") } })
 │  ╰─ By({ "$literal": null })
 ╰─ $ProjectF
-   ├─ Name("value" -> "$f0")
+   ├─ Name("__quasar_mongodb_sigil" -> "$f0")
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_distinct_as_function_with_group.txt
+++ b/mongodb/src/test/resources/planner/plan_distinct_as_function_with_group.txt
@@ -117,4 +117,4 @@ Chain
 ╰─ $ProjectF
    ├─ Name("state" -> { "$arrayElemAt": ["$left", { "$literal": NumberInt("1") }] })
    ├─ Name("1" -> { "$arrayElemAt": ["$right", { "$literal": NumberInt("1") }] })
-   ╰─ IgnoreId
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_distinct_of_expression_as_expression.txt
+++ b/mongodb/src/test/resources/planner/plan_distinct_of_expression_as_expression.txt
@@ -59,5 +59,5 @@ Chain
 │  │  ╰─ Name("f0" -> { "$sum": { "$literal": NumberInt("1") } })
 │  ╰─ By({ "$literal": null })
 ╰─ $ProjectF
-   ├─ Name("value" -> "$f0")
+   ├─ Name("__quasar_mongodb_sigil" -> "$f0")
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_distinct_of_wildcard.txt
+++ b/mongodb/src/test/resources/planner/plan_distinct_of_wildcard.txt
@@ -9,5 +9,5 @@ Chain
 │  ╰─ By
 │     ╰─ Name("0" -> "$$ROOT")
 ╰─ $ProjectF
-   ├─ Name("value" -> "$_id.0")
+   ├─ Name("__quasar_mongodb_sigil" -> "$_id.0")
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_distinct_of_wildcard_as_expression.txt
+++ b/mongodb/src/test/resources/planner/plan_distinct_of_wildcard_as_expression.txt
@@ -20,5 +20,5 @@ Chain
 │  │  ╰─ Name("f0" -> { "$sum": { "$literal": NumberInt("1") } })
 │  ╰─ By({ "$literal": null })
 ╰─ $ProjectF
-   ├─ Name("value" -> "$f0")
+   ├─ Name("__quasar_mongodb_sigil" -> "$f0")
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_distinct_with_simple_order_by.txt
+++ b/mongodb/src/test/resources/planner/plan_distinct_with_simple_order_by.txt
@@ -24,9 +24,9 @@ Chain
 │  ├─ Name("src" -> [
 │  │       { "$arrayElemAt": [["$_id.0", "$f0"], { "$literal": NumberInt("1") }] },
 │  │       ["$_id.0", "$f0"]])
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $SortF
 │  ╰─ SortKey(0 -> Ascending)
 ╰─ $ProjectF
-   ├─ Name("value" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
+   ├─ Name("__quasar_mongodb_sigil" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_distinct_with_sum,_group,_and_orderBy.txt
+++ b/mongodb/src/test/resources/planner/plan_distinct_with_sum,_group,_and_orderBy.txt
@@ -127,9 +127,9 @@ Chain
 │  │         "$arrayElemAt": [["$_id.0", "$f0", "$f0.totalPop"], { "$literal": NumberInt("1") }]
 │  │       },
 │  │       ["$_id.0", "$f0", "$f0.totalPop"]])
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $SortF
 │  ╰─ SortKey(0 -> Descending)
 ╰─ $ProjectF
-   ├─ Name("value" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
+   ├─ Name("__quasar_mongodb_sigil" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_distinct_with_sum_and_group.txt
+++ b/mongodb/src/test/resources/planner/plan_distinct_with_sum_and_group.txt
@@ -107,5 +107,5 @@ Chain
 │  ╰─ By
 │     ╰─ Name("0" -> "$b0")
 ╰─ $ProjectF
-   ├─ Name("value" -> "$f0")
+   ├─ Name("__quasar_mongodb_sigil" -> "$f0")
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_distinct_with_unrelated_order_by.txt
+++ b/mongodb/src/test/resources/planner/plan_distinct_with_unrelated_order_by.txt
@@ -11,7 +11,7 @@ Chain
 ├─ $ProjectF
 │  ├─ Name("0" -> { "$arrayElemAt": ["$$ROOT", { "$literal": NumberInt("1") }] })
 │  ├─ Name("src" -> "$$ROOT")
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $SortF
 │  ╰─ SortKey(0 -> Descending)
 ├─ $SimpleMapF
@@ -43,9 +43,9 @@ Chain
 │  │         { "$literal": NumberInt("2") }]
 │  │     })
 │  ├─ Name("src" -> "$$ROOT")
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $SortF
 │  ╰─ SortKey(0 -> Descending)
 ╰─ $ProjectF
-   ├─ Name("value" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
+   ├─ Name("__quasar_mongodb_sigil" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_double_aggregation_with_another_projection.txt
+++ b/mongodb/src/test/resources/planner/plan_double_aggregation_with_another_projection.txt
@@ -101,7 +101,7 @@ Chain
 │     │  ╰─ Scope(Map())
 │     ├─ $ProjectF
 │     │  ├─ Name("0" -> { "$arrayElemAt": ["$$ROOT", { "$literal": NumberInt("2") }] })
-│     │  ╰─ IgnoreId
+│     │  ╰─ ExcludeId
 │     ├─ $MapF
 │     │  ├─ JavaScript(function (key, value) { return [null, { "left": [], "right": [value["0"]] }] })
 │     │  ╰─ Scope(Map())
@@ -123,10 +123,6 @@ Chain
 ├─ $UnwindF(DocField(BsonField.Name("right")))
 ├─ $UnwindF(DocField(BsonField.Name("left")))
 ╰─ $ProjectF
-   ├─ Name("0" -> { "$arrayElemAt": [["$left", "$right"], { "$literal": NumberInt("0") }] })
-   ├─ Name("1" -> {
-   │       "$arrayElemAt": [
-   │         { "$arrayElemAt": [["$left", "$right"], { "$literal": NumberInt("1") }] },
-   │         { "$literal": NumberInt("1") }]
-   │     })
-   ╰─ IgnoreId
+   ├─ Name("0" -> "$left")
+   ├─ Name("1" -> { "$arrayElemAt": ["$right", { "$literal": NumberInt("1") }] })
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_efficient_count_and_field_ref.txt
+++ b/mongodb/src/test/resources/planner/plan_efficient_count_and_field_ref.txt
@@ -71,9 +71,9 @@ Chain
 │  │         { "$literal": NumberInt("1") }]
 │  │     })
 │  ├─ Name("src" -> "$$ROOT")
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $SortF
 │  ╰─ SortKey(0 -> Descending)
 ╰─ $ProjectF
-   ├─ Name("value" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
+   ├─ Name("__quasar_mongodb_sigil" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_filter_array_element.txt
+++ b/mongodb/src/test/resources/planner/plan_filter_array_element.txt
@@ -57,10 +57,10 @@ Chain
 │  │         { "$literal": undefined }]
 │  │     })
 │  ├─ Name("src" -> "$$ROOT")
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $MatchF
 │  ╰─ Doc
 │     ╰─ Expr($0 -> Eq(Bool(true)))
 ╰─ $ProjectF
-   ├─ Name("value" -> "$src.loc")
+   ├─ Name("__quasar_mongodb_sigil" -> "$src.loc")
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_filter_by_date_field_(SD-1508).txt
+++ b/mongodb/src/test/resources/planner/plan_filter_by_date_field_(SD-1508).txt
@@ -4,7 +4,7 @@ Chain
 │  ├─ Name("0" -> "$ts")
 │  ├─ Name("1" -> { "$year": "$ts" })
 │  ├─ Name("src" -> "$$ROOT")
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $MatchF
 │  ╰─ And
 │     ├─ Doc
@@ -12,5 +12,5 @@ Chain
 │     ╰─ Doc
 │        ╰─ Expr($1 -> Eq(Int32(2016)))
 ╰─ $ProjectF
-   ├─ Name("value" -> "$src")
+   ├─ Name("__quasar_mongodb_sigil" -> "$src")
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_filter_with_both_index_and_field_projections.txt
+++ b/mongodb/src/test/resources/planner/plan_filter_with_both_index_and_field_projections.txt
@@ -13,7 +13,10 @@ Chain
 │  ├─ Map
 │  │  ╰─ Obj
 │  ╰─ Scope(Map())
-╰─ $GroupF
-   ├─ Grouped
-   │  ╰─ Name("count" -> { "$sum": { "$literal": NumberInt("1") } })
-   ╰─ By({ "$literal": null })
+├─ $GroupF
+│  ├─ Grouped
+│  │  ╰─ Name("f0" -> { "$sum": { "$literal": NumberInt("1") } })
+│  ╰─ By({ "$literal": null })
+╰─ $ProjectF
+   ├─ Name("count" -> "$f0")
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_filter_with_field_containing_constant_value.txt
+++ b/mongodb/src/test/resources/planner/plan_filter_with_field_containing_constant_value.txt
@@ -10,5 +10,5 @@ Chain
 │  ╰─ Doc
 │     ╰─ Expr($0 -> Eq(Bool(true)))
 ╰─ $ProjectF
-   ├─ Name("value" -> "$src")
+   ├─ Name("__quasar_mongodb_sigil" -> "$src")
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_filter_with_field_containing_other_field.txt
+++ b/mongodb/src/test/resources/planner/plan_filter_with_field_containing_other_field.txt
@@ -10,5 +10,5 @@ Chain
 │  ╰─ Doc
 │     ╰─ Expr($0 -> Eq(Bool(true)))
 ╰─ $ProjectF
-   ├─ Name("value" -> "$src")
+   ├─ Name("__quasar_mongodb_sigil" -> "$src")
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_filter_with_js_and_non-js_3.txt
+++ b/mongodb/src/test/resources/planner/plan_filter_with_js_and_non-js_3.txt
@@ -31,5 +31,5 @@ Chain
 │     ╰─ Doc
 │        ╰─ Expr($3 -> Lt(Int32(20000)))
 ╰─ $ProjectF
-   ├─ Name("value" -> "$src")
+   ├─ Name("__quasar_mongodb_sigil" -> "$src")
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_filter_with_timestamp_and_interval.txt
+++ b/mongodb/src/test/resources/planner/plan_filter_with_timestamp_and_interval.txt
@@ -6,7 +6,7 @@ Chain
 │  ├─ Name("2" -> "$date")
 │  ├─ Name("3" -> { "$subtract": ["$date", { "$literal": 4.32E7 }] })
 │  ├─ Name("src" -> "$$ROOT")
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $MatchF
 │  ╰─ And
 │     ├─ Or
@@ -36,5 +36,5 @@ Chain
 │     ╰─ Doc
 │        ╰─ Expr($3 -> Gt(Date(1416182400000)))
 ╰─ $ProjectF
-   ├─ Name("value" -> "$src")
+   ├─ Name("__quasar_mongodb_sigil" -> "$src")
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_group_by_expression.txt
+++ b/mongodb/src/test/resources/planner/plan_group_by_expression.txt
@@ -76,10 +76,10 @@ Chain
 ├─ $SimpleMapF
 │  ├─ Map
 │  │  ╰─ Obj
-│  │     ├─ Key(city: [_.left, _.right][0][2].city)
-│  │     ╰─ Key(1: [_.left, _.right][1])
+│  │     ├─ Key(city: _.left[2].city)
+│  │     ╰─ Key(1: _.right)
 │  ╰─ Scope(Map())
 ╰─ $ProjectF
    ├─ Name("city" -> true)
    ├─ Name("1" -> true)
-   ╰─ IgnoreId
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_group_by_month.txt
+++ b/mongodb/src/test/resources/planner/plan_group_by_month.txt
@@ -1,48 +1,52 @@
 Chain
 ├─ $ReadF(db; caloriesBurnedData)
-╰─ $GroupF
-   ├─ Grouped
-   │  ├─ Name("a" -> {
-   │  │       "$avg": {
-   │  │         "$cond": [
-   │  │           {
-   │  │             "$and": [
-   │  │               { "$lt": [{ "$literal": null }, "$score"] },
-   │  │               { "$lt": ["$score", { "$literal": "" }] }]
-   │  │           },
-   │  │           "$score",
-   │  │           { "$literal": undefined }]
-   │  │       }
-   │  │     })
-   │  ╰─ Name("m" -> {
-   │          "$first": {
-   │            "$cond": [
-   │              {
-   │                "$and": [
-   │                  {
-   │                    "$lte": [
-   │                      { "$literal": ISODate("-292275055-05-16T16:47:04.192Z") },
-   │                      "$date"]
-   │                  },
-   │                  { "$lt": ["$date", { "$literal": new RegExp("", "") }] }]
-   │              },
-   │              { "$month": "$date" },
-   │              { "$literal": undefined }]
-   │          }
-   │        })
-   ╰─ By
-      ╰─ Name("0" -> [
-              {
-                "$cond": [
-                  {
-                    "$and": [
-                      {
-                        "$lte": [
-                          { "$literal": ISODate("-292275055-05-16T16:47:04.192Z") },
-                          "$date"]
-                      },
-                      { "$lt": ["$date", { "$literal": new RegExp("", "") }] }]
-                  },
-                  { "$month": "$date" },
-                  { "$literal": undefined }]
-              }])
+├─ $GroupF
+│  ├─ Grouped
+│  │  ├─ Name("f0" -> {
+│  │  │       "$avg": {
+│  │  │         "$cond": [
+│  │  │           {
+│  │  │             "$and": [
+│  │  │               { "$lt": [{ "$literal": null }, "$score"] },
+│  │  │               { "$lt": ["$score", { "$literal": "" }] }]
+│  │  │           },
+│  │  │           "$score",
+│  │  │           { "$literal": undefined }]
+│  │  │       }
+│  │  │     })
+│  │  ╰─ Name("f1" -> {
+│  │          "$first": {
+│  │            "$cond": [
+│  │              {
+│  │                "$and": [
+│  │                  {
+│  │                    "$lte": [
+│  │                      { "$literal": ISODate("-292275055-05-16T16:47:04.192Z") },
+│  │                      "$date"]
+│  │                  },
+│  │                  { "$lt": ["$date", { "$literal": new RegExp("", "") }] }]
+│  │              },
+│  │              { "$month": "$date" },
+│  │              { "$literal": undefined }]
+│  │          }
+│  │        })
+│  ╰─ By
+│     ╰─ Name("0" -> [
+│             {
+│               "$cond": [
+│                 {
+│                   "$and": [
+│                     {
+│                       "$lte": [
+│                         { "$literal": ISODate("-292275055-05-16T16:47:04.192Z") },
+│                         "$date"]
+│                     },
+│                     { "$lt": ["$date", { "$literal": new RegExp("", "") }] }]
+│                 },
+│                 { "$month": "$date" },
+│                 { "$literal": undefined }]
+│             }])
+╰─ $ProjectF
+   ├─ Name("a" -> "$f0")
+   ├─ Name("m" -> "$f1")
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_having_with_multiple_projections.txt
+++ b/mongodb/src/test/resources/planner/plan_having_with_multiple_projections.txt
@@ -79,7 +79,7 @@ Chain
 │  │  │  │  │  ├─ Name("0" -> { "$literal": true })
 │  │  │  │  │  ├─ Name("1" -> { "$arrayElemAt": [["$left", "$right"], { "$literal": NumberInt("1") }] })
 │  │  │  │  │  ├─ Name("src" -> ["$left", "$right"])
-│  │  │  │  │  ╰─ IgnoreId
+│  │  │  │  │  ╰─ ExcludeId
 │  │  │  │  ├─ $MatchF
 │  │  │  │  │  ╰─ And
 │  │  │  │  │     ├─ Doc
@@ -188,7 +188,7 @@ Chain
 │  │  ├─ $UnwindF(DocField(BsonField.Name("left")))
 │  │  ├─ $ProjectF
 │  │  │  ├─ Name("0" -> ["$left", "$right"])
-│  │  │  ╰─ IgnoreId
+│  │  │  ╰─ ExcludeId
 │  │  ├─ $SimpleMapF
 │  │  │  ├─ Map
 │  │  │  │  ╰─ Obj
@@ -259,7 +259,7 @@ Chain
 │     │     │  ╰─ Scope(Map())
 │     │     ├─ $ProjectF
 │     │     │  ├─ Name("0" -> { "$arrayElemAt": ["$$ROOT", { "$literal": NumberInt("2") }] })
-│     │     │  ╰─ IgnoreId
+│     │     │  ╰─ ExcludeId
 │     │     ├─ $SimpleMapF
 │     │     │  ├─ Map
 │     │     │  │  ╰─ Obj
@@ -297,7 +297,7 @@ Chain
 │     │  ├─ Name("0" -> { "$literal": true })
 │     │  ├─ Name("1" -> { "$arrayElemAt": [["$left", "$right"], { "$literal": NumberInt("1") }] })
 │     │  ├─ Name("src" -> ["$left", "$right"])
-│     │  ╰─ IgnoreId
+│     │  ╰─ ExcludeId
 │     ├─ $MatchF
 │     │  ╰─ And
 │     │     ├─ Doc
@@ -336,6 +336,6 @@ Chain
 ├─ $UnwindF(DocField(BsonField.Name("right")))
 ├─ $UnwindF(DocField(BsonField.Name("left")))
 ╰─ $ProjectF
-   ├─ Name("city" -> { "$arrayElemAt": [["$left", "$right"], { "$literal": NumberInt("0") }] })
-   ├─ Name("1" -> { "$arrayElemAt": [["$left", "$right"], { "$literal": NumberInt("1") }] })
-   ╰─ IgnoreId
+   ├─ Name("city" -> "$left")
+   ├─ Name("1" -> "$right")
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_join_with_multiple_conditions.txt
+++ b/mongodb/src/test/resources/planner/plan_join_with_multiple_conditions.txt
@@ -26,7 +26,7 @@ Chain
 │  │  ├─ $ProjectF
 │  │  │  ├─ Name("0" -> { "$arrayElemAt": ["$$ROOT", { "$literal": NumberInt("3") }] })
 │  │  │  ├─ Name("src" -> "$$ROOT")
-│  │  │  ╰─ IgnoreId
+│  │  │  ╰─ ExcludeId
 │  │  ├─ $MatchF
 │  │  │  ╰─ Doc
 │  │  │     ╰─ Expr($0 -> Eq(Bool(true)))
@@ -80,13 +80,13 @@ Chain
 │     │  │         { "$literal": NumberInt("2") }]
 │     │  │     })
 │     │  ├─ Name("src" -> "$$ROOT")
-│     │  ╰─ IgnoreId
+│     │  ╰─ ExcludeId
 │     ├─ $MatchF
 │     │  ╰─ Doc
 │     │     ╰─ Expr($0 -> Eq(Bool(true)))
 │     ├─ $ProjectF
 │     │  ├─ Name("0" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("4") }] })
-│     │  ╰─ IgnoreId
+│     │  ╰─ ExcludeId
 │     ├─ $MapF
 │     │  ├─ JavaScript(function (key, value) {
 │     │  │               return [
@@ -124,4 +124,4 @@ Chain
    ├─ Name("c_auth" -> true)
    ├─ Name("parent" -> true)
    ├─ Name("p_auth" -> true)
-   ╰─ IgnoreId
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_join_with_non-JS-able_condition.txt
+++ b/mongodb/src/test/resources/planner/plan_join_with_non-JS-able_condition.txt
@@ -4,7 +4,7 @@ Chain
 │  │  ├─ $ReadF(db; zips)
 │  │  ├─ $ProjectF
 │  │  │  ├─ Name("0" -> ["$_id", "$$ROOT"])
-│  │  │  ╰─ IgnoreId
+│  │  │  ╰─ ExcludeId
 │  │  ├─ $SimpleMapF
 │  │  │  ├─ Map
 │  │  │  │  ╰─ Obj
@@ -68,7 +68,7 @@ Chain
 │     ├─ $ReadF(db; zips)
 │     ├─ $ProjectF
 │     │  ├─ Name("0" -> ["$_id", "$$ROOT"])
-│     │  ╰─ IgnoreId
+│     │  ╰─ ExcludeId
 │     ├─ $SimpleMapF
 │     │  ├─ Map
 │     │  │  ╰─ Obj
@@ -140,4 +140,4 @@ Chain
    ├─ Name("loc" -> true)
    ├─ Name("city2" -> true)
    ├─ Name("pop" -> true)
-   ╰─ IgnoreId
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_length_of_min_(JS_on_top_of_reduce).txt
+++ b/mongodb/src/test/resources/planner/plan_length_of_min_(JS_on_top_of_reduce).txt
@@ -26,4 +26,4 @@ Chain
 ╰─ $ProjectF
    ├─ Name("state" -> true)
    ├─ Name("shortest" -> true)
-   ╰─ IgnoreId
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_many_sort_columns.txt
+++ b/mongodb/src/test/resources/planner/plan_many_sort_columns.txt
@@ -25,7 +25,7 @@ Chain
 │  │           { "$literal": undefined }]
 │  │       },
 │  │       ["$_id", "$$ROOT"]])
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $SimpleMapF
 │  ├─ Map
 │  │  ╰─ Obj
@@ -45,5 +45,5 @@ Chain
 │  ├─ SortKey(4 -> Ascending)
 │  ╰─ SortKey(5 -> Ascending)
 ╰─ $ProjectF
-   ├─ Name("value" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
+   ├─ Name("__quasar_mongodb_sigil" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_multiple_column_sort_with_wildcard.txt
+++ b/mongodb/src/test/resources/planner/plan_multiple_column_sort_with_wildcard.txt
@@ -25,7 +25,7 @@ Chain
 │  │           { "$literal": undefined }]
 │  │       },
 │  │       ["$_id", "$$ROOT"]])
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $SimpleMapF
 │  ├─ Map
 │  │  ╰─ Obj
@@ -37,5 +37,5 @@ Chain
 │  ├─ SortKey(0 -> Ascending)
 │  ╰─ SortKey(1 -> Descending)
 ╰─ $ProjectF
-   ├─ Name("value" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
+   ├─ Name("__quasar_mongodb_sigil" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_multiple_expressions_using_same_field.txt
+++ b/mongodb/src/test/resources/planner/plan_multiple_expressions_using_same_field.txt
@@ -114,21 +114,15 @@ Chain
 │     ╰─ NotExpr($right -> Size(0))
 ├─ $UnwindF(DocField(BsonField.Name("right")))
 ├─ $UnwindF(DocField(BsonField.Name("left")))
-╰─ $SimpleMapF
-   ├─ Map
-   │  ╰─ Let(__val)
-   │     ├─ Arr
-   │     │  ├─ Arr
-   │     │  │  ├─ JsCore(_.left[0][0])
-   │     │  │  ├─ Obj
-   │     │  │  │  ╰─ Key(pop: (isObject(_.left[0][1]) && (! Array.isArray(_.left[0][1]))) ? _.left[0][1].pop : undefined)
-   │     │  │  ╰─ Obj
-   │     │  │     ╰─ Key(1: _.left[1])
-   │     │  ╰─ JsCore(_.right[2])
-   │     ╰─ SpliceObjects
-   │        ├─ SpliceObjects
-   │        │  ├─ JsCore(__val[0][1])
-   │        │  ╰─ JsCore(__val[0][2])
-   │        ╰─ Obj
-   │           ╰─ Key(2: ((isNumber(__val[1][1]) || ((__val[1][1] instanceof NumberInt) || (__val[1][1] instanceof NumberLong))) || (__val[1][1] instanceof Date)) ? __val[1][2] : undefined)
-   ╰─ Scope(Map())
+├─ $SimpleMapF
+│  ├─ Map
+│  │  ╰─ Obj
+│  │     ├─ Key(pop: (isObject(_.left[0][1]) && (! Array.isArray(_.left[0][1]))) ? _.left[0][1].pop : undefined)
+│  │     ├─ Key(1: _.left[1])
+│  │     ╰─ Key(2: ((isNumber(_.right[2][1]) || ((_.right[2][1] instanceof NumberInt) || (_.right[2][1] instanceof NumberLong))) || (_.right[2][1] instanceof Date)) ? _.right[2][2] : undefined)
+│  ╰─ Scope(Map())
+╰─ $ProjectF
+   ├─ Name("pop" -> true)
+   ├─ Name("1" -> true)
+   ├─ Name("2" -> true)
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_non-equi_join.txt
+++ b/mongodb/src/test/resources/planner/plan_non-equi_join.txt
@@ -4,7 +4,7 @@ Chain
 │  │  ├─ $ReadF(db; zips)
 │  │  ├─ $ProjectF
 │  │  │  ├─ Name("0" -> ["$_id", "$$ROOT"])
-│  │  │  ╰─ IgnoreId
+│  │  │  ╰─ ExcludeId
 │  │  ├─ $SimpleMapF
 │  │  │  ├─ Map
 │  │  │  │  ╰─ Obj
@@ -50,7 +50,7 @@ Chain
 │     ├─ $ReadF(db; zips2)
 │     ├─ $ProjectF
 │     │  ├─ Name("0" -> ["$_id", "$$ROOT"])
-│     │  ╰─ IgnoreId
+│     │  ╰─ ExcludeId
 │     ├─ $SimpleMapF
 │     │  ├─ Map
 │     │  │  ╰─ Obj
@@ -128,5 +128,6 @@ Chain
 │        ╰─ Expr($1 -> Eq(Bool(true)))
 ╰─ $SimpleMapF
    ├─ Map
-   │  ╰─ JsCore((isObject(_.src[1][2]) && (! Array.isArray(_.src[1][2]))) ? _.src[1][2].city : undefined)
+   │  ╰─ Obj
+   │     ╰─ Key(__quasar_mongodb_sigil: (isObject(_.src[1][2]) && (! Array.isArray(_.src[1][2]))) ? _.src[1][2].city : undefined)
    ╰─ Scope(Map())

--- a/mongodb/src/test/resources/planner/plan_object_flatten.txt
+++ b/mongodb/src/test/resources/planner/plan_object_flatten.txt
@@ -11,11 +11,11 @@ Chain
 │  │         "$geo",
 │  │         { "$literal": undefined }]
 │  │     })
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $SimpleMapF
 │  ├─ Flatten
 │  │  ╰─ JsCore(_["0"])
 │  ╰─ Scope(Map())
 ╰─ $ProjectF
-   ├─ Name("value" -> "$0")
+   ├─ Name("__quasar_mongodb_sigil" -> "$0")
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_order_by_JS_expr_with_filter.txt
+++ b/mongodb/src/test/resources/planner/plan_order_by_JS_expr_with_filter.txt
@@ -33,5 +33,5 @@ Chain
 ├─ $SortF
 │  ╰─ SortKey(0 -> Ascending)
 ╰─ $ProjectF
-   ├─ Name("value" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
+   ├─ Name("__quasar_mongodb_sigil" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_select_with_multiple_wildcards_and_fields.txt
+++ b/mongodb/src/test/resources/planner/plan_select_with_multiple_wildcards_and_fields.txt
@@ -19,16 +19,18 @@ Chain
 │        ╰─ Expr($pop -> Lt(Int32(1000)))
 ╰─ $SimpleMapF
    ├─ Map
-   │  ╰─ SpliceObjects
-   │     ├─ SpliceObjects
-   │     │  ├─ SpliceObjects
-   │     │  │  ├─ SpliceObjects
-   │     │  │  │  ├─ Obj
-   │     │  │  │  │  ╰─ Key(state2: _.state)
-   │     │  │  │  ╰─ Ident(_)
-   │     │  │  ╰─ Obj
-   │     │  │     ╰─ Key(city2: _.city)
-   │     │  ╰─ Ident(_)
-   │     ╰─ Obj
-   │        ╰─ Key(pop2: _.pop)
+   │  ╰─ Obj
+   │     ╰─ Key(__quasar_mongodb_sigil)
+   │        ╰─ SpliceObjects
+   │           ├─ SpliceObjects
+   │           │  ├─ SpliceObjects
+   │           │  │  ├─ SpliceObjects
+   │           │  │  │  ├─ Obj
+   │           │  │  │  │  ╰─ Key(state2: _.state)
+   │           │  │  │  ╰─ Ident(_)
+   │           │  │  ╰─ Obj
+   │           │  │     ╰─ Key(city2: _.city)
+   │           │  ╰─ Ident(_)
+   │           ╰─ Obj
+   │              ╰─ Key(pop2: _.pop)
    ╰─ Scope(Map())

--- a/mongodb/src/test/resources/planner/plan_select_with_wildcard_and_two_constants.txt
+++ b/mongodb/src/test/resources/planner/plan_select_with_wildcard_and_two_constants.txt
@@ -2,11 +2,13 @@ Chain
 ├─ $ReadF(db; zips)
 ╰─ $SimpleMapF
    ├─ Map
-   │  ╰─ SpliceObjects
-   │     ├─ SpliceObjects
-   │     │  ├─ Ident(_)
-   │     │  ╰─ Obj
-   │     │     ╰─ Key(1: "1")
-   │     ╰─ Obj
-   │        ╰─ Key(2: "2")
+   │  ╰─ Obj
+   │     ╰─ Key(__quasar_mongodb_sigil)
+   │        ╰─ SpliceObjects
+   │           ├─ SpliceObjects
+   │           │  ├─ Ident(_)
+   │           │  ╰─ Obj
+   │           │     ╰─ Key(1: "1")
+   │           ╰─ Obj
+   │              ╰─ Key(2: "2")
    ╰─ Scope(Map())

--- a/mongodb/src/test/resources/planner/plan_select_with_wildcard_and_two_fields.txt
+++ b/mongodb/src/test/resources/planner/plan_select_with_wildcard_and_two_fields.txt
@@ -2,11 +2,13 @@ Chain
 ├─ $ReadF(db; zips)
 ╰─ $SimpleMapF
    ├─ Map
-   │  ╰─ SpliceObjects
-   │     ├─ SpliceObjects
-   │     │  ├─ Ident(_)
-   │     │  ╰─ Obj
-   │     │     ╰─ Key(city2: _.city)
-   │     ╰─ Obj
-   │        ╰─ Key(pop2: _.pop)
+   │  ╰─ Obj
+   │     ╰─ Key(__quasar_mongodb_sigil)
+   │        ╰─ SpliceObjects
+   │           ├─ SpliceObjects
+   │           │  ├─ Ident(_)
+   │           │  ╰─ Obj
+   │           │     ╰─ Key(city2: _.city)
+   │           ╰─ Obj
+   │              ╰─ Key(pop2: _.pop)
    ╰─ Scope(Map())

--- a/mongodb/src/test/resources/planner/plan_simple_Sort.txt
+++ b/mongodb/src/test/resources/planner/plan_simple_Sort.txt
@@ -14,5 +14,5 @@ Chain
 ├─ $SortF
 │  ╰─ SortKey(0 -> Ascending)
 ╰─ $ProjectF
-   ├─ Name("value" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
+   ├─ Name("__quasar_mongodb_sigil" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_simple_cross.txt
+++ b/mongodb/src/test/resources/planner/plan_simple_cross.txt
@@ -4,7 +4,7 @@ Chain
 │  │  ├─ $ReadF(db; zips)
 │  │  ├─ $ProjectF
 │  │  │  ├─ Name("0" -> ["$_id", "$$ROOT"])
-│  │  │  ╰─ IgnoreId
+│  │  │  ╰─ ExcludeId
 │  │  ├─ $SimpleMapF
 │  │  │  ├─ Map
 │  │  │  │  ╰─ Obj
@@ -50,7 +50,7 @@ Chain
 │     ├─ $ReadF(db; zips2)
 │     ├─ $ProjectF
 │     │  ├─ Name("0" -> ["$_id", "$$ROOT"])
-│     │  ╰─ IgnoreId
+│     │  ╰─ ExcludeId
 │     ├─ $SimpleMapF
 │     │  ├─ Map
 │     │  │  ╰─ Obj
@@ -128,5 +128,6 @@ Chain
 │        ╰─ Expr($1 -> Eq(Bool(true)))
 ╰─ $SimpleMapF
    ├─ Map
-   │  ╰─ JsCore((isObject(_.src[1][2]) && (! Array.isArray(_.src[1][2]))) ? _.src[1][2].city : undefined)
+   │  ╰─ Obj
+   │     ╰─ Key(__quasar_mongodb_sigil: (isObject(_.src[1][2]) && (! Array.isArray(_.src[1][2]))) ? _.src[1][2].city : undefined)
    ╰─ Scope(Map())

--- a/mongodb/src/test/resources/planner/plan_simple_having_filter.txt
+++ b/mongodb/src/test/resources/planner/plan_simple_having_filter.txt
@@ -88,7 +88,7 @@ Chain
 │     │  ├─ Name("0" -> { "$literal": true })
 │     │  ├─ Name("1" -> { "$arrayElemAt": [["$left", "$right"], { "$literal": NumberInt("1") }] })
 │     │  ├─ Name("src" -> ["$left", "$right"])
-│     │  ╰─ IgnoreId
+│     │  ╰─ ExcludeId
 │     ├─ $MatchF
 │     │  ╰─ And
 │     │     ├─ Doc
@@ -137,7 +137,7 @@ Chain
 │     │  │           { "$arrayElemAt": ["$src", { "$literal": NumberInt("1") }] },
 │     │  │           { "$literal": NumberInt("10") }]
 │     │  │       }])
-│     │  ╰─ IgnoreId
+│     │  ╰─ ExcludeId
 │     ├─ $MapF
 │     │  ├─ JavaScript(function (key, value) { return [null, { "right": [], "left": [value["0"]] }] })
 │     │  ╰─ Scope(Map())
@@ -174,5 +174,5 @@ Chain
 │  ╰─ By
 │     ╰─ Name("0" -> "$b0")
 ╰─ $ProjectF
-   ├─ Name("value" -> "$f0")
+   ├─ Name("__quasar_mongodb_sigil" -> "$f0")
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_simple_inner_equi-join_($lookup).txt
+++ b/mongodb/src/test/resources/planner/plan_simple_inner_equi-join_($lookup).txt
@@ -6,7 +6,7 @@ Chain
 │  │  │  ├─ Name("0" -> { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] })
 │  │  │  ├─ Name("1" -> { "$literal": true })
 │  │  │  ├─ Name("src" -> ["$_id", "$$ROOT"])
-│  │  │  ╰─ IgnoreId
+│  │  │  ╰─ ExcludeId
 │  │  ├─ $MatchF
 │  │  │  ╰─ And
 │  │  │     ├─ Doc
@@ -37,7 +37,7 @@ Chain
 │     │  ├─ Name("0" -> { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] })
 │     │  ├─ Name("1" -> { "$literal": true })
 │     │  ├─ Name("src" -> ["$_id", "$$ROOT"])
-│     │  ╰─ IgnoreId
+│     │  ╰─ ExcludeId
 │     ├─ $MatchF
 │     │  ╰─ And
 │     │     ├─ Doc
@@ -75,4 +75,4 @@ Chain
 ╰─ $ProjectF
    ├─ Name("name" -> true)
    ├─ Name("address" -> true)
-   ╰─ IgnoreId
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_simple_inner_equi-join_(map-reduce).txt
+++ b/mongodb/src/test/resources/planner/plan_simple_inner_equi-join_(map-reduce).txt
@@ -83,4 +83,4 @@ Chain
 ╰─ $ProjectF
    ├─ Name("name" -> true)
    ├─ Name("address" -> true)
-   ╰─ IgnoreId
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_simple_inner_equi-join_with_expression_($lookup).txt
+++ b/mongodb/src/test/resources/planner/plan_simple_inner_equi-join_with_expression_($lookup).txt
@@ -6,7 +6,7 @@ Chain
 │  │  │  ├─ Name("0" -> { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] })
 │  │  │  ├─ Name("1" -> { "$literal": true })
 │  │  │  ├─ Name("src" -> ["$_id", "$$ROOT"])
-│  │  │  ╰─ IgnoreId
+│  │  │  ╰─ ExcludeId
 │  │  ├─ $MatchF
 │  │  │  ╰─ And
 │  │  │     ├─ Doc
@@ -35,7 +35,7 @@ Chain
 │     ├─ $ReadF(db; foo)
 │     ├─ $ProjectF
 │     │  ├─ Name("0" -> ["$_id", "$$ROOT"])
-│     │  ╰─ IgnoreId
+│     │  ╰─ ExcludeId
 │     ├─ $SimpleMapF
 │     │  ├─ Map
 │     │  │  ╰─ Obj
@@ -86,4 +86,4 @@ Chain
 ╰─ $ProjectF
    ├─ Name("name" -> true)
    ├─ Name("address" -> true)
-   ╰─ IgnoreId
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_simple_inner_equi-join_with_pre-filtering_($lookup).txt
+++ b/mongodb/src/test/resources/planner/plan_simple_inner_equi-join_with_pre-filtering_($lookup).txt
@@ -6,7 +6,7 @@ Chain
 │  │  │  ├─ Name("0" -> { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] })
 │  │  │  ├─ Name("1" -> { "$literal": true })
 │  │  │  ├─ Name("src" -> ["$_id", "$$ROOT"])
-│  │  │  ╰─ IgnoreId
+│  │  │  ╰─ ExcludeId
 │  │  ├─ $MatchF
 │  │  │  ╰─ And
 │  │  │     ├─ Doc
@@ -35,7 +35,7 @@ Chain
 │     ├─ $ReadF(db; bar)
 │     ├─ $ProjectF
 │     │  ├─ Name("0" -> ["$_id", "$$ROOT"])
-│     │  ╰─ IgnoreId
+│     │  ╰─ ExcludeId
 │     ├─ $SimpleMapF
 │     │  ├─ Map
 │     │  │  ╰─ Obj
@@ -100,4 +100,4 @@ Chain
 ╰─ $ProjectF
    ├─ Name("name" -> true)
    ├─ Name("address" -> true)
-   ╰─ IgnoreId
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_simple_join_($lookup).txt
+++ b/mongodb/src/test/resources/planner/plan_simple_join_($lookup).txt
@@ -6,7 +6,7 @@ Chain
 │  │  │  ├─ Name("0" -> { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] })
 │  │  │  ├─ Name("1" -> { "$literal": true })
 │  │  │  ├─ Name("src" -> ["$_id", "$$ROOT"])
-│  │  │  ╰─ IgnoreId
+│  │  │  ╰─ ExcludeId
 │  │  ├─ $MatchF
 │  │  │  ╰─ And
 │  │  │     ├─ Doc
@@ -37,7 +37,7 @@ Chain
 │     │  ├─ Name("0" -> { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] })
 │     │  ├─ Name("1" -> { "$literal": true })
 │     │  ├─ Name("src" -> ["$_id", "$$ROOT"])
-│     │  ╰─ IgnoreId
+│     │  ╰─ ExcludeId
 │     ├─ $MatchF
 │     │  ╰─ And
 │     │     ├─ Doc
@@ -66,5 +66,6 @@ Chain
 ├─ $UnwindF(DocField(BsonField.Name("left")))
 ╰─ $SimpleMapF
    ├─ Map
-   │  ╰─ JsCore(_.right[1].city)
+   │  ╰─ Obj
+   │     ╰─ Key(__quasar_mongodb_sigil: _.right[1].city)
    ╰─ Scope(Map())

--- a/mongodb/src/test/resources/planner/plan_simple_join_(map-reduce).txt
+++ b/mongodb/src/test/resources/planner/plan_simple_join_(map-reduce).txt
@@ -74,5 +74,6 @@ Chain
 ├─ $UnwindF(DocField(BsonField.Name("left")))
 ╰─ $SimpleMapF
    ├─ Map
-   │  ╰─ JsCore(_.right[1].city)
+   │  ╰─ Obj
+   │     ╰─ Key(__quasar_mongodb_sigil: _.right[1].city)
    ╰─ Scope(Map())

--- a/mongodb/src/test/resources/planner/plan_simple_js_filter_3.txt
+++ b/mongodb/src/test/resources/planner/plan_simple_js_filter_3.txt
@@ -14,5 +14,5 @@ Chain
 │     ╰─ Doc
 │        ╰─ Expr($1 -> Lt(Int32(4)))
 ╰─ $ProjectF
-   ├─ Name("value" -> "$src")
+   ├─ Name("__quasar_mongodb_sigil" -> "$src")
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_simple_left_equi-join_($lookup).txt
+++ b/mongodb/src/test/resources/planner/plan_simple_left_equi-join_($lookup).txt
@@ -6,7 +6,7 @@ Chain
 │  │  │  ├─ Name("0" -> { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] })
 │  │  │  ├─ Name("1" -> { "$literal": true })
 │  │  │  ├─ Name("src" -> ["$_id", "$$ROOT"])
-│  │  │  ╰─ IgnoreId
+│  │  │  ╰─ ExcludeId
 │  │  ├─ $MatchF
 │  │  │  ╰─ And
 │  │  │     ├─ Doc
@@ -37,7 +37,7 @@ Chain
 │     │  ├─ Name("0" -> { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] })
 │     │  ├─ Name("1" -> { "$literal": true })
 │     │  ├─ Name("src" -> ["$_id", "$$ROOT"])
-│     │  ╰─ IgnoreId
+│     │  ╰─ ExcludeId
 │     ├─ $MatchF
 │     │  ╰─ And
 │     │     ├─ Doc
@@ -71,7 +71,7 @@ Chain
 │  │         { "$literal": [{  }] },
 │  │         "$right"]
 │  │     })
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $UnwindF(DocField(BsonField.Name("right")))
 ├─ $UnwindF(DocField(BsonField.Name("left")))
 ├─ $SimpleMapF
@@ -83,4 +83,4 @@ Chain
 ╰─ $ProjectF
    ├─ Name("name" -> true)
    ├─ Name("address" -> true)
-   ╰─ IgnoreId
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_simple_left_equi-join_(map-reduce).txt
+++ b/mongodb/src/test/resources/planner/plan_simple_left_equi-join_(map-reduce).txt
@@ -6,7 +6,7 @@ Chain
 │  │  │  ├─ Name("0" -> { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] })
 │  │  │  ├─ Name("1" -> { "$literal": true })
 │  │  │  ├─ Name("src" -> ["$_id", "$$ROOT"])
-│  │  │  ╰─ IgnoreId
+│  │  │  ╰─ ExcludeId
 │  │  ├─ $MatchF
 │  │  │  ╰─ And
 │  │  │     ├─ Doc
@@ -37,7 +37,7 @@ Chain
 │     │  ├─ Name("0" -> { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] })
 │     │  ├─ Name("1" -> { "$literal": true })
 │     │  ├─ Name("src" -> ["$_id", "$$ROOT"])
-│     │  ╰─ IgnoreId
+│     │  ╰─ ExcludeId
 │     ├─ $MatchF
 │     │  ╰─ And
 │     │     ├─ Doc
@@ -71,7 +71,7 @@ Chain
 │  │         { "$literal": [{  }] },
 │  │         "$right"]
 │  │     })
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $UnwindF(DocField(BsonField.Name("right")))
 ├─ $UnwindF(DocField(BsonField.Name("left")))
 ├─ $SimpleMapF
@@ -83,4 +83,4 @@ Chain
 ╰─ $ProjectF
    ├─ Name("name" -> true)
    ├─ Name("address" -> true)
-   ╰─ IgnoreId
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_simple_outer_equi-join_with_wildcard.txt
+++ b/mongodb/src/test/resources/planner/plan_simple_outer_equi-join_with_wildcard.txt
@@ -6,7 +6,7 @@ Chain
 │  │  │  ├─ Name("0" -> { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] })
 │  │  │  ├─ Name("1" -> { "$literal": true })
 │  │  │  ├─ Name("src" -> ["$_id", "$$ROOT"])
-│  │  │  ╰─ IgnoreId
+│  │  │  ╰─ ExcludeId
 │  │  ├─ $MatchF
 │  │  │  ╰─ And
 │  │  │     ├─ Doc
@@ -37,7 +37,7 @@ Chain
 │     │  ├─ Name("0" -> { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] })
 │     │  ├─ Name("1" -> { "$literal": true })
 │     │  ├─ Name("src" -> ["$_id", "$$ROOT"])
-│     │  ╰─ IgnoreId
+│     │  ╰─ ExcludeId
 │     ├─ $MatchF
 │     │  ╰─ And
 │     │     ├─ Doc
@@ -73,18 +73,17 @@ Chain
 │  │         { "$literal": [{  }] },
 │  │         "$right"]
 │  │     })
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $UnwindF(DocField(BsonField.Name("right")))
 ├─ $UnwindF(DocField(BsonField.Name("left")))
 ╰─ $SimpleMapF
    ├─ Map
-   │  ╰─ If
-   │     ├─ JsCore(isObject(_.right[1]) && (! Array.isArray(_.right[1])))
-   │     ├─ If
-   │     │  ├─ JsCore(isObject(_.left[1]) && (! Array.isArray(_.left[1])))
-   │     │  ├─ SpliceObjects
-   │     │  │  ├─ JsCore(_.left[1])
-   │     │  │  ╰─ JsCore(_.right[1])
-   │     │  ╰─ Ident(undefined)
-   │     ╰─ Ident(undefined)
+   │  ╰─ Obj
+   │     ╰─ Key(__quasar_mongodb_sigil)
+   │        ╰─ If
+   │           ├─ JsCore((isObject(_.right[1]) && (! Array.isArray(_.right[1]))) && (isObject(_.left[1]) && (! Array.isArray(_.left[1]))))
+   │           ├─ SpliceObjects
+   │           │  ├─ JsCore(_.left[1])
+   │           │  ╰─ JsCore(_.right[1])
+   │           ╰─ Ident(undefined)
    ╰─ Scope(Map())

--- a/mongodb/src/test/resources/planner/plan_simple_right_equi-join_($lookup).txt
+++ b/mongodb/src/test/resources/planner/plan_simple_right_equi-join_($lookup).txt
@@ -6,7 +6,7 @@ Chain
 │  │  │  ├─ Name("0" -> { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] })
 │  │  │  ├─ Name("1" -> { "$literal": true })
 │  │  │  ├─ Name("src" -> ["$_id", "$$ROOT"])
-│  │  │  ╰─ IgnoreId
+│  │  │  ╰─ ExcludeId
 │  │  ├─ $MatchF
 │  │  │  ╰─ And
 │  │  │     ├─ Doc
@@ -37,7 +37,7 @@ Chain
 │     │  ├─ Name("0" -> { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] })
 │     │  ├─ Name("1" -> { "$literal": true })
 │     │  ├─ Name("src" -> ["$_id", "$$ROOT"])
-│     │  ╰─ IgnoreId
+│     │  ╰─ ExcludeId
 │     ├─ $MatchF
 │     │  ╰─ And
 │     │     ├─ Doc
@@ -71,7 +71,7 @@ Chain
 │  │         "$left"]
 │  │     })
 │  ├─ Name("right" -> "$right")
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $UnwindF(DocField(BsonField.Name("right")))
 ├─ $UnwindF(DocField(BsonField.Name("left")))
 ├─ $SimpleMapF
@@ -83,4 +83,4 @@ Chain
 ╰─ $ProjectF
    ├─ Name("name" -> true)
    ├─ Name("address" -> true)
-   ╰─ IgnoreId
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_simple_single_field_selection_and_limit.txt
+++ b/mongodb/src/test/resources/planner/plan_simple_single_field_selection_and_limit.txt
@@ -1,0 +1,15 @@
+Chain
+├─ $ReadF(db; zips)
+├─ $LimitF(5)
+╰─ $ProjectF
+   ├─ Name("__quasar_mongodb_sigil" -> {
+   │       "$cond": [
+   │         {
+   │           "$and": [
+   │             { "$lte": [{ "$literal": {  } }, "$$ROOT"] },
+   │             { "$lt": ["$$ROOT", { "$literal": [] }] }]
+   │         },
+   │         "$city",
+   │         { "$literal": undefined }]
+   │     })
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_simple_sort_with_field_in_projection.txt
+++ b/mongodb/src/test/resources/planner/plan_simple_sort_with_field_in_projection.txt
@@ -2,7 +2,7 @@ Chain
 ├─ $ReadF(db; foo)
 ├─ $ProjectF
 │  ├─ Name("0" -> ["$bar", "$$ROOT"])
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $SimpleMapF
 │  ├─ Map
 │  │  ╰─ Obj
@@ -12,5 +12,5 @@ Chain
 ├─ $SortF
 │  ╰─ SortKey(0 -> Ascending)
 ╰─ $ProjectF
-   ├─ Name("value" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
+   ├─ Name("__quasar_mongodb_sigil" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_simple_sort_with_field_not_in_projections.txt
+++ b/mongodb/src/test/resources/planner/plan_simple_sort_with_field_not_in_projections.txt
@@ -14,5 +14,5 @@ Chain
 ├─ $SortF
 │  ╰─ SortKey(0 -> Ascending)
 ╰─ $ProjectF
-   ├─ Name("value" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
+   ├─ Name("__quasar_mongodb_sigil" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_simple_sort_with_wildcard.txt
+++ b/mongodb/src/test/resources/planner/plan_simple_sort_with_wildcard.txt
@@ -1,16 +1,20 @@
 Chain
 ├─ $ReadF(db; zips)
 ├─ $ProjectF
-│  ├─ Name("0" -> ["$$ROOT", "$$ROOT"])
-│  ╰─ IgnoreId
-├─ $SimpleMapF
-│  ├─ Map
-│  │  ╰─ Obj
-│  │     ├─ Key(0: (isObject(_["0"][1]) && (! Array.isArray(_["0"][1]))) ? _["0"][1].pop : undefined)
-│  │     ╰─ Key(src: _["0"])
-│  ╰─ Scope(Map())
+│  ├─ Name("0" -> {
+│  │       "$cond": [
+│  │         {
+│  │           "$and": [
+│  │             { "$lte": [{ "$literal": {  } }, "$$ROOT"] },
+│  │             { "$lt": ["$$ROOT", { "$literal": [] }] }]
+│  │         },
+│  │         "$pop",
+│  │         { "$literal": undefined }]
+│  │     })
+│  ├─ Name("src" -> "$$ROOT")
+│  ╰─ ExcludeId
 ├─ $SortF
 │  ╰─ SortKey(0 -> Ascending)
 ╰─ $ProjectF
-   ├─ Name("value" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
+   ├─ Name("__quasar_mongodb_sigil" -> "$src")
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_sort_and_limit.txt
+++ b/mongodb/src/test/resources/planner/plan_sort_and_limit.txt
@@ -16,5 +16,5 @@ Chain
 │  ╰─ SortKey(0 -> Descending)
 ├─ $LimitF(5)
 ╰─ $ProjectF
-   ├─ Name("value" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
+   ├─ Name("__quasar_mongodb_sigil" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_sort_with_expression,_alias,_and_filter.txt
+++ b/mongodb/src/test/resources/planner/plan_sort_with_expression,_alias,_and_filter.txt
@@ -32,5 +32,5 @@ Chain
 ├─ $SortF
 │  ╰─ SortKey(0 -> Ascending)
 ╰─ $ProjectF
-   ├─ Name("value" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
+   ├─ Name("__quasar_mongodb_sigil" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_sort_with_expression_and_alias.txt
+++ b/mongodb/src/test/resources/planner/plan_sort_with_expression_and_alias.txt
@@ -14,5 +14,5 @@ Chain
 ├─ $SortF
 │  ╰─ SortKey(0 -> Ascending)
 ╰─ $ProjectF
-   ├─ Name("value" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
+   ├─ Name("__quasar_mongodb_sigil" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_sort_with_expression_in_key.txt
+++ b/mongodb/src/test/resources/planner/plan_sort_with_expression_in_key.txt
@@ -15,5 +15,5 @@ Chain
 ├─ $SortF
 │  ╰─ SortKey(0 -> Ascending)
 ╰─ $ProjectF
-   ├─ Name("value" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
+   ├─ Name("__quasar_mongodb_sigil" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_sort_with_filter.txt
+++ b/mongodb/src/test/resources/planner/plan_sort_with_filter.txt
@@ -34,5 +34,5 @@ Chain
 │  ├─ SortKey(0 -> Descending)
 │  ╰─ SortKey(1 -> Ascending)
 ╰─ $ProjectF
-   ├─ Name("value" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
+   ├─ Name("__quasar_mongodb_sigil" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_sort_with_wildcard_and_expression_in_key.txt
+++ b/mongodb/src/test/resources/planner/plan_sort_with_wildcard_and_expression_in_key.txt
@@ -12,5 +12,5 @@ Chain
 ├─ $SortF
 │  ╰─ SortKey(0 -> Descending)
 ╰─ $ProjectF
-   ├─ Name("value" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
+   ├─ Name("__quasar_mongodb_sigil" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_sum_grouped_by_single_field_with_filter.txt
+++ b/mongodb/src/test/resources/planner/plan_sum_grouped_by_single_field_with_filter.txt
@@ -3,19 +3,22 @@ Chain
 ├─ $MatchF
 │  ╰─ Doc
 │     ╰─ Expr($state -> Eq(Text(CO)))
-╰─ $GroupF
-   ├─ Grouped
-   │  ╰─ Name("sm" -> {
-   │          "$sum": {
-   │            "$cond": [
-   │              {
-   │                "$and": [
-   │                  { "$lt": [{ "$literal": null }, "$pop"] },
-   │                  { "$lt": ["$pop", { "$literal": "" }] }]
-   │              },
-   │              "$pop",
-   │              { "$literal": undefined }]
-   │          }
-   │        })
-   ╰─ By
-      ╰─ Name("0" -> ["$city"])
+├─ $GroupF
+│  ├─ Grouped
+│  │  ╰─ Name("f0" -> {
+│  │          "$sum": {
+│  │            "$cond": [
+│  │              {
+│  │                "$and": [
+│  │                  { "$lt": [{ "$literal": null }, "$pop"] },
+│  │                  { "$lt": ["$pop", { "$literal": "" }] }]
+│  │              },
+│  │              "$pop",
+│  │              { "$literal": undefined }]
+│  │          }
+│  │        })
+│  ╰─ By
+│     ╰─ Name("0" -> ["$city"])
+╰─ $ProjectF
+   ├─ Name("sm" -> "$f0")
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_sum_of_expression_in_expression_with_another_projection_when_grouped.txt
+++ b/mongodb/src/test/resources/planner/plan_sum_of_expression_in_expression_with_another_projection_when_grouped.txt
@@ -37,4 +37,4 @@ Chain
    │         },
    │         { "$divide": ["$f1", { "$literal": NumberInt("1000") }] }]
    │     })
-   ╰─ IgnoreId
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_unaggregated_field_when_grouping,_second_case.txt
+++ b/mongodb/src/test/resources/planner/plan_unaggregated_field_when_grouping,_second_case.txt
@@ -34,7 +34,7 @@ Chain
 │     │  ├─ Name("0" -> [
 │     │  │       { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("0") }] },
 │     │  │       { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] }])
-│     │  ╰─ IgnoreId
+│     │  ╰─ ExcludeId
 │     ├─ $SimpleMapF
 │     │  ├─ Map
 │     │  │  ╰─ Obj
@@ -68,13 +68,10 @@ Chain
 ├─ $SimpleMapF
 │  ├─ Map
 │  │  ╰─ Obj
-│  │     ├─ Key(0: [_.left, _.right][0] / 1000)
-│  │     ╰─ Key(pop: (function (__val) {
-│  │            return (isObject(__val[1][1]) && (! Array.isArray(__val[1][1]))) ? __val[1][1].pop : undefined
-│  │          })(
-│  │            [_.left, _.right]))
+│  │     ├─ Key(0: _.left / 1000)
+│  │     ╰─ Key(pop: (isObject(_.right[1]) && (! Array.isArray(_.right[1]))) ? _.right[1].pop : undefined)
 │  ╰─ Scope(Map())
 ╰─ $ProjectF
    ├─ Name("0" -> true)
    ├─ Name("pop" -> true)
-   ╰─ IgnoreId
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_useful_group_by.txt
+++ b/mongodb/src/test/resources/planner/plan_useful_group_by.txt
@@ -82,4 +82,4 @@ Chain
    │       }
    │     })
    ├─ Name("1" -> "$f2")
-   ╰─ IgnoreId
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_with_extra_squash_and_flattening.txt
+++ b/mongodb/src/test/resources/planner/plan_with_extra_squash_and_flattening.txt
@@ -32,7 +32,7 @@ Chain
 ├─ $ProjectF
 │  ├─ Name("0" -> { "$arrayElemAt": ["$$ROOT", { "$literal": NumberInt("1") }] })
 │  ├─ Name("src" -> "$$ROOT")
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $MatchF
 │  ╰─ Doc
 │     ╰─ Expr($0 -> Eq(Bool(true)))
@@ -43,4 +43,4 @@ Chain
 │  ╰─ Scope(Map())
 ╰─ $ProjectF
    ├─ Name("city" -> true)
-   ╰─ IgnoreId
+   ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/prefer_projection+filter_over_nested_JS_filter.txt
+++ b/mongodb/src/test/resources/planner/prefer_projection+filter_over_nested_JS_filter.txt
@@ -5,7 +5,7 @@ Chain
 │  ├─ Name("1" -> { "$ne": ["$city", "$state"] })
 │  ├─ Name("2" -> "$pop")
 │  ├─ Name("src" -> "$$ROOT")
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $MatchF
 │  ╰─ And
 │     ├─ Or
@@ -26,5 +26,5 @@ Chain
 │     ╰─ Doc
 │        ╰─ Expr($2 -> Lt(Int32(10000)))
 ╰─ $ProjectF
-   ├─ Name("value" -> "$src")
+   ├─ Name("__quasar_mongodb_sigil" -> "$src")
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/unify_flattened_fields.txt
+++ b/mongodb/src/test/resources/planner/unify_flattened_fields.txt
@@ -32,7 +32,7 @@ Chain
 ├─ $ProjectF
 │  ├─ Name("0" -> { "$arrayElemAt": ["$$ROOT", { "$literal": NumberInt("1") }] })
 │  ├─ Name("src" -> "$$ROOT")
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $MatchF
 │  ╰─ Doc
 │     ╰─ Expr($0 -> Eq(Bool(true)))
@@ -41,4 +41,7 @@ Chain
    │  ╰─ JsCore(Array.isArray(_.src[0].loc) ? _.src[0].loc : undefined)
    ├─ Flatten
    │  ╰─ Ident(_)
+   ├─ Map
+   │  ╰─ Obj
+   │     ╰─ Key(__quasar_mongodb_sigil: _)
    ╰─ Scope(Map())

--- a/mongodb/src/test/resources/planner/unify_flattened_fields_with_unflattened_field.txt
+++ b/mongodb/src/test/resources/planner/unify_flattened_fields_with_unflattened_field.txt
@@ -40,9 +40,9 @@ Chain
 │  │         { "$literal": NumberInt("1") }]
 │  │     })
 │  ├─ Name("src" -> "$$ROOT")
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $SortF
 │  ╰─ SortKey(0 -> Ascending)
 ╰─ $ProjectF
-   ├─ Name("value" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
+   ├─ Name("__quasar_mongodb_sigil" -> { "$arrayElemAt": ["$src", { "$literal": NumberInt("0") }] })
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/unify_flattened_with_double-flattened.txt
+++ b/mongodb/src/test/resources/planner/unify_flattened_with_double-flattened.txt
@@ -69,7 +69,7 @@ Chain
 │     │  │         },
 │     │  │         { "$literal": undefined }]
 │     │  │     })
-│     │  ╰─ IgnoreId
+│     │  ╰─ ExcludeId
 │     ├─ $SimpleMapF
 │     │  ├─ SubMap
 │     │  │  ├─ JsCore(_.f)
@@ -119,7 +119,7 @@ Chain
 │     │  │         },
 │     │  │         { "$literal": undefined }]
 │     │  │     })
-│     │  ╰─ IgnoreId
+│     │  ╰─ ExcludeId
 │     ├─ $SimpleMapF
 │     │  ├─ Flatten
 │     │  │  ╰─ JsCore(_.f)
@@ -161,7 +161,7 @@ Chain
 │  │         { "$literal": NumberInt("1") }]
 │  │     })
 │  ├─ Name("src" -> ["$left", "$right"])
-│  ╰─ IgnoreId
+│  ╰─ ExcludeId
 ├─ $MatchF
 │  ╰─ And
 │     ├─ Doc
@@ -172,7 +172,7 @@ Chain
 │        ╰─ Doc
 │           ╰─ Expr($2 -> Eq(Bool(true)))
 ╰─ $ProjectF
-   ├─ Name("value" -> {
+   ├─ Name("__quasar_mongodb_sigil" -> {
    │       "$cond": [
    │         {
    │           "$and": [

--- a/mongodb/src/test/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutionSpec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutionSpec.scala
@@ -251,7 +251,7 @@ class JavaScriptWorkflowExecutionSpec extends quasar.Qspec {
           ListMap()))
 
       toJS(wf) must beRightDisjunction(
-        """db.zips.mapReduce(
+        s"""db.zips.mapReduce(
           |  function () {
           |    emit.apply(
           |      null,
@@ -260,7 +260,10 @@ class JavaScriptWorkflowExecutionSpec extends quasar.Qspec {
           |        this))
           |  },
           |  function (key, values) { return Array.sum(values) },
-          |  { "out": { "inline": NumberLong("1") } });
+          |  {
+          |    "out": { "inline": NumberLong("1") },
+          |    "finalize": function (key, value) { return { "${sigil.Quasar}": value } }
+          |  });
           |""".stripMargin)
     }
 


### PR DESCRIPTION
Eliminates the "value-wrapping" from MongoDB query results using the strategies described in #2762.

Additionally:
* Adds `EquiJoin` variants of normalization alongside the `ThetaJoin` versions. I didn't have time to explore how to unify these, but I think we should eventually.
* Adds support for multiple test directives per backend in regression test. This was useful during development, even though it didn't end up being necessary at the end.

Fixes #2762.
Fixes #2805.
Fixes #2826.