### PR TITLE
RDBMS table model

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -105,6 +105,7 @@ object Dependencies {
       "org.tpolecat" %% "doobie-postgres"   % doobieVersion,
       "org.tpolecat" %% "doobie-hikari"     % doobieVersion,
       "org.tpolecat" %% "doobie-h2"         % doobieVersion,
+      "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.6" % Test,
       ("org.tpolecat" %% "doobie-specs2"     % doobieVersion % Test)
         .exclude("org.specs2", "specs2-core_2.11") // conflicting version
     )

--- a/rdbms/src/main/scala/quasar/physical/rdbms/Interpreter.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/Interpreter.scala
@@ -23,7 +23,7 @@ import quasar.fp.{TaskRef, reflNT}
 import quasar.fp.free._
 import quasar.fs.ReadFile.ReadHandle
 import quasar.fs.WriteFile.WriteHandle
-import quasar.physical.rdbms.common.TablePath
+import quasar.physical.rdbms.fs.WriteCursor
 import quasar.physical.rdbms.model.DbDataStream
 
 import doobie.imports.Transactor
@@ -36,10 +36,10 @@ trait Interpreter {
 
   def interp(xa: Task[Transactor[Task]]): Task[Eff ~> Task] =
     (
-      TaskRef(Map.empty[ReadHandle, DbDataStream])  |@|
-        TaskRef(Map.empty[WriteHandle, TablePath])  |@|
-        xa                                          |@|
-        TaskRef(0L)                                 |@|
+      TaskRef(Map.empty[ReadHandle, DbDataStream])   |@|
+        TaskRef(Map.empty[WriteHandle, WriteCursor]) |@|
+        xa                                           |@|
+        TaskRef(0L)                                  |@|
         GenUUID.type1[Task]
       )(
       (kvR, kvW, x, i, genUUID) =>

--- a/rdbms/src/main/scala/quasar/physical/rdbms/Rdbms.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/Rdbms.scala
@@ -105,5 +105,5 @@ trait Rdbms extends BackendModule with RdbmsReadFile with RdbmsWriteFile with Rd
     ???
   } // TODO
 
-  def parseConnectionUri(uri: ConnectionUri): \/[DefinitionError, JdbcConnectionInfo]
+  def parseConnectionUri(uri: ConnectionUri): DefinitionError \/ JdbcConnectionInfo
 }

--- a/rdbms/src/main/scala/quasar/physical/rdbms/Rdbms.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/Rdbms.scala
@@ -26,7 +26,6 @@ import quasar.fs.MonadFsErr
 import quasar.fs.mount.BackendDef.{DefErrT, DefinitionError}
 import quasar.fs.mount.ConnectionUri
 import quasar.physical.rdbms.fs._
-
 import quasar.qscript.{EquiJoin, ExtractPath, Injectable, Optimize, QScriptCore, QScriptTotal, ShiftedRead, Unicoalesce, Unirewrite}
 import quasar.physical.rdbms.common.Config
 import quasar.physical.rdbms.jdbc.JdbcConnectionInfo

--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsCreate.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsCreate.scala
@@ -18,7 +18,7 @@ package quasar.physical.rdbms.fs
 
 import slamdata.Predef._
 import quasar.physical.rdbms.common._
-import quasar.physical.rdbms.model.TableModel
+import quasar.physical.rdbms.model.{AlterColumn, TableModel}
 
 import doobie.free.connection.ConnectionIO
 
@@ -26,4 +26,5 @@ trait RdbmsCreate {
 
   def createSchema(schema: Schema): ConnectionIO[Unit]
   def createTable(tablePath: TablePath, model: TableModel): ConnectionIO[Unit]
+  def alterTable(tablePath: TablePath, cols: Set[AlterColumn]): ConnectionIO[Unit]
 }

--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsCreate.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsCreate.scala
@@ -17,12 +17,13 @@
 package quasar.physical.rdbms.fs
 
 import slamdata.Predef._
-import quasar.physical.rdbms.common.{Schema, TablePath}
+import quasar.physical.rdbms.common._
+import quasar.physical.rdbms.model.TableModel
 
 import doobie.free.connection.ConnectionIO
 
 trait RdbmsCreate {
 
   def createSchema(schema: Schema): ConnectionIO[Unit]
-  def createTable(tablePath: TablePath): ConnectionIO[Unit]
+  def createTable(tablePath: TablePath, model: TableModel): ConnectionIO[Unit]
 }

--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsDescribeTable.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsDescribeTable.scala
@@ -17,7 +17,8 @@
 package quasar.physical.rdbms.fs
 
 import slamdata.Predef._
-import quasar.physical.rdbms.common.{Schema, TableName, TablePath}
+import quasar.physical.rdbms.common._
+import quasar.physical.rdbms.model.TableModel
 
 import doobie.imports.ConnectionIO
 
@@ -27,4 +28,5 @@ trait RdbmsDescribeTable {
   def findChildTables(schema: Schema): ConnectionIO[Vector[TableName]]
   def schemaExists(schema: Schema): ConnectionIO[Boolean]
   def tableExists(tablePath: TablePath): ConnectionIO[Boolean]
+  def tableModel(tablePath: TablePath): ConnectionIO[Option[TableModel]]
 }

--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsInsert.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsInsert.scala
@@ -16,16 +16,19 @@
 
 package quasar.physical.rdbms.fs
 
-import doobie.free.connection.ConnectionIO
 import quasar.Data
 import quasar.fs.FileSystemError
 import quasar.physical.rdbms.common.TablePath
+import quasar.physical.rdbms.model.TableModel
 import slamdata.Predef.Vector
+
+import doobie.free.connection.ConnectionIO
 
 trait RdbmsInsert {
 
   def batchInsert(
       dbPath: TablePath,
-      chunk: Vector[Data]
+      chunk: Vector[Data],
+      model: TableModel
   ): ConnectionIO[Vector[FileSystemError]]
 }

--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsWriteFile.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsWriteFile.scala
@@ -79,7 +79,7 @@ trait RdbmsWriteFile
             .liftB)
         dbPath = c.tablePath
         newModel <- prepareTable(c, chunk)
-        _ <- batchInsert(dbPath, chunk).liftB
+        _ <- batchInsert(dbPath, chunk, newModel).liftB
         _ <- writeKvs.put(h, WriteCursor(dbPath, model = Some(newModel))).liftB
       } yield Vector()).run.value.map(_.valueOr(Vector(_)))
     }

--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsWriteFile.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsWriteFile.scala
@@ -24,51 +24,74 @@ import quasar.effect.{KeyValueStore, MonotonicSeq}
 import quasar.fs._
 import quasar.physical.rdbms.Rdbms
 import quasar.physical.rdbms.common.TablePath
-import quasar.physical.rdbms.model.JsonTable
+import quasar.physical.rdbms.model.TableModel
 
 import doobie.imports.Meta
-import scalaz.Monad
-import scalaz.syntax.monad._
-import scalaz.std.vector._
+import scalaz._
+import Scalaz._
 
-trait RdbmsWriteFile extends RdbmsInsert with RdbmsDescribeTable with RdbmsCreate {
+final case class WriteCursor(tablePath: TablePath, model: Option[TableModel])
+
+trait RdbmsWriteFile
+    extends RdbmsInsert
+    with RdbmsDescribeTable
+    with RdbmsCreate {
   this: Rdbms =>
 
   import WriteFile._
 
-  val writeKvs = KeyValueStore.Ops[WriteHandle, TablePath, Eff]
-
   implicit def MonadM: Monad[M]
   implicit def dataMeta: Meta[Data]
 
+  val writeKvs = KeyValueStore.Ops[WriteHandle, WriteCursor, Eff]
+
   override def WriteFileModule: WriteFileModule = new WriteFileModule {
 
-    private def getDbPath(h: WriteHandle) = ME.unattempt(
-      writeKvs
-        .get(h)
-        .toRight(FileSystemError.unknownWriteHandle(h))
-        .run
-        .liftB)
+    def prepareTable(c: WriteCursor,
+                     chunk: Vector[Data]): Backend[TableModel] = {
+      ME.unattempt(
+        TableModel
+          .fromData(chunk)
+          .flatMap { newModel =>
+            (c.model match {
+              case Some(prevModel) =>
+                TableModel
+                  .alter(prevModel, newModel)
+                  .map(alterTable(c.tablePath, _))
+              case None =>
+                createTable(c.tablePath, newModel).right
+            }).map(_.map(_ => newModel))
+          }
+          .sequence
+          .liftB)
+    }
 
     override def write(
         h: WriteHandle,
         chunk: Vector[Data]): Configured[Vector[FileSystemError]] = {
+
       (for {
-        _ <- ME.unattempt(writeKvs.get(h).toRight(FileSystemError.unknownWriteHandle(h)).run.liftB)
-        dbPath <- getDbPath(h)
+        c <- ME.unattempt(
+          writeKvs
+            .get(h)
+            .toRight(FileSystemError.unknownWriteHandle(h))
+            .run
+            .liftB)
+        dbPath = c.tablePath
+        newModel <- prepareTable(c, chunk)
         _ <- batchInsert(dbPath, chunk).liftB
+        _ <- writeKvs.put(h, WriteCursor(dbPath, model = Some(newModel))).liftB
       } yield Vector()).run.value.map(_.valueOr(Vector(_)))
     }
 
-    override def open(file: AFile): Backend[WriteHandle] =
+    override def open(file: AFile): Backend[WriteHandle] = {
+      val dbPath = TablePath.create(file)
       for {
         i <- MonotonicSeq.Ops[Eff].next.liftB
-        dbPath = TablePath.create(file)
-        // TODO derive model from chunk using TableModel.fromData(), store model in handle and update it on inserting when necessary
-        _ <- createTable(dbPath, JsonTable).liftB
         handle = WriteHandle(file, i)
-        _ <- writeKvs.put(handle, dbPath).liftB
+        _ <- writeKvs.put(handle, WriteCursor(dbPath, model = None)).liftB
       } yield handle
+    }
 
     override def close(h: WriteHandle): Configured[Unit] =
       writeKvs.delete(h).liftM[ConfiguredT]

--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsWriteFile.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsWriteFile.scala
@@ -24,6 +24,7 @@ import quasar.effect.{KeyValueStore, MonotonicSeq}
 import quasar.fs._
 import quasar.physical.rdbms.Rdbms
 import quasar.physical.rdbms.common.TablePath
+import quasar.physical.rdbms.model.JsonTable
 
 import doobie.imports.Meta
 import scalaz.Monad
@@ -63,7 +64,8 @@ trait RdbmsWriteFile extends RdbmsInsert with RdbmsDescribeTable with RdbmsCreat
       for {
         i <- MonotonicSeq.Ops[Eff].next.liftB
         dbPath = TablePath.create(file)
-        _ <- createTable(dbPath).liftB
+        // TODO derive model from chunk using TableModel.fromData(), store model in handle and update it on inserting when necessary
+        _ <- createTable(dbPath, JsonTable).liftB
         handle = WriteHandle(file, i)
         _ <- writeKvs.put(handle, dbPath).liftB
       } yield handle

--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsWriteFile.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsWriteFile.scala
@@ -89,7 +89,8 @@ trait RdbmsWriteFile
       for {
         i <- MonotonicSeq.Ops[Eff].next.liftB
         handle = WriteHandle(file, i)
-        _ <- writeKvs.put(handle, WriteCursor(dbPath, model = None)).liftB
+        initialModel <- tableModel(dbPath).liftB
+        _ <- writeKvs.put(handle, WriteCursor(dbPath, initialModel)).liftB
       } yield handle
     }
 

--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/postgres/Postgres.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/postgres/Postgres.scala
@@ -52,7 +52,7 @@ object Postgres
       s"Cannot extract credentials from URI [${uri.value}]. Expected format: $formatHint"))
 
   override def parseConnectionUri(
-      uri: ConnectionUri): \/[DefinitionError, JdbcConnectionInfo] = {
+      uri: ConnectionUri): DefinitionError \/ JdbcConnectionInfo = {
 
     val jUri = new URI(uri.value.substring(jdbcPrefixLength + 1))
     val connectionInfo = (Option(jUri.getScheme),

--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/postgres/PostgresCreate.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/postgres/PostgresCreate.scala
@@ -62,10 +62,12 @@ trait PostgresCreate extends RdbmsCreate {
   override def alterTable(tablePath: TablePath, cols: Set[AlterColumn]): ConnectionIO[Unit] = {
     if (cols.isEmpty)
       ().point[ConnectionIO]
-    else
-      cols.map {
-        case AddColumn(name, tpe) => Fragment.const(s"ADD COLUMN $name ${pgType(tpe)}")
-        case ModifyColumn(name, tpe) => Fragment.const(s"MODIFY COLUMN $name ${pgType(tpe)}")
-      }.toList.intercalate(fr",").update.run.void
+    else {
+      (fr"ALTER TABLE" ++ Fragment.const(tablePath.shows) ++
+        cols.map {
+          case AddColumn(name, tpe) => Fragment.const(s"ADD COLUMN $name ${pgType(tpe)}")
+          case ModifyColumn(name, tpe) => Fragment.const(s"MODIFY COLUMN $name ${pgType(tpe)}")
+        }.toList.intercalate(fr",")).update.run.void
+    }
   }
 }

--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/postgres/PostgresDescribeTable.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/postgres/PostgresDescribeTable.scala
@@ -88,12 +88,7 @@ trait PostgresDescribeTable extends RdbmsDescribeTable {
   def tableModel(tablePath: TablePath): ConnectionIO[Option[TableModel]] = {
     val cols = descQuery(whereSchemaAndTable(tablePath), _.map {
       case (colName, colTypeStr) =>
-        ColumnDesc(colName, colTypeStr.toLowerCase match {
-          case "text" | "varchar" => StringCol
-          case "int" | "bigint" => IntCol
-          case "jsonb" | "json" => JsonCol
-            // TODO more types
-        })
+        ColumnDesc(colName, colTypeStr.mapToColumnType)
     })
 
     cols.map {

--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/postgres/PostgresInsert.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/postgres/PostgresInsert.scala
@@ -21,27 +21,58 @@ import quasar.Data
 import quasar.fs.FileSystemError
 import quasar.physical.rdbms.common.TablePath
 import quasar.physical.rdbms.fs.RdbmsInsert
+import quasar.physical.rdbms.model.{ColumnDesc, ColumnarTable, JsonTable, TableModel}
 
-import doobie.free.connection.ConnectionIO
-import doobie.imports.{Meta, Update}
-import doobie.syntax.string._
-import doobie.util.fragment.Fragment
-import scalaz.std.vector._
-import scalaz.syntax.show._
+import doobie.imports._
+import scalaz._
+import Scalaz._
 
 trait PostgresInsert extends RdbmsInsert {
 
   implicit def dataMeta: Meta[Data]
 
+  def toColValues(cols: Set[ColumnDesc])(row: Data): \/[FileSystemError, List[String]] = {
+    row match {
+      case Data.Obj(fields) =>
+        (fields.toList.filter(f => cols.exists(_.name === f._1)).sortBy(_._1).map {
+          case (_, v) =>
+            v match {
+              case Data.Obj(innerJs) => "{TODO decode this to JS string}"// TODO
+              case Data.Int(num) => s"$num"
+              case Data.Str(txt) => s"'$txt'"
+              case _ => s"TODO" // TODO
+            }
+        }).right
+      case _ => FileSystemError.unsupportedOperation(s"Unexpected data row $row not matching model $cols").left
+    }
+  }
+
   def batchInsert(
       dbPath: TablePath,
-      chunk: Vector[Data]
+      chunk: Vector[Data],
+      model: TableModel
   ): ConnectionIO[Vector[FileSystemError]] = {
 
-    val fQuery = fr"insert into " ++ Fragment.const(dbPath.shows) ++ fr"(data) values(?::JSON)"
+    val insertIntoTable = fr"insert into " ++ Fragment.const(dbPath.shows)
 
-    Update[Data](fQuery.update.sql)
-      .updateMany(chunk)
-      .map(_ => Vector.empty[FileSystemError])
+    model match {
+      case JsonTable =>
+        val fQuery = fr"(data) values(?::JSON)"
+        Update[Data](fQuery.update.sql)
+          .updateMany(chunk)
+          .map(_ => Vector.empty[FileSystemError])
+      case ColumnarTable(cols) =>
+        (chunk.traverse(toColValues(cols)).traverse {
+            valRows => valRows.traverse { valRow =>
+              val query = insertIntoTable ++ fr"(" ++ Fragment.const(cols.map(_.name).mkString(",")) ++
+                fr") values (" ++
+                valRow.map(v => Fragment.const(v)).intercalate(fr",") ++ fr")"
+              query.update.run.void
+            }
+        }).map {
+          case -\/(err) => Vector(err)
+          case _ => Vector.empty
+        }
+    }
   }
 }

--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/postgres/PostgresInsert.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/postgres/PostgresInsert.scala
@@ -32,7 +32,7 @@ trait PostgresInsert extends RdbmsInsert {
   implicit def dataMeta: Meta[Data]
 
   def toColValues(cols: Set[ColumnDesc])(
-      row: Data)(implicit formatter: DataFormatter): \/[FileSystemError, Map[String, String]] = {
+      row: Data)(implicit formatter: DataFormatter): FileSystemError \/ Map[String, String] = {
     row match {
       case Data.Obj(fields) =>
         fields.toVector
@@ -53,7 +53,7 @@ trait PostgresInsert extends RdbmsInsert {
 
   def buildQuery(chunk: Vector[Data],
                  cols: Set[ColumnDesc],
-                 dbPath: TablePath): \/[FileSystemError, Vector[Fragment]] = {
+                 dbPath: TablePath): FileSystemError \/ Vector[Fragment] = {
     val insertIntoTable = fr"insert into " ++ Fragment.const(dbPath.shows)
 
     chunk.traverse(toColValues(cols)).map { insertColVectors =>

--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/postgres/PostgresScanTable.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/postgres/PostgresScanTable.scala
@@ -42,7 +42,7 @@ trait PostgresScanTable extends RdbmsScanTable {
   }
 
   override def selectAllQuery(tablePath: TablePath, offset: Natural, limit: Option[Positive]): Fragment = {
-    fr"select * from" ++ Fragment.const(tablePath.shows) ++ limitFr(limit) ++ offsetFr(offset)
+    fr"select row_to_json(row) from" ++ Fragment.const(tablePath.shows) ++ fr"row" ++ limitFr(limit) ++ offsetFr(offset)
   }
 
 }

--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/postgres/package.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/postgres/package.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.rdbms.fs
+
+import slamdata.Predef._
+import quasar.{Data, DataCodec}
+import quasar.physical.rdbms.model._
+
+package object postgres {
+  
+  implicit val codec: DataCodec = DataCodec.Precise
+
+  implicit val typeMapper: TypeMapper = TypeMapper(
+    {
+      case JsonCol   => "jsonb"
+      case StringCol => "text"
+      case IntCol    => "bigint"
+      case NullCol   => "int"
+    },
+    _.toLowerCase match {
+      case "text" | "varchar" => StringCol
+      case "int" | "bigint"   => IntCol
+      case "jsonb" | "json"   => JsonCol
+      // TODO more types
+    }
+  )
+
+  implicit val dataFormatter: DataFormatter = DataFormatter((n, v) =>
+    v match {
+      case Data.Obj(_) | Data.Arr(_) =>
+        "'" + DataCodec.render(v).getOrElse("{}") + "'"
+      case Data.Int(num) => s"$num"
+      case Data.Str(txt) => s"'$txt'"
+      case _             => s"""'{"$n": "unsupported""}'""" // TODO
+    })
+}

--- a/rdbms/src/main/scala/quasar/physical/rdbms/model/DataFormatter.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/model/DataFormatter.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.rdbms.model
+
+import slamdata.Predef._
+import quasar.Data
+
+trait DataFormatter {
+
+  def apply(n: String, d: Data): String
+
+}
+
+object DataFormatter {
+
+  def apply(f: (String, Data) => String): DataFormatter = new DataFormatter {
+    def apply(n: String, d: Data) = f(n, d)
+  }
+
+}

--- a/rdbms/src/main/scala/quasar/physical/rdbms/model/TableModel.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/model/TableModel.scala
@@ -42,6 +42,12 @@ case object JsonTable extends TableModel
 final case class ColumnarTable(columns: Set[ColumnDesc])
   extends TableModel
 
+object ColumnarTable {
+  import TableModel._
+
+  def fromColumns(cs: List[ColumnDesc]): ColumnarTable = ColumnarTable(TreeSet.empty ++ cs)
+}
+
 object TableModel {
 
   implicit val columnDescOrdering: Ordering[ColumnDesc] =
@@ -78,7 +84,7 @@ object TableModel {
               .getOrElse(c.some)
           }
           .map(cs =>
-            ColumnarTable(TreeSet.empty ++ cs ++ newCols.diff(cols)): TableModel)
+            ColumnarTable.fromColumns(cs ++ newCols.diff(cols)): TableModel)
           .getOrElse(JsonTable)
       }
 
@@ -116,9 +122,9 @@ object TableModel {
   def rowModel(row: Data): TableModel = {
     row match {
       case Data.Obj(fields) =>
-        ColumnarTable(TreeSet.empty ++ fields.map {
+        ColumnarTable.fromColumns(fields.map {
           case (label, value) => ColumnDesc(label, columnType(value))
-        })
+        }.toList)
       case _ => JsonTable
     }
   }

--- a/rdbms/src/main/scala/quasar/physical/rdbms/model/TableModel.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/model/TableModel.scala
@@ -76,11 +76,25 @@ object TableModel {
     }
   }
 
+  implicit val columnDescEq: Equal[ColumnDesc] = Equal.equalBy(_.name)
+
   implicit val columnDescOrdering: Ordering[ColumnDesc] =
     Ordering.fromLessThan[ColumnDesc](_.name < _.name)
 
   implicit val columnTypeEq: Equal[ColumnType] = Equal.equalA
 
+  implicit val tableModelEq: Equal[TableModel] = new Equal[TableModel] {
+
+    def equal(tm1: TableModel, tm2: TableModel): Boolean = {
+      (tm1, tm2) match {
+        case (JsonTable, JsonTable) => true
+        case (ColumnarTable(c1), ColumnarTable(c2)) => c1.toList === c2.toList
+        case _ => false
+      }
+    }
+  }
+
+  implicit val tableModelShow: Show[TableModel] = Show.showFromToString[TableModel]
   /**
     * When updating current table model with new model, the resulting model
     * can be either extended by new columns, or just a JsonTable. The latter

--- a/rdbms/src/main/scala/quasar/physical/rdbms/model/TableModel.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/model/TableModel.scala
@@ -83,15 +83,10 @@ object TableModel {
 
   implicit val columnTypeEq: Equal[ColumnType] = Equal.equalA
 
-  implicit val tableModelEq: Equal[TableModel] = new Equal[TableModel] {
-
-    def equal(tm1: TableModel, tm2: TableModel): Boolean = {
-      (tm1, tm2) match {
-        case (JsonTable, JsonTable) => true
-        case (ColumnarTable(c1), ColumnarTable(c2)) => c1.toList === c2.toList
-        case _ => false
-      }
-    }
+  implicit val tableModelEq: Equal[TableModel] =  Equal.equal {
+    case (JsonTable, JsonTable) => true
+    case (ColumnarTable(c1), ColumnarTable(c2)) => c1.toList === c2.toList
+    case _ => false
   }
 
   implicit val tableModelShow: Show[TableModel] = Show.showFromToString[TableModel]

--- a/rdbms/src/main/scala/quasar/physical/rdbms/model/TableModel.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/model/TableModel.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.rdbms.model
+
+import slamdata.Predef._
+import quasar.Data
+import quasar.fs.FileSystemError
+import quasar.fs.FileSystemError._
+
+import scalaz._
+import Scalaz._
+
+sealed trait ColumnType
+case object JsonCol extends ColumnType
+case object StringCol extends ColumnType
+case object IntCol extends ColumnType
+case object NullCol extends ColumnType
+
+final case class ColumnDesc(name: String, tpe: ColumnType)
+
+sealed trait TableModel
+
+case object JsonTable extends TableModel
+
+final case class ColumnarTable(columns: ISet[ColumnDesc])
+  extends TableModel
+
+object TableModel {
+
+  implicit val columnDescOrder: Order[ColumnDesc] = Order.orderBy(_.name)
+
+  implicit val columnTypeEq: Equal[ColumnType] = Equal.equalA
+
+  /**
+    * When updating current table model with new model, the resulting model
+    * can be either extended by new columns, or just a JsonTable. The latter
+    * means that current and new models cannot produce a new definition which
+    * reconciles data types for both (data is heterogenous).
+    */
+  implicit val tableModelMonoid: Monoid[TableModel] = new Monoid[TableModel] {
+    override def zero: TableModel = ColumnarTable(ISet.empty)
+    def empty: TableModel = zero
+
+    override def append(s1: TableModel, s2: => TableModel): TableModel = {
+
+      def updateCols(cols: ISet[ColumnDesc],
+                     newCols: ISet[ColumnDesc]): TableModel = {
+        cols.toList
+          .traverse { c =>
+            newCols
+              .lookupIndex(c)
+              .flatMap(newCols.elemAt)
+              .map { newC =>
+                if (c.tpe === NullCol)
+                  newC.some
+                else if (c.tpe === newC.tpe || newC.tpe === NullCol)
+                  c.some
+                else
+                  none
+              }
+              .getOrElse(c.some)
+          }
+          .map(cs =>
+            ColumnarTable(ISet.fromList(cs) ⊹ newCols.difference(cols)): TableModel)
+          .getOrElse(JsonTable)
+      }
+
+      s1 match {
+        case JsonTable                           => JsonTable
+        case ColumnarTable(cols) if cols.isEmpty => s2
+        case ColumnarTable(cols) =>
+          s2 match {
+            case JsonTable                                 => JsonTable
+            case ColumnarTable(newCols) if newCols.isEmpty => s1
+            case ColumnarTable(newCols)                    =>
+              updateCols(cols, newCols)
+          }
+      }
+    }
+  }
+
+
+  def simpleColumnType(data: Data): ColumnType = {
+    data match {
+      case Data.Null   => NullCol
+      case Data.Str(_) => StringCol
+      case Data.Int(_) => IntCol
+      case _           => NullCol // TODO support all types
+    }
+  }
+
+  def columnType(data: Data): ColumnType = {
+    data match {
+      case Data.Obj(_) => JsonCol
+      case Data.Arr(_) => JsonCol
+      case _           => simpleColumnType(data)
+    }
+  }
+
+  def rowModel(row: Data): TableModel = {
+    row match {
+      case Data.Obj(fields) =>
+        ColumnarTable(ISet.fromList(fields.map {
+          case (label, value) => ColumnDesc(label, columnType(value))
+        }.toList))
+      case _ => JsonTable
+    }
+  }
+
+  def fromData(ds: Vector[Data]): FileSystemError \/ TableModel = {
+    ds match {
+      case _ :+ _ =>
+        ds.foldMap(rowModel).right
+      case _ =>
+        unsupportedOperation("Cannot map empty data row to a RDBMS table model.").left
+    }
+  }
+}

--- a/rdbms/src/main/scala/quasar/physical/rdbms/model/TableModel.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/model/TableModel.scala
@@ -56,7 +56,7 @@ object ColumnarTable {
 
 object TableModel {
 
-  def alter(initial: TableModel, newModel: TableModel): \/[FileSystemError, Set[AlterColumn]] = {
+  def alter(initial: TableModel, newModel: TableModel): FileSystemError \/ Set[AlterColumn] = {
     initial match {
       case JsonTable => Set.empty.right
       case ColumnarTable(initialCols) =>

--- a/rdbms/src/main/scala/quasar/physical/rdbms/model/TypeMapper.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/model/TypeMapper.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.rdbms.model
+
+import slamdata.Predef._
+
+trait TypeMapper {
+
+  def map(ctpe: ColumnType): String
+
+  def comap(colTypeStr: String): ColumnType
+
+}
+
+object TypeMapper {
+
+  def apply(mapping: ColumnType => String, inverse: String => ColumnType): TypeMapper = new TypeMapper {
+
+    def map(ctpe: ColumnType): String = mapping(ctpe)
+
+    def comap(colTypeStr: String): ColumnType = inverse(colTypeStr)
+  }
+
+}

--- a/rdbms/src/main/scala/quasar/physical/rdbms/model/package.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/model/package.scala
@@ -16,6 +16,7 @@
 
 package quasar.physical.rdbms
 
+import slamdata.Predef._
 import quasar.effect.uuid.GenUUID
 import quasar.effect.{KeyValueStore, MonotonicSeq, Read}
 import quasar.fp.{:/:, :\:}
@@ -50,5 +51,13 @@ package object model {
   )#M[A]
 
   type M[A] = Free[Eff, A]
+
+  implicit class StringTypeMapperOps(s: String) {
+    def mapToColumnType(implicit tm: TypeMapper): ColumnType = tm.comap(s)
+  }
+
+  implicit class ColumnTypeMapperOps(cte: ColumnType) {
+    def mapToStringName(implicit tm: TypeMapper): String = tm.map(cte)
+  }
 }
 

--- a/rdbms/src/main/scala/quasar/physical/rdbms/model/package.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/model/package.scala
@@ -22,9 +22,9 @@ import quasar.fp.{:/:, :\:}
 import quasar.fs.ReadFile.ReadHandle
 import quasar.fs.WriteFile.WriteHandle
 import quasar.fs.impl.DataStream
-import quasar.physical.rdbms.common.TablePath
-import doobie.imports.{ConnectionIO, Transactor}
+import quasar.physical.rdbms.fs.WriteCursor
 
+import doobie.imports.{ConnectionIO, Transactor}
 import scalaz.Free
 import scalaz.concurrent.Task
 import scalaz.stream.Process
@@ -46,7 +46,7 @@ package object model {
       :\: MonotonicSeq
       :\: GenUUID
       :\: KeyValueStore[ReadHandle, DbDataStream, ?]
-      :/: KeyValueStore[WriteHandle, TablePath, ?]
+      :/: KeyValueStore[WriteHandle, WriteCursor, ?]
   )#M[A]
 
   type M[A] = Free[Eff, A]

--- a/rdbms/src/test/scala/quasar/physical/rdbms/model/TableModelTest.scala
+++ b/rdbms/src/test/scala/quasar/physical/rdbms/model/TableModelTest.scala
@@ -19,10 +19,12 @@ package quasar.physical.rdbms.model
 import quasar.{Data, DataCodec, Qspec}
 import slamdata.Predef._
 import TableModel._
+
+import scala.collection.immutable.TreeSet
+
 import org.scalacheck.Gen
 import org.scalacheck.Prop._
 import org.specs2.scalacheck.Parameters
-
 import scalaz._
 import Scalaz._
 
@@ -51,18 +53,18 @@ class TableModelTest extends Qspec {
       val row = data("""{"name":"John","surname":"Smith","birthYear":1980}""")
       TableModel.fromData(Vector(row)) should beRightDisjunction(
         ColumnarTable(
-          ISet.fromList(List(ColumnDesc("name", StringCol),
+          TreeSet(ColumnDesc("name", StringCol),
             ColumnDesc("birthYear", IntCol),
-            ColumnDesc("surname", StringCol)))))
+            ColumnDesc("surname", StringCol))))
     }
 
     "devise columnar schema for homogenous data" in {
       val row = data("""{"age": 25,"id":"748abf","keys": [4, 5, 6, 7]}""")
       TableModel.fromData(Vector(row, row, row, row, row, row)) should beRightDisjunction(
         ColumnarTable(
-          ISet.fromList(List(ColumnDesc("age", IntCol),
+          TreeSet(ColumnDesc("age", IntCol),
             ColumnDesc("keys", JsonCol),
-            ColumnDesc("id", StringCol)))))
+            ColumnDesc("id", StringCol))))
     }
 
     "devise columnar schema when extra columns appear" in {
@@ -81,13 +83,13 @@ class TableModelTest extends Qspec {
           row))) { rows =>
 
         TableModel.fromData(rows) should beRightDisjunction(
-          ColumnarTable(ISet.fromList(List(
+          ColumnarTable(TreeSet(
             ColumnDesc("age", IntCol),
             ColumnDesc("keys", JsonCol),
             ColumnDesc("id", StringCol),
             ColumnDesc("extra-col", StringCol),
             ColumnDesc("another-extra-col", StringCol)
-          ))))
+          )))
       }
     }
 
@@ -100,13 +102,13 @@ class TableModelTest extends Qspec {
 
         TableModel.fromData(rows) should beRightDisjunction(
           ColumnarTable(
-            ISet.fromList(List(ColumnDesc("age", IntCol),
+            TreeSet(ColumnDesc("age", IntCol),
               ColumnDesc("keys", JsonCol),
-              ColumnDesc("id", StringCol)))))
+              ColumnDesc("id", StringCol))))
       }
     }
 
-    "devise columnar schema when some columns get nulled and some added" in {
+    "devise columnar schema when some columns get nulled and some get added" in {
         val row = data("""{"age": 25,"id":"748abf","keys": [4, 5, 6, 7]}""")
         val updatedRow1 = data("""{"id":"a748abf","keys": []}""")
         val updatedRow2 = data("""{"extra": {"nested1": "val"}, "id":"a748abf","keys": []}""")
@@ -120,11 +122,10 @@ class TableModelTest extends Qspec {
 
         TableModel.fromData(rows) should beRightDisjunction(
           ColumnarTable(
-            ISet.fromList(
-              List(ColumnDesc("age", IntCol),
+            TreeSet(ColumnDesc("age", IntCol),
                 ColumnDesc("keys", JsonCol),
                 ColumnDesc("id", StringCol),
-                ColumnDesc("extra", JsonCol)))))
+                ColumnDesc("extra", JsonCol))))
       }
     }
 
@@ -142,12 +143,11 @@ class TableModelTest extends Qspec {
 
         TableModel.fromData(rows) should beRightDisjunction(
           ColumnarTable(
-            ISet.fromList(
-              List(ColumnDesc("age", IntCol),
+            TreeSet(ColumnDesc("age", IntCol),
                 ColumnDesc("keys", JsonCol),
                 ColumnDesc("id", StringCol),
                 ColumnDesc("extra", IntCol),
-                ColumnDesc("extra2", StringCol)))))
+                ColumnDesc("extra2", StringCol))))
       }
     }
 
@@ -169,10 +169,9 @@ class TableModelTest extends Qspec {
 
         TableModel.fromData(rows) should beRightDisjunction(
           ColumnarTable(
-            ISet.fromList(
-              List(ColumnDesc("age", IntCol),
+            TreeSet(ColumnDesc("age", IntCol),
                 ColumnDesc("id", StringCol),
-                ColumnDesc("name", StringCol)))))
+                ColumnDesc("name", StringCol))))
       }
     }
   }

--- a/rdbms/src/test/scala/quasar/physical/rdbms/model/TableModelTest.scala
+++ b/rdbms/src/test/scala/quasar/physical/rdbms/model/TableModelTest.scala
@@ -19,22 +19,26 @@ package quasar.physical.rdbms.model
 import quasar.{Data, DataCodec, Qspec}
 import slamdata.Predef._
 import TableModel._
-
 import org.scalacheck.Gen
 import org.scalacheck.Prop._
+import org.specs2.scalacheck.Parameters
+
 import scalaz._
 import Scalaz._
 
 class TableModelTest extends Qspec {
 
   implicit val codec: DataCodec = DataCodec.Precise
+  implicit val params: Parameters = Parameters(minTestsOk = 1000)
+
 
   def data(str: String): Data =
     DataCodec.parse(str).valueOr(err => scala.sys.error(err.shows))
   
   def permutations[T](v: Vector[T]): Gen[Vector[T]] = {
-    val perms = v.permutations
-    Gen.oneOf(perms.toList)
+    val perms = v.permutations.toList
+    val permStream = Stream.continually(perms).flatMap(_.toStream).toIterator
+    Gen.delay(permStream.next())
   }
 
   "Table Model" should {

--- a/rdbms/src/test/scala/quasar/physical/rdbms/model/TableModelTest.scala
+++ b/rdbms/src/test/scala/quasar/physical/rdbms/model/TableModelTest.scala
@@ -60,11 +60,10 @@ class TableModelTest extends Spec  with ScalazMatchers {
 
   implicit val arbColDesc: Arbitrary[Set[ColumnDesc]] = Arbitrary(columnDescsGen)
 
+  checkAll(propz.equal.laws[TableModel])
+  checkAll(propz.monoid.laws[TableModel])
 
-  "Table Model Monoid" >> {
-    checkAll(propz.monoid.laws[TableModel])
-    checkAll(propz.equal.laws[TableModel])
-
+  "Table Model Monoid must" >> {
     "be commutative" >> {
       prop { (x: TableModel, y: TableModel) =>
         (x ⊹ y) must equal(y ⊹ x)
@@ -202,7 +201,7 @@ class TableModelTest extends Spec  with ScalazMatchers {
     }
   }
 
-  "Table Model alter" >> {
+  "Table Model alter must" >> {
 
     "return no updates if initial model is json-based" >> {
       TableModel.alter(JsonTable, JsonTable) must beRightDisjunction(Set.empty)
@@ -238,6 +237,5 @@ class TableModelTest extends Spec  with ScalazMatchers {
       TableModel.alter(initial, newModel) must beRightDisjunction(
         Set(ModifyColumn("c2", StringCol), AddColumn("c3", IntCol)))
     }
-
   }
 }

--- a/rdbms/src/test/scala/quasar/physical/rdbms/model/TableModelTest.scala
+++ b/rdbms/src/test/scala/quasar/physical/rdbms/model/TableModelTest.scala
@@ -63,6 +63,7 @@ class TableModelTest extends Spec  with ScalazMatchers {
 
   "Table Model Monoid" >> {
     checkAll(propz.monoid.laws[TableModel])
+    checkAll(propz.equal.laws[TableModel])
 
     "be commutative" >> {
       prop { (x: TableModel, y: TableModel) =>

--- a/rdbms/src/test/scala/quasar/physical/rdbms/model/TableModelTest.scala
+++ b/rdbms/src/test/scala/quasar/physical/rdbms/model/TableModelTest.scala
@@ -16,19 +16,24 @@
 
 package quasar.physical.rdbms.model
 
-import quasar.{Data, DataCodec, Qspec}
 import slamdata.Predef._
+import quasar.{Data, DataCodec}
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Gen._
+import org.scalacheck.Prop._
+import org.scalacheck.ScalacheckShapeless._
+import org.specs2.scalacheck.Parameters
+import org.specs2.scalaz.{ScalazMatchers, Spec}
+import scala.collection.immutable.TreeSet
 import TableModel._
 
-import scala.collection.immutable.TreeSet
+import scala.Predef.implicitly
 
-import org.scalacheck.Gen
-import org.scalacheck.Prop._
-import org.specs2.scalacheck.Parameters
 import scalaz._
+import scalaz.scalacheck.{ScalazProperties => propz}
 import Scalaz._
 
-class TableModelTest extends Qspec {
+class TableModelTest extends Spec  with ScalazMatchers {
 
   implicit val codec: DataCodec = DataCodec.Precise
   implicit val params: Parameters = Parameters(minTestsOk = 1000)
@@ -43,31 +48,51 @@ class TableModelTest extends Qspec {
     Gen.delay(permStream.next())
   }
 
-  "Table Model Monoid" should {
+  val arbCt: Arbitrary[ColumnType] = implicitly[Arbitrary[ColumnType]]
 
-    "fail for empty vector" in {
-      TableModel.fromData(Vector.empty) should beLeftDisjunction
+  val columnDescsGen: Gen[Set[ColumnDesc]] = Gen.nonEmptyListOf {
+    for {
+      name <- Gen.alphaNumStr.suchThat(_.nonEmpty)
+      tpe <- arbCt.arbitrary
+    }
+      yield ColumnDesc(name, tpe)
+  }.map(_.toSet)
+
+  implicit val arbColDesc: Arbitrary[Set[ColumnDesc]] = Arbitrary(columnDescsGen)
+
+
+  "Table Model Monoid" >> {
+    checkAll(propz.monoid.laws[TableModel])
+
+    "be commutative" >> {
+      prop { (x: TableModel, y: TableModel) =>
+        (x ⊹ y) must equal(y ⊹ x)
+      }
     }
 
-    "devise columnar schema for a single row" in {
+    "fail for empty vector" >> {
+      TableModel.fromData(Vector.empty) must beLeftDisjunction
+    }
+
+    "devise columnar schema for a single row" >> {
       val row = data("""{"name":"John","surname":"Smith","birthYear":1980}""")
-      TableModel.fromData(Vector(row)) should beRightDisjunction(
+      TableModel.fromData(Vector(row)) must beRightDisjunction(
         ColumnarTable(
           TreeSet(ColumnDesc("name", StringCol),
             ColumnDesc("birthYear", IntCol),
             ColumnDesc("surname", StringCol))))
     }
 
-    "devise columnar schema for homogenous data" in {
+    "devise columnar schema for homogenous data" >> {
       val row = data("""{"age": 25,"id":"748abf","keys": [4, 5, 6, 7]}""")
-      TableModel.fromData(Vector(row, row, row, row, row, row)) should beRightDisjunction(
+      TableModel.fromData(Vector(row, row, row, row, row, row)) must beRightDisjunction(
         ColumnarTable(
           TreeSet(ColumnDesc("age", IntCol),
             ColumnDesc("keys", JsonCol),
             ColumnDesc("id", StringCol))))
     }
 
-    "devise columnar schema when extra columns appear" in {
+    "devise columnar schema when extra columns appear" >> {
         val row = data("""{"age": 25,"id":"748abf","keys": [4, 5, 6, 7]}""")
         val updatedRow1 =
           data("""{"age": 35,"id":"a748abf","keys": [], "extra-col" : "v1"}""")
@@ -82,7 +107,7 @@ class TableModelTest extends Qspec {
           row,
           row))) { rows =>
 
-        TableModel.fromData(rows) should beRightDisjunction(
+        TableModel.fromData(rows) must beRightDisjunction(
           ColumnarTable(TreeSet(
             ColumnDesc("age", IntCol),
             ColumnDesc("keys", JsonCol),
@@ -93,14 +118,14 @@ class TableModelTest extends Qspec {
       }
     }
 
-    "devise columnar schema when some columns get nulled" in {
+    "devise columnar schema when some columns get nulled" >> {
         val row = data("""{"age": 25,"id":"748abf","keys": [4, 5, 6, 7]}""")
         val updatedRow1 = data("""{"id":"a748abf","keys": []}""")
 
         forAll(permutations(
           Vector(row, row, updatedRow1, row, row))) { rows =>
 
-        TableModel.fromData(rows) should beRightDisjunction(
+        TableModel.fromData(rows) must beRightDisjunction(
           ColumnarTable(
             TreeSet(ColumnDesc("age", IntCol),
               ColumnDesc("keys", JsonCol),
@@ -108,7 +133,7 @@ class TableModelTest extends Qspec {
       }
     }
 
-    "devise columnar schema when some columns get nulled and some get added" in {
+    "devise columnar schema when some columns get nulled and some get added" >> {
         val row = data("""{"age": 25,"id":"748abf","keys": [4, 5, 6, 7]}""")
         val updatedRow1 = data("""{"id":"a748abf","keys": []}""")
         val updatedRow2 = data("""{"extra": {"nested1": "val"}, "id":"a748abf","keys": []}""")
@@ -120,7 +145,7 @@ class TableModelTest extends Qspec {
           row,
           updatedRow2))) { rows =>
 
-        TableModel.fromData(rows) should beRightDisjunction(
+        TableModel.fromData(rows) must beRightDisjunction(
           ColumnarTable(
             TreeSet(ColumnDesc("age", IntCol),
                 ColumnDesc("keys", JsonCol),
@@ -129,7 +154,7 @@ class TableModelTest extends Qspec {
       }
     }
 
-    "devise columnar schema when all columns are nulled and some row has only new columns" in {
+    "devise columnar schema when all columns are nulled and some row has only new columns" >> {
         val row = data("""{"age": 25,"id":"748abf","keys": [4, 5, 6, 7]}""")
         val updatedRow1 = data("""{}""")
         val updatedRow2 = data("""{"extra": 35, "extra2": "str value"}""")
@@ -141,7 +166,7 @@ class TableModelTest extends Qspec {
         row,
         updatedRow2))) { rows =>
 
-        TableModel.fromData(rows) should beRightDisjunction(
+        TableModel.fromData(rows) must beRightDisjunction(
           ColumnarTable(
             TreeSet(ColumnDesc("age", IntCol),
                 ColumnDesc("keys", JsonCol),
@@ -151,23 +176,23 @@ class TableModelTest extends Qspec {
       }
     }
 
-    "devise json schema on encountering incompatible data types" in {
+    "devise json schema on encountering incompatible data types" >> {
       val row1 = data("""{"age": 25,"id":"748abf","keys": [4, 5, 6, 7]}""")
       val row2 = data("""{"age": "25","id":"648abf","keys": [4, 5, 6, 7]}""")
 
       forAll(permutations(Vector(row1, row2, row2, row2, row1))) { rows =>
 
-        TableModel.fromData(rows) should beRightDisjunction(JsonTable)
+        TableModel.fromData(rows) must beRightDisjunction(JsonTable)
       }
     }
 
-    "treat nulls as 'always compatible' column types" in {
+    "treat nulls as 'always compatible' column types" >> {
       val row1 = data("""{"age": 25,"id":"748abf", "name": "Bob"}""")
       val row2 = data("""{"age": 35,"id":"648abf", "name": null}""")
 
       forAll(permutations(Vector(row1, row2, row2, row2, row1))) { rows =>
 
-        TableModel.fromData(rows) should beRightDisjunction(
+        TableModel.fromData(rows) must beRightDisjunction(
           ColumnarTable(
             TreeSet(ColumnDesc("age", IntCol),
                 ColumnDesc("id", StringCol),
@@ -176,40 +201,40 @@ class TableModelTest extends Qspec {
     }
   }
 
-  "Table Model alter" should {
+  "Table Model alter" >> {
 
-    "return no updates if initial model is json-based" in {
-      TableModel.alter(JsonTable, JsonTable) should beRightDisjunction(Set.empty)
-      TableModel.alter(JsonTable, ColumnarTable(Set(ColumnDesc("l", IntCol)))) should beRightDisjunction(Set.empty)
+    "return no updates if initial model is json-based" >> {
+      TableModel.alter(JsonTable, JsonTable) must beRightDisjunction(Set.empty)
+      TableModel.alter(JsonTable, ColumnarTable(Set(ColumnDesc("l", IntCol)))) must beRightDisjunction(Set.empty)
     }
 
-    "fail if updating from columnar to json-based single column model" in {
-      TableModel.alter(ColumnarTable(Set(ColumnDesc("l", IntCol))), JsonTable) should beLeftDisjunction
+    "fail if updating from columnar to json-based single column model" >> {
+      TableModel.alter(ColumnarTable(Set(ColumnDesc("l", IntCol))), JsonTable) must beLeftDisjunction
     }
 
-    "return no updates if both initial and new model are the same" in {
+    "return no updates if both initial and new model are the same" >> {
       val model = ColumnarTable(Set(ColumnDesc("l", IntCol), ColumnDesc("s", StringCol)))
-      TableModel.alter(model, model) should beRightDisjunction(Set.empty)
+      TableModel.alter(model, model) must beRightDisjunction(Set.empty)
     }
 
-    "return information about new columns" in {
+    "return information about new columns" >> {
       val initial = ColumnarTable(Set(ColumnDesc("c1", IntCol), ColumnDesc("c2", StringCol)))
       val newModel = ColumnarTable(Set(ColumnDesc("c3", IntCol), ColumnDesc("c4", StringCol), ColumnDesc("c1", IntCol)))
-      TableModel.alter(initial, newModel) should beRightDisjunction(
+      TableModel.alter(initial, newModel) must beRightDisjunction(
         Set(AddColumn("c3", IntCol), AddColumn("c4", StringCol)))
     }
 
-    "return information about updated columns" in {
+    "return information about updated columns" >> {
       val initial = ColumnarTable(Set(ColumnDesc("c1", IntCol), ColumnDesc("c2", NullCol), ColumnDesc("c3", NullCol)))
       val newModel = ColumnarTable(Set(ColumnDesc("c2", StringCol), ColumnDesc("c3", IntCol)))
-      TableModel.alter(initial, newModel) should beRightDisjunction(
+      TableModel.alter(initial, newModel) must beRightDisjunction(
         Set(ModifyColumn("c2", StringCol), ModifyColumn("c3", IntCol)))
     }
 
-    "return information about updated and added columns" in {
+    "return information about updated and added columns" >> {
       val initial = ColumnarTable(Set(ColumnDesc("c1", IntCol), ColumnDesc("c2", NullCol)))
       val newModel = ColumnarTable(Set(ColumnDesc("c2", StringCol), ColumnDesc("c3", IntCol)))
-      TableModel.alter(initial, newModel) should beRightDisjunction(
+      TableModel.alter(initial, newModel) must beRightDisjunction(
         Set(ModifyColumn("c2", StringCol), AddColumn("c3", IntCol)))
     }
 

--- a/rdbms/src/test/scala/quasar/physical/rdbms/model/TableModelTest.scala
+++ b/rdbms/src/test/scala/quasar/physical/rdbms/model/TableModelTest.scala
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.rdbms.model
+
+import quasar.{Data, DataCodec, Qspec}
+import slamdata.Predef._
+import TableModel._
+
+import org.scalacheck.Gen
+import org.scalacheck.Prop._
+import scalaz._
+import Scalaz._
+
+class TableModelTest extends Qspec {
+
+  implicit val codec: DataCodec = DataCodec.Precise
+
+  def data(str: String): Data =
+    DataCodec.parse(str).valueOr(err => scala.sys.error(err.shows))
+  
+  def permutations[T](v: Vector[T]): Gen[Vector[T]] = {
+    val perms = v.permutations
+    Gen.oneOf(perms.toList)
+  }
+
+  "Table Model" should {
+
+    "fail for empty vector" in {
+      TableModel.fromData(Vector.empty) should beLeftDisjunction
+    }
+
+    "devise columnar schema for a single row" in {
+      val row = data("""{"name":"John","surname":"Smith","birthYear":1980}""")
+      TableModel.fromData(Vector(row)) should beRightDisjunction(
+        ColumnarTable(
+          ISet.fromList(List(ColumnDesc("name", StringCol),
+            ColumnDesc("birthYear", IntCol),
+            ColumnDesc("surname", StringCol)))))
+    }
+
+    "devise columnar schema for homogenous data" in {
+      val row = data("""{"age": 25,"id":"748abf","keys": [4, 5, 6, 7]}""")
+      TableModel.fromData(Vector(row, row, row, row, row, row)) should beRightDisjunction(
+        ColumnarTable(
+          ISet.fromList(List(ColumnDesc("age", IntCol),
+            ColumnDesc("keys", JsonCol),
+            ColumnDesc("id", StringCol)))))
+    }
+
+    "devise columnar schema when extra columns appear" in {
+        val row = data("""{"age": 25,"id":"748abf","keys": [4, 5, 6, 7]}""")
+        val updatedRow1 =
+          data("""{"age": 35,"id":"a748abf","keys": [], "extra-col" : "v1"}""")
+        val updatedRow2 = data(
+          """{"age": 45, "another-extra-col": "v2", "id":"11","keys": [222]}""")
+
+        forAll(permutations(Vector(row,
+          row,
+          updatedRow1,
+          row,
+          updatedRow2,
+          row,
+          row))) { rows =>
+
+        TableModel.fromData(rows) should beRightDisjunction(
+          ColumnarTable(ISet.fromList(List(
+            ColumnDesc("age", IntCol),
+            ColumnDesc("keys", JsonCol),
+            ColumnDesc("id", StringCol),
+            ColumnDesc("extra-col", StringCol),
+            ColumnDesc("another-extra-col", StringCol)
+          ))))
+      }
+    }
+
+    "devise columnar schema when some columns get nulled" in {
+        val row = data("""{"age": 25,"id":"748abf","keys": [4, 5, 6, 7]}""")
+        val updatedRow1 = data("""{"id":"a748abf","keys": []}""")
+
+        forAll(permutations(
+          Vector(row, row, updatedRow1, row, row))) { rows =>
+
+        TableModel.fromData(rows) should beRightDisjunction(
+          ColumnarTable(
+            ISet.fromList(List(ColumnDesc("age", IntCol),
+              ColumnDesc("keys", JsonCol),
+              ColumnDesc("id", StringCol)))))
+      }
+    }
+
+    "devise columnar schema when some columns get nulled and some added" in {
+        val row = data("""{"age": 25,"id":"748abf","keys": [4, 5, 6, 7]}""")
+        val updatedRow1 = data("""{"id":"a748abf","keys": []}""")
+        val updatedRow2 = data("""{"extra": {"nested1": "val"}, "id":"a748abf","keys": []}""")
+
+        forAll(permutations(Vector(row,
+          row,
+          updatedRow1,
+          row,
+          row,
+          updatedRow2))) { rows =>
+
+        TableModel.fromData(rows) should beRightDisjunction(
+          ColumnarTable(
+            ISet.fromList(
+              List(ColumnDesc("age", IntCol),
+                ColumnDesc("keys", JsonCol),
+                ColumnDesc("id", StringCol),
+                ColumnDesc("extra", JsonCol)))))
+      }
+    }
+
+    "devise columnar schema when all columns are nulled and some row has only new columns" in {
+        val row = data("""{"age": 25,"id":"748abf","keys": [4, 5, 6, 7]}""")
+        val updatedRow1 = data("""{}""")
+        val updatedRow2 = data("""{"extra": 35, "extra2": "str value"}""")
+
+      forAll(permutations(Vector(row,
+        row,
+        updatedRow1,
+        row,
+        row,
+        updatedRow2))) { rows =>
+
+        TableModel.fromData(rows) should beRightDisjunction(
+          ColumnarTable(
+            ISet.fromList(
+              List(ColumnDesc("age", IntCol),
+                ColumnDesc("keys", JsonCol),
+                ColumnDesc("id", StringCol),
+                ColumnDesc("extra", IntCol),
+                ColumnDesc("extra2", StringCol)))))
+      }
+    }
+
+    "devise json schema on encountering incompatible data types" in {
+      val row1 = data("""{"age": 25,"id":"748abf","keys": [4, 5, 6, 7]}""")
+      val row2 = data("""{"age": "25","id":"648abf","keys": [4, 5, 6, 7]}""")
+
+      forAll(permutations(Vector(row1, row2, row2, row2, row1))) { rows =>
+
+        TableModel.fromData(rows) should beRightDisjunction(JsonTable)
+      }
+    }
+
+    "treat nulls as 'always compatible' column types" in {
+      val row1 = data("""{"age": 25,"id":"748abf", "name": "Bob"}""")
+      val row2 = data("""{"age": 35,"id":"648abf", "name": null}""")
+
+      forAll(permutations(Vector(row1, row2, row2, row2, row1))) { rows =>
+
+        TableModel.fromData(rows) should beRightDisjunction(
+          ColumnarTable(
+            ISet.fromList(
+              List(ColumnDesc("age", IntCol),
+                ColumnDesc("id", StringCol),
+                ColumnDesc("name", StringCol)))))
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR brings a notion of `Table Model`. We now don't store everything in single-json-column tables, but we try to determine the best column types to represent data. `RdbmsWriteFile` scans the incoming `Vector[Data]` and incrementally creates columns. For simple elements like `Data.Int`, `Data.String` etc. we create appropriate DB fields. For nested `Data.Obj`, arrays and such, we use a `jsonb` column.
More details available here: https://docs.google.com/document/d/1loSdaInrdMaFg08EHqaLa2oxWP6wZziN2-uzLenJCuA/edit?usp=sharing

More column type <-> quasar data type mappings will be added later.