### PR TITLE
Include failtrace for specs2 console output in travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,9 @@ script:
     SPECIFIC_DELEGATE=
 
     case $CONNECTOR in
-      couchbase) SPECIFIC_DELEGATE="couchbaseIt/testOnly -- xonly" ;;
-      marklogic_*) SPECIFIC_DELEGATE="marklogicIt/testOnly -- xonly" ;;
-      mongodb_*) SPECIFIC_DELEGATE="mongoIt/testOnly -- xonly" ;;
+      couchbase) SPECIFIC_DELEGATE="couchbaseIt/testOnly -- xonly failtrace" ;;
+      marklogic_*) SPECIFIC_DELEGATE="marklogicIt/testOnly -- xonly failtrace" ;;
+      mongodb_*) SPECIFIC_DELEGATE="mongoIt/testOnly -- xonly failtrace" ;;
       spark_hdfs) ./sbt 'set every sparkDependencyProvided := true' sparkcore/assembly ;;
       *) ;;
     esac
@@ -69,7 +69,7 @@ script:
   - |-
     ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION \
       it/sideEffectTestFSConfig \
-      "it/testOnly -- xonly" \
+      "it/testOnly -- xonly failtrace" \
       "$SPECIFIC_DELEGATE"
 
   - set +e
@@ -99,8 +99,8 @@ jobs:
         - |-
           ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION \
             it/sideEffectTestFSConfig \
-            "testOnly -- xonly" \
-            "exclusive:testOnly -- xonly"
+            "testOnly -- xonly failtrace" \
+            "exclusive:testOnly -- xonly failtrace"
 
     - stage: publish
       env:


### PR DESCRIPTION
Without `failtrace` enabled, the console sometimes prints too little information about a failed test, since only the test name is printed along with a single line number reference.

Usually this is enough information, but in the case of `StdLibSpec`, each connector delegates to that specification, and the line number in the test failure references the individual connector spec, not `StdLibSpec`, which is not enough information to know which test failed if there are multiple tests with the same name. (For example, we have a case for "any doubles" for many different mathematical operations.)

See https://github.com/quasar-analytics/quasar/issues/2923 for an example.