### PR TITLE
QScript/EJson construction DSL

### DIFF
--- a/connector/src/main/scala/quasar/qscript/construction.scala
+++ b/connector/src/main/scala/quasar/qscript/construction.scala
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript
+
+import slamdata.Predef._
+import matryoshka._
+import matryoshka.data.Fix
+
+import scalaz._
+import scalaz.Leibniz.===
+import quasar.qscript
+import quasar.common.{JoinType, SortDir}
+import quasar.std.TemporalPart
+import quasar.ejson.EJson
+
+object construction {
+  final case class Func[T[_[_]]]()(implicit corec: CorecursiveT[T]) {
+      private def rollCore[A](in: MapFuncCore[T, FreeMapA[T, A]]): FreeMapA[T, A] = Free.roll(MFC(in))
+      private def rollDerived[A](in: MapFuncDerived[T, FreeMapA[T, A]]): FreeMapA[T, A] = Free.roll(MFD(in))
+      def Constant[A](in: T[EJson]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Constant(in))
+      def Undefined[A]: FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Undefined())
+      def Now[A]: FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Now())
+      def JoinSideName[A](sym: Symbol): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.JoinSideName(sym))
+      def ExtractCentury[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ExtractCentury(a1))
+      def ExtractDayOfMonth[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ExtractDayOfMonth(a1))
+      def ExtractDecade[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ExtractDecade(a1))
+      def ExtractDayOfWeek[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ExtractDayOfWeek(a1))
+      def ExtractDayOfYear[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ExtractDayOfYear(a1))
+      def ExtractEpoch[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ExtractEpoch(a1))
+      def ExtractHour[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ExtractHour(a1))
+      def ExtractIsoDayOfWeek[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ExtractIsoDayOfWeek(a1))
+      def ExtractIsoYear[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ExtractIsoYear(a1))
+      def ExtractMicroseconds[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ExtractMicroseconds(a1))
+      def ExtractMillennium[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ExtractMillennium(a1))
+      def ExtractMilliseconds[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ExtractMilliseconds(a1))
+      def ExtractMinute[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ExtractMinute(a1))
+      def ExtractMonth[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ExtractMonth(a1))
+      def ExtractQuarter[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ExtractQuarter(a1))
+      def ExtractSecond[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ExtractSecond(a1))
+      def ExtractTimezone[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ExtractTimezone(a1))
+      def ExtractTimezoneHour[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ExtractTimezoneHour(a1))
+      def ExtractTimezoneMinute[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ExtractTimezoneMinute(a1))
+      def ExtractWeek[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ExtractWeek(a1))
+      def ExtractYear[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ExtractYear(a1))
+      def Date[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Date(a1))
+      def Time[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Time(a1))
+      def Timestamp[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Timestamp(a1))
+      def Interval[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Interval(a1))
+      def StartOfDay[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.StartOfDay(a1))
+      def TimeOfDay[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.TimeOfDay(a1))
+      def ToTimestamp[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ToTimestamp(a1))
+      def TypeOf[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.TypeOf(a1))
+      def Negate[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Negate(a1))
+      def Not[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Not(a1))
+      def Length[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Length(a1))
+      def Lower[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Lower(a1))
+      def Upper[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Upper(a1))
+      def Bool[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Bool(a1))
+      def Integer[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Integer(a1))
+      def Decimal[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Decimal(a1))
+      def Null[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Null(a1))
+      def ToString[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ToString(a1))
+      def MakeArray[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.MakeArray(a1))
+      def Meta[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Meta(a1))
+      def ProjectField[A](src: FreeMapA[T, A], field: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ProjectField(src, field))
+      def ProjectFieldS[A](src: FreeMapA[T, A], field: String): FreeMapA[T, A] =
+        ProjectField(src, Constant(EJson.str(field)))
+      def DeleteField[A](src: FreeMapA[T, A], field: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.DeleteField(src, field))
+      def DeleteFieldS[A](src: FreeMapA[T, A], field: String): FreeMapA[T, A] =
+        DeleteField(src, Constant(EJson.str(field)))
+      def MakeMap[A](key: FreeMapA[T, A], src: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.MakeMap(key, src))
+      def MakeMapS[A](key: String, src: FreeMapA[T, A]): FreeMapA[T, A] =
+        MakeMap(Constant(EJson.str(key)), src)
+      def ProjectIndex[A](src: FreeMapA[T, A], index: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ProjectIndex(src, index))
+      def ProjectIndexI[A](src: FreeMapA[T, A], index: Int): FreeMapA[T, A] =
+        ProjectIndex(src, Constant(EJson.int(index)))
+      def ConcatArrays[A](left: FreeMapA[T, A], right: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ConcatArrays(left, right))
+      def ConcatMaps[A](left: FreeMapA[T, A], right: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.ConcatMaps(left, right))
+      def Add[A](left: FreeMapA[T, A], right: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Add(left, right))
+      def Multiply[A](left: FreeMapA[T, A], right: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Multiply(left, right))
+      def Subtract[A](left: FreeMapA[T, A], right: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Subtract(left, right))
+      def Divide[A](left: FreeMapA[T, A], right: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Divide(left, right))
+      def Modulo[A](a1: FreeMapA[T, A], a2: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Modulo(a1, a2))
+      def Power[A](a1: FreeMapA[T, A], a2: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Power(a1, a2))
+      def Lt[A](a1: FreeMapA[T, A], a2: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Lt(a1, a2))
+      def Lte[A](a1: FreeMapA[T, A], a2: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Lte(a1, a2))
+      def Gt[A](a1: FreeMapA[T, A], a2: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Gt(a1, a2))
+      def Gte[A](a1: FreeMapA[T, A], a2: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Gte(a1, a2))
+      def IfUndefined[A](a1: FreeMapA[T, A], a2: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.IfUndefined(a1, a2))
+      def And[A](a1: FreeMapA[T, A], a2: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.And(a1, a2))
+      def Or[A](a1: FreeMapA[T, A], a2: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Or(a1, a2))
+      def TemporalTrunc[A](part: TemporalPart, a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.TemporalTrunc(part, a1))
+      def Within[A](a1: FreeMapA[T, A], a2: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Within(a1, a2))
+      def Range[A](a1: FreeMapA[T, A], a2: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Range(a1, a2))
+      def Split[A](a1: FreeMapA[T, A], a2: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Split(a1, a2))
+      def Eq[A](left: FreeMapA[T, A], right: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Eq(left, right))
+      def Neq[A](left: FreeMapA[T, A], right: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Neq(left, right))
+      def Between[A](a1: FreeMapA[T, A], a2: FreeMapA[T, A], a3: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Between(a1, a2, a3))
+      def Cond[A](a1: FreeMapA[T, A], a2: FreeMapA[T, A], a3: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Cond(a1, a2, a3))
+      def Search[A](a1: FreeMapA[T, A], a2: FreeMapA[T, A], a3: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Search(a1, a2, a3))
+      def Substring[A](a1: FreeMapA[T, A], a2: FreeMapA[T, A], a3: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Substring(a1, a2, a3))
+      def Guard[A](a1: FreeMapA[T, A], tpe: quasar.Type, a2: FreeMapA[T, A], a3: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollCore(MapFuncsCore.Guard(a1, tpe, a2, a3))
+      def Hole: FreeMap[T] = Free.pure(SrcHole)
+      def LeftSide: JoinFunc[T] = Free.pure(qscript.LeftSide)
+      def RightSide: JoinFunc[T] = Free.pure(qscript.RightSide)
+
+      def Abs[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollDerived(MapFuncsDerived.Abs(a1))
+      def Ceil[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollDerived(MapFuncsDerived.Ceil(a1))
+      def Floor[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollDerived(MapFuncsDerived.Floor(a1))
+      def Trunc[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollDerived(MapFuncsDerived.Trunc(a1))
+      def Round[A](a1: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollDerived(MapFuncsDerived.Round(a1))
+
+      def FloorScale[A](a1: FreeMapA[T, A], a2: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollDerived(MapFuncsDerived.FloorScale(a1, a2))
+      def CeilScale[A](a1: FreeMapA[T, A], a2: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollDerived(MapFuncsDerived.CeilScale(a1, a2))
+      def RoundScale[A](a1: FreeMapA[T, A], a2: FreeMapA[T, A]): FreeMapA[T, A] =
+        rollDerived(MapFuncsDerived.RoundScale(a1, a2))
+  }
+
+  final case class Dsl[T[_[_]], F[_], R](embed: F[R] => R)
+                                        (implicit corec: CorecursiveT[T],
+                                         injCore: Injectable.Aux[QScriptCore[T, ?], F],
+                                         injTotal: Injectable.Aux[F, QScriptTotal[T, ?]]) {
+    private def core(fr: QScriptCore[T, R]): R = embed(injCore.inject(fr))
+      def Map(r: R, func: FreeMap[T]): R =
+        core(qscript.Map[T, R](r, func))
+      def LeftShift(src: R,
+                    struct: FreeMap[T],
+                    idStatus: IdStatus,
+                    repair: JoinFunc[T]): R =
+        core(qscript.LeftShift(src, struct, idStatus, repair))
+      def Reduce(src: R,
+                 bucket: List[FreeMap[T]],
+                 reducers: List[ReduceFunc[FreeMap[T]]],
+                 repair: FreeMapA[T, ReduceIndex]): R =
+        core(qscript.Reduce(src, bucket, reducers, repair))
+      def Sort(src: R,
+               bucket: List[FreeMap[T]],
+               order: NonEmptyList[(FreeMap[T], SortDir)]): R =
+        core(qscript.Sort(src, bucket, order))
+      def Union(src: R,
+                lBranch: Free[F, Hole],
+                rBranch: Free[F, Hole]): R =
+        core(qscript.Union(src, lBranch.mapSuspension(injTotal.inject), rBranch.mapSuspension(injTotal.inject)))
+      def Filter(src: R,
+                 f: FreeMap[T]): R =
+        core(qscript.Filter(src, f))
+      def Subset(src: R,
+                 from: Free[F, Hole],
+                 op: SelectionOp,
+                 count: Free[F, Hole]): R =
+        core(qscript.Subset(src, from.mapSuspension(injTotal.inject), op, count.mapSuspension(injTotal.inject)))
+      def Unreferenced: R =
+        core(qscript.Unreferenced())
+      def BucketField(src: R, value: FreeMap[T], name: FreeMap[T])(implicit F: Injectable.Aux[ProjectBucket[T, ?], F]): R =
+        embed(F.inject(qscript.BucketField(src, value, name)))
+      def BucketIndex(src: R, value: FreeMap[T], index: FreeMap[T])(implicit F: Injectable.Aux[ProjectBucket[T, ?], F]): R =
+        embed(F.inject(qscript.BucketIndex(src, value, index)))
+      def ThetaJoin(src: R,
+                    lBranch: Free[F, Hole],
+                    rBranch: Free[F, Hole],
+                    on: JoinFunc[T],
+                    f: JoinType,
+                    combine: JoinFunc[T])
+                   (implicit F: Injectable.Aux[ThetaJoin[T, ?], F]): R =
+        embed(F.inject(qscript.ThetaJoin(src, lBranch.mapSuspension(injTotal.inject), rBranch.mapSuspension(injTotal.inject), on, f, combine)))
+      def EquiJoin(src: R,
+                   lBranch: Free[F, Hole],
+                   rBranch: Free[F, Hole],
+                   key: List[(FreeMap[T], FreeMap[T])],
+                   f: JoinType,
+                   combine: JoinFunc[T])
+                  (implicit F: Injectable.Aux[EquiJoin[T, ?], F]): R =
+        embed(F.inject(qscript.EquiJoin(src, lBranch.mapSuspension(injTotal.inject), rBranch.mapSuspension(injTotal.inject), key, f, combine)))
+      def ShiftedRead[A](path: A,
+                         idStatus: IdStatus)
+                        (implicit F: Injectable.Aux[Const[ShiftedRead[A], ?], F]): R =
+        embed(F.inject(Const(qscript.ShiftedRead(path, idStatus))))
+      def Read[A](path: A)
+                 (implicit F: Injectable.Aux[Const[Read[A], ?], F]): R =
+        embed(F.inject(Const(qscript.Read(path))))
+      def Root(implicit F: Injectable.Aux[Const[DeadEnd, ?], F]): R =
+        embed(F.inject(Const(qscript.Root)))
+      def Hole(implicit ev: Free[F, Hole] === R): R =
+        ev(Free.pure(SrcHole))
+  }
+
+  def mkDefaults[T[_[_]]: CorecursiveT, F[_]](implicit
+                                              injCore: Injectable.Aux[QScriptCore[T, ?], F],
+                                              injTotal: Injectable.Aux[F, QScriptTotal[T, ?]]): (Func[T], Dsl[T, F, Free[F, Hole]], Dsl[T, F, Fix[F]]) =
+    (Func[T], mkFree[T, F], mkFix[T, F])
+
+  def mkFree[T[_[_]]: CorecursiveT, F[_]](implicit
+                                          injCore: Injectable.Aux[QScriptCore[T, ?], F],
+                                          injTotal: Injectable.Aux[F, QScriptTotal[T, ?]]): Dsl[T, F, Free[F, Hole]] =
+    Dsl[T, F, Free[F, Hole]](Free.roll)
+
+  def mkFix[T[_[_]]: CorecursiveT, F[_]](implicit
+                                         injCore: Injectable.Aux[QScriptCore[T, ?], F],
+                                         injTotal: Injectable.Aux[F, QScriptTotal[T, ?]]): Dsl[T, F, Fix[F]] =
+    Dsl[T, F, Fix[F]](Fix(_))
+
+  def mkGeneric[T[_[_]], F[_]: Functor](implicit corec: CorecursiveT[T],
+                                        injCore: Injectable.Aux[QScriptCore[T, ?], F],
+                                        injTotal: Injectable.Aux[F, QScriptTotal[T, ?]]): Dsl[T, F, T[F]] =
+    Dsl[T, F, T[F]](corec.embedT(_))
+}

--- a/couchbase/src/main/scala/quasar/physical/couchbase/Couchbase.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/Couchbase.scala
@@ -51,10 +51,10 @@ trait Couchbase extends BackendModule with DefaultAnalyzeModule {
     KeyValueStore[ResultHandle, Cursor, ?]
   )#M[A]
 
-  type QS[T[_[_]]] = QScriptCore[T, ?] :\: EquiJoin[T, ?] :/: Const[ShiftedRead[AFile], ?]
+  type QS[T[_[_]]] = CouchbaseQScriptCP[T]
 
   implicit def qScriptToQScriptTotal[T[_[_]]]: Injectable.Aux[QSM[T, ?], QScriptTotal[T, ?]] =
-    ::\::[QScriptCore[T, ?]](::/::[T, EquiJoin[T, ?], Const[ShiftedRead[AFile], ?]])
+    quasar.physical.couchbase.qScriptToQScriptTotal[T]
 
   type Repr = Mu[N1QL]
 

--- a/couchbase/src/main/scala/quasar/physical/couchbase/package.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/package.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical
+
+import quasar.fp._
+import quasar.qscript._
+import quasar.contrib.pathy.AFile
+import scalaz.Const
+
+package object couchbase {
+  type CouchbaseQScriptCP[T[_[_]]] = QScriptCore[T, ?] :\: EquiJoin[T, ?] :/: Const[ShiftedRead[AFile], ?]
+  
+  implicit def qScriptToQScriptTotal[T[_[_]]]: Injectable.Aux[CouchbaseQScriptCP[T]#M, QScriptTotal[T, ?]] =
+    ::\::[QScriptCore[T, ?]](::/::[T, EquiJoin[T, ?], Const[ShiftedRead[AFile], ?]])
+
+  implicit def qScriptCoreToQScript[T[_[_]]]: Injectable.Aux[QScriptCore[T, ?], CouchbaseQScriptCP[T]#M] =
+    Injectable.inject[QScriptCore[T, ?], CouchbaseQScriptCP[T]#M]
+
+  implicit def equiJoinToQScript[T[_[_]]]: Injectable.Aux[EquiJoin[T, ?], CouchbaseQScriptCP[T]#M] =
+    Injectable.inject[EquiJoin[T, ?], CouchbaseQScriptCP[T]#M]
+
+  implicit def shiftedReadToQScript[T[_[_]]]: Injectable.Aux[Const[ShiftedRead[AFile], ?], CouchbaseQScriptCP[T]#M] =
+    Injectable.inject[Const[ShiftedRead[AFile], ?], CouchbaseQScriptCP[T]#M]
+}

--- a/ejson/src/main/scala/quasar/ejson/package.scala
+++ b/ejson/src/main/scala/quasar/ejson/package.scala
@@ -87,8 +87,32 @@ package object ejson {
     def fromExt[T](e: Extension[T])(implicit T: Corecursive.Aux[T, EJson]): T =
       ExtEJson(e).embed
 
+    def arr[T[_[_]]](xs: T[EJson]*)(implicit T: CorecursiveT[T]): T[EJson] =
+      fromCommon(Arr(xs.toList))
+
+    def bool[T[_[_]]](b: Boolean)(implicit T: CorecursiveT[T]): T[EJson] =
+      fromCommon(Bool(b))
+
+    def dec[T[_[_]]](d: BigDecimal)(implicit T: CorecursiveT[T]): T[EJson] =
+      fromCommon(Dec(d))
+
+    def nul[T[_[_]]](implicit T: CorecursiveT[T]): T[EJson] =
+      fromCommon(Null())
+
+    def str[T[_[_]]](s: String)(implicit T: CorecursiveT[T]): T[EJson] =
+      fromCommon(Str(s))
+
+    def int[T[_[_]]](d: BigInt)(implicit T: CorecursiveT[T]): T[EJson] =
+      fromExt(ejson.Int(d))
+
+    def obj[T[_[_]]](xs: (String, T[EJson])*)(implicit T: CorecursiveT[T]): T[EJson] =
+      map((xs.map { case (s, t) => str[T](s) -> t }): _*)
+
+    def map[T[_[_]]](xs: (T[EJson], T[EJson])*)(implicit T: CorecursiveT[T]): T[EJson] =
+      fromExt(ejson.Map(xs.toList))
+
     def isNull[T](ej: T)(implicit T: Recursive.Aux[T, EJson]): Boolean =
-      CommonEJson.prj(ej.project) exists (nul.nonEmpty(_))
+      CommonEJson.prj(ej.project) exists (ejson.nul.nonEmpty(_))
 
     /** Replaces `Meta` nodes with their value component. */
     def elideMetadata[T](
@@ -101,7 +125,7 @@ package object ejson {
     def replaceString[T](
       implicit T: Corecursive.Aux[T, EJson]
     ): EJson[T] => EJson[T] = totally {
-      case CommonEJson(Str(s)) => CommonEJson(arr[T](s.toList map (c => fromExt(char[T](c)))))
+      case CommonEJson(Str(s)) => CommonEJson(ejson.arr[T](s.toList map (c => fromExt(ejson.char[T](c)))))
     }
 
     /** Replace an array of characters with a string. */
@@ -111,8 +135,8 @@ package object ejson {
       TR: Recursive.Aux[T, EJson]
     ): EJson[T] => EJson[T] = totally {
       case a @ CommonEJson(Arr(t :: ts)) =>
-        (t :: ts).traverse(t => ExtEJson.prj(t.project) >>= (char[T].getOption(_)))
-          .fold(a)(cs => CommonEJson(str[T](cs.mkString)))
+        (t :: ts).traverse(t => ExtEJson.prj(t.project) >>= (ejson.char[T].getOption(_)))
+          .fold(a)(cs => CommonEJson(ejson.str[T](cs.mkString)))
     }
   }
 

--- a/marklogic/src/main/scala/quasar/physical/marklogic/MarkLogic.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/MarkLogic.scala
@@ -40,7 +40,7 @@ import quasar.physical.marklogic.qscript._
 import quasar.physical.marklogic.xcc._, Xcc.ops._
 import quasar.physical.marklogic.xquery._
 import quasar.physical.marklogic.xquery.syntax._
-import quasar.qscript.{Read => QRead, _}
+import quasar.qscript.{Read => _, _}
 import quasar.qscript.analysis._
 
 import scala.Predef.implicitly
@@ -72,7 +72,7 @@ sealed class MarkLogic protected (readChunkSize: Positive, writeChunkSize: Posit
   val Type = FsType
 
   implicit def qScriptToQScriptTotal[T[_[_]]]: Injectable.Aux[QSM[T, ?], QScriptTotal[T, ?]] =
-    ::\::[QScriptCore[T, ?]](::\::[ThetaJoin[T, ?]](::/::[T, Const[ShiftedRead[ADir], ?], Const[QRead[AFile], ?]]))
+    physical.marklogic.qScriptToQScriptTotal[T]
 
   // BackendModule
   def CardinalityQSM: Cardinality[QSM[Fix, ?]] = {

--- a/marklogic/src/main/scala/quasar/physical/marklogic/package.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/package.scala
@@ -17,9 +17,11 @@
 package quasar.physical
 
 import slamdata.Predef.String
+import quasar.qscript._
 import quasar.contrib.scalaz.MonadError_
+import quasar.contrib.pathy.{ADir, AFile}
 
-import scalaz.{NonEmptyList, MonadError}
+import scalaz.{Const, NonEmptyList, MonadError}
 
 package object marklogic {
   type ErrorMessages = NonEmptyList[String]
@@ -35,4 +37,21 @@ package object marklogic {
   object MonadErrMsgs_ {
     def apply[F[_]](implicit F: MonadErrMsgs_[F]): MonadErrMsgs_[F] = F
   }
+
+  implicit def qScriptToQScriptTotal[T[_[_]]]: Injectable.Aux[fs.MLQScriptCP[T]#M, QScriptTotal[T, ?]] =
+    ::\::[QScriptCore[T, ?]](::\::[ThetaJoin[T, ?]](::/::[T, Const[ShiftedRead[ADir], ?], Const[Read[AFile], ?]]))
+  
+  implicit def qScriptCoreToQScript[T[_[_]]]: Injectable.Aux[QScriptCore[T, ?], fs.MLQScriptCP[T]#M] =
+    Injectable.inject[QScriptCore[T, ?], fs.MLQScriptCP[T]#M]
+
+  implicit def thetaJoinToQScript[T[_[_]]]: Injectable.Aux[ThetaJoin[T, ?], fs.MLQScriptCP[T]#M] =
+    Injectable.inject[ThetaJoin[T, ?], fs.MLQScriptCP[T]#M]
+
+  implicit def readToQScript[T[_[_]]]: Injectable.Aux[Const[Read[AFile], ?], fs.MLQScriptCP[T]#M] =
+    Injectable.inject[Const[Read[AFile], ?], fs.MLQScriptCP[T]#M]
+
+  implicit def shiftedReadToQScript[T[_[_]]]: Injectable.Aux[Const[ShiftedRead[ADir], ?], fs.MLQScriptCP[T]#M] =
+    Injectable.inject[Const[ShiftedRead[ADir], ?], fs.MLQScriptCP[T]#M]
+
+
 }

--- a/mimir/src/main/scala/quasar/mimir/Mimir.scala
+++ b/mimir/src/main/scala/quasar/mimir/Mimir.scala
@@ -71,14 +71,20 @@ object Mimir extends BackendModule with Logging with DefaultAnalyzeModule {
   import PathError._
   import Precog.startTask
 
-  // pessimistically equal to couchbase's
   type QS[T[_[_]]] =
-    QScriptCore[T, ?] :\:
-    EquiJoin[T, ?] :/:
-    Const[ShiftedRead[AFile], ?]
+    MimirQScriptCP[T]
 
   implicit def qScriptToQScriptTotal[T[_[_]]]: Injectable.Aux[QSM[T, ?], QScriptTotal[T, ?]] =
-    ::\::[QScriptCore[T, ?]](::/::[T, EquiJoin[T, ?], Const[ShiftedRead[AFile], ?]])
+    mimir.qScriptToQScriptTotal[T]
+
+  implicit def qScriptCoreToQScript[T[_[_]]]: Injectable.Aux[QScriptCore[T, ?], QSM[T, ?]] =
+    Injectable.inject[QScriptCore[T, ?], QSM[T, ?]]
+
+  implicit def equiJoinToQScript[T[_[_]]]: Injectable.Aux[EquiJoin[T, ?], QSM[T, ?]] =
+    Injectable.inject[EquiJoin[T, ?], QSM[T, ?]]
+
+  implicit def shiftedReadToQScript[T[_[_]]]: Injectable.Aux[Const[ShiftedRead[AFile], ?], QSM[T, ?]] =
+    Injectable.inject[Const[ShiftedRead[AFile], ?], QSM[T, ?]]
 
   private type Cake = Precog with Singleton
 

--- a/mimir/src/main/scala/quasar/mimir/package.scala
+++ b/mimir/src/main/scala/quasar/mimir/package.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar
+
+import quasar.fp._
+import quasar.qscript._
+import quasar.contrib.pathy.AFile
+import scalaz.Const
+
+package object mimir {
+  // pessimistically equal to couchbase's
+  type MimirQScriptCP[T[_[_]]] =
+    QScriptCore[T, ?] :\:
+      EquiJoin[T, ?] :/:
+      Const[ShiftedRead[AFile], ?]
+
+  implicit def qScriptToQScriptTotal[T[_[_]]]: Injectable.Aux[MimirQScriptCP[T]#M, QScriptTotal[T, ?]] =
+    ::\::[QScriptCore[T, ?]](::/::[T, EquiJoin[T, ?], Const[ShiftedRead[AFile], ?]])
+
+  implicit def qScriptCoreToQScript[T[_[_]]]: Injectable.Aux[QScriptCore[T, ?], MimirQScriptCP[T]#M] =
+    Injectable.inject[QScriptCore[T, ?], MimirQScriptCP[T]#M]
+
+  implicit def equiJoinToQScript[T[_[_]]]: Injectable.Aux[EquiJoin[T, ?], MimirQScriptCP[T]#M] =
+    Injectable.inject[EquiJoin[T, ?], MimirQScriptCP[T]#M]
+
+  implicit def shiftedReadToQScript[T[_[_]]]: Injectable.Aux[Const[ShiftedRead[AFile], ?], MimirQScriptCP[T]#M] =
+    Injectable.inject[Const[ShiftedRead[AFile], ?], MimirQScriptCP[T]#M]
+}

--- a/mongodb/src/main/scala/quasar/physical/mongodb/MongoDb.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/MongoDb.scala
@@ -52,7 +52,7 @@ object MongoDb
   type QS[T[_[_]]] = fs.MongoQScriptCP[T]
 
   implicit def qScriptToQScriptTotal[T[_[_]]]: Injectable.Aux[QSM[T, ?], QScriptTotal[T, ?]] =
-    ::\::[QScriptCore[T, ?]](::/::[T, EquiJoin[T, ?], Const[ShiftedRead[AFile], ?]])
+    physical.mongodb.qScriptToQScriptTotal[T]
 
   type Repr = Crystallized[WorkflowF]
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/MongoDbPlanner.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/MongoDbPlanner.scala
@@ -71,10 +71,6 @@ object MongoDbPlanner {
   type OutputM[A]      = PlannerError \/ A
   type ExecTimeR[F[_]] = MonadReader_[F, Instant]
 
-  implicit def mongoQScriptToQScriptTotal[T[_[_]]]: Injectable.Aux[fs.MongoQScript[T, ?], QScriptTotal[T, ?]] =
-    ::\::[QScriptCore[T, ?]](::/::[T, EquiJoin[T, ?], Const[ShiftedRead[AFile], ?]])
-
-
   @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
   def generateTypeCheck[In, Out](or: (Out, Out) => Out)(f: PartialFunction[Type, In => Out]):
       Type => Option[In => Out] =

--- a/mongodb/src/main/scala/quasar/physical/mongodb/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/package.scala
@@ -21,6 +21,8 @@ import quasar.common.SortDir
 import quasar.javascript.Js
 import quasar.fs.PhysicalError
 import quasar.namegen._
+import quasar.qscript._
+import quasar.contrib.pathy.AFile
 
 import com.mongodb.async.AsyncBatchCursor
 import org.bson.BsonValue
@@ -45,4 +47,17 @@ package object mongodb {
     case SortDir.Ascending => Bson.Int32(1)
     case SortDir.Descending => Bson.Int32(-1)
   }
+
+  implicit def qScriptToQScriptTotal[T[_[_]]]: Injectable.Aux[fs.MongoQScriptCP[T]#M, QScriptTotal[T, ?]] =
+    ::\::[QScriptCore[T, ?]](::/::[T, EquiJoin[T, ?], Const[ShiftedRead[AFile], ?]])
+
+  implicit def qScriptCoreToQScript[T[_[_]]]: Injectable.Aux[QScriptCore[T, ?], fs.MongoQScriptCP[T]#M] =
+    Injectable.inject[QScriptCore[T, ?], fs.MongoQScriptCP[T]#M]
+
+  implicit def equiJoinToQScript[T[_[_]]]: Injectable.Aux[EquiJoin[T, ?], fs.MongoQScriptCP[T]#M] =
+    Injectable.inject[EquiJoin[T, ?], fs.MongoQScriptCP[T]#M]
+
+  implicit def shiftedReadToQScript[T[_[_]]]: Injectable.Aux[Const[ShiftedRead[AFile], ?], fs.MongoQScriptCP[T]#M] =
+    Injectable.inject[Const[ShiftedRead[AFile], ?], fs.MongoQScriptCP[T]#M]
+
 }

--- a/rdbms/src/main/scala/quasar/physical/rdbms/Rdbms.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/Rdbms.scala
@@ -29,7 +29,7 @@ import quasar.fs.ReadFile.ReadHandle
 import quasar.fs.mount.BackendDef.{DefErrT, DefinitionError}
 import quasar.fs.mount.ConnectionUri
 import quasar.physical.rdbms.fs._
-import quasar.qscript.{::/::, ::\::, EquiJoin, ExtractPath, Injectable, Optimize, QScriptCore, QScriptTotal, ShiftedRead, Unicoalesce, Unirewrite}
+import quasar.qscript.{EquiJoin, ExtractPath, Injectable, Optimize, QScriptCore, QScriptTotal, ShiftedRead, Unicoalesce, Unirewrite}
 import quasar.fs.WriteFile.WriteHandle
 import quasar.physical.rdbms.common.{Config, TablePath}
 import quasar.physical.rdbms.jdbc.JdbcConnectionInfo
@@ -83,8 +83,7 @@ trait Rdbms extends BackendModule with RdbmsReadFile with RdbmsWriteFile with Rd
 
   implicit def qScriptToQScriptTotal[T[_[_]]]: Injectable.Aux[
     QSM[T, ?],
-    QScriptTotal[T, ?]] =
-    ::\::[QScriptCore[T, ?]](::/::[T, EquiJoin[T, ?], Const[ShiftedRead[AFile], ?]])
+    QScriptTotal[T, ?]] = quasar.physical.rdbms.qScriptToQScriptTotal[T]
 
   override def optimize[T[_[_]]: BirecursiveT: EqualT: ShowT]: QSM[T, T[QSM[T, ?]]] => QSM[T, T[QSM[T, ?]]] = {
     val O = new Optimize[T]

--- a/rdbms/src/main/scala/quasar/physical/rdbms/package.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/package.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical
+
+import quasar.fp._
+import quasar.qscript._
+import scalaz.Const
+import quasar.contrib.pathy.AFile
+
+package object rdbms {
+  type PostgresQScriptCP[T[_[_]]] = QScriptCore[T, ?] :\: EquiJoin[T, ?] :/: Const[ShiftedRead[AFile], ?]
+
+  implicit def qScriptToQScriptTotal[T[_[_]]]: Injectable.Aux[
+  PostgresQScriptCP[T]#M,
+  QScriptTotal[T, ?]] =
+  ::\::[QScriptCore[T, ?]](::/::[T, EquiJoin[T, ?], Const[ShiftedRead[AFile], ?]])
+
+  implicit def qScriptCoreToQScript[T[_[_]]]: Injectable.Aux[QScriptCore[T, ?], PostgresQScriptCP[T]#M] =
+  Injectable.inject[QScriptCore[T, ?], PostgresQScriptCP[T]#M]
+
+  implicit def equiJoinToQScript[T[_[_]]]: Injectable.Aux[EquiJoin[T, ?], PostgresQScriptCP[T]#M] =
+  Injectable.inject[EquiJoin[T, ?], PostgresQScriptCP[T]#M]
+
+  implicit def shiftedReadToQScript[T[_[_]]]: Injectable.Aux[Const[ShiftedRead[AFile], ?], PostgresQScriptCP[T]#M] =
+  Injectable.inject[Const[ShiftedRead[AFile], ?], PostgresQScriptCP[T]#M]
+}

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/cassandra/SparkCassandra.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/cassandra/SparkCassandra.scala
@@ -34,7 +34,6 @@ import quasar.fs.mount._, BackendDef._
 import quasar.physical.sparkcore.fs._
 import quasar.physical.sparkcore.fs.SparkCore
 import quasar.physical.sparkcore.fs.{SparkCore, SparkConnectorDetails}, SparkConnectorDetails._
-import quasar.qscript.{QScriptTotal, Injectable, QScriptCore, EquiJoin, ShiftedRead, ::/::, ::\::}
 
 import org.apache.spark._
 import org.apache.spark.rdd._
@@ -63,9 +62,6 @@ object SparkCassandra extends SparkCore with ManagedWriteFile[AFile] with Chroot
   type Eff2[A] = Coproduct[CassandraDDL, Eff3, A]
   type Eff1[A] = Coproduct[MonotonicSeq, Eff2, A]
   type Eff[A]  = Coproduct[SparkConnectorDetails, Eff1, A]
-
-  implicit def qScriptToQScriptTotal[T[_[_]]]: Injectable.Aux[QSM[T, ?], QScriptTotal[T, ?]] =
-    ::\::[QScriptCore[T, ?]](::/::[T, EquiJoin[T, ?], Const[ShiftedRead[AFile], ?]])
 
   def ReadSparkContextInj = Inject[Read[SparkContext, ?], Eff]
   def RFKeyValueStoreInj = Inject[KeyValueStore[ReadFile.ReadHandle, SparkCursor, ?], Eff]

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/elastic/SparkElastic.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/elastic/SparkElastic.scala
@@ -35,7 +35,6 @@ import quasar.fs.mount._, BackendDef._
 import quasar.physical.sparkcore.fs._
 import quasar.physical.sparkcore.fs.SparkCore
 import quasar.physical.sparkcore.fs.{SparkCore, SparkConnectorDetails}, SparkConnectorDetails._
-import quasar.qscript.{QScriptTotal, Injectable, QScriptCore, EquiJoin, ShiftedRead, ::/::, ::\::}
 
 import org.apache.spark._
 import org.apache.spark.rdd._
@@ -63,9 +62,6 @@ object SparkElastic extends SparkCore with ManagedWriteFile[AFile] with Chrooted
   type Eff5[A]  = Coproduct[KeyValueStore[ReadHandle, SparkCursor, ?], Eff4, A]
   type Eff6[A]  = Coproduct[KeyValueStore[WriteHandle, AFile, ?], Eff5, A]
   type Eff[A]   = Coproduct[SparkConnectorDetails, Eff6, A]
-
-  implicit def qScriptToQScriptTotal[T[_[_]]]: Injectable.Aux[QSM[T, ?], QScriptTotal[T, ?]] =
-        ::\::[QScriptCore[T, ?]](::/::[T, EquiJoin[T, ?], Const[ShiftedRead[AFile], ?]])
 
   def ReadSparkContextInj = Inject[Read[SparkContext, ?], Eff]
   def RFKeyValueStoreInj = Inject[KeyValueStore[ReadFile.ReadHandle, SparkCursor, ?], Eff]

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/hdfs/SparkHdfs.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/hdfs/SparkHdfs.scala
@@ -30,7 +30,6 @@ import quasar.fs._,
   QueryFile.ResultHandle, ReadFile.ReadHandle, WriteFile.WriteHandle
 import quasar.physical.sparkcore.fs._, SparkConnectorDetails._
 import quasar.physical.sparkcore.fs.hdfs.parquet.ParquetRDD
-import quasar.qscript.{QScriptTotal, Injectable, QScriptCore, EquiJoin, ShiftedRead, ::/::, ::\::}
 
 import java.io.BufferedWriter
 import java.net.{URLDecoder, URI}
@@ -68,9 +67,6 @@ object SparkHdfs extends SparkCore with ChrootedInterpreter {
   type Eff6[A]  = Coproduct[MonotonicSeq, Eff5, A]
   type Eff7[A]  = Coproduct[SparkConnectorDetails, Eff6, A]
   type Eff[A]   = Coproduct[Read[HdfsFileSystem, ?], Eff7, A]
-
-  implicit def qScriptToQScriptTotal[T[_[_]]]: Injectable.Aux[QSM[T, ?], QScriptTotal[T, ?]] =
-        ::\::[QScriptCore[T, ?]](::/::[T, EquiJoin[T, ?], Const[ShiftedRead[AFile], ?]])
 
   def ReadSparkContextInj = Inject[Read[SparkContext, ?], Eff]
   def RFKeyValueStoreInj = Inject[KeyValueStore[ReadFile.ReadHandle, SparkCursor, ?], Eff]

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/local/SparkLocal.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/local/SparkLocal.scala
@@ -30,7 +30,6 @@ import quasar.fs._,
   QueryFile.ResultHandle, ReadFile.ReadHandle, WriteFile.WriteHandle
 import quasar.physical.sparkcore.fs._
 import quasar.physical.sparkcore.fs.SparkCore
-import quasar.qscript.{QScriptTotal, Injectable, QScriptCore, EquiJoin, ShiftedRead, ::/::, ::\::}
 
 import java.io.{FileNotFoundException, File, PrintWriter}
 import java.lang.Exception
@@ -59,9 +58,6 @@ object SparkLocal extends SparkCore with ChrootedInterpreter {
   type Eff5[A]  = Coproduct[PhysErr, Eff4, A]
   type Eff6[A]  = Coproduct[MonotonicSeq, Eff5, A]
   type Eff[A]   = Coproduct[SparkConnectorDetails, Eff6, A]
-
-  implicit def qScriptToQScriptTotal[T[_[_]]]: Injectable.Aux[QSM[T, ?], QScriptTotal[T, ?]] =
-        ::\::[QScriptCore[T, ?]](::/::[T, EquiJoin[T, ?], Const[ShiftedRead[AFile], ?]])
 
   def ReadSparkContextInj = Inject[Read[SparkContext, ?], Eff]
   def RFKeyValueStoreInj = Inject[KeyValueStore[ReadFile.ReadHandle, SparkCursor, ?], Eff]

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/package.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/package.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.sparkcore
+
+import quasar.fp._
+import quasar.qscript._
+import quasar.contrib.pathy.AFile
+import scalaz.Const
+
+package object fs {
+  type SparkCoreQScriptCP[T[_[_]]] = QScriptCore[T, ?] :\: EquiJoin[T, ?] :/: Const[ShiftedRead[AFile], ?]
+
+  implicit def qScriptToQScriptTotal[T[_[_]]]: Injectable.Aux[SparkCoreQScriptCP[T]#M, QScriptTotal[T, ?]] =
+    ::\::[QScriptCore[T, ?]](::/::[T, EquiJoin[T, ?], Const[ShiftedRead[AFile], ?]])
+
+  implicit def qScriptCoreToQScript[T[_[_]]]: Injectable.Aux[QScriptCore[T, ?], SparkCoreQScriptCP[T]#M] =
+    Injectable.inject[QScriptCore[T, ?], SparkCoreQScriptCP[T]#M]
+
+  implicit def equiJoinToQScript[T[_[_]]]: Injectable.Aux[EquiJoin[T, ?], SparkCoreQScriptCP[T]#M] =
+    Injectable.inject[EquiJoin[T, ?], SparkCoreQScriptCP[T]#M]
+
+  implicit def shiftedReadToQScript[T[_[_]]]: Injectable.Aux[Const[ShiftedRead[AFile], ?], SparkCoreQScriptCP[T]#M] =
+    Injectable.inject[Const[ShiftedRead[AFile], ?], SparkCoreQScriptCP[T]#M]
+}

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/sparkcore.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/sparkcore.scala
@@ -65,8 +65,11 @@ trait SparkCore extends BackendModule with DefaultAnalyzeModule {
 
   // common for all spark based connecotrs
   type M[A] = Free[Eff, A]
-  type QS[T[_[_]]] = QScriptCore[T, ?] :\: EquiJoin[T, ?] :/: Const[ShiftedRead[AFile], ?]
+  type QS[T[_[_]]] = SparkCoreQScriptCP[T]
   type Repr = RDD[Data]
+
+  implicit def qScriptToQScriptTotal[T[_[_]]]: Injectable.Aux[QSM[T, ?], QScriptTotal[T, ?]] =
+    quasar.physical.sparkcore.fs.qScriptToQScriptTotal[T]
 
   private final implicit def _ReadSparkContextInj: Inject[Read[SparkContext, ?], Eff] =
     ReadSparkContextInj


### PR DESCRIPTION
Designed for use in app code and in tests. Instantiate a `Dsl` and a `Func`, or (more likely, for tests) just use `makeDefaults` to get a `Dsl` for your `FreeQS` analogue and your `Fix[QST]` analogue as well as a `Func` for your `T[_[_]]`.

Edit: See `ExprOpCoreF.fixpoint` for a *very* similar DSL for Mongo plans.

Fixes #2989 