### PR TITLE
Converted BackendConfig to use File rather than Path

### DIFF
--- a/web/src/main/scala/quasar/server/Server.scala
+++ b/web/src/main/scala/quasar/server/Server.scala
@@ -22,7 +22,6 @@ import quasar.api.{redirectService, staticFileService, ResponseOr, ResponseT}
 import quasar.cli.Cmd
 import quasar.config._
 import quasar.console.{logErrors, stdout}
-import quasar.contrib.pathy.ADir
 import quasar.contrib.scalaz._
 import quasar.contrib.scopt._
 import quasar.db.DbConnectionConfig
@@ -63,7 +62,8 @@ object Server {
       val loadConfigM: Task[BackendConfig] = opts.loadConfig.fold(
         { plugins =>
           val err = Task.fail(new RuntimeException("plugin directory does not exist (or is a file)"))
-          ADir.fromFile(plugins).getOrElseF(err).map(BackendConfig.JarDirectory(_))
+          val check = Task.delay(plugins.exists() && plugins.isFile())
+          check.ifM(Task.now(BackendConfig.JarDirectory(plugins)), err)
         },
         backends => BackendConfig.fromBackends(IList.fromList(backends)))
 


### PR DESCRIPTION
Fixes #2813 
Fixes #2797

Obviously using `File` directly is not great, but I think it's more or less justified here since a) the Pathy representation of the same data is clunky due to sandboxing, and b) the previous pipeline was `File` -> `APath` -> `File`, with `APath` not serving any useful purpose (now we just have `File`).