### PR TITLE
Fix streaming of responses

### DIFF
--- a/foundation/src/main/scala/quasar/fp/process.scala
+++ b/foundation/src/main/scala/quasar/fp/process.scala
@@ -54,7 +54,7 @@ trait ProcessOps {
       firstStep[F2, O2] flatMap { next =>
         val (hd, tl) = next.unemit
 
-        if (hd.isEmpty || p(hd))
+        if (hd.isEmpty || p(hd) || tl.isHalt)
           (Process.emitAll(hd) ++ tl).point[F2]
         else
           (Process.emitAll(hd) ++ tl).stepUntil(p)

--- a/foundation/src/main/scala/quasar/fp/process.scala
+++ b/foundation/src/main/scala/quasar/fp/process.scala
@@ -54,7 +54,7 @@ trait ProcessOps {
       firstStep[F2, O2] flatMap { next =>
         val (hd, tl) = next.unemit
 
-        if (hd.isEmpty || p(hd) || tl.isHalt)
+        if (p(hd) || tl.isHalt)
           (Process.emitAll(hd) ++ tl).point[F2]
         else
           (Process.emitAll(hd) ++ tl).stepUntil(p)

--- a/foundation/src/main/scala/quasar/fp/process.scala
+++ b/foundation/src/main/scala/quasar/fp/process.scala
@@ -47,6 +47,7 @@ trait ProcessOps {
     /** Step through `Await`s in this `Process`, combining effects via `Bind`,
       * until the predicate returns true or the stream ends. The returned inner
       * `Process` emits the same values, in the same order as this process.
+      * @param p A predicate that receives all elements seen so far and returns whether to continue or not
       */
     @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
     final def stepUntil[F2[x] >: F[x], O2 >: O](p: SSeq[O2] => Boolean)(implicit F: Monad[F2], C: Catchable[F2]): F2[Process[F2, O2]] =
@@ -56,7 +57,7 @@ trait ProcessOps {
         if (hd.isEmpty || p(hd))
           (Process.emitAll(hd) ++ tl).point[F2]
         else
-          tl.stepUntil(p).map(Process.emitAll(hd) ++ _)
+          (Process.emitAll(hd) ++ tl).stepUntil(p)
       }
   }
 

--- a/web/src/main/scala/quasar/api/QHttpService.scala
+++ b/web/src/main/scala/quasar/api/QHttpService.scala
@@ -21,10 +21,9 @@ import quasar.fp._
 import quasar.fp.free
 import quasar.fp.ski._
 import org.http4s.{Request, Status, HttpService}
-import scalaz.std.iterable._
-import scalaz._, Scalaz._
+import scalaz._
 
-final class QHttpService[S[_]] private (val f: PartialFunction[Request, Free[S, QResponse[S]]]) {
+final case class QHttpService[S[_]] private (val f: PartialFunction[Request, Free[S, QResponse[S]]]) {
   def apply(req: Request): Free[S, QResponse[S]] =
     f.applyOrElse(req, κ(Free.pure(QResponse.empty[S].withStatus(Status.NotFound))))
 
@@ -49,48 +48,4 @@ final class QHttpService[S[_]] private (val f: PartialFunction[Request, Free[S, 
 
     HttpService(f andThen mkResponse)
   }
-}
-
-object QHttpService {
-  /** Producing this many bytes from a `Process[F, ByteVector]` should require
-    * at least one `F` effect.
-    *
-    * The scenarios this is intended to handle involve prepending a small wrapper
-    * around a stream, like "[\n" when outputting JSON data in an array, and thus
-    * 100 bytes seemed large enough to contain these cases and small enough as to
-    * not force more than is needed.
-    *
-    * This exists because of how http4s handles errors from `Process` responses.
-    * If an error is produced by a `Process` while streaming the connection is
-    * severed, but the headers and status code have already been emitted to the
-    * wire so it isn't possible to emit a useful error message or status. In an
-    * attempt to handle many common scenarios where the first effect in the stream
-    * is the most likely to error (i.e. opening a file, or other resource to stream
-    * from) we'd like to step the stream until we've reached the first `F` effect
-    * so that we can see if it succeeds before continuing with the rest of the
-    * stream, providing a chance to respond with an error in the failure case.
-    *
-    * We cannot just `Process.unemit` the `Process` as there may be non-`F` `Await`
-    * steps encountered before an actual `F` effect (from many of the combinators
-    * in `process1` and the like).
-    *
-    * This leads us to the current workaround which is to define this threshold
-    * which should be, ideally, just large enough to require the first `F` to
-    * produce the bytes, but not more. We then consume the byte stream until it
-    * ends or we've consumed this many bytes. Finally we have a chance to inspect
-    * the `F` and see if anything failed before handing the rest of the process
-    * to http4s to continue streaming to the client as normal.
-    */
-  val PROCESS_EFFECT_THRESHOLD_BYTES = 100L
-
-  def apply[S[_]](
-    f: PartialFunction[Request, Free[S, QResponse[S]]]
-  )(implicit
-    C: Catchable[Free[S, ?]]
-  ): QHttpService[S] =
-    new QHttpService(
-      f andThen (_ >>= (r =>
-        r.body
-          .stepUntil(_.foldMap(_.length) >= PROCESS_EFFECT_THRESHOLD_BYTES)
-          .map(b => r.copy(body = b)))))
 }

--- a/web/src/main/scala/quasar/api/QResponse.scala
+++ b/web/src/main/scala/quasar/api/QResponse.scala
@@ -17,6 +17,7 @@
 package quasar.api
 
 import slamdata.Predef._
+import quasar.contrib.scalaz.catchable._
 import quasar.contrib.scalaz.eitherT._
 import quasar.effect.Failure
 import quasar.fp._
@@ -27,7 +28,8 @@ import org.http4s._
 import org.http4s.headers._
 import org.http4s.dsl._
 import scalaz.{Optional => _, _}
-import scalaz.syntax.monad._
+import scalaz.std.iterable._
+import scalaz.Scalaz._
 import scalaz.concurrent.Task
 import scalaz.stream.Process
 import scodec.bits.ByteVector
@@ -97,21 +99,51 @@ object QResponse {
       E.headers,
       Process.await(E.toEntity(a))(_.body).translate[Free[S, ?]](free.injectFT))
 
+  /**
+    * This QResponse constructor guards against `Processes` that include "expected"
+    * errors as part of the head of the `Process` so that these get transformed into
+    * useful Http responses to the user of endpoints who make use of such streams.
+    */
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
   def streaming[S[_], A]
       (p: Process[Free[S, ?], A])
       (implicit E: EntityEncoder[A], S0: Task :<: S)
-      : QResponse[S] =
-    QResponse(
-      Ok,
-      E.headers,
-      p.flatMap[Free[S, ?], ByteVector](a =>
-        Process.await(E.toEntity(a))(_.body).translate[Free[S, ?]](free.injectFT)))
+      : Free[S, QResponse[S]] = {
+    val responseBody = p.flatMap[Free[S, ?], ByteVector](a =>
+      Process.await(E.toEntity(a))(_.body).translate[Free[S, ?]](free.injectFT))
+
+    /** Producing this many bytes from a `Process[F, ByteVector]` should require
+      * at least one `F` effect.
+      *
+      * The scenarios this is intended to handle involve prepending a small wrapper
+      * around a stream, like "[\n" when outputting JSON data in an array, and thus
+      * 100 bytes seemed large enough to contain these cases and small enough as to
+      * not force more than is needed.
+      *
+      * We cannot just `Process.unemit` the `Process` as there may be non-`F` `Await`
+      * steps encountered before an actual `F` effect (from many of the combinators
+      * in `process1` and the like).
+      *
+      * This leads us to the current workaround which is to define this threshold
+      * which should be, ideally, just large enough to require the first `F` to
+      * produce the bytes, but not more. We then consume the byte stream until it
+      * ends or we've consumed this many bytes. Finally we have a chance to inspect
+      * the `F` and see if anything failed before handing the rest of the process
+      * to http4s to continue streaming to the client as normal.
+      */
+    val PROCESS_EFFECT_THRESHOLD_BYTES = 100L
+
+    guardStream(responseBody, PROCESS_EFFECT_THRESHOLD_BYTES).map(guardedStream =>
+      QResponse(
+        Ok,
+        E.headers,
+        guardedStream))
+  }
 
   def streaming[S[_], A, E]
       (p: Process[EitherT[Free[S, ?], E, ?], A])
       (implicit A: EntityEncoder[A], S0: Task :<: S, S1: Failure[E, ?] :<: S)
-      : QResponse[S] = {
+      : Free[S, QResponse[S]] = {
     val failure = Failure.Ops[E, S]
     streaming(p.translate(failure.unattemptT))
   }
@@ -121,4 +153,11 @@ object QResponse {
       status,
       Headers(`Content-Type`(MediaType.`text/plain`, Some(Charset.`UTF-8`))),
       Process.emit(ByteVector.view(s.getBytes(Charset.`UTF-8`.nioCharset))))
+
+  /**
+    * If any errors were to occur before lookAhead bytes would be read from `stream`, these errors will
+    * now happen whenever the outer `M` is first evaluated.
+    */
+  private def guardStream[M[_]: Catchable: Monad](stream: Process[M, ByteVector], lookAhead: Long): M[Process[M, ByteVector]] =
+    stream.stepUntil(_.foldMap(_.length) >= lookAhead)
 }

--- a/web/src/main/scala/quasar/api/services/analyze/schema.scala
+++ b/web/src/main/scala/quasar/api/services/analyze/schema.scala
@@ -20,7 +20,6 @@ import slamdata.Predef.{-> => _, _}
 import quasar.api._, ToApiError.ops._
 import quasar.api.services._
 import quasar.api.services.query._
-import quasar.contrib.scalaz.catchable._
 import quasar.contrib.scalaz.disjunction._
 import quasar.contrib.scalaz.foldable._
 import quasar.ejson.EJson
@@ -94,10 +93,9 @@ object schema {
                            blob, requestVars(req), dir, DefaultSampleSize, settings
                          ).leftMap(_.toApiError)
           schema      <- r.liftT[Free[S, ?]].leftMap(_.toApiError)
-        } yield {
-          formattedDataResponse(
-            MessageFormat.fromAccept(req.headers.get(Accept)),
-            schema.map(analysis.schemaToData(_)).toProcess)
-        })
+          response    <- EitherT.right(formattedDataResponse(
+                           MessageFormat.fromAccept(req.headers.get(Accept)),
+                           schema.map(analysis.schemaToData(_)).toProcess))
+        } yield response)
     }
 }

--- a/web/src/main/scala/quasar/api/services/metadata.scala
+++ b/web/src/main/scala/quasar/api/services/metadata.scala
@@ -20,7 +20,6 @@ import slamdata.Predef.{ -> => _, _ }
 import quasar.fp.ski._
 import quasar.api._
 import quasar.contrib.pathy._
-import quasar.contrib.scalaz.catchable._
 import quasar.contrib.std._
 import quasar.fp.numeric._
 import quasar.fs._

--- a/web/src/main/scala/quasar/api/services/metastore.scala
+++ b/web/src/main/scala/quasar/api/services/metastore.scala
@@ -18,7 +18,6 @@ package quasar.api.services
 
 import slamdata.Predef.StringContext
 import quasar.api._
-import quasar.contrib.scalaz.catchable._
 import quasar.db.DbConnectionConfig
 import quasar.fp.free._
 import quasar.main.{MainErrT, MetaStoreLocation}

--- a/web/src/main/scala/quasar/api/services/mount.scala
+++ b/web/src/main/scala/quasar/api/services/mount.scala
@@ -19,7 +19,6 @@ package quasar.api.services
 import slamdata.Predef.{ -> => _, _ }
 import quasar.api._, ToApiError.ops._
 import quasar.contrib.pathy._
-import quasar.contrib.scalaz.catchable._
 import quasar.effect.{KeyValueStore, Timing}
 import quasar.fp._, ski._
 import quasar.fs.mount._

--- a/web/src/main/scala/quasar/api/services/query/analysis.scala
+++ b/web/src/main/scala/quasar/api/services/query/analysis.scala
@@ -21,7 +21,6 @@ import quasar._
 import quasar.api._, ToApiError.ops._
 import quasar.api.services._
 import quasar.contrib.pathy._
-import quasar.contrib.scalaz.catchable._
 import quasar.fp.numeric._
 import quasar.fs._
 import quasar.fs.mount.Mounting

--- a/web/src/main/scala/quasar/api/services/query/compile.scala
+++ b/web/src/main/scala/quasar/api/services/query/compile.scala
@@ -21,7 +21,6 @@ import quasar._
 import quasar.api._, ToApiError.ops._
 import quasar.api.services._
 import quasar.contrib.pathy._
-import quasar.contrib.scalaz.catchable._
 import quasar.fp.numeric._
 import quasar.fs._
 import quasar.fs.mount.Mounting


### PR DESCRIPTION
Unbeknownst to us streaming in Quasar has been broken for quite a while. The implementation of `stepUntil` was to blame\.

Also reworks the "guarding" of streams to be more pinpointed and easier to work with