### PR TITLE
ApplyProvenance and MappableRegion for QSU

### DIFF
--- a/connector/src/main/scala/quasar/qscript/provenance/Dimension.scala
+++ b/connector/src/main/scala/quasar/qscript/provenance/Dimension.scala
@@ -35,11 +35,19 @@ trait Dimension[D, I, P] {
   val empty: Dimensions[P] =
     IList[P]()
 
+  /** Updates the dimensional stack by sequencing a new dimension from value
+    * space with the current head dimension.
+    */
+  def flatten(id: I, ds: Dimensions[P]): Dimensions[P] =
+    nest(lshift(id, ds))
+
   /** Joins two dimensions into a single dimension stack, starting from the base. */
   def join(ls: Dimensions[P], rs: Dimensions[P])(implicit D: Equal[D], I: Equal[I]): Dimensions[P] =
     alignRtoL(ls, rs)(ι, ι, (l, r) => if (l ≟ r) l else both(l, r))
 
-  /** Shifts the dimensional stack by pushing a new dimension from value space onto the stack. */
+  /** Shifts the dimensional stack by pushing a new dimension from value space
+    * onto the stack.
+    */
   def lshift(id: I, ds: Dimensions[P]): Dimensions[P] =
     identity(id) :: ds
 

--- a/connector/src/main/scala/quasar/qscript/provenance/ProvF.scala
+++ b/connector/src/main/scala/quasar/qscript/provenance/ProvF.scala
@@ -20,7 +20,7 @@ import slamdata.Predef._
 import quasar.fp.ski.κ
 
 import matryoshka._
-import monocle.Prism
+import monocle.{Prism, Traversal}
 import scalaz._, Scalaz._
 
 /**
@@ -80,6 +80,14 @@ object ProvF extends ProvFInstances {
         case Then(l, r) => (l, r)
       } {
         case (l, r) => Then(l, r)
+      }
+
+    def identities[A]: Traversal[ProvF[D, I, A], I] =
+      new Traversal[ProvF[D, I, A], I] {
+        def modifyF[F[_]: Applicative](f: I => F[I])(pf: ProvF[D, I, A]) =
+          identity.getOrModify(pf).fold(
+            grouping.modifyF(f),
+            i => f(i) map (identity(_)))
       }
   }
 

--- a/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.qsu
+
+import slamdata.Predef.{Map => SMap, _}
+import quasar.contrib.scalaz.{MonadError_, MonadState_}
+import quasar.ejson
+import quasar.ejson.EJson
+import quasar.ejson.implicits._
+import quasar.fp._
+import quasar.qscript.provenance._
+
+import matryoshka._
+import matryoshka.data._
+import matryoshka.implicits._
+import pathy.Path
+import scalaz.{Free, IList, Monad, StateT}
+import scalaz.syntax.foldable1._
+import scalaz.syntax.monad._
+
+final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT] {
+  import ApplyProvenance._
+  import QScriptUniform._
+
+  type P = QProv.P[T]
+  type Dims = Dimensions[P]
+  type QSU[A] = QScriptUniform[T, A]
+
+  type GPF[A] = QSUGraph.QSUPattern[T, A]
+  val GPF = QSUGraph.QSUPattern
+
+  type GStateM[F[_]] = MonadState_[F, QSUGraph[T]]
+  def GStateM[F[_]](implicit ev: GStateM[F]): GStateM[F] = ev
+
+  // TODO: Real errors
+  type ErrorM[F[_]] = MonadError_[F, String]
+  def ErrorM[F[_]](implicit ev: ErrorM[F]): ErrorM[F] = ev
+
+  val dims = QProv[T]
+
+  def apply[F[_]: Monad: ErrorM](graph: QSUGraph[T]): F[AuthenticatedQSU[T]] = {
+    type X[A] = StateT[F, QSUGraph[T], A]
+    graph.elgotZygoM(computeProvenanceƒ[X], applyProvenanceƒ[X])
+      .run(graph)
+      .map { case (g, (_, d)) => AuthenticatedQSU(g, d) }
+  }
+
+  def applyProvenanceƒ[F[_]: Monad: GStateM]: ElgotAlgebraM[(Dims, ?), F, GPF, (Symbol, QSUDims[T])] = {
+    case (updDims, GPF(deId, DimEdit((srcId, qdims), _))) =>
+      val srcDims = dims.rename(deId, srcId, updDims)
+      GStateM[F].modify(_.replace(deId, srcId))
+        .as((srcId, qdims + (srcId -> srcDims)))
+
+    case (nodeDims, GPF(nodeId, node)) =>
+      (nodeId, node.foldRight[QSUDims[T]](SMap(nodeId -> nodeDims))(_._2 ++ _)).point[F]
+  }
+
+  def computeProvenanceƒ[F[_]: Monad: ErrorM]: AlgebraM[F, GPF, Dims] =
+    gpf => gpf.qsu match {
+      case AutoJoin(srcs, _) => srcs.foldLeft1(dims.join(_, _)).point[F]
+
+      case DimEdit(src, DTrans.Squash()) => dims.squash(src).point[F]
+
+      case DimEdit(src, DTrans.Group(k)) =>
+        dims.swap(0, 1, dims.lshift(k as gpf.root, src)).point[F]
+
+      case Distinct(src) => src.point[F]
+
+      case GroupBy(_, _) => unexpectedError("GroupBy", gpf.root)
+
+      case JoinSideRef(_) => dims.empty.point[F]
+
+      case LeftShift(_, _, _, _) => unexpectedError("LeftShift", gpf.root)
+
+      case LPFilter(src, _) => unexpectedError("LPFilter", gpf.root)
+
+      case LPJoin(_, _, _, _, _, _) => unexpectedError("LPJoin", gpf.root)
+
+      case LPReduce(src, _) => dims.reduce(src).point[F]
+
+      case QSFilter(src, _) => src.point[F]
+
+      case QSReduce(src, _, _, _) => dims.reduce(src).point[F]
+
+      case Map(src, _) => src.point[F]
+
+      case Nullary(_) => dims.empty.point[F]
+
+      case Read(file) => dims.squash(segments(file).map(projStr).reverse).point[F]
+
+      case Sort(_, _) => unexpectedError("Sort", gpf.root)
+
+      case Subset(from, _, count) => dims.join(from, count).point[F]
+
+      case ThetaJoin(left, right, _, _) => dims.join(left, right).point[F]
+
+      case Transpose(src, rot) =>
+        val tid: dims.I = Free.pure(gpf.root)
+        (rot match {
+          case Rotation.ShiftMap   | Rotation.ShiftArray   => dims.lshift(tid, src)
+          case Rotation.FlattenMap | Rotation.FlattenArray => dims.flatten(tid, src)
+        }).point[F]
+
+      case UniformSort(src, _, _) => src.point[F]
+
+      case Union(left, right) => dims.union(left, right).point[F]
+    }
+
+  ////
+
+  private def projStr(s: String): P =
+    dims.prov.proj(ejson.CommonEJson(ejson.Str[T[EJson]](s)).embed)
+
+  private def segments(p: Path[_, _, _]): IList[String] = {
+    val segs = Path.flatten[IList[String]](IList(), IList(), IList(), IList(_), IList(_), p)
+    (segs.head :: segs.tail).join
+  }
+
+  private def unexpectedError[F[_]: ErrorM, A](nodeName: String, id: Symbol): F[A] =
+    ErrorM[F].raiseError(s"ComputeProvenance: Encountered unexpected $nodeName[$id].")
+}
+
+object ApplyProvenance {
+  def apply[T[_[_]]: BirecursiveT: EqualT]: ApplyProvenance[T] =
+    new ApplyProvenance[T]
+
+  final case class AuthenticatedQSU[T[_[_]]](
+      graph: QSUGraph[T],
+      dims: QSUDims[T])
+}

--- a/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
@@ -82,7 +82,7 @@ final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT] {
 
       case GroupBy(_, _) => unexpectedError("GroupBy", gpf.root)
 
-      case JoinSideRef(_) => dims.empty.point[F]
+      case JoinSideRef(_) => unexpectedError("JoinSideRef", gpf.root)
 
       case LeftShift(_, _, _, _) => unexpectedError("LeftShift", gpf.root)
 

--- a/connector/src/main/scala/quasar/qscript/qsu/MappableRegion.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/MappableRegion.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.qsu
+
+import slamdata.Predef.{Boolean, Option, Symbol}
+import quasar.fp._
+import quasar.fp.ski.κ
+import quasar.qscript.{
+  FreeMap,
+  FreeMapA,
+  JoinFunc,
+  JoinSide,
+  LeftSide,
+  MapFunc,
+  RightSide,
+  SrcHole
+}
+
+import matryoshka._
+import matryoshka.data._
+import matryoshka.implicits._
+import matryoshka.patterns._
+import scalaz.{\/, Kleisli, Traverse}
+import scalaz.std.option._
+import scalaz.syntax.bind._
+import scalaz.syntax.either._
+import scalaz.syntax.equal._
+import scalaz.syntax.foldable._
+import scalaz.syntax.plus._
+import scalaz.syntax.std.boolean._
+
+/** The maximal "mappable" (expressable via MapFunc) region of a graph. */
+object MappableRegion {
+  import QScriptUniform._
+  import QSUGraph.QSUPattern
+
+  def apply[T[_[_]]](halt: Symbol => Boolean, g: QSUGraph[T]): FreeMapA[T, QSUGraph[T]] =
+    g.elgotApo[FreeMapA[T, QSUGraph[T]]](mappableRegionƒ[T](halt))
+
+  def binaryOf[T[_[_]]](left: Symbol, right: Symbol, g: QSUGraph[T]): Option[JoinFunc[T]] =
+    funcOf(Kleisli(replaceWith[JoinSide](left, LeftSide)) <+> Kleisli(replaceWith(right, RightSide)), g)
+
+  def funcOf[T[_[_]], A](f: Symbol => Option[A], g: QSUGraph[T]): Option[FreeMapA[T, A]] =
+    Traverse[FreeMapA[T, ?]].traverse(apply(s => f(s).isDefined, g))(qg => f(qg.root))
+
+  def maximal[T[_[_]]](g: QSUGraph[T]): FreeMapA[T, QSUGraph[T]] =
+    apply(κ(false), g)
+
+  def unaryOf[T[_[_]]](src: Symbol, g: QSUGraph[T]): Option[FreeMap[T]] =
+    funcOf(replaceWith(src, SrcHole), g)
+
+  def mappableRegionƒ[T[_[_]]](halt: Symbol => Boolean)
+      : ElgotCoalgebra[FreeMapA[T, QSUGraph[T]] \/ ?, CoEnv[QSUGraph[T], MapFunc[T, ?], ?], QSUGraph[T]] =
+    g => g.project match {
+      case QSUPattern(s, _) if halt(s) =>
+        CoEnv(g.left).right
+
+      case QSUPattern(_, AutoJoin(srcs, combine)) =>
+        CoEnv(combine.map(srcs.toVector).right[QSUGraph[T]]).right
+
+      case QSUPattern(_, Map(srcG, mf)) =>
+        mf.as(srcG).left
+
+      case QSUPattern(_, Nullary(mf)) =>
+        CoEnv(mf[QSUGraph[T]].right[QSUGraph[T]]).right
+
+      case _ =>
+        CoEnv(g.left).right
+    }
+
+  ////
+
+  private def replaceWith[A](target: Symbol, a: A): Symbol => Option[A] =
+    s => (s === target) option a
+}

--- a/connector/src/main/scala/quasar/qscript/qsu/QProv.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/QProv.scala
@@ -24,6 +24,7 @@ import quasar.qscript._
 import quasar.qscript.provenance._
 
 import matryoshka._
+import matryoshka.implicits._
 import matryoshka.data._
 import scalaz.{Lens => _, _}, Scalaz._
 
@@ -52,6 +53,18 @@ final class QProv[T[_[_]]: BirecursiveT: EqualT]
       jks.foldMapLeft1(eqCond)((l, r) => Free.roll(MFC(And(l, eqCond(r)))))
     }
   }
+
+  /** Renames `from` to `to` in the given dimensions. */
+  def rename(from: Symbol, to: Symbol, dims: Dimensions[P]): Dimensions[P] = {
+    def rename0(sym: Symbol): Symbol =
+      (sym === from) ? to | sym
+
+    dims map (_.transCata[P](pfo.identities modify (_ map rename0)))
+  }
+
+  ////
+
+  private val pfo = ProvF.Optics[D, I]
 }
 
 object QProv {

--- a/connector/src/main/scala/quasar/qscript/qsu/ReadLP.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ReadLP.scala
@@ -50,7 +50,7 @@ import matryoshka.{AlgebraM, BirecursiveT}
 import matryoshka.implicits._
 import matryoshka.patterns.{interpretM, CoEnv}
 import pathy.Path.{rootDir, Sandboxed}
-import scalaz.{\/, Free, Inject, Monad, NonEmptyList => NEL, StateT}
+import scalaz.{\/, Forall, Free, Inject, Monad, NonEmptyList => NEL, StateT}
 import scalaz.std.tuple._
 import scalaz.syntax.bifunctor._
 import scalaz.syntax.either._
@@ -92,7 +92,7 @@ sealed abstract class ReadLP[
       val back = fromData(data).fold[PlannerError \/ QSU[Symbol]](
         {
           case Data.NA =>
-            QSU.Nullary(IC(MapFuncsCore.Undefined[T, Symbol]())).right
+            QSU.Nullary[T, Symbol](Forall(_(IC(MapFuncsCore.Undefined())))).right
 
           case d =>
             NonRepresentableData(d).left

--- a/connector/src/main/scala/quasar/qscript/qsu/package.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/package.scala
@@ -17,7 +17,8 @@
 package quasar.qscript
 
 import slamdata.Predef.{Map => SMap, _}
+import quasar.qscript.provenance.Dimensions
 
 package object qsu {
-  type ProvGraph[T[_[_]]] = SMap[Symbol, QProv.P[T]]
+  type QSUDims[T[_[_]]] = SMap[Symbol, Dimensions[QProv.P[T]]]
 }

--- a/foundation/src/main/scala/quasar/contrib/scalaz/MonadState_.scala
+++ b/foundation/src/main/scala/quasar/contrib/scalaz/MonadState_.scala
@@ -25,14 +25,13 @@ import scalaz.{Bind, Functor, MonadState}
   */
 trait MonadState_[F[_], S] {
   def get: F[S]
-  def init: F[S]
   def put(s: S): F[Unit]
 
   def gets[A](f: S => A)(implicit F: Functor[F]): F[A] =
-    F.map(init)(f)
+    F.map(get)(f)
 
   def modify(f: S => S)(implicit F: Bind[F]): F[Unit] =
-    F.bind(init)(f andThen put)
+    F.bind(get)(f andThen put)
 }
 
 object MonadState_ {
@@ -42,7 +41,6 @@ object MonadState_ {
       : MonadState_[F, S] =
     new MonadState_[F, S] {
       def get = F.get
-      def init = F.init
       def put(s: S) = F.put(s)
     }
 }


### PR DESCRIPTION
Adds a function to compute provenance for `QSUGraph` and remove `DimEdit` nodes in the process. Also provides `MappableRegion` which attempts to express as much of a graph as possible in terms of `MapFunc`.