### PR TITLE
Upgrade `http4s` to `0.16.5a` (latest on `0.16.x` series)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   private val raptureVersion      = "2.0.0-M9"
   private val refinedVersion      = "0.8.3"
   private val scodecBitsVersion   = "1.1.2"
-  private val http4sVersion       = "0.16.0a"
+  private val http4sVersion       = "0.16.5a"
   private val scalacheckVersion   = "1.13.4"
   private val scalazVersion       = "7.2.15"
   private val scalazStreamVersion = "0.8.6a"


### PR DESCRIPTION
There were a few important fixes released in these past few releases that we probably want to have in the release.