### PR TITLE
Enable `locationCount.test` for most connectors.

### DIFF
--- a/it/src/main/resources/tests/jobs_jobinfo.data
+++ b/it/src/main/resources/tests/jobs_jobinfo.data
@@ -1,7 +1,7 @@
-{ "PositionHeader" : {   "PositionLocation" : {     "LocationCity" : "Denver",     "LocationState" : "unknown",     "LocationZip" : "unknown",     "LocationCountry" : "unknown" }  } }
-{ "PositionHeader" : {   "PositionLocation" : {     "LocationCity" : "Boston",     "LocationState" : "MA",     "LocationZip" : "z02121",     "LocationCountry" : "US" }  } }
-{ "PositionHeader" : {   "PositionLocation" : {     "LocationCity" : "Boston",     "LocationState" : "MA",     "LocationZip" : "z",     "LocationCountry" : "US" }  } }
-{ "PositionHeader" : {   "PositionLocation" : {     "LocationCity" : "Denver",     "LocationState" : "unknown",     "LocationZip" : "zunknown",     "LocationCountry" : "unknown" }  } }
-{ "PositionHeader" : {   "PositionLocation" : {     "LocationCity" : "Boston",     "LocationState" : "unknown",     "LocationZip" : "zunknown",     "LocationCountry" : "unknown" }  }   }
-{ "PositionHeader" : {   "PositionLocation" : {     "LocationCity" : "Boulder",     "LocationState" : "unknown",     "LocationZip" : "zunknown",     "LocationCountry" : "unknown" }  }   }
-{ "PositionHeader" : {   "PositionLocation" : {     "LocationCity" : "Boston",     "LocationState" : "unknown",     "LocationZip" : "zunknown",     "LocationCountry" : "unknown" }  }   }
+{ "PositionHeader" : { "PositionLocation" : { "LocationCity" : "Denver",  "LocationState" : "unknown", "LocationZip" : "unknown",  "LocationCountry" : "unknown" }  } }
+{ "PositionHeader" : { "PositionLocation" : { "LocationCity" : "Boston",  "LocationState" : "MA",      "LocationZip" : "z02121",   "LocationCountry" : "US" }  } }
+{ "PositionHeader" : { "PositionLocation" : { "LocationCity" : "Boston",  "LocationState" : "MA",      "LocationZip" : "z",        "LocationCountry" : "US" }  } }
+{ "PositionHeader" : { "PositionLocation" : { "LocationCity" : "Denver",  "LocationState" : "unknown", "LocationZip" : "zunknown", "LocationCountry" : "unknown" }  } }
+{ "PositionHeader" : { "PositionLocation" : { "LocationCity" : "Boston",  "LocationState" : "unknown", "LocationZip" : "zunknown", "LocationCountry" : "unknown" }  }   }
+{ "PositionHeader" : { "PositionLocation" : { "LocationCity" : "Boulder", "LocationState" : "unknown", "LocationZip" : "zunknown", "LocationCountry" : "unknown" }  }   }
+{ "PositionHeader" : { "PositionLocation" : { "LocationCity" : "Boston",  "LocationState" : "unknown", "LocationZip" : "zunknown", "LocationCountry" : "unknown" }  }   }

--- a/it/src/main/resources/tests/locationCount.test
+++ b/it/src/main/resources/tests/locationCount.test
@@ -1,29 +1,21 @@
 {
-    "name": "job postings by city ",
+    "name": "job postings by city",
     "backends": {
-        "couchbase":         "pending",
-        "marklogic_json":    "pending",
-        "marklogic_xml":     "timeout",
-        "mimir":"pendingIgnoreFieldOrder",
-        "mongodb_2_6":       "pendingIgnoreFieldOrder",
-        "mongodb_3_0":       "pendingIgnoreFieldOrder",
-        "mongodb_3_2":       "pendingIgnoreFieldOrder",
-        "mongodb_3_4":       "pendingIgnoreFieldOrder",
-        "mongodb_read_only": "pendingIgnoreFieldOrder",
-        "spark_hdfs":        "pending",
-        "spark_local":       "pending",
-        "spark_cassandra":   "pending"
+        "marklogic_json": "ignoreFieldOrder",
+        "mongodb_2_6": "ignoreResultOrder",
+        "mongodb_3_0": "ignoreResultOrder",
+        "mongodb_read_only": "ignoreResultOrder",
+        "mimir": "ignoreFieldOrder"
     },
-    "NB": "Skipped for marklogic_xml because it times out.",
     "data": "jobs_jobinfo.data",
     "query": "select count(PositionHeader.PositionLocation.LocationCity) as counter,
               PositionHeader.PositionLocation.LocationCity as location
               from jobs_jobinfo
-              group by location
+              group by PositionHeader.PositionLocation.LocationCity
               order by counter desc
               limit 10",
-    "predicate": "initial",
-    "expected": [{ "counter": 3, "location": "Boston"  },
+    "predicate": "exactly",
+    "expected": [{ "counter": 4, "location": "Boston"  },
                  { "counter": 2, "location": "Denver"  },
                  { "counter": 1, "location": "Boulder" }]
 }


### PR DESCRIPTION
Fixes #2494 

The test query and test expectations for `locationCount.test` were both incorrect.