### PR TITLE
AutoJoin3 handling in ReifyProvenance

### DIFF
--- a/connector/src/main/scala/quasar/qscript/JoinSide.scala
+++ b/connector/src/main/scala/quasar/qscript/JoinSide.scala
@@ -29,3 +29,14 @@ object JoinSide {
   implicit val show: Show[JoinSide] = Show.showFromToString
   implicit val renderTree: RenderTree[JoinSide] = RenderTree.fromShowAsType("JoinSide")
 }
+
+sealed abstract class JoinSide3
+final object LeftSide3 extends JoinSide3
+final object Center extends JoinSide3
+final object RightSide3 extends JoinSide3
+
+object JoinSide3 {
+  implicit val equal: Equal[JoinSide3] = Equal.equalRef
+  implicit val show: Show[JoinSide3] = Show.showFromToString
+  implicit val renderTree: RenderTree[JoinSide3] = RenderTree.fromShowAsType("JoinSide3")
+}

--- a/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
@@ -69,7 +69,9 @@ final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT] {
 
   def computeProvenanceƒ[F[_]: Monad: PlannerErrorME]: AlgebraM[F, GPF, Dims] =
     gpf => gpf.qsu match {
-      case AutoJoin(srcs, _) => srcs.foldLeft1(dims.join(_, _)).point[F]
+      case AutoJoin2(left, right, _) => dims.join(left, right).point[F]
+
+      case AutoJoin3(left, center, right, _) => dims.join(dims.join(left, center), right).point[F]
 
       case DimEdit(src, DTrans.Squash()) => dims.squash(src).point[F]
 

--- a/connector/src/main/scala/quasar/qscript/qsu/Graduate.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/Graduate.scala
@@ -16,7 +16,7 @@
 
 package quasar.qscript.qsu
 
-import slamdata.Predef.{Map => SMap, _}
+import slamdata.Predef._
 
 import quasar.NameGenerator
 import quasar.Planner.{InternalError, PlannerErrorME}
@@ -94,8 +94,7 @@ final class Graduate[T[_[_]]: CorecursiveT] extends QSUTTypes[T] {
 
     // we merge the vertices in the result, just in case the graphs are
     // additively applied to a common root
-    val mergedVertices: SMap[Symbol, QSU[Symbol]] =
-      left.vertices ++ right.vertices
+    val mergedVertices: QSUNodes[T] = left.vertices ++ right.vertices
 
     source.headOption match {
       case hole @ Some(root) =>
@@ -112,7 +111,7 @@ final class Graduate[T[_[_]]: CorecursiveT] extends QSUTTypes[T] {
         } yield {
           val root: Symbol = Symbol(name)
 
-          val newVertices: SMap[Symbol, QSU[Symbol]] =
+          val newVertices: QSUNodes[T] =
             mergedVertices + (root -> QSU.Unreferenced[T, Symbol]())
 
           SrcMerge(QSUGraph[T](root, newVertices), lGrad, rGrad)

--- a/connector/src/main/scala/quasar/qscript/qsu/Graduate.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/Graduate.scala
@@ -94,7 +94,7 @@ final class Graduate[T[_[_]]: CorecursiveT] extends QSUTTypes[T] {
 
     // we merge the vertices in the result, just in case the graphs are
     // additively applied to a common root
-    val mergedVertices: QSUNodes[T] = left.vertices ++ right.vertices
+    val mergedVertices: QSUVerts[T] = left.vertices ++ right.vertices
 
     source.headOption match {
       case hole @ Some(root) =>
@@ -111,7 +111,7 @@ final class Graduate[T[_[_]]: CorecursiveT] extends QSUTTypes[T] {
         } yield {
           val root: Symbol = Symbol(name)
 
-          val newVertices: QSUNodes[T] =
+          val newVertices: QSUVerts[T] =
             mergedVertices + (root -> QSU.Unreferenced[T, Symbol]())
 
           SrcMerge(QSUGraph[T](root, newVertices), lGrad, rGrad)

--- a/connector/src/main/scala/quasar/qscript/qsu/MappableRegion.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/MappableRegion.scala
@@ -20,13 +20,16 @@ import slamdata.Predef.{tailrec, Boolean, Option, Symbol}
 import quasar.fp._
 import quasar.fp.ski.κ
 import quasar.qscript.{
+  Center,
   FreeMap,
   FreeMapA,
   JoinFunc,
   JoinSide,
   LeftSide,
+  LeftSide3,
   MapFunc,
   RightSide,
+  RightSide3,
   SrcHole
 }
 
@@ -38,7 +41,6 @@ import scalaz.{-\/, \/-, Kleisli, Traverse}
 import scalaz.std.option._
 import scalaz.syntax.either._
 import scalaz.syntax.equal._
-import scalaz.syntax.foldable._
 import scalaz.syntax.plus._
 import scalaz.syntax.std.boolean._
 
@@ -69,8 +71,18 @@ object MappableRegion {
       case QSUPattern(s, _) if halt(s) =>
         CoEnv(g.left)
 
-      case QSUPattern(_, AutoJoin(srcs, combine)) =>
-        CoEnv(combine.map(srcs.toVector).right[QSUGraph[T]])
+      case QSUPattern(_, AutoJoin2(left, right, combine)) =>
+        CoEnv(combine.map {
+          case LeftSide => left
+          case RightSide => right
+        }.right[QSUGraph[T]])
+
+      case QSUPattern(_, AutoJoin3(left, center, right, combine)) =>
+        CoEnv(combine.map {
+          case LeftSide3 => left
+          case Center => center
+          case RightSide3 => right
+        }.right[QSUGraph[T]])
 
       case QSUPattern(s, Map(srcG, fm)) =>
         fm.project.run match {

--- a/connector/src/main/scala/quasar/qscript/qsu/QSUGraph.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/QSUGraph.scala
@@ -169,9 +169,16 @@ object QSUGraph extends QSUGraphInstances {
   object Extractors {
     import quasar.qscript.qsu.{QScriptUniform => QSU}
 
-    object AutoJoin {
+    object AutoJoin2 {
       def unapply[T[_[_]]](g: QSUGraph[T]) = g.unfold match {
-        case g: QSU.AutoJoin[T, QSUGraph[T]] => QSU.AutoJoin.unapply(g)
+        case g: QSU.AutoJoin2[T, QSUGraph[T]] => QSU.AutoJoin2.unapply(g)
+        case _ => None
+      }
+    }
+
+    object AutoJoin3 {
+      def unapply[T[_[_]]](g: QSUGraph[T]) = g.unfold match {
+        case g: QSU.AutoJoin3[T, QSUGraph[T]] => QSU.AutoJoin3.unapply(g)
         case _ => None
       }
     }

--- a/connector/src/main/scala/quasar/qscript/qsu/QSUGraph.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/QSUGraph.scala
@@ -29,7 +29,7 @@ import scalaz.{Applicative, Id, Monad, MonadState, Traverse, Scalaz, State, Stat
 @Lenses
 final case class QSUGraph[T[_[_]]](
     root: Symbol,
-    vertices: QSUNodes[T]) {
+    vertices: QSUVerts[T]) {
 
   /**
    * Uniquely merge the graphs, retaining the root from the right.
@@ -98,7 +98,7 @@ final case class QSUGraph[T[_[_]]](
             recursive <- g.unfold.traverse(inner)
 
             collapsed =
-              recursive.foldRight[QSUNodes[T]](SMap())(_.vertices ++ _)
+              recursive.foldRight[QSUVerts[T]](SMap())(_.vertices ++ _)
 
             self2 = QSUGraph(root, collapsed)
 

--- a/connector/src/main/scala/quasar/qscript/qsu/QSUGraph.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/QSUGraph.scala
@@ -29,7 +29,7 @@ import scalaz.{Applicative, Id, Monad, MonadState, Traverse, Scalaz, State, Stat
 @Lenses
 final case class QSUGraph[T[_[_]]](
     root: Symbol,
-    vertices: SMap[Symbol, QScriptUniform[T, Symbol]]) {
+    vertices: QSUNodes[T]) {
 
   /**
    * Uniquely merge the graphs, retaining the root from the right.
@@ -98,7 +98,7 @@ final case class QSUGraph[T[_[_]]](
             recursive <- g.unfold.traverse(inner)
 
             collapsed =
-              recursive.foldRight(SMap[Symbol, QScriptUniform[T, Symbol]]())(_.vertices ++ _)
+              recursive.foldRight[QSUNodes[T]](SMap())(_.vertices ++ _)
 
             self2 = QSUGraph(root, collapsed)
 

--- a/connector/src/main/scala/quasar/qscript/qsu/ReifyProvenance.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ReifyProvenance.scala
@@ -143,13 +143,14 @@ final class ReifyProvenance[T[_[_]]: BirecursiveT: EqualT] extends QSUTTypes[T] 
   def apply[F[_]: Monad: PlannerErrorME: NameGenerator](qsu: AuthenticatedQSU[T])
       : F[AuthenticatedQSU[T]] = {
 
-    val pair: F[(List[NewVertex], SMap[Symbol, QSU[Symbol]])] =
-      qsu.graph.vertices.traverse[X[F, ?], QSU[Symbol]](toQScript[F](qsu.dims))(appX[F])
+    val pair: F[(List[NewVertex], QSUNodes[T])] =
+      qsu.graph.vertices.traverse[X[F, ?], QSU[Symbol]](
+        toQScript[F](qsu.dims))(appX[F])
 
     pair.map {
       case (nw, oldVertices) =>
         val (newV, newD) =
-          nw.foldLeft((SMap[Symbol, QSU[Symbol]](), SMap[Symbol, Dimensions[prov.P]]())) {
+          nw.foldLeft[(QSUNodes[T], QSUDims[T])](SMap() -> SMap()) {
             case ((vAcc, dAcc), NewVertex(name, value, dims)) =>
               (vAcc + (name -> value), dAcc + (name -> dims))
           }

--- a/connector/src/main/scala/quasar/qscript/qsu/ReifyProvenance.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ReifyProvenance.scala
@@ -143,14 +143,14 @@ final class ReifyProvenance[T[_[_]]: BirecursiveT: EqualT] extends QSUTTypes[T] 
   def apply[F[_]: Monad: PlannerErrorME: NameGenerator](qsu: AuthenticatedQSU[T])
       : F[AuthenticatedQSU[T]] = {
 
-    val pair: F[(List[NewVertex], QSUNodes[T])] =
+    val pair: F[(List[NewVertex], QSUVerts[T])] =
       qsu.graph.vertices.traverse[X[F, ?], QSU[Symbol]](
         toQScript[F](qsu.dims))(appX[F])
 
     pair.map {
       case (nw, oldVertices) =>
         val (newV, newD) =
-          nw.foldLeft[(QSUNodes[T], QSUDims[T])](SMap() -> SMap()) {
+          nw.foldLeft[(QSUVerts[T], QSUDims[T])](SMap() -> SMap()) {
             case ((vAcc, dAcc), NewVertex(name, value, dims)) =>
               (vAcc + (name -> value), dAcc + (name -> dims))
           }

--- a/connector/src/main/scala/quasar/qscript/qsu/package.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/package.scala
@@ -21,4 +21,5 @@ import quasar.qscript.provenance.Dimensions
 
 package object qsu {
   type QSUDims[T[_[_]]] = SMap[Symbol, Dimensions[QProv.P[T]]]
+  type QSUNodes[T[_[_]]] = SMap[Symbol, QScriptUniform[T, Symbol]]
 }

--- a/connector/src/main/scala/quasar/qscript/qsu/package.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/package.scala
@@ -21,5 +21,5 @@ import quasar.qscript.provenance.Dimensions
 
 package object qsu {
   type QSUDims[T[_[_]]] = SMap[Symbol, Dimensions[QProv.P[T]]]
-  type QSUNodes[T[_[_]]] = SMap[Symbol, QScriptUniform[T, Symbol]]
+  type QSUVerts[T[_[_]]] = SMap[Symbol, QScriptUniform[T, Symbol]]
 }


### PR DESCRIPTION
Depends on #3067 

Closes #3066 

Handles the case where we need to turn an `AutoJoin3` into nested `ThetaJoin`s because we have failed to eliminate any of the joins.

Also, this needs tests.