### PR TITLE
Fixed spark jar publication (both sparkless and plugin jars)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ env:
     - CONNECTOR=spark_local_test
     - CONNECTOR=spark_hdfs
   global:
-    - 'SBT="./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION"'
     - COURSIER_PROGRESS=0
 
 # this is also the test stage :eyeroll:
@@ -61,7 +60,7 @@ script:
       mongodb_*) SPECIFIC_DELEGATE="mongoIt/testOnly -- xonly failtrace" ;;
 
       spark_hdfs)
-        $SBT \
+        ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION" \
           'set every assemblyJarName in assembly := "sparkcore.jar"' \
           'set every sparkDependencyProvided := true' \
           sparkcore/assembly
@@ -71,11 +70,11 @@ script:
     esac
 
   # workaround for the fact that travis caching isn't working. when it starts working again, remove this
-  - travis_wait 40 $SBT connector/test:compile
+  - travis_wait 40 ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION" connector/test:compile
 
   # then run the tests (note that this re-runs some tests; we can get rid of that once we have polyrepo)
   - |-
-    $SBT \
+    ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION" \
       it/sideEffectTestFSConfig \
       "it/testOnly -- xonly failtrace" \
       "$SPECIFIC_DELEGATE"
@@ -94,7 +93,7 @@ jobs:
         - set -e
 
         - |-
-          $SBT \
+          ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION" \
             checkHeaders \
             test:compile
 
@@ -105,7 +104,7 @@ jobs:
       env:
       script:
         - |-
-          $SBT \
+          ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION" \
             it/sideEffectTestFSConfig \
             "testOnly -- xonly failtrace" \
             "exclusive:testOnly -- xonly failtrace"
@@ -114,7 +113,7 @@ jobs:
       env:
       script:
         - set -e
-        - '$SBT doc web/assembly'
+        - './sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION" doc web/assembly'
         - scripts/testJar
 
         # release to sonatype
@@ -122,7 +121,7 @@ jobs:
 
         # recreate sparkcore.jar, which is just going to hang out
         - |-
-          $SBT \
+          ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION" \
             'set every assemblyJarName in assembly := "sparkcore.jar"' \
             'set every sparkDependencyProvided := true' \
             sparkcore/assembly

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ script:
       mongodb_*) SPECIFIC_DELEGATE="mongoIt/testOnly -- xonly failtrace" ;;
 
       spark_hdfs)
-        ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION" \
+        ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION \
           'set every assemblyJarName in assembly := "sparkcore.jar"' \
           'set every sparkDependencyProvided := true' \
           sparkcore/assembly
@@ -70,11 +70,11 @@ script:
     esac
 
   # workaround for the fact that travis caching isn't working. when it starts working again, remove this
-  - travis_wait 40 ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION" connector/test:compile
+  - travis_wait 40 ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION connector/test:compile
 
   # then run the tests (note that this re-runs some tests; we can get rid of that once we have polyrepo)
   - |-
-    ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION" \
+    ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION \
       it/sideEffectTestFSConfig \
       "it/testOnly -- xonly failtrace" \
       "$SPECIFIC_DELEGATE"
@@ -93,7 +93,7 @@ jobs:
         - set -e
 
         - |-
-          ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION" \
+          ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION \
             checkHeaders \
             test:compile
 
@@ -104,7 +104,7 @@ jobs:
       env:
       script:
         - |-
-          ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION" \
+          ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION \
             it/sideEffectTestFSConfig \
             "testOnly -- xonly failtrace" \
             "exclusive:testOnly -- xonly failtrace"
@@ -113,7 +113,7 @@ jobs:
       env:
       script:
         - set -e
-        - './sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION" doc web/assembly'
+        - './sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION doc web/assembly'
         - scripts/testJar
 
         # release to sonatype
@@ -121,7 +121,7 @@ jobs:
 
         # recreate sparkcore.jar, which is just going to hang out
         - |-
-          ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION" \
+          ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION \
             'set every assemblyJarName in assembly := "sparkcore.jar"' \
             'set every sparkDependencyProvided := true' \
             sparkcore/assembly

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ env:
     - CONNECTOR=spark_local_test
     - CONNECTOR=spark_hdfs
   global:
+    - 'SBT="./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION"'
     - COURSIER_PROGRESS=0
 
 # this is also the test stage :eyeroll:
@@ -58,16 +59,23 @@ script:
       couchbase) SPECIFIC_DELEGATE="couchbaseIt/testOnly -- xonly failtrace" ;;
       marklogic_*) SPECIFIC_DELEGATE="marklogicIt/testOnly -- xonly failtrace" ;;
       mongodb_*) SPECIFIC_DELEGATE="mongoIt/testOnly -- xonly failtrace" ;;
-      spark_hdfs) ./sbt 'set every sparkDependencyProvided := true' sparkcore/assembly ;;
+
+      spark_hdfs)
+        $SBT \
+          'set every assemblyJarName in assembly := "sparkcore.jar"' \
+          'set every sparkDependencyProvided := true' \
+          sparkcore/assembly
+        ;;
+
       *) ;;
     esac
 
   # workaround for the fact that travis caching isn't working. when it starts working again, remove this
-  - travis_wait 40 ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION connector/test:compile
+  - travis_wait 40 $SBT connector/test:compile
 
   # then run the tests (note that this re-runs some tests; we can get rid of that once we have polyrepo)
   - |-
-    ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION \
+    $SBT \
       it/sideEffectTestFSConfig \
       "it/testOnly -- xonly failtrace" \
       "$SPECIFIC_DELEGATE"
@@ -86,7 +94,7 @@ jobs:
         - set -e
 
         - |-
-          ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION \
+          $SBT \
             checkHeaders \
             test:compile
 
@@ -97,7 +105,7 @@ jobs:
       env:
       script:
         - |-
-          ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION \
+          $SBT \
             it/sideEffectTestFSConfig \
             "testOnly -- xonly failtrace" \
             "exclusive:testOnly -- xonly failtrace"
@@ -106,11 +114,19 @@ jobs:
       env:
       script:
         - set -e
-        - './sbt ++$TRAVIS_SCALA_VERSION doc web/assembly'
+        - '$SBT doc web/assembly'
         - scripts/testJar
 
         # release to sonatype
         - scripts/quasarPublishAndTag
+
+        # recreate sparkcore.jar, which is just going to hang out
+        - |-
+          $SBT \
+            'set every assemblyJarName in assembly := "sparkcore.jar"' \
+            'set every sparkDependencyProvided := true' \
+            sparkcore/assembly
+          ;;
 
         # release to github
         - scripts/publishJar

--- a/build.sbt
+++ b/build.sbt
@@ -454,8 +454,11 @@ lazy val sparkcore = project
     )
   .settings(commonSettings)
   .settings(targetSettings)
-  // .settings(githubReleaseSettings)
-  .settings(assemblyJarName in assembly := "sparkcore.jar")
+  .settings(githubReleaseSettings)
+  // re-add the sparkcore.jar that we hopefully generated
+  // se really should generate this more explicitly, rather than relying on the CI script
+  // it's hard though because generating it requires setting and then un-setting some keys
+  .settings(GithubKeys.assets += crossTarget.value / "sparkcore.jar")
   .settings(parallelExecution in Test := false)
   .settings(
     sparkDependencyProvided := false,


### PR DESCRIPTION
The `sparkcore.jar` publication is a bit of a hack.  We should do better in future when we have more time.