### PR TITLE
Avoid extracting guards from OR expressions.

### DIFF
--- a/connector/src/main/scala/quasar/qscript/MapFuncCore.scala
+++ b/connector/src/main/scala/quasar/qscript/MapFuncCore.scala
@@ -255,7 +255,9 @@ object MapFuncCore {
       //     doing that for certain MapFuncs, so we add explicit `none`s.
       case Guard(_, _, _, _)
          | IfUndefined(_, _)
-         | MakeArray(_) | MakeMap(_, _) => none
+         | MakeArray(_)
+         | MakeMap(_, _)
+         | Or(_, _) => none
       // TODO: This should be able to extract a guard where _either_ side is
       //       `Undefined`, and should also extract `Cond` with `Undefined` on a
       //       branch.

--- a/it/src/main/resources/tests/filterWithDisjunctionAndGuards.test
+++ b/it/src/main/resources/tests/filterWithDisjunctionAndGuards.test
@@ -1,0 +1,28 @@
+{
+    "name": "filter on disjunction of expressions involving guards",
+    "backends": {
+        "couchbase":  "ignoreFieldOrder",
+        "marklogic_json": "pendingIgnoreFieldOrder",
+        "marklogic_xml": "pending",
+        "mimir":"pendingIgnoreFieldOrder"
+    },
+    "data": "zips.data",
+    "query": "select `_id`, city from zips where city ~ \"IN$\" or pop ~ \"IN$\"",
+    "predicate": "atLeast",
+    "ignoreResultOrder": true,
+    "expected": [
+        { "_id": "01340", "city": "COLRAIN" }
+      , { "_id": "01503", "city": "BERLIN" }
+      , { "_id": "02038", "city": "FRANKLIN" }
+      , { "_id": "02130", "city": "JAMAICA PLAIN" }
+      , { "_id": "03235", "city": "FRANKLIN" }
+      , { "_id": "03444", "city": "DUBLIN" }
+      , { "_id": "03570", "city": "BERLIN" }
+      , { "_id": "04024", "city": "EAST BALDWIN" }
+      , { "_id": "04091", "city": "WEST BALDWIN" }
+      , { "_id": "04541", "city": "CHAMBERLAIN" }
+      , { "_id": "04616", "city": "BROOKLIN" }
+      , { "_id": "04634", "city": "FRANKLIN" }
+      , { "_id": "04661", "city": "NORTH BROOKLIN" }
+    ]
+}

--- a/it/src/main/resources/tests/filterWithDisjunctionAndGuards.test
+++ b/it/src/main/resources/tests/filterWithDisjunctionAndGuards.test
@@ -3,7 +3,6 @@
     "backends": {
         "couchbase":  "ignoreFieldOrder",
         "marklogic_json": "pendingIgnoreFieldOrder",
-        "marklogic_xml": "pending",
         "mimir":"pendingIgnoreFieldOrder"
     },
     "data": "zips.data",

--- a/mongodb/src/test/resources/planner/plan_filter_on_date.txt
+++ b/mongodb/src/test/resources/planner/plan_filter_on_date.txt
@@ -1,40 +1,39 @@
 Chain
 ├─ $ReadF(db; logs)
 ╰─ $MatchF
-   ╰─ And
-      ├─ Or
+   ╰─ Or
+      ├─ And
+      │  ├─ Or
+      │  │  ├─ Doc
+      │  │  │  ╰─ Expr($ts -> Type(Int32))
+      │  │  ├─ Doc
+      │  │  │  ╰─ Expr($ts -> Type(Int64))
+      │  │  ├─ Doc
+      │  │  │  ╰─ Expr($ts -> Type(Dec))
+      │  │  ├─ Doc
+      │  │  │  ╰─ Expr($ts -> Type(Text))
+      │  │  ├─ Doc
+      │  │  │  ╰─ Expr($ts -> Type(Date))
+      │  │  ╰─ Doc
+      │  │     ╰─ Expr($ts -> Type(Bool))
+      │  ├─ Or
+      │  │  ├─ Doc
+      │  │  │  ╰─ Expr($ts -> Type(Int32))
+      │  │  ├─ Doc
+      │  │  │  ╰─ Expr($ts -> Type(Int64))
+      │  │  ├─ Doc
+      │  │  │  ╰─ Expr($ts -> Type(Dec))
+      │  │  ├─ Doc
+      │  │  │  ╰─ Expr($ts -> Type(Text))
+      │  │  ├─ Doc
+      │  │  │  ╰─ Expr($ts -> Type(Date))
+      │  │  ╰─ Doc
+      │  │     ╰─ Expr($ts -> Type(Bool))
       │  ├─ Doc
-      │  │  ╰─ Expr($ts -> Type(Int32))
+      │  │  ╰─ Expr($ts -> Gt(Date(1421884800000)))
       │  ├─ Doc
-      │  │  ╰─ Expr($ts -> Type(Int64))
-      │  ├─ Doc
-      │  │  ╰─ Expr($ts -> Type(Dec))
-      │  ├─ Doc
-      │  │  ╰─ Expr($ts -> Type(Text))
-      │  ├─ Doc
-      │  │  ╰─ Expr($ts -> Type(Date))
+      │  │  ╰─ Expr($ts -> Lte(Date(1422316800000)))
       │  ╰─ Doc
-      │     ╰─ Expr($ts -> Type(Bool))
-      ├─ Or
-      │  ├─ Doc
-      │  │  ╰─ Expr($ts -> Type(Int32))
-      │  ├─ Doc
-      │  │  ╰─ Expr($ts -> Type(Int64))
-      │  ├─ Doc
-      │  │  ╰─ Expr($ts -> Type(Dec))
-      │  ├─ Doc
-      │  │  ╰─ Expr($ts -> Type(Text))
-      │  ├─ Doc
-      │  │  ╰─ Expr($ts -> Type(Date))
-      │  ╰─ Doc
-      │     ╰─ Expr($ts -> Type(Bool))
-      ╰─ Or
-         ├─ And
-         │  ├─ Doc
-         │  │  ╰─ Expr($ts -> Gt(Date(1421884800000)))
-         │  ├─ Doc
-         │  │  ╰─ Expr($ts -> Lte(Date(1422316800000)))
-         │  ╰─ Doc
-         │     ╰─ Expr($ts -> Neq(Date(1422144000000)))
-         ╰─ Doc
-            ╰─ Expr($ts -> Eq(Date(1422489600000)))
+      │     ╰─ Expr($ts -> Neq(Date(1422144000000)))
+      ╰─ Doc
+         ╰─ Expr($ts -> Eq(Date(1422489600000)))

--- a/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/planner.scala
@@ -896,12 +896,15 @@ class PlannerSpec extends
        beWorkflow(chain[Workflow](
          $read(collection("db", "foo")),
          $match(
-           Selector.And(
-             Selector.Doc(
-               BsonField.Name("bar") -> Selector.Type(BsonType.Text)),
-             Selector.Or(
+           Selector.Or(
+             Selector.And(
                Selector.Doc(
-                 BsonField.Name("bar") -> Selector.Regex("^A.*$", false, true, false, false)),
+                 BsonField.Name("bar") -> Selector.Type(BsonType.Text)),
+               Selector.Doc(
+                 BsonField.Name("bar") -> Selector.Regex("^A.*$", false, true, false, false))),
+             Selector.And(
+               Selector.Doc(
+                 BsonField.Name("bar") -> Selector.Type(BsonType.Text)),
                Selector.Doc(
                  BsonField.Name("bar") -> Selector.Regex("^Z.*$", false, true, false, false)))))))
     }
@@ -1000,22 +1003,25 @@ class PlannerSpec extends
         $read(collection("db", "a")),
         $simpleMap(NonEmptyList(MapExpr(JsFn(Name("x"), obj(
           "0" -> Select(ident("x"), "pattern"),
-          "1" -> Select(ident("x"), "target"),
-          "2" -> Call(
+          "1" -> Call(
             Select(New(Name("RegExp"), List(Select(ident("x"), "pattern"), jscore.Literal(Js.Str("m")))), "test"),
             List(jscore.Literal(Js.Str("foo")))),
-          "3" -> Call(
+          "2" -> Select(ident("x"), "pattern"),
+          "3" -> Select(ident("x"), "target"),
+          "4" -> Call(
             Select(New(Name("RegExp"), List(Select(ident("x"), "pattern"), jscore.Literal(Js.Str("m")))), "test"),
             List(Select(ident("x"), "target"))),
           "src" -> ident("x"))))),
           ListMap()),
         $match(
-          Selector.And(
-            Selector.Doc(BsonField.Name("0") -> Selector.Type(BsonType.Text)),
-            Selector.Doc(BsonField.Name("1") -> Selector.Type(BsonType.Text)),
-            Selector.Or(
-              Selector.Doc(BsonField.Name("2") -> Selector.Eq(Bson.Bool(true))),
-              Selector.Doc(BsonField.Name("3") -> Selector.Eq(Bson.Bool(true)))))),
+          Selector.Or(
+            Selector.And(
+              Selector.Doc(BsonField.Name("0") -> Selector.Type(BsonType.Text)),
+              Selector.Doc(BsonField.Name("1") -> Selector.Eq(Bson.Bool(true)))),
+            Selector.And(
+              Selector.Doc(BsonField.Name("2") -> Selector.Type(BsonType.Text)),
+              Selector.Doc(BsonField.Name("3") -> Selector.Type(BsonType.Text)),
+              Selector.Doc(BsonField.Name("4") -> Selector.Eq(Bson.Bool(true)))))),
         $project(
           reshape(sigil.Quasar -> $field("src")),
           ExcludeId)))


### PR DESCRIPTION
Pulling guards out of `or` expressions has the effect of requiring all the guards in the expression to pass before the `or` is evaluated whereas we'd rather evaluate each operand to the `or` independently, guards and all.

This is necessary for the search card functionality in SlamData to work (see slamdata/slamdata#2367) as well as other queries involving guards in filter disjunctions.