### PR TITLE
Organize and extend optics for EJson

### DIFF
--- a/connector/src/main/scala/quasar/qscript/ExpandMapFunc.scala
+++ b/connector/src/main/scala/quasar/qscript/ExpandMapFunc.scala
@@ -18,7 +18,7 @@ package quasar.qscript
 
 import slamdata.Predef._
 
-import quasar.ejson
+import quasar.ejson.EJson
 import quasar.qscript.{MapFuncsDerived => D}, MapFuncsCore._
 
 import matryoshka._
@@ -59,10 +59,10 @@ sealed abstract class ExpandMapFuncInstances extends ExpandMapFuncInstancesʹ {
       type OutFree[A] = (OUT ∘ Free[OUT, ?])#λ[A]
 
       def intR[A](i: Int): Free[OUT, A] =
-        Free.roll(MFC(Constant(ejson.EJson.fromExt(ejson.int(i)))))
+        Free.roll(MFC(Constant(EJson.int(i))))
 
       def decR[A](d: BigDecimal): Free[OUT, A] =
-        Free.roll(MFC(Constant(ejson.EJson.fromCommon(ejson.dec(d)))))
+        Free.roll(MFC(Constant(EJson.dec(d))))
 
       def truncR[A](a: Free[OUT, A]): Free[OUT, A] =
         Free.roll[OUT, A](trunc(a))

--- a/ejson/src/main/scala/quasar/ejson/Common.scala
+++ b/ejson/src/main/scala/quasar/ejson/Common.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.ejson
+
+import slamdata.Predef._
+import quasar.{RenderTree, NonTerminal, Terminal}, RenderTree.ops._
+
+import matryoshka._
+import scalaz.{Applicative, Cord, Equal, Order, Scalaz, Show, Traverse}, Scalaz._
+
+sealed abstract class Common[A]
+final case class Arr[A](value: List[A])    extends Common[A]
+final case class Null[A]()                 extends Common[A]
+final case class Bool[A](value: Boolean)   extends Common[A]
+final case class Str[A](value: String)     extends Common[A]
+final case class Dec[A](value: BigDecimal) extends Common[A]
+
+object Common extends CommonInstances
+
+sealed abstract class CommonInstances extends CommonInstances0 {
+  implicit val traverse: Traverse[Common] = new Traverse[Common] {
+    def traverseImpl[G[_], A, B](
+      fa: Common[A])(
+      f: A => G[B])(
+      implicit G: Applicative[G]):
+        G[Common[B]] =
+      fa match {
+        case Arr(value)  => value.traverse(f).map(Arr(_))
+        case Null()      => G.point(Null())
+        case Bool(value) => G.point(Bool(value))
+        case Str(value)  => G.point(Str(value))
+        case Dec(value)  => G.point(Dec(value))
+      }
+  }
+
+  implicit val order: Delay[Order, Common] =
+    new Delay[Order, Common] {
+      def apply[α](ord: Order[α]) = {
+        implicit val ordA: Order[α] = ord
+        Order.orderBy(generic)
+      }
+    }
+
+  implicit val show: Delay[Show, Common] =
+    new Delay[Show, Common] {
+      def apply[α](eq: Show[α]) = Show.show(a => a match {
+        case Arr(v)  => Cord(s"Arr($v)")
+        case Null()  => Cord("Null()")
+        case Bool(v) => Cord(s"Bool($v)")
+        case Str(v)  => Cord(s"Str($v)")
+        case Dec(v)  => Cord(s"Dec($v)")
+      })
+    }
+
+  implicit val renderTree: Delay[RenderTree, Common] =
+    new Delay[RenderTree, Common] {
+      def apply[A](rt: RenderTree[A]) = {
+        implicit val rtA = rt
+        RenderTree.make {
+          case Arr(vs) => NonTerminal("Array" :: c, none, vs map (_.render))
+          case Null()  => Terminal("Null" :: c, none)
+          case Bool(b) => t("Bool", b)
+          case Str(v)  => t("Str", v)
+          case Dec(v)  => t("Dec", v)
+        }
+      }
+
+      val c = List("Common")
+
+      def t[A: Show](l: String, a: A) =
+        Terminal(l :: c, some(a.shows))
+    }
+}
+
+sealed abstract class CommonInstances0 {
+  implicit val equal: Delay[Equal, Common] =
+    new Delay[Equal, Common] {
+      def apply[α](eql: Equal[α]) = {
+        implicit val eqlA: Equal[α] = eql
+        Equal.equalBy(generic)
+      }
+    }
+
+  ////
+
+  private[ejson] def generic[A](c: Common[A]) = (
+    arr.getOption(c) ,
+    bool.getOption(c),
+    dec.getOption(c) ,
+    nul.nonEmpty(c),
+    str.getOption(c)
+  )
+}

--- a/ejson/src/main/scala/quasar/ejson/EJson.scala
+++ b/ejson/src/main/scala/quasar/ejson/EJson.scala
@@ -16,257 +16,77 @@
 
 package quasar.ejson
 
-import slamdata.Predef.{Byte => SByte, Char => SChar, Map => SMap, _}
-import quasar.{RenderTree, NonTerminal, Terminal}, RenderTree.ops._
-import quasar.contrib.matryoshka._
-import quasar.fp._
+import slamdata.Predef.{Int => _, Map => _, _}
+import quasar.contrib.matryoshka.totally
 
 import matryoshka._
-import scalaz._, Scalaz._
+import matryoshka.implicits._
+import scalaz.Coproduct
+import scalaz.std.list._
+import scalaz.std.option._
+import scalaz.syntax.bind._
+import scalaz.syntax.traverse._
 
-sealed abstract class Common[A]
-final case class Arr[A](value: List[A])    extends Common[A]
-final case class Null[A]()                 extends Common[A]
-final case class Bool[A](value: Boolean)   extends Common[A]
-final case class Str[A](value: String)     extends Common[A]
-final case class Dec[A](value: BigDecimal) extends Common[A]
+object EJson {
+  def fromJson[A](f: String => A): Json[A] => EJson[A] =
+    json => Coproduct(json.run.leftMap(Extension.fromObj(f)))
 
-object Common extends CommonInstances
+  def fromCommon[T](c: Common[T])(implicit T: Corecursive.Aux[T, EJson]): T =
+    CommonEJson(c).embed
 
-sealed abstract class CommonInstances extends CommonInstances0 {
-  implicit val traverse: Traverse[Common] = new Traverse[Common] {
-    def traverseImpl[G[_], A, B](
-      fa: Common[A])(
-      f: A => G[B])(
-      implicit G: Applicative[G]):
-        G[Common[B]] =
-      fa match {
-        case Arr(value)  => value.traverse(f).map(Arr(_))
-        case Null()      => G.point(Null())
-        case Bool(value) => G.point(Bool(value))
-        case Str(value)  => G.point(Str(value))
-        case Dec(value)  => G.point(Dec(value))
-      }
+  def fromExt[T](e: Extension[T])(implicit T: Corecursive.Aux[T, EJson]): T =
+    ExtEJson(e).embed
+
+  def arr[T[_[_]]](xs: T[EJson]*)(implicit T: CorecursiveT[T]): T[EJson] =
+    fromCommon(Arr(xs.toList))
+
+  def bool[T[_[_]]](b: Boolean)(implicit T: CorecursiveT[T]): T[EJson] =
+    fromCommon(Bool(b))
+
+  def dec[T[_[_]]](d: BigDecimal)(implicit T: CorecursiveT[T]): T[EJson] =
+    fromCommon(Dec(d))
+
+  def nul[T[_[_]]](implicit T: CorecursiveT[T]): T[EJson] =
+    fromCommon(Null())
+
+  def str[T[_[_]]](s: String)(implicit T: CorecursiveT[T]): T[EJson] =
+    fromCommon(Str(s))
+
+  def int[T[_[_]]](d: BigInt)(implicit T: CorecursiveT[T]): T[EJson] =
+    fromExt(Int(d))
+
+  def obj[T[_[_]]](xs: (String, T[EJson])*)(implicit T: CorecursiveT[T]): T[EJson] =
+    map((xs.map { case (s, t) => str[T](s) -> t }): _*)
+
+  def map[T[_[_]]](xs: (T[EJson], T[EJson])*)(implicit T: CorecursiveT[T]): T[EJson] =
+    fromExt(Map(xs.toList))
+
+  def isNull[T](ej: T)(implicit T: Recursive.Aux[T, EJson]): Boolean =
+    CommonEJson.prj(ej.project) exists (quasar.ejson.nul.nonEmpty(_))
+
+  /** Replaces `Meta` nodes with their value component. */
+  def elideMetadata[T](
+    implicit T: Recursive.Aux[T, EJson]
+  ): EJson[T] => EJson[T] = totally {
+    case ExtEJson(Meta(v, _)) => v.project
   }
 
-  implicit val order: Delay[Order, Common] =
-    new Delay[Order, Common] {
-      def apply[α](ord: Order[α]) = {
-        implicit val ordA: Order[α] = ord
-        Order.orderBy(generic)
-      }
-    }
-
-  implicit val show: Delay[Show, Common] =
-    new Delay[Show, Common] {
-      def apply[α](eq: Show[α]) = Show.show(a => a match {
-        case Arr(v)  => Cord(s"Arr($v)")
-        case Null()  => Cord("Null()")
-        case Bool(v) => Cord(s"Bool($v)")
-        case Str(v)  => Cord(s"Str($v)")
-        case Dec(v)  => Cord(s"Dec($v)")
-      })
-    }
-
-  implicit val renderTree: Delay[RenderTree, Common] =
-    new Delay[RenderTree, Common] {
-      def apply[A](rt: RenderTree[A]) = {
-        implicit val rtA = rt
-        RenderTree.make {
-          case Arr(vs) => NonTerminal("Array" :: c, none, vs map (_.render))
-          case Null()  => Terminal("Null" :: c, none)
-          case Bool(b) => t("Bool", b)
-          case Str(v)  => t("Str", v)
-          case Dec(v)  => t("Dec", v)
-        }
-      }
-
-      val c = List("Common")
-
-      def t[A: Show](l: String, a: A) =
-        Terminal(l :: c, some(a.shows))
-    }
-}
-
-sealed abstract class CommonInstances0 {
-  implicit val equal: Delay[Equal, Common] =
-    new Delay[Equal, Common] {
-      def apply[α](eql: Equal[α]) = {
-        implicit val eqlA: Equal[α] = eql
-        Equal.equalBy(generic)
-      }
-    }
-
-  ////
-
-  private[ejson] def generic[A](c: Common[A]) = (
-    arr.getOption(c) ,
-    bool.getOption(c),
-    dec.getOption(c) ,
-    nul.nonEmpty(c),
-    str.getOption(c)
-  )
-}
-
-final case class Obj[A](value: ListMap[String, A])
-
-object Obj extends ObjInstances
-
-sealed abstract class ObjInstances extends ObjInstances0 {
-  implicit val traverse: Traverse[Obj] = new Traverse[Obj] {
-    def traverseImpl[G[_]: Applicative, A, B](fa: Obj[A])(f: A => G[B]):
-        G[Obj[B]] =
-      fa.value.traverse(f).map(Obj(_))
+  /** Replace a string with an array of characters. */
+  def replaceString[T](
+    implicit T: Corecursive.Aux[T, EJson]
+  ): EJson[T] => EJson[T] = totally {
+    case CommonEJson(Str(s)) =>
+      CommonEJson(quasar.ejson.arr[T](s.toList map (c => fromExt(quasar.ejson.char[T](c)))))
   }
 
-  implicit val order: Delay[Order, Obj] =
-    new Delay[Order, Obj] {
-      def apply[α](ord: Order[α]) = {
-        implicit val ordA: Order[α] = ord
-        Order.orderBy(_.value: SMap[String, α])
-      }
-    }
-
-  implicit val show: Delay[Show, Obj] =
-    new Delay[Show, Obj] {
-      def apply[α](shw: Show[α]) = {
-        implicit val shwA: Show[α] = shw
-        Show.show(o => (o.value: SMap[String, α]).show)
-      }
-    }
-
-  implicit val renderTree: Delay[RenderTree, Obj] =
-    new Delay[RenderTree, Obj] {
-      def apply[A](rt: RenderTree[A]) = {
-        implicit val rtA = rt
-        RenderTree.make(obj => NonTerminal(List("Obj"), None, List(obj.value.render)))
-      }
-    }
-}
-
-sealed abstract class ObjInstances0 {
-  implicit val equal: Delay[Equal, Obj] =
-    new Delay[Equal, Obj] {
-      def apply[α](eql: Equal[α]) = {
-        implicit val eqlA: Equal[α] = eql
-        Equal.equalBy(_.value: SMap[String, α])
-      }
-    }
-}
-
-/** This is an extension to JSON that allows arbitrary expressions as map (née
-  * object) keys and adds additional primitive types, including characters,
-  * bytes, and distinct integers. It also adds metadata, which allows arbitrary
-  * annotations on values.
-  */
-sealed abstract class Extension[A]
-final case class Meta[A](value: A, meta: A)  extends Extension[A]
-final case class Map[A](value: List[(A, A)]) extends Extension[A]
-final case class Byte[A](value: SByte)       extends Extension[A]
-final case class Char[A](value: SChar)       extends Extension[A]
-final case class Int[A](value: BigInt)       extends Extension[A]
-
-object Extension extends ExtensionInstances {
-  def fromObj[A](f: String => A): Obj[A] => Extension[A] =
-    obj => map(obj.value.toList.map(_.leftMap(f)))
-}
-
-sealed abstract class ExtensionInstances {
-  /** Structural ordering, which _does_ consider metadata and thus needs to
-    * be elided before using for proper semantics.
-    */
-  val structuralOrder: Delay[Order, Extension] =
-    new Delay[Order, Extension] {
-      def apply[α](ord: Order[α]) = {
-        implicit val ordA: Order[α] = ord
-        // TODO: Not sure why this isn't found?
-        implicit val ordC: Order[SChar] = scalaz.std.anyVal.char
-        Order.orderBy { e =>
-          val g = generic(e)
-          g.copy(_4 = g._4 map (IMap.fromFoldable(_)))
-        }
-      }
-    }
-
-  /** Structural equality, which _does_ consider metadata and thus needs to
-    * be elided before using for proper semantics.
-    */
-  val structuralEqual: Delay[Equal, Extension] =
-    new Delay[Equal, Extension] {
-      def apply[α](eql: Equal[α]) = {
-        implicit val eqlA: Equal[α] = eql
-        // TODO: Not sure why this isn't found?
-        implicit val eqlC: Equal[SChar] = scalaz.std.anyVal.char
-        Equal.equalBy { e =>
-          val g = generic(e)
-          g.copy(_4 = g._4 map (EqMap.fromFoldable(_)))
-        }
-      }
-    }
-
-  implicit val traverse: Traverse[Extension] = new Traverse[Extension] {
-    def traverseImpl[G[_], A, B](
-      fa: Extension[A])(
-      f: A => G[B])(
-      implicit G: Applicative[G]):
-        G[Extension[B]] =
-      fa match {
-        case Meta(value, meta) => (f(value) ⊛ f(meta))(Meta(_, _))
-        case Map(value)        => value.traverse(_.bitraverse(f, f)).map(Map(_))
-        case Byte(value)       => G.point(Byte(value))
-        case Char(value)       => G.point(Char(value))
-        case Int(value)        => G.point(Int(value))
-      }
+  /** Replace an array of characters with a string. */
+  def restoreString[T](
+    implicit
+    TC: Corecursive.Aux[T, EJson],
+    TR: Recursive.Aux[T, EJson]
+  ): EJson[T] => EJson[T] = totally {
+    case a @ CommonEJson(Arr(t :: ts)) =>
+      (t :: ts).traverse(t => ExtEJson.prj(t.project) >>= (quasar.ejson.char[T].getOption(_)))
+        .fold(a)(cs => CommonEJson(quasar.ejson.str[T](cs.mkString)))
   }
-
-  implicit val show: Delay[Show, Extension] =
-    new Delay[Show, Extension] {
-      def apply[α](eq: Show[α]) = Show.show(a => a match {
-        case Meta(v, m) => Cord(s"Meta($v, $m)")
-        case Map(v)     => Cord(s"Map($v)")
-        case Byte(v)    => Cord(s"Byte($v)")
-        case Char(v)    => Cord(s"Char($v)")
-        case Int(v)     => Cord(s"Int($v)")
-      })
-    }
-
-  implicit val renderTree: Delay[RenderTree, Extension] =
-    new Delay[RenderTree, Extension] {
-      def apply[A](rt: RenderTree[A]) = {
-        implicit val rtA = rt
-        implicit val sc: Show[SChar] = scalaz.std.anyVal.char
-        RenderTree.make {
-          case Meta(v, m) =>
-            NonTerminal("Meta" :: c, none, List(
-              nt("Value", v),
-              nt("Metadata", m)))
-
-          case Map(v)  =>
-            NonTerminal("Map" :: c, none, v map (_.render))
-
-          case Byte(b) => t("Byte", b)
-          case Char(v)  => t("Char", v)
-          case Int(v)  => t("Int", v)
-        }
-      }
-
-      val c = List("Extension")
-
-      def nt[A: RenderTree](l: String, a: A) =
-        NonTerminal(l :: c, none, a.render :: Nil)
-
-      def t[A: Show](l: String, a: A) =
-        Terminal(l :: c, some(a.shows))
-    }
-
-  ////
-
-  private def generic[A](e: Extension[A]) =
-    (
-      byte.getOption(e),
-      char.getOption(e),
-      int.getOption(e) ,
-      map.getOption(e) ,
-      meta.getOption(e)
-    )
 }

--- a/ejson/src/main/scala/quasar/ejson/EncodeEJson.scala
+++ b/ejson/src/main/scala/quasar/ejson/EncodeEJson.scala
@@ -53,7 +53,7 @@ sealed abstract class EncodeEJsonInstances extends EncodeEJsonInstances0 {
   implicit val bigIntEncodeEJson: EncodeEJson[BigInt] =
     new EncodeEJson[BigInt] {
       def encode[J](i: BigInt)(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): J =
-        ExtEJson(int[J](i)).embed
+        Fixed[J].int(i)
     }
 
   implicit val intEncodeEJson: EncodeEJson[SInt] =
@@ -68,19 +68,19 @@ sealed abstract class EncodeEJsonInstances extends EncodeEJsonInstances0 {
   implicit val byteEncodeEJson: EncodeEJson[SByte] =
     new EncodeEJson[SByte] {
       def encode[J](b: SByte)(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): J =
-        ExtEJson(byte[J](b)).embed
+        Fixed[J].byte(b)
     }
 
   implicit val charEncodeEJson: EncodeEJson[SChar] =
     new EncodeEJson[SChar] {
       def encode[J](c: SChar)(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): J =
-        ExtEJson(char[J](c)).embed
+        Fixed[J].char(c)
     }
 
   implicit def optionEncodeEJson[A](implicit A: EncodeEJson[A]): EncodeEJson[Option[A]] =
     new EncodeEJson[Option[A]] {
       def encode[J](oa: Option[A])(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): J =
-        oa.fold(CommonEJson(nul[J]()).embed)(A.encode[J](_))
+        oa.fold(Fixed[J].nul())(A.encode[J](_))
     }
 
   implicit def encodeJsonT[T[_[_]]: RecursiveT, F[_]: Functor: EncodeEJsonK]: EncodeEJson[T[F]] =
@@ -90,9 +90,7 @@ sealed abstract class EncodeEJsonInstances extends EncodeEJsonInstances0 {
 sealed abstract class EncodeEJsonInstances0 {
   implicit def encodeJsonEJson[A: EncodeJson]: EncodeEJson[A] =
     new EncodeEJson[A] {
-      def encode[J](a: A)(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): J = {
-        val mkKey: String => J = s => CommonEJson(str[J](s)).embed
-        EncodeJson.of[A].encode(a).transCata[J](EJson.fromJson(mkKey))
-      }
+      def encode[J](a: A)(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): J =
+        EncodeJson.of[A].encode(a).transCata[J](EJson.fromJson(Fixed[J].str(_)))
     }
 }

--- a/ejson/src/main/scala/quasar/ejson/EncodeEJsonK.scala
+++ b/ejson/src/main/scala/quasar/ejson/EncodeEJsonK.scala
@@ -47,11 +47,11 @@ object EncodeEJsonK extends EncodeEJsonKInstances {
     new EncodeEJsonK[EnvT[E, F, ?]] {
       def encodeK[J](implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): Algebra[EnvT[E, F, ?], J] = {
         case EnvT((ask, lower)) =>
+          val j = Fixed[J]
           val fAlg = EncodeEJsonK[F].encodeK[J]
-          ExtEJson(map[J](List(
-            CommonEJson(str[J](askLabel)).embed   -> ask.asEJson[J],
-            CommonEJson(str[J](lowerLabel)).embed -> fAlg(lower)
-          ))).embed
+          j.map(List(
+            j.str(askLabel)   -> ask.asEJson[J],
+            j.str(lowerLabel) -> fAlg(lower)))
       }
     }
 }

--- a/ejson/src/main/scala/quasar/ejson/Extension.scala
+++ b/ejson/src/main/scala/quasar/ejson/Extension.scala
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.ejson
+
+import slamdata.Predef.{Byte => SByte, Char => SChar, _}
+import quasar.{RenderTree, NonTerminal, Terminal}, RenderTree.ops._
+import quasar.contrib.matryoshka._
+import quasar.fp._
+
+import matryoshka._
+import scalaz.{Applicative, Cord, Equal, IMap, Order, Scalaz, Show, Traverse}, Scalaz._
+
+/** This is an extension to JSON that allows arbitrary expressions as map (née
+  * object) keys and adds additional primitive types, including characters,
+  * bytes, and distinct integers. It also adds metadata, which allows arbitrary
+  * annotations on values.
+  */
+sealed abstract class Extension[A]
+final case class Meta[A](value: A, meta: A)  extends Extension[A]
+final case class Map[A](value: List[(A, A)]) extends Extension[A]
+final case class Byte[A](value: SByte)       extends Extension[A]
+final case class Char[A](value: SChar)       extends Extension[A]
+final case class Int[A](value: BigInt)       extends Extension[A]
+
+object Extension extends ExtensionInstances {
+  def fromObj[A](f: String => A): Obj[A] => Extension[A] =
+    obj => map(obj.value.toList.map(_.leftMap(f)))
+}
+
+sealed abstract class ExtensionInstances {
+  /** Structural ordering, which _does_ consider metadata and thus needs to
+    * be elided before using for proper semantics.
+    */
+  val structuralOrder: Delay[Order, Extension] =
+    new Delay[Order, Extension] {
+      def apply[α](ord: Order[α]) = {
+        implicit val ordA: Order[α] = ord
+        // TODO: Not sure why this isn't found?
+        implicit val ordC: Order[SChar] = scalaz.std.anyVal.char
+        Order.orderBy { e =>
+          val g = generic(e)
+          g.copy(_4 = g._4 map (IMap.fromFoldable(_)))
+        }
+      }
+    }
+
+  /** Structural equality, which _does_ consider metadata and thus needs to
+    * be elided before using for proper semantics.
+    */
+  val structuralEqual: Delay[Equal, Extension] =
+    new Delay[Equal, Extension] {
+      def apply[α](eql: Equal[α]) = {
+        implicit val eqlA: Equal[α] = eql
+        // TODO: Not sure why this isn't found?
+        implicit val eqlC: Equal[SChar] = scalaz.std.anyVal.char
+        Equal.equalBy { e =>
+          val g = generic(e)
+          g.copy(_4 = g._4 map (EqMap.fromFoldable(_)))
+        }
+      }
+    }
+
+  implicit val traverse: Traverse[Extension] = new Traverse[Extension] {
+    def traverseImpl[G[_], A, B](
+      fa: Extension[A])(
+      f: A => G[B])(
+      implicit G: Applicative[G]):
+        G[Extension[B]] =
+      fa match {
+        case Meta(value, meta) => (f(value) ⊛ f(meta))(Meta(_, _))
+        case Map(value)        => value.traverse(_.bitraverse(f, f)).map(Map(_))
+        case Byte(value)       => G.point(Byte(value))
+        case Char(value)       => G.point(Char(value))
+        case Int(value)        => G.point(Int(value))
+      }
+  }
+
+  implicit val show: Delay[Show, Extension] =
+    new Delay[Show, Extension] {
+      def apply[α](eq: Show[α]) = Show.show(a => a match {
+        case Meta(v, m) => Cord(s"Meta($v, $m)")
+        case Map(v)     => Cord(s"Map($v)")
+        case Byte(v)    => Cord(s"Byte($v)")
+        case Char(v)    => Cord(s"Char($v)")
+        case Int(v)     => Cord(s"Int($v)")
+      })
+    }
+
+  implicit val renderTree: Delay[RenderTree, Extension] =
+    new Delay[RenderTree, Extension] {
+      def apply[A](rt: RenderTree[A]) = {
+        implicit val rtA = rt
+        implicit val sc: Show[SChar] = scalaz.std.anyVal.char
+        RenderTree.make {
+          case Meta(v, m) =>
+            NonTerminal("Meta" :: c, none, List(
+              nt("Value", v),
+              nt("Metadata", m)))
+
+          case Map(v)  =>
+            NonTerminal("Map" :: c, none, v map (_.render))
+
+          case Byte(b) => t("Byte", b)
+          case Char(v)  => t("Char", v)
+          case Int(v)  => t("Int", v)
+        }
+      }
+
+      val c = List("Extension")
+
+      def nt[A: RenderTree](l: String, a: A) =
+        NonTerminal(l :: c, none, a.render :: Nil)
+
+      def t[A: Show](l: String, a: A) =
+        Terminal(l :: c, some(a.shows))
+    }
+
+  ////
+
+  private def generic[A](e: Extension[A]) =
+    (
+      byte.getOption(e),
+      char.getOption(e),
+      int.getOption(e) ,
+      map.getOption(e) ,
+      meta.getOption(e)
+    )
+}

--- a/ejson/src/main/scala/quasar/ejson/Fixed.scala
+++ b/ejson/src/main/scala/quasar/ejson/Fixed.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.ejson
+
+import slamdata.Predef.{Byte => SByte, Char => SChar, Int => _, Map => _, _}
+import quasar.contrib.matryoshka.birecursiveIso
+
+import matryoshka._
+import monocle.Prism
+
+final class Fixed[J] private ()(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]) {
+  private val iso = birecursiveIso[J, EJson]
+
+  val arr: Prism[J, List[J]] =
+    iso composePrism optics.arr
+
+  val bool: Prism[J, Boolean] =
+    iso composePrism optics.bool
+
+  val byte: Prism[J, SByte] =
+    iso composePrism optics.byte
+
+  val char: Prism[J, SChar] =
+    iso composePrism optics.char
+
+  val dec: Prism[J, BigDecimal] =
+    iso composePrism optics.dec
+
+  val int: Prism[J, BigInt] =
+    iso composePrism optics.int
+
+  val map: Prism[J, List[(J, J)]] =
+    iso composePrism optics.map
+
+  val meta: Prism[J, (J, J)] =
+    iso composePrism optics.meta
+
+  val nul: Prism[J, Unit] =
+    iso composePrism optics.nul
+
+  val sizedTpe: Prism[J, (TypeTag, BigInt)] =
+    Prism[J, (TypeTag, BigInt)](j => SizedType.unapply(JR.project(j))) {
+      case (tag, s) => SizedType(tag, s)
+    }
+
+  val str: Prism[J, String] =
+    iso composePrism optics.str
+
+  val tpe: Prism[J, TypeTag] =
+    Prism[J, TypeTag](j => Type.unapply(JR.project(j)))(Type(_))
+}
+
+object Fixed {
+  def apply[J](implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): Fixed[J] =
+    new Fixed[J]
+}

--- a/ejson/src/main/scala/quasar/ejson/Obj.scala
+++ b/ejson/src/main/scala/quasar/ejson/Obj.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.ejson
+
+import slamdata.Predef.{Map => SMap, _}
+import quasar.{RenderTree, NonTerminal}, RenderTree.ops._
+import quasar.fp._
+
+import matryoshka._
+import scalaz.{Applicative, Equal, Order, Scalaz, Show, Traverse}, Scalaz._
+
+final case class Obj[A](value: ListMap[String, A])
+
+object Obj extends ObjInstances
+
+sealed abstract class ObjInstances extends ObjInstances0 {
+  implicit val traverse: Traverse[Obj] = new Traverse[Obj] {
+    def traverseImpl[G[_]: Applicative, A, B](fa: Obj[A])(f: A => G[B]):
+        G[Obj[B]] =
+      fa.value.traverse(f).map(Obj(_))
+  }
+
+  implicit val order: Delay[Order, Obj] =
+    new Delay[Order, Obj] {
+      def apply[α](ord: Order[α]) = {
+        implicit val ordA: Order[α] = ord
+        Order.orderBy(_.value: SMap[String, α])
+      }
+    }
+
+  implicit val show: Delay[Show, Obj] =
+    new Delay[Show, Obj] {
+      def apply[α](shw: Show[α]) = {
+        implicit val shwA: Show[α] = shw
+        Show.show(o => (o.value: SMap[String, α]).show)
+      }
+    }
+
+  implicit val renderTree: Delay[RenderTree, Obj] =
+    new Delay[RenderTree, Obj] {
+      def apply[A](rt: RenderTree[A]) = {
+        implicit val rtA = rt
+        RenderTree.make(obj => NonTerminal(List("Obj"), None, List(obj.value.render)))
+      }
+    }
+}
+
+sealed abstract class ObjInstances0 {
+  implicit val equal: Delay[Equal, Obj] =
+    new Delay[Equal, Obj] {
+      def apply[α](eql: Equal[α]) = {
+        implicit val eqlA: Equal[α] = eql
+        Equal.equalBy(_.value: SMap[String, α])
+      }
+    }
+}

--- a/ejson/src/main/scala/quasar/ejson/Obj.scala
+++ b/ejson/src/main/scala/quasar/ejson/Obj.scala
@@ -21,9 +21,13 @@ import quasar.{RenderTree, NonTerminal}, RenderTree.ops._
 import quasar.fp._
 
 import matryoshka._
+import monocle.Iso
 import scalaz.{Applicative, Equal, Order, Scalaz, Show, Traverse}, Scalaz._
 
-final case class Obj[A](value: ListMap[String, A])
+final case class Obj[A](value: ListMap[String, A]) {
+  def obj[A] =
+    Iso[Obj[A], ListMap[String, A]](_.value)(Obj(_))
+}
 
 object Obj extends ObjInstances
 

--- a/ejson/src/main/scala/quasar/ejson/SizedType.scala
+++ b/ejson/src/main/scala/quasar/ejson/SizedType.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.ejson
+
+import slamdata.Predef._
+
+import matryoshka._
+import scalaz.std.option._
+import scalaz.syntax.apply._
+
+object SizedType {
+  import EJson._
+
+  val SizeKey = "_ejson.size"
+
+  def apply[T](tag: TypeTag, size: BigInt)(implicit T: Corecursive.Aux[T, EJson]): T =
+    fromExt(Map(List(
+      fromCommon[T](Str(Type.TypeKey)) -> fromCommon[T](Str(tag.value)),
+      fromCommon[T](Str(SizeKey))      -> fromExt[T](Int(size))
+    )))
+
+  /** Extracts the type tag and size from a metadata map, if both are present. */
+  def unapply[T](ejs: EJson[T])(implicit T: Recursive.Aux[T, EJson]): Option[(TypeTag, BigInt)] =
+    ejs match {
+      case ExtEJson(Map(xs)) =>
+        val size = xs collectFirst {
+          case (Embed(CommonEJson(Str(SizeKey))), Embed(ExtEJson(Int(s)))) => s
+        }
+        Type.unapply(ejs) tuple size
+
+      case _ => none
+    }
+}

--- a/ejson/src/main/scala/quasar/ejson/Type.scala
+++ b/ejson/src/main/scala/quasar/ejson/Type.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.ejson
+
+import slamdata.Predef._
+
+import matryoshka._
+import scalaz.std.option._
+
+object Type {
+  import EJson._
+
+  val TypeKey = "_ejson.type"
+
+  def apply[T](tag: TypeTag)(implicit T: Corecursive.Aux[T, EJson]): T =
+    fromExt(Map(List(fromCommon[T](Str(TypeKey)) -> fromCommon[T](Str(tag.value)))))
+
+  /** Extracts the type tag from a metadata map, if present. */
+  def unapply[T](ejs: EJson[T])(implicit T: Recursive.Aux[T, EJson]): Option[TypeTag] =
+    ejs match {
+      case ExtEJson(Map(xs)) =>
+        xs collectFirst {
+          case (Embed(CommonEJson(Str(TypeKey))), Embed(CommonEJson(Str(t)))) => TypeTag(t)
+        }
+      case _ => none
+    }
+}

--- a/ejson/src/main/scala/quasar/ejson/TypeTag.scala
+++ b/ejson/src/main/scala/quasar/ejson/TypeTag.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.ejson
+
+import slamdata.Predef.String
+
+import monocle.Iso
+import scalaz.{Order, Show}
+import scalaz.std.string._
+
+final case class TypeTag(value: String) extends scala.AnyVal
+
+object TypeTag {
+  val Binary    = TypeTag("_ejson.binary")
+  val Date      = TypeTag("_ejson.date")
+  val Interval  = TypeTag("_ejson.interval")
+  val Time      = TypeTag("_ejson.time")
+  val Timestamp = TypeTag("_ejson.timestamp")
+
+  val stringIso: Iso[TypeTag, String] =
+    Iso[TypeTag, String](_.value)(TypeTag(_))
+
+  implicit val encodeEJson: EncodeEJson[TypeTag] =
+    EncodeEJson[String].contramap(_.value)
+
+  implicit val order: Order[TypeTag] =
+    Order.orderBy(_.value)
+
+  implicit val show: Show[TypeTag] =
+    Show.showFromToString
+}

--- a/ejson/src/main/scala/quasar/ejson/optics.scala
+++ b/ejson/src/main/scala/quasar/ejson/optics.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.ejson
+
+import slamdata.Predef.{Byte => SByte, Char => SChar, Int => _, Map => _, _}
+import quasar.fp.PrismNT
+
+import monocle.Prism
+
+object optics {
+  import Common.{Optics => CO}
+  import Extension.{Optics => EO}
+
+  def com[A]: Prism[EJson[A], Common[A]] =
+    PrismNT.inject[Common, EJson].asPrism[A]
+
+  def ext[A]: Prism[EJson[A], Extension[A]] =
+    PrismNT.inject[Extension, EJson].asPrism[A]
+
+  def arr[A]: Prism[EJson[A], List[A]] =
+    com composePrism CO.arr
+
+  def bool[A]: Prism[EJson[A], Boolean] =
+    com composePrism CO.bool
+
+  def byte[A]: Prism[EJson[A], SByte] =
+    ext composePrism EO.byte
+
+  def char[A]: Prism[EJson[A], SChar] =
+    ext composePrism EO.char
+
+  def dec[A]: Prism[EJson[A], BigDecimal] =
+    com composePrism CO.dec
+
+  def int[A]: Prism[EJson[A], BigInt] =
+    ext composePrism EO.int
+
+  def map[A]: Prism[EJson[A], List[(A, A)]] =
+    ext composePrism EO.map
+
+  def meta[A]: Prism[EJson[A], (A, A)] =
+    ext composePrism EO.meta
+
+  def nul[A]: Prism[EJson[A], Unit] =
+    com composePrism CO.nul
+
+  def str[A]: Prism[EJson[A], String] =
+    com composePrism CO.str
+}

--- a/ejson/src/main/scala/quasar/ejson/package.scala
+++ b/ejson/src/main/scala/quasar/ejson/package.scala
@@ -16,61 +16,17 @@
 
 package quasar
 
-import slamdata.Predef._
-import quasar.fp.ski._
-
-import java.lang.String
-import scala.Predef.implicitly
-import scala.Unit
-import scala.collection.immutable.{List, ListMap}
-import scala.math.{BigDecimal, BigInt}
-
-import monocle.{Iso, Prism}
-import scalaz._
+import scalaz.{Coproduct, Inject}
 
 package object ejson {
-  def arr[A] =
-    Prism.partial[Common[A], List[A]] { case Arr(a) => a } (Arr(_))
-
-  def bool[A] =
-    Prism.partial[Common[A], Boolean] { case Bool(b) => b } (Bool(_))
-
-  def dec[A] =
-    Prism.partial[Common[A], BigDecimal] { case Dec(bd) => bd } (Dec(_))
-
-  def nul[A] =
-    Prism.partial[Common[A], Unit] { case Null() => () } (κ(Null()))
-
-  def str[A] =
-    Prism.partial[Common[A], String] { case Str(s) => s } (Str(_))
-
-  def obj[A] =
-    Iso[Obj[A], ListMap[String, A]](_.value)(Obj(_))
-
-  def byte[A] =
-    Prism.partial[Extension[A], scala.Byte] { case Byte(b) => b } (Byte(_))
-
-  def char[A] =
-    Prism.partial[Extension[A], scala.Char] { case Char(c) => c } (Char(_))
-
-  def int[A] =
-    Prism.partial[Extension[A], BigInt] { case Int(i) => i } (Int(_))
-
-  def map[A] =
-    Prism.partial[Extension[A], List[(A, A)]] { case Map(m) => m } (Map(_))
-
-  def meta[A] =
-    Prism.partial[Extension[A], (A, A)] {
-      case Meta(v, m) => (v, m)
-    } ((Meta(_: A, _: A)).tupled)
 
   /** For _strict_ JSON, you want something like `Obj[Mu[Json]]`.
     */
   type Json[A]    = Coproduct[Obj, Common, A]
-  val ObjJson     = implicitly[Obj :<: Json]
-  val CommonJson  = implicitly[Common :<: Json]
+  val ObjJson     = Inject[Obj, Json]
+  val CommonJson  = Inject[Common, Json]
 
   type EJson[A]   = Coproduct[Extension, Common, A]
-  val ExtEJson    = implicitly[Extension :<: EJson]
-  val CommonEJson = implicitly[Common :<: EJson]
+  val ExtEJson    = Inject[Extension, EJson]
+  val CommonEJson = Inject[Common, EJson]
 }

--- a/ejson/src/test/scala/quasar/ejson/EJson.scala
+++ b/ejson/src/test/scala/quasar/ejson/EJson.scala
@@ -34,6 +34,8 @@ import scalaz._, Scalaz._
 import scalaz.scalacheck.ScalazProperties._
 
 class EJsonSpecs extends Spec with EJsonArbitrary {
+  import Extension.Optics.meta
+
   // To keep generated EJson managable
   implicit val params = Parameters(maxSize = 10)
 

--- a/ejson/src/test/scala/quasar/ejson/JsonCodecSpec.scala
+++ b/ejson/src/test/scala/quasar/ejson/JsonCodecSpec.scala
@@ -31,6 +31,7 @@ import scalaz._, Scalaz._
 
 final class JsonCodecSpec extends Qspec with EJsonArbitrary {
   import JsonCodec.DecodingFailed
+  import Common.Optics.{nul, str}
 
   implicit val params = Parameters(maxSize = 10)
 

--- a/foundation/src/main/scala/quasar/contrib/matryoshka/package.scala
+++ b/foundation/src/main/scala/quasar/contrib/matryoshka/package.scala
@@ -35,6 +35,11 @@ package object matryoshka {
       first)(
       (prev, next) => x => prev(x).fold(next(x))(orOriginal(next)(_).some))
 
+  def birecursiveIso[T, F[_]: Functor]
+      (implicit TC: Corecursive.Aux[T, F], TR: Recursive.Aux[T, F])
+      : Iso[T, F[T]] =
+    Iso[T, F[T]](TR.project(_))(TC.embed(_))
+
   object convertToFree {
     def apply[F[_], A] = new PartiallyApplied[F, A]
     final class PartiallyApplied[F[_], A] {

--- a/frontend/src/main/scala/quasar/sst/TypeStat.scala
+++ b/frontend/src/main/scala/quasar/sst/TypeStat.scala
@@ -214,7 +214,7 @@ sealed abstract class TypeStatInstances {
     JR: Recursive.Aux[J, EJson]
   ): J = {
     def emap(xs: (String, J)*): J =
-      E(ejs.map(xs.toList.map(_.leftMap(_.asEJson[J])))).embed
+      ejs.Fixed[J].map(xs.toList.map(_.leftMap(_.asEJson[J])))
 
     def kmap(kind: String, rest: (String, J)*): J =
       emap(("kind" -> kind.asEJson[J]) +: rest : _*)

--- a/frontend/src/main/scala/quasar/tpe/TypeF.scala
+++ b/frontend/src/main/scala/quasar/tpe/TypeF.scala
@@ -19,8 +19,7 @@ package quasar.tpe
 import slamdata.Predef._
 import quasar.contrib.matryoshka._
 import quasar.contrib.scalaz.foldable._
-import quasar.ejson
-import quasar.ejson.{CommonEJson => C, ExtEJson => E, EJson, EncodeEJson, EncodeEJsonK}
+import quasar.ejson.{Common, CommonEJson => C, Extension, ExtEJson => E, EJson, EncodeEJson, EncodeEJsonK}
 import quasar.fp.ski.κ
 
 import scala.Tuple2
@@ -359,46 +358,49 @@ private[quasar] sealed abstract class TypeFInstances {
 
   implicit def encodeEJsonK[A](implicit A: EncodeEJson[A]): EncodeEJsonK[TypeF[A, ?]] =
     new EncodeEJsonK[TypeF[A, ?]] {
+      import Common.{Optics => CO}
+      import Extension.{Optics => EO}
+
       def encodeK[J](implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): Algebra[TypeF[A, ?], J] = {
         case Bottom()        => tlabel("bottom")
         case Top()           => tlabel("top")
         case Simple(s)       => tlabel(SimpleType.name(s))
         case Const(a)        => tof("const", A.encode[J](a))
-        case Union(x, y, zs) => tof("sum", C(ejson.arr((x :: y :: zs).toList)).embed)
+        case Union(x, y, zs) => tof("sum", C(CO.arr((x :: y :: zs).toList)).embed)
 
         case Arr(a) =>
-          tof("array", a.leftMap(js => C(ejson.arr(js.toList)).embed).merge)
+          tof("array", a.leftMap(js => C(CO.arr(js.toList)).embed).merge)
 
         case Map(kvs, unk) =>
           val jjs   = kvs.toList.map(_.leftMap(A.encode[J](_)))
           val other = unk map { case (k, v) => (
-            C(ejson.str[J]("other")).embed,
+            C(CO.str[J]("other")).embed,
             map1(
-              C(ejson.str[J]("keys")).embed   -> k,
-              C(ejson.str[J]("values")).embed -> v)
+              C(CO.str[J]("keys")).embed   -> k,
+              C(CO.str[J]("values")).embed -> v)
           )}
-          tof("map", E(ejson.map(jjs)).embed, other.toList: _*)
+          tof("map", E(EO.map(jjs)).embed, other.toList: _*)
       }
 
       private def map1[J](assoc: (J, J), assocs: (J, J)*)(
         implicit J: Corecursive.Aux[J, EJson]
       ): J =
-        E(ejson.map(assoc :: assocs.toList)).embed
+        E(EO.map(assoc :: assocs.toList)).embed
 
       private def tmap[J](v: J, assocs: (J, J)*)(
         implicit J: Corecursive.Aux[J, EJson]
       ): J =
-        map1(C(ejson.str[J]("type")).embed -> v, assocs: _*)
+        map1(C(CO.str[J]("type")).embed -> v, assocs: _*)
 
       private def tlabel[J](label: String, assocs: (J, J)*)(
         implicit J: Corecursive.Aux[J, EJson]
       ): J =
-        tmap(C(ejson.str[J](label)).embed, assocs: _*)
+        tmap(C(CO.str[J](label)).embed, assocs: _*)
 
       private def tof[J](label: String, of: J, assocs: (J, J)*)(
         implicit J: Corecursive.Aux[J, EJson]
       ): J =
-        tlabel(label, ((C(ejson.str[J]("of")).embed -> of) :: assocs.toList): _*)
+        tlabel(label, ((C(CO.str[J]("of")).embed -> of) :: assocs.toList): _*)
     }
 
   implicit def traverse[J]: Traverse[TypeF[J, ?]] =

--- a/frontend/src/test/scala/quasar/tpe/TypeFSpec.scala
+++ b/frontend/src/test/scala/quasar/tpe/TypeFSpec.scala
@@ -20,7 +20,7 @@ import slamdata.Predef._
 import quasar.contrib.algebra._
 import quasar.contrib.matryoshka._
 import quasar.contrib.matryoshka.arbitrary._
-import quasar.ejson, ejson.{CommonEJson, EJson, EJsonArbitrary}
+import quasar.ejson.{EJson, EJsonArbitrary, Fixed}
 import quasar.ejson.implicits._
 import quasar.fp._, Helpers._
 
@@ -41,6 +41,8 @@ final class TypeFSpec extends Spec with TypeFArbitrary with EJsonArbitrary {
 
   type J = Fix[EJson]
   type T = Fix[TypeF[J, ?]]
+
+  val J = Fixed[J]
 
   implicit def typeFIntEqual[A: Equal]: Equal[TypeF[Int, A]] =
     TypeF.structuralEqual(Equal[Int])(Equal[A])
@@ -152,13 +154,13 @@ final class TypeFSpec extends Spec with TypeFArbitrary with EJsonArbitrary {
 
     "str <: char[]" >> prop { (s: String) =>
       isSubtypeOf[J](
-        const[J, T](CommonEJson(ejson.str[J]("s" + s)).embed).embed,
+        const[J, T](J.str("s" + s)).embed,
         arr[J, T](simple[J, T](SimpleType.Char).embed.right).embed)
     }
 
     "[] = ''" >> {
       val emptyArr = arr[J, T](IList().left).embed
-      val emptyStr = const[J, T](CommonEJson(ejson.str[J]("")).embed).embed
+      val emptyStr = const[J, T](J.str("")).embed
       emptyArr ≟ emptyStr
     }
   }

--- a/interface/src/test/scala/quasar/main/ExtractSchemaSpec.scala
+++ b/interface/src/test/scala/quasar/main/ExtractSchemaSpec.scala
@@ -19,8 +19,7 @@ package quasar.main
 import slamdata.Predef.{Int => SInt, _}
 import quasar.Data
 import quasar.contrib.matryoshka._
-import quasar.{ejson => e}
-import quasar.ejson.{CommonEJson => C, EJson, ExtEJson => E}
+import quasar.ejson.{EJson, Fixed}
 import quasar.ejson.implicits._
 import quasar.fp._
 import quasar.fp.numeric.SampleStats
@@ -40,6 +39,7 @@ final class ExtractSchemaSpec extends quasar.Qspec {
   type J = Fix[EJson]
   type S = SST[J, Double]
 
+  val J = Fixed[J]
   val settings = analysis.CompressionSettings(1000L, 1000L, 1000L, 1000L)
 
   def verify(cs: analysis.CompressionSettings, input: List[Data], expected: S) =
@@ -51,7 +51,7 @@ final class ExtractSchemaSpec extends quasar.Qspec {
     NonEmptyList(n, ns: _*) map (n =>
       envT(
         TypeStat.int(SampleStats.one(n.toDouble), BigInt(n), BigInt(n)),
-        TypeST(TypeF.const[J, S](E(e.int[J](BigInt(n))).embed))).embed)
+        TypeST(TypeF.const[J, S](J.int(BigInt(n))))).embed)
 
   "compress arrays" >> {
     val input = List(
@@ -62,11 +62,11 @@ final class ExtractSchemaSpec extends quasar.Qspec {
     val expected = envT(
       TypeStat.coll(2.0, 1.0.some, 1.0.some),
       TypeST(TypeF.map[J, S](IMap(
-        C(e.str[J]("foo")).embed -> envT(
+        J.str("foo") -> envT(
           TypeStat.coll(1.0, 2.0.some, 2.0.some),
           TypeST(TypeF.arr[J, S](ints(1, 2).list.left))).embed,
 
-        C(e.str[J]("bar")).embed -> envT(
+        J.str("bar") -> envT(
           TypeStat.coll(1.0, 3.0.some, 3.0.some),
           TypeST(TypeF.arr[J, S](ints(1, 2, 3).suml1.right))).embed
       ), None))).embed
@@ -83,16 +83,16 @@ final class ExtractSchemaSpec extends quasar.Qspec {
     val expected = envT(
       TypeStat.coll(2.0, 1.0.some, 1.0.some),
       TypeST(TypeF.map[J, S](IMap(
-        C(e.str[J]("foo")).embed -> envT(
+        J.str("foo") -> envT(
           TypeStat.coll(1.0, 6.0.some, 6.0.some),
           TypeST(TypeF.arr[J, S](envT(
             TypeStat.count(1.0),
             TypeST(TypeF.simple[J, S](SimpleType.Char))
           ).embed.right))).embed,
 
-        C(e.str[J]("bar")).embed -> envT(
+        J.str("bar") -> envT(
           TypeStat.str(1.0, 5.0, 5.0, "abcde", "abcde"),
-          TypeST(TypeF.const[J, S](C(e.str[J]("abcde")).embed))
+          TypeST(TypeF.const[J, S](J.str("abcde")))
         ).embed
       ), None))).embed
 
@@ -113,14 +113,14 @@ final class ExtractSchemaSpec extends quasar.Qspec {
     val expected = envT(
       TypeStat.coll(2.0, 1.0.some, 1.0.some),
       TypeST(TypeF.map[J, S](IMap(
-        C(e.str[J]("foo")).embed -> envT(
+        J.str("foo") -> envT(
           TypeStat.coll(1.0, l1.some, l1.some),
           TypeST(TypeF.arr[J, S](envT(
             TypeStat.count(1.0),
             TypeST(TypeF.simple[J, S](SimpleType.Byte))
           ).embed.right))).embed,
 
-        C(e.str[J]("bar")).embed -> envT(
+        J.str("bar") -> envT(
           TypeStat.coll(1.0, l2.some, l2.some),
           TypeST(TypeF.arr[J, S](envT(
             TypeStat.count(1.0),
@@ -150,7 +150,7 @@ final class ExtractSchemaSpec extends quasar.Qspec {
           ).embed.right))).embed,
         envT(
           TypeStat.int(SampleStats.freq(4.0, 1.0), BigInt(1), BigInt(1)),
-          TypeST(TypeF.const[J, S](E(e.int[J](1)).embed))
+          TypeST(TypeF.const[J, S](J.int(1)))
         ).embed
       ))))).embed
 
@@ -176,7 +176,7 @@ final class ExtractSchemaSpec extends quasar.Qspec {
           ).embed.right))).embed,
         envT(
           TypeStat.int(SampleStats.freq(4.0, 1.0), BigInt(1), BigInt(1)),
-          TypeST(TypeF.const[J, S](E(e.int[J](1)).embed))
+          TypeST(TypeF.const[J, S](J.int(1)))
         ).embed
       ))))).embed
 
@@ -194,7 +194,7 @@ final class ExtractSchemaSpec extends quasar.Qspec {
     val expected = envT(
       TypeStat.coll(4.0, 1.0.some, 1.0.some),
       TypeST(TypeF.map[J, S](IMap(
-        C(e.str[J]("foo")).embed -> envT(
+        J.str("foo") -> envT(
           TypeStat.count(4.0),
           TypeST(TypeF.coproduct[J, S](
             envT(
@@ -223,7 +223,7 @@ final class ExtractSchemaSpec extends quasar.Qspec {
     val expected = envT(
       TypeStat.coll(4.0, 1.0.some, 1.0.some),
       TypeST(TypeF.map[J, S](IMap(
-        C(e.str[J]("foo")).embed -> envT(
+        J.str("foo") -> envT(
           TypeStat.count(4.0),
           TypeST(TypeF.coproduct[J, S](
             envT(
@@ -234,7 +234,7 @@ final class ExtractSchemaSpec extends quasar.Qspec {
               TypeST(TypeF.simple[J, S](SimpleType.Int))).embed,
             envT(
               TypeStat.bool(1.0, 0.0),
-              TypeST(TypeF.const[J, S](C(e.bool[J](true)).embed))).embed))
+              TypeST(TypeF.const[J, S](J.bool(true)))).embed))
         ).embed
       ), None))).embed
 

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -25,6 +25,7 @@ import quasar.contrib.pathy.Helpers._
 import quasar.contrib.scalaz.eitherT._
 import quasar.contrib.scalaz.writerT._
 import quasar.ejson
+import quasar.ejson.Common.{Optics => CO}
 import quasar.frontend._
 import quasar.contrib.pathy._
 import quasar.fp._, free._
@@ -186,7 +187,7 @@ abstract class QueryRegressionTest[S[_]](
     * they have different precisions for their floating point values.
     */
   val reducePrecision =
-    λ[EndoK[ejson.Common]](ejson.dec.modify(_.round(TestContext))(_))
+    λ[EndoK[ejson.Common]](CO.dec.modify(_.round(TestContext))(_))
 
   val normalizeJson: Json => Json =
     j => Recursive[Json, ejson.Json].transCata(j)(liftFF(reducePrecision[Json]))

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/StaticHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/StaticHandler.scala
@@ -18,7 +18,7 @@ package quasar.physical.mongodb.planner
 
 import slamdata.Predef._
 
-import quasar.ejson._
+import quasar.ejson.{EJson, Fixed}
 import quasar.physical.mongodb.BsonField
 import quasar.physical.mongodb.expression._
 import quasar.qscript._
@@ -45,9 +45,8 @@ object StaticHandler {
     (implicit e26: ExprOpCoreF :<: EX)
       : StaticHandler[T, EX] =
     new StaticHandler[T, EX] {
-
       def toBsonFieldName(ej: T[EJson]): Option[BsonField.Name] =
-        (CommonEJson.prj(ej.project) >>= (str.getOption(_))).map(BsonField.Name(_))
+        Fixed[T[EJson]].str.getOption(ej) map (BsonField.Name(_))
 
       def handle[A](fm: FreeMapA[T, A]): Option[EX[FreeMapA[T, A]]] =
         fm.project match {

--- a/mongodb/src/test/scala/quasar/physical/mongodb/PlannerQScriptSpec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/PlannerQScriptSpec.scala
@@ -21,7 +21,7 @@ import quasar._
 import quasar.common.{Map => _, _}
 import quasar.contrib.pathy._
 import quasar.contrib.specs2.PendingWithActualTracking
-import quasar.ejson.EJson._
+import quasar.ejson.{EJson, Fixed}
 import quasar.physical.mongodb.expression._
 import quasar.physical.mongodb.planner._
 import quasar.physical.mongodb.workflow._
@@ -43,6 +43,8 @@ class PlannerQScriptSpec extends
   val (func, free, fix) =
     quasar.qscript.construction.mkDefaults[Fix, fs.MongoQScript[Fix, ?]]
 
+  val ejs = Fixed[Fix[EJson]]
+
   //TODO make this independent of MongoQScript and move to a place where all
   //     connector tests can refer to it
   val simpleJoin: Fix[fs.MongoQScript[Fix, ?]] =
@@ -50,10 +52,10 @@ class PlannerQScriptSpec extends
       fix.Unreferenced,
       free.Filter(
         free.ShiftedRead[AFile](rootDir </> dir("db") </> file("zips"), qscript.ExcludeId),
-        func.Guard(func.Hole, Type.AnyObject, func.Constant(bool[Fix](true)), func.Constant(bool[Fix](false)))),
+        func.Guard(func.Hole, Type.AnyObject, func.Constant(ejs.bool(true)), func.Constant(ejs.bool(false)))),
       free.Filter(
         free.ShiftedRead[AFile](rootDir </> dir("db") </> file("smallZips"), qscript.ExcludeId),
-        func.Guard(func.Hole, Type.AnyObject, func.Constant(bool[Fix](true)), func.Constant(bool[Fix](false)))),
+        func.Guard(func.Hole, Type.AnyObject, func.Constant(ejs.bool(true)), func.Constant(ejs.bool(false)))),
       List((func.ProjectKeyS(func.Hole, "_id"), func.ProjectKeyS(func.Hole, "_id"))),
       JoinType.Inner,
       func.ProjectKeyS(func.RightSide, "city"))


### PR DESCRIPTION
Improves the optics story for EJson by

1. Moving types and type-specific optics out of the package object and into their own respective files, making them easier to find and easier to import a la carte.

2. Adding fixpoint prisms, based on component prisms, allowing for convenient, compositional construction and pattern matching for values having `EJson` as their pattern-functor.