### PR TITLE
Postgres: Fix checking if schema exists

### DIFF
--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/postgres/PostgresDescribeTable.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/postgres/PostgresDescribeTable.scala
@@ -74,10 +74,14 @@ trait PostgresDescribeTable extends RdbmsDescribeTable {
       .map(_.map(Schema.apply))
   }
 
+
   override def schemaExists(schema: Schema): ConnectionIO[Boolean] =
     if (schema.isRoot) true.point[ConnectionIO]
     else
-      descQuery(whereSchema(schema), _.nonEmpty)
+      sql"""SELECT 1 FROM information_schema.schemata WHERE SCHEMA_NAME=${schema.shows}"""
+      .query[Int]
+      .list
+      .map(_.nonEmpty)
 
   override def tableExists(
       tablePath: TablePath): ConnectionIO[Boolean] =


### PR DESCRIPTION
This code should correctly check whether a schema exists. Previous implementation wasn't working for some cases, causing problems with integration tests.