### PR TITLE
Remove dead code in untypers, add a comment explaining the typechecker

### DIFF
--- a/frontend/src/main/scala/quasar/frontend/logicalplan/LogicalPlanR.scala
+++ b/frontend/src/main/scala/quasar/frontend/logicalplan/LogicalPlanR.scala
@@ -422,6 +422,25 @@ final class LogicalPlanR[T]
     // TODO[scalaz]: Shadow the scalaz.Monad.monadMTMAB SI-2712 workaround
     import StateT.stateTMonadState
 
+    // Firstly we infer the types in the LogicalPlan. We start with the assumption
+    // that the entire thing returns `Type.Top`, then we feed that into the outermost untyper,
+    // asking "if this expression returns `Type.Top`, what are the types of the arguments?"
+    // We then continue in a top-down fashion, calling untypers exclusively to infer all of the types.
+    // Only the type *checker* calls the typers, because untypers always have the option to "give up"
+    // and return a fixed input type regardless of the expected output.
+    // In several other areas where we have no type information, we feed in `Type.Top` as well.
+
+    // Secondly we check the types. Type checking means calling typers in a bottom-up
+    // fashion, to verify that all of the argument types returned by untypers actually correspond
+    // to the result types returned by untypers. This includes propagation of constant types.
+
+    // Note that this means there is *no reason* to return a constant type from an untyper.
+    // Not only do they not exist yet, because `Type.Top` is the starting assumption of
+    // type inference, but even if they did, they could only propagate backwards.
+    // Elaborating, there is no way to work back from the knowledge that a function returns a constant
+    // to the knowledge that the function's parameters are constants, because
+    // there is no way to know a function returns a constant unless you already know
+    // the parameters are constants!
     inferTypes(Type.Top, term).flatMap(
       _.cataM(liftTM(checkTypesƒ)).map(appConst(_, constant(Data.NA))).evalZero.validation)
   }

--- a/frontend/src/main/scala/quasar/std/date.scala
+++ b/frontend/src/main/scala/quasar/std/date.scala
@@ -288,7 +288,6 @@ trait DateLib extends Library with Serializable {
         success(Type.Timestamp)
     },
     untyper[nat._1] {
-      case Type.Const(Data.Timestamp(ts)) => success(Func.Input1(Type.Const(Data.Date(ts.atZone(UTC).toLocalDate))))
       case Type.Timestamp                 => success(Func.Input1(Type.Date))
       case t                              => success(Func.Input1(t))
     })

--- a/frontend/src/main/scala/quasar/std/identity.scala
+++ b/frontend/src/main/scala/quasar/std/identity.scala
@@ -79,10 +79,6 @@ trait IdentityLib extends Library {
                         ,
     partialUntyper[nat._1] {
       case Type.Bottom => Func.Input1(Type.Bottom)
-      case Type.Const(Data.Str(name)) =>
-        Func.Input1(PrimaryType.name.getOption(name).fold[Type](
-          Type.Top)(
-          Type.fromPrimaryType))
       case _ => Func.Input1(Type.Top)
     })
 }

--- a/frontend/src/main/scala/quasar/std/structural.scala
+++ b/frontend/src/main/scala/quasar/std/structural.scala
@@ -43,10 +43,6 @@ trait StructuralLib extends Library {
       case Sized(_, valueType)                       => Obj(Map(), Some(valueType))
     },
     partialUntyperV[nat._2] {
-      case Const(Data.Obj(map)) => map.headOption match {
-        case Some((key, value)) => success(Func.Input2(Const(Data.Str(key)), Const(value)))
-        case None => failure(NonEmptyList(GenericError("MAKE_OBJECT can’t result in an empty object")))
-      }
       case Obj(map, uk) => map.headOption.fold(
         uk.fold[Func.VDomain[nat._2]](
           failure(NonEmptyList(GenericError("MAKE_OBJECT can’t result in an empty object"))))(
@@ -68,7 +64,6 @@ trait StructuralLib extends Library {
       case Sized(valueType)             => Arr(List(valueType))
     },
     partialUntyper[nat._1] {
-      case Const(Data.Arr(List(elem))) => Func.Input1(Const(elem))
       case Arr(List(elemType))         => Func.Input1(elemType)
       case FlexArr(_, _, elemType)     => Func.Input1(elemType)
     })
@@ -231,7 +226,6 @@ trait StructuralLib extends Library {
       case Sized(v1, _) => Obj(Map(), v1.objectType)
     },
     partialUntyperV[nat._2] {
-      case Const(o @ Data.Obj(map)) => DeleteField.untpe(o.dataType)
       case Obj(map, _)              => success(Func.Input2(Obj(map, Some(Top)), Str))
     })
 


### PR DESCRIPTION
Low priority. Noticed this during datetime shift, a bunch of functions have untypers which do calculation on constant values and they actually cannot be called at runtime. Removed them and documented how the typechecker works and why they can't be called.