### PR TITLE
More `graduate` specifications

### DIFF
--- a/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
@@ -90,17 +90,19 @@ final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT] {
 
       case LPReduce(src, _) => dims.reduce(src).point[F]
 
+      case LPSort(_, _) => unexpectedError("LPSort", gpf.root)
+
       case QSFilter(src, _) => src.point[F]
 
       case QSReduce(src, _, _, _) => dims.reduce(src).point[F]
+
+      case QSSort(src, _, _) => src.point[F]
 
       case Map(src, _) => src.point[F]
 
       case Unreferenced() => dims.empty.point[F]
 
       case Read(file) => dims.squash(segments(file).map(projStr).reverse).point[F]
-
-      case Sort(_, _) => unexpectedError("Sort", gpf.root)
 
       case Subset(from, _, count) => dims.join(from, count).point[F]
 
@@ -112,8 +114,6 @@ final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT] {
           case Rotation.ShiftMap   | Rotation.ShiftArray   => dims.lshift(tid, src)
           case Rotation.FlattenMap | Rotation.FlattenArray => dims.flatten(tid, src)
         }).point[F]
-
-      case UniformSort(src, _, _) => src.point[F]
 
       case Union(left, right) => dims.union(left, right).point[F]
     }

--- a/connector/src/main/scala/quasar/qscript/qsu/ExtractFreeMap.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ExtractFreeMap.scala
@@ -58,12 +58,12 @@ object ExtractFreeMap {
           .map(ThetaJoin(left, right, _, jtype, combiner))
           .toSuccessNel(s"Invalid join condition, $cond, must be a mappable function of $left and $right.")
 
-      case Sort(src, keys) =>
+      case LPSort(src, keys) =>
         keys traverse { case (k, sortDir) =>
           MappableRegion.unaryOf(src, graph refocus k)
             .strengthR(sortDir)
             .toSuccessNel(s"Invalid sort key, $k, must be a mappable function of $src.")
-        } map (UniformSort(src, Nil, _))
+        } map (QSSort(src, Nil, _))
 
       case other => other.point[ValidationNel[String, ?]]
     })(graph).fold(e => PlannerErrorME[F].raiseError(InternalError(e intercalate ", ", None)), _.point[F])

--- a/connector/src/main/scala/quasar/qscript/qsu/Graduate.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/Graduate.scala
@@ -85,7 +85,7 @@ final class Graduate[T[_[_]]: CorecursiveT] extends QSUTTypes[T] {
       case QSU.LeftShift(source, struct, idStatus, repair) =>
         QCE(LeftShift[T, QSUGraph](source, struct, idStatus, repair)).point[F]
 
-      case QSU.UniformSort(source, buckets, order) =>
+      case QSU.QSSort(source, buckets, order) =>
         QCE(Sort[T, QSUGraph](source, buckets, order)).point[F]
 
       case QSU.Union(left, right) =>

--- a/connector/src/main/scala/quasar/qscript/qsu/QSUGraph.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/QSUGraph.scala
@@ -253,16 +253,16 @@ object QSUGraph extends QSUGraphInstances {
       }
     }
 
-    object Sort {
+    object LPSort {
       def unapply[T[_[_]]](g: QSUGraph[T]) = g.unfold match {
-        case g: QSU.Sort[T, QSUGraph[T]] => QSU.Sort.unapply(g)
+        case g: QSU.LPSort[T, QSUGraph[T]] => QSU.LPSort.unapply(g)
         case _ => None
       }
     }
 
-    object UniformSort {
+    object QSSort {
       def unapply[T[_[_]]](g: QSUGraph[T]) = g.unfold match {
-        case g: QSU.UniformSort[T, QSUGraph[T]] => QSU.UniformSort.unapply(g)
+        case g: QSU.QSSort[T, QSUGraph[T]] => QSU.QSSort.unapply(g)
         case _ => None
       }
     }

--- a/connector/src/main/scala/quasar/qscript/qsu/ReadLP.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ReadLP.scala
@@ -233,7 +233,7 @@ final class ReadLP[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T] {
       }
 
     case lp.Sort(src, order) =>
-      val node = QSU.Sort[T, Symbol](src.root, order.map(_.leftMap(_.root)))
+      val node = QSU.LPSort[T, Symbol](src.root, order.map(_.leftMap(_.root)))
       val graphs = src <:: order.map(_._1)
 
       withName[G](node).map(g => graphs.foldLeft(g)(_ :++ _))

--- a/connector/src/test/scala/quasar/qscript/qsu/ReadLPSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/ReadLPSpec.scala
@@ -271,7 +271,7 @@ object ReadLPSpec extends Qspec with CompilerHelpers with DataArbitrary with QSU
         NEL(
           read("bar") -> SortDir.Ascending,
           read("baz") -> SortDir.Descending)) must readQsuAs {
-        case Sort(
+        case LPSort(
           TRead("foo"),
           NELE(
             (TRead("bar"), SortDir.Ascending),


### PR DESCRIPTION
Also renamed `UniformSort` to `QSSort` and `Sort` to `LPSort` to be consistent with our other naming.