### PR TITLE
Add some tests in `ApiSpec` to validate how querying views behaves

### DIFF
--- a/connector/src/main/scala/quasar/fs/FileSystemError.scala
+++ b/connector/src/main/scala/quasar/fs/FileSystemError.scala
@@ -17,7 +17,7 @@
 package quasar.fs
 
 import slamdata.Predef._
-import quasar.Data
+import quasar.{Data, QuasarError}
 import quasar.Planner.PlannerError
 import quasar.fp._
 import quasar.frontend.logicalplan.LogicalPlan
@@ -30,7 +30,7 @@ import pathy.Path.posixCodec
 import scalaz._
 import scalaz.syntax.show._
 
-sealed abstract class FileSystemError
+sealed abstract class FileSystemError extends QuasarError
 
 object FileSystemError {
   import QueryFile.ResultHandle

--- a/connector/src/main/scala/quasar/fs/PhysicalError.scala
+++ b/connector/src/main/scala/quasar/fs/PhysicalError.scala
@@ -16,6 +16,8 @@
 
 package quasar.fs
 
+import quasar.QuasarError
+
 import java.lang.Exception
 
 import monocle.macros.Lenses
@@ -29,7 +31,7 @@ import scalaz._
   * This should not be used to communicate configuration/validation errors at
   * mount-time as `DefinitionError` is more appropriate in that case.
   */
-sealed abstract class PhysicalError {
+sealed abstract class PhysicalError extends QuasarError {
   val cause: Exception
 }
 

--- a/connector/src/main/scala/quasar/fs/ReadFile.scala
+++ b/connector/src/main/scala/quasar/fs/ReadFile.scala
@@ -18,6 +18,7 @@ package quasar.fs
 
 import slamdata.Predef._
 import quasar.contrib.pathy._
+import quasar.effect.Failure
 import quasar.fp.numeric.{Natural, Positive}
 import eu.timepit.refined.auto._
 
@@ -87,6 +88,11 @@ object ReadFile {
       */
     def scanAll(file: AFile): Process[M, Data] =
       scan(file, 0L, None)
+
+    def scanAll_(file: AFile)(implicit S0: Failure[FileSystemError, ?] :<: S): Process[Free[S, ?], Data] = {
+      val nat: M ~> Free[S, ?] = λ[M ~> Free[S, ?]] { x => Failure.Ops[FileSystemError, S].unattempt(x.run) }
+      scanAll(file).translate(nat)
+    }
   }
 
   object Ops {

--- a/core/src/main/scala/quasar/fs/mount/Mounting.scala
+++ b/core/src/main/scala/quasar/fs/mount/Mounting.scala
@@ -17,7 +17,7 @@
 package quasar.fs.mount
 
 import slamdata.Predef._
-import quasar.Variables
+import quasar.{QuasarError, Variables}
 import quasar.contrib.pathy._
 import quasar.effect.LiftedOps
 import quasar.fp.ski._
@@ -66,7 +66,7 @@ object Mounting {
   /** Indicates the wrong type of path (file vs. dir) was supplied to the `mount`
     * convenience function.
     */
-  final case class PathTypeMismatch(path: APath) extends scala.AnyVal
+  final case class PathTypeMismatch(path: APath) extends QuasarError
 
   object PathTypeMismatch {
     implicit val pathTypeMismatchShow: Show[PathTypeMismatch] =

--- a/core/src/main/scala/quasar/fs/mount/MountingError.scala
+++ b/core/src/main/scala/quasar/fs/mount/MountingError.scala
@@ -17,6 +17,7 @@
 package quasar.fs.mount
 
 import slamdata.Predef._
+import quasar.QuasarError
 import quasar.connector.EnvironmentError
 import quasar.fs._
 
@@ -24,7 +25,7 @@ import monocle.Prism
 import scalaz.NonEmptyList
 import scalaz._, Scalaz._
 
-sealed abstract class MountingError
+sealed abstract class MountingError extends QuasarError
 
 object MountingError {
   final case class PError private (err: PathError)

--- a/core/src/main/scala/quasar/fs/mount/module/Module.scala
+++ b/core/src/main/scala/quasar/fs/mount/module/Module.scala
@@ -45,7 +45,7 @@ object Module {
     implicit val order: Order[ResultHandle] = Order.orderBy(_.run)
   }
 
-  sealed trait Error
+  sealed trait Error extends QuasarError
 
   type ErrorT[M[_], A] = EitherT[M, Error, A]
   type Failure[A] = quasar.effect.Failure[Error, A]

--- a/core/src/main/scala/quasar/package.scala
+++ b/core/src/main/scala/quasar/package.scala
@@ -37,6 +37,9 @@ import matryoshka.implicits._
 import scalaz._, Scalaz._
 
 package object quasar {
+
+  type QuasarErrT[M[_], A] = EitherT[M, QuasarError, A]
+
   private def phase[A: RenderTree](label: String, r: SemanticErrors \/ A):
       CompileM[A] =
     EitherT(r.point[PhaseResultW]) flatMap { a =>

--- a/foundation/src/main/scala/quasar/QuasarError.scala
+++ b/foundation/src/main/scala/quasar/QuasarError.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar
+
+abstract class QuasarError

--- a/foundation/src/main/scala/quasar/contrib/scalaz/eitherT.scala
+++ b/foundation/src/main/scala/quasar/contrib/scalaz/eitherT.scala
@@ -80,4 +80,7 @@ object eitherT extends EitherTInstances {
     def flattenLeft: EitherT[F, E, A] =
       a.run.flatMapF(_.point[F])
   }
+
+  def leftMapNT[F[_]: Functor, E0, E1](f: E0 => E1): EitherT[F, E0, ?] ~> EitherT[F, E1, ?] =
+    λ[EitherT[F, E0, ?] ~> EitherT[F, E1, ?]](_.leftMap(f))
 }

--- a/interface/src/main/scala/quasar/main/QuasarAPIImpl.scala
+++ b/interface/src/main/scala/quasar/main/QuasarAPIImpl.scala
@@ -22,7 +22,7 @@ import quasar.contrib.pathy._
 import quasar.sql._
 import quasar.fp.free.foldMapNT
 import quasar.fs.{FileSystemError, QueryFile, ReadFile}
-import quasar.fs.mount.{Mounting, MountConfig}
+import quasar.fs.mount.{Mounting, MountConfig, MountingError}
 import quasar.fs.mount.module.Module
 
 import matryoshka.data.Fix
@@ -45,7 +45,7 @@ final case class QuasarAPIImpl[F[_]: Monad](inter: CoreEff ~> F) {
   def createModule(path: ADir, statements: List[Statement[Fix[Sql]]]) =
     mount.mount(path, MountConfig.moduleConfig(statements)) foldMap inter
 
-  def getMount(path: APath) =
+  def getMount(path: APath): F[Option[MountingError \/ MountConfig]] =
     mount.lookupConfig(path).run.run.foldMap(inter)
 
   def ls(path: ADir): F[FileSystemError \/ Set[PathSegment]] =

--- a/interface/src/main/scala/quasar/main/QuasarAPIImpl.scala
+++ b/interface/src/main/scala/quasar/main/QuasarAPIImpl.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.main
+
+import slamdata.Predef._
+import quasar.{Data, resolveImports, Variables, SemanticError}
+import quasar.contrib.pathy._
+import quasar.sql._
+import quasar.fp.free.foldMapNT
+import quasar.fs.{FileSystemError, QueryFile, ReadFile}
+import quasar.fs.mount.{Mounting, MountConfig}
+import quasar.fs.mount.module.Module
+
+import matryoshka.data.Fix
+import eu.timepit.refined.auto._
+import scalaz._, Scalaz._
+import scalaz.stream.{Process, Process0}
+
+/**
+  * The top level Quasar programmatic API. Not yet complete, but will be added made
+  * more exhaustive over time.
+  */
+final case class QuasarAPIImpl[F[_]: Monad](inter: CoreEff ~> F) {
+
+  private val mount = Mounting.Ops[CoreEff]
+  private val fsQ = new FilesystemQueries[CoreEff]
+
+  def createView(path: AFile, sql: ScopedExpr[Fix[Sql]]): F[Unit] =
+    mount.mount(path, MountConfig.viewConfig(sql, Variables.empty)) foldMap inter
+
+  def createModule(path: ADir, statements: List[Statement[Fix[Sql]]]) =
+    mount.mount(path, MountConfig.moduleConfig(statements)) foldMap inter
+
+  def getMount(path: APath) =
+    mount.lookupConfig(path).run.run.foldMap(inter)
+
+  def ls(path: ADir): F[FileSystemError \/ Set[PathSegment]] =
+    QueryFile.Ops[CoreEff].ls(path).run.foldMap(inter)
+
+  def invoke(function: AFile, args: Map[String, Fix[Sql]]) =
+    Module.Ops[CoreEff].invokeFunction_(function, args, offset = 0L, limit = None).translate(foldMapNT(inter))
+
+  def readFile(path: AFile): Process[F, Data] =
+    ReadFile.Ops[CoreEff].scanAll_(path).translate(foldMapNT(inter))
+
+  def query(workingDir: ADir, sql: ScopedExpr[Fix[Sql]]): F[NonEmptyList[SemanticError] \/ (FileSystemError \/ Process0[Data])] =
+    (for {
+      expr   <- resolveImports[CoreEff](sql, workingDir).leftMap(_.wrapNel)
+      stream <- EitherT(fsQ.queryResults(expr, Variables.empty, workingDir, off = 0L, lim = None).run.run.value)
+    } yield stream).run.foldMap(inter)
+}

--- a/interface/src/main/scala/quasar/main/package.scala
+++ b/interface/src/main/scala/quasar/main/package.scala
@@ -74,6 +74,8 @@ package object main extends Logging {
     // sparkcore.fs.local.SparkLocalBackendModule.definition translate injectFT[Task, PhysFsEff]
   ).fold
 
+  val QuasarAPI = QuasarAPIImpl[Free[CoreEff, ?]](liftFT)
+
   /**
    * The physical filesystems currently supported.  Please note that it
    * is really best if you only sequence this task ''once'' per runtime.


### PR DESCRIPTION
- Add `QuasarAPIImpl` with the intention of eventually aggregating the entire "top-level" Quasar programmatic API
- Make all Quasar errors a subclass of `QuasarError`
- Add `interpWithErrs` to Quasar to provide a better programmatic API
- Add `initMimirOnly` to have a no argument constructor for `Quasar` for the simplest case