### PR TITLE
Make use of `InMemFS` instead of custom interpreters in `DataServiceSpec`

### DIFF
--- a/connector/src/main/scala/quasar/fs/InMemory.scala
+++ b/connector/src/main/scala/quasar/fs/InMemory.scala
@@ -270,6 +270,9 @@ object InMemory {
   def runBackend(initial: InMemState): Task[BackendEffect ~> Task] =
     runStatefully(initial).map(_ compose fileSystem0)
 
+  def runBackendInspect(initial: InMemState): Task[(BackendEffect ~> Task, Task[InMemState])] =
+    runInspect(initial).map { case (inter, read) => (inter compose fileSystem0, read)}
+
   ////
 
   private val lpr = new LogicalPlanR[Fix[LogicalPlan]]


### PR DESCRIPTION
View cache requires some extra special interpreter so leaving that there for now (although I have a hunch those tests could be re-written in another way to avoid the custom interpreter)