### PR TITLE
Initial work on provenance reification for autojoin, transpose, reduce.

### DIFF
--- a/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
@@ -106,7 +106,7 @@ final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT] {
 
       case Subset(from, _, count) => dims.join(from, count).point[F]
 
-      case ThetaJoin(left, right, _, _) => dims.join(left, right).point[F]
+      case ThetaJoin(left, right, _, _, _) => dims.join(left, right).point[F]
 
       case Transpose(src, rot) =>
         val tid: dims.I = Free.pure(gpf.root)

--- a/connector/src/main/scala/quasar/qscript/qsu/QScriptUniform.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/QScriptUniform.scala
@@ -47,8 +47,8 @@ object QScriptUniform {
       case LPJoin(left, right, condition, joinType, leftRef, rightRef) =>
         (f(left) |@| f(right) |@| f(condition))(LPJoin(_, _, _, joinType, leftRef, rightRef))
 
-      case ThetaJoin(left, right, condition, joinType) =>
-        (f(left) |@| f(right))(ThetaJoin(_, _, condition, joinType))
+      case ThetaJoin(left, right, condition, joinType, combiner) =>
+        (f(left) |@| f(right))(ThetaJoin(_, _, condition, joinType, combiner))
 
       case Map(source, fm) =>
         f(source).map(Map(_, fm))
@@ -144,7 +144,8 @@ object QScriptUniform {
       left: A,
       right: A,
       condition: JoinFunc[T],
-      joinType: JoinType) extends QScriptUniform[T, A]
+      joinType: JoinType,
+      combiner: JoinFunc[T]) extends QScriptUniform[T, A]
 
   final case class Map[T[_[_]], A](
       source: A,

--- a/connector/src/main/scala/quasar/qscript/qsu/ReifyProvenance.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ReifyProvenance.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.qsu
+
+import slamdata.Predef._
+
+import quasar.common.JoinType
+import quasar.contrib.scalaz.MonadError_
+import quasar.fp.ski.κ
+import quasar.qscript.{HoleF, IncludeId, LeftSideF, MFC, ReduceIndexF, RightSideF}
+import quasar.qscript.ReduceFunc._
+import quasar.qscript.MapFuncsCore.ConcatArrays
+import quasar.qscript.qsu.{QScriptUniform => QSU}
+import quasar.qscript.qsu.ApplyProvenance.AuthenticatedQSU
+
+import matryoshka.{BirecursiveT, EqualT}
+import scalaz.{\/-, Applicative, Free, ICons, INil, Monad}
+import scalaz.Scalaz._
+
+final class ReifyProvenance[T[_[_]]: BirecursiveT: EqualT] extends QSUTTypes[T] {
+
+  type QSU[A] = QScriptUniform[A]
+
+  type ErrorM[F[_]] = MonadError_[F, String]
+  def ErrorM[F[_]](implicit ev: ErrorM[F]): ErrorM[F] = ev
+
+  val prov = new QProv[T]
+
+  private def toQScript[F[_]: Applicative: ErrorM](dims: QSUDims[T])
+      : QSU[Symbol] => F[QSU[Symbol]] = {
+    case QSU.AutoJoin(sources, combiner0) =>
+      sources.list match {
+        case ICons(left, ICons(right, INil())) =>
+          val condition: JoinFunc =
+            prov.autojoinCondition(dims(left), dims(right))(κ(HoleF))
+
+          val combiner: JoinFunc = Free.roll(combiner0.map {
+            case 0 => LeftSideF
+            case 1 => RightSideF
+            case n => scala.sys.error(s"AutoJoin combiner has wrong size $n. Expected size 2.")
+          })
+
+          val qsu: QSU[Symbol] = QSU.ThetaJoin(left, right, condition, JoinType.Inner, combiner)
+
+          qsu.point[F]
+
+        // TODO support autojoins of any size - requires name generation
+        case _ =>
+          ErrorM[F].raiseError(s"AutoJoin on a list of size ${sources.size} is not supported.")
+      }
+
+    case QSU.Transpose(source, _) =>
+      // TODO only reify the identity/value information when it's used
+      val repair: JoinFunc = Free.roll(MFC(ConcatArrays(LeftSideF, RightSideF)))
+      val qsu: QSU[Symbol] = QSU.LeftShift[T, Symbol](source, HoleF, IncludeId, repair)
+
+      qsu.point[F]
+
+    case QSU.LPReduce(source, reduce) =>
+      val bucket: FreeMap = slamdata.Predef.??? // TODO computed from provenance
+      val qsu: QSU[Symbol] = QSU.QSReduce[T, Symbol](source, List(bucket), List(reduce.map(κ(HoleF))), ReduceIndexF(\/-(0)))
+
+      qsu.point[F]
+
+    case qsu => qsu.point[F]
+  }
+
+  def reifyProvenance[F[_]: Monad: ErrorM](qsuF: F[AuthenticatedQSU[T]])
+      : F[AuthenticatedQSU[T]] =
+    for {
+      qsu <- qsuF
+      vertices <- qsu.graph.vertices.traverse[F, QSU[Symbol]](toQScript[F](qsu.dims))
+    } yield {
+      AuthenticatedQSU[T](QSUGraph(qsu.graph.root, vertices), qsu.dims)
+    }
+}
+
+object ReifyProvenance {
+  def apply[T[_[_]]: BirecursiveT: EqualT]: ReifyProvenance[T] =
+    new ReifyProvenance[T]
+}


### PR DESCRIPTION
`AutoJoin` of size 2 defaults to `ThetaJoin`. `AutoJoin` of greater sizes not yet supported.

`LPReduce` requires an adjusted impl of [`reifiedIdArray`](https://github.com/wemrysi/quasar/blob/wip/proper-prov/connector/src/main/scala/quasar/qscript/QProv.scala#L68) to compute its `buckets`.