### PR TITLE
Rewrite tests to use QScript DSL

### DIFF
--- a/connector/src/test/scala/quasar/qscript/MapFuncStdLibTestRunner.scala
+++ b/connector/src/test/scala/quasar/qscript/MapFuncStdLibTestRunner.scala
@@ -63,6 +63,7 @@ trait MapFuncStdLibTestRunner extends StdLibTestRunner {
   ): Result
 
   val qsr = new Transform[Fix, QScriptTotal[Fix, ?]]
+  val func = construction.Func[Fix]
 
   /** Translate to MapFunc (common to all QScript backends). */
   def translate[A](prg: Fix[LP], args: Symbol => A): Free[MapFunc[Fix, ?], A] =
@@ -88,10 +89,10 @@ trait MapFuncStdLibTestRunner extends StdLibTestRunner {
       case lp.Constant(data) =>
         qsr.fromData(data).fold(
           _ => sys.error("invalid Data"),
-          ej => Free.roll(MFC(MapFuncsCore.Constant[Fix, Free[MapFunc[Fix, ?], A]](ej))))
+          func.Constant)
 
       case lp.TemporalTrunc(part, src) =>
-        Free.roll(MFC(MapFuncsCore.TemporalTrunc(part, src)))
+        func.TemporalTrunc(part, src)
     }
 
   def absurd[A, B](a: A): B = sys.error("impossible!")

--- a/connector/src/test/scala/quasar/qscript/QScriptHelpers.scala
+++ b/connector/src/test/scala/quasar/qscript/QScriptHelpers.scala
@@ -31,7 +31,6 @@ import scala.Predef.implicitly
 
 import matryoshka._
 import matryoshka.data.Fix
-import matryoshka.implicits._
 import pathy.Path._
 import scalaz._, Scalaz._
 

--- a/connector/src/test/scala/quasar/qscript/QScriptHelpers.scala
+++ b/connector/src/test/scala/quasar/qscript/QScriptHelpers.scala
@@ -20,7 +20,7 @@ import slamdata.Predef._
 import quasar.common.{PhaseResult, PhaseResults, PhaseResultT}
 import quasar.contrib.pathy._
 import quasar.contrib.scalaz.eitherT._
-import quasar.ejson, ejson.EJson
+import quasar.ejson, ejson.{EJson, Fixed}
 import quasar.ejson.implicits._
 import quasar.fp._
 import quasar.fs._
@@ -56,12 +56,21 @@ trait QScriptHelpers extends CompilerHelpers with TTypes[Fix] {
         ::\::[Const[Read[ADir], ?]](
           ::/::[Fix, Const[Read[AFile], ?], Const[DeadEnd, ?]])))
 
-  val RootR: QS[Fix[QS]] = DE.inj(Const[DeadEnd, Fix[QS]](Root))
-  val UnreferencedR: QS[Fix[QS]] = QC.inj(Unreferenced[Fix, Fix[QS]]())
-  def ReadR(path: APath): QS[Fix[QS]] =
-    refineType(path).fold(
-      d => RD.inj(Const(Read(d))),
-      f => RF.inj(Const(Read(f))))
+  implicit def qScriptCoreToQScript: Injectable.Aux[QScriptCore, QS] =
+    Injectable.inject[QScriptCore, QS]
+
+  implicit def thetaJoinToQScript: Injectable.Aux[ThetaJoin, QS] =
+    Injectable.inject[ThetaJoin, QS]
+
+  implicit def readFileToQScript: Injectable.Aux[Const[Read[AFile], ?], QS] =
+    Injectable.inject[Const[Read[AFile], ?], QS]
+
+  implicit def readDirToQScript: Injectable.Aux[Const[Read[ADir], ?], QS] =
+    Injectable.inject[Const[Read[ADir], ?], QS]
+
+  val qsdsl = construction.mkDefaults[Fix, QS]
+  val qstdsl = construction.mkDefaults[Fix, QST]
+  val json = Fixed[Fix[EJson]]
 
   type QST[A] = QScriptTotal[A]
 
@@ -77,73 +86,6 @@ trait QScriptHelpers extends CompilerHelpers with TTypes[Fix] {
   val SRTD = implicitly[Const[ShiftedRead[ADir], ?]  :<: QST]
   val SRTF = implicitly[Const[ShiftedRead[AFile], ?] :<: QST]
 
-  val RootRT: QST[Fix[QST]] = DET.inj(Const[DeadEnd, Fix[QST]](Root))
-  val UnreferencedRT: QST[Fix[QST]] = QCT.inj(Unreferenced[Fix, Fix[QST]]())
-  def ReadRT(file: AFile): QST[Fix[QST]] = RTF.inj(Const(Read(file)))
-
-  def ConstantR[A](value: Fix[EJson]):
-      FreeMapA[A] =
-    Free.roll(MFC(MapFuncsCore.Constant[Fix, FreeMapA[A]](value)))
-
-  def ProjectKeyR[A](src: FreeMapA[A], key: FreeMapA[A]):
-      FreeMapA[A] =
-    Free.roll(MFC(MapFuncsCore.ProjectKey(src, key)))
-
-  def DeleteKeyR[A](src: FreeMapA[A], key: FreeMapA[A]):
-      FreeMapA[A] =
-    Free.roll(MFC(MapFuncsCore.DeleteKey(src, key)))
-
-  def ProjectIndexR[A](src: FreeMapA[A], key: FreeMapA[A]):
-      FreeMapA[A] =
-    Free.roll(MFC(MapFuncsCore.ProjectIndex(src, key)))
-
-  def MakeArrayR[A](src: FreeMapA[A]):
-      FreeMapA[A] =
-    Free.roll(MFC(MapFuncsCore.MakeArray(src)))
-
-  def MakeMapR[A](key: FreeMapA[A], src: FreeMapA[A]):
-      FreeMapA[A] =
-    Free.roll(MFC(MapFuncsCore.MakeMap(key, src)))
-
-  def ConcatArraysR[A](left: FreeMapA[A], right: FreeMapA[A]):
-      FreeMapA[A] =
-    Free.roll(MFC(MapFuncsCore.ConcatArrays(left, right)))
-
-  def ConcatMapsR[A](left: FreeMapA[A], right: FreeMapA[A]):
-      FreeMapA[A] =
-    Free.roll(MFC(MapFuncsCore.ConcatMaps(left, right)))
-
-  def AddR[A](left: FreeMapA[A], right: FreeMapA[A]):
-      FreeMapA[A] =
-    Free.roll(MFC(MapFuncsCore.Add(left, right)))
-
-  def SubtractR[A](left: FreeMapA[A], right: FreeMapA[A]):
-      FreeMapA[A] =
-    Free.roll(MFC(MapFuncsCore.Subtract(left, right)))
-
-  def EqR[A](left: FreeMapA[A], right: FreeMapA[A]):
-      FreeMapA[A] =
-    Free.roll(MFC(MapFuncsCore.Eq(left, right)))
-
-  def LtR[A](left: FreeMapA[A], right: FreeMapA[A]):
-      FreeMapA[A] =
-    Free.roll(MFC(MapFuncsCore.Lt(left, right)))
-
-  def AndR[A](left: FreeMapA[A], right: FreeMapA[A]):
-      FreeMapA[A] =
-    Free.roll(MFC(MapFuncsCore.And(left, right)))
-
-  def OrR[A](left: FreeMapA[A], right: FreeMapA[A]):
-      FreeMapA[A] =
-    Free.roll(MFC(MapFuncsCore.Or(left, right)))
-
-  def NotR[A](value: FreeMapA[A]):
-      FreeMapA[A] =
-    Free.roll(MFC(MapFuncsCore.Not(value)))
-
-  def UndefinedR[A]: FreeMapA[A] =
-    Free.roll(MFC(MapFuncsCore.Undefined[Fix, FreeMapA[A]]()))
-
   def lpRead(path: String): Fix[LP] =
     lpf.read(unsafeSandboxAbs(posixCodec.parseAbsFile(path).get))
 
@@ -152,16 +94,12 @@ trait QScriptHelpers extends CompilerHelpers with TTypes[Fix] {
   /** A helper when writing examples that allows them to be written in order of
     * execution.
     */
-  // NB: Would prefer this to be `ops: (T => F[T])*`, but it makes the call
+  // NB: Would prefer this to be generic over `Fix[QS]`, but it makes the call
   //     site too annotate-y.
-  // FIXME: The `Corecursive` implicit here isn’t resolved unless there are
-  //        _exactly_ two arguments passed to the function. When this is fixed,
-  //        remove the implicit lists from all of the call sites.
-  def chain[T, F[_]: Functor]
-    (op: F[T], ops: F[Unit]*)
-    (implicit T: Corecursive.Aux[T, F])
-      : T =
-    ops.foldLeft(op.embed)((acc, elem) => elem.as(acc).embed)
+  def chainQS
+  (op: Fix[QS], ops: (Fix[QS] => Fix[QS])*)
+  : Fix[QS] =
+    ops.foldLeft(op)((acc, elem) => elem(acc))
 
   val listContents: DiscoverPath.ListContents[Id] =
     d =>
@@ -203,31 +141,6 @@ trait QScriptHelpers extends CompilerHelpers with TTypes[Fix] {
       QueryFile.convertToQScriptRead[Fix, FileSystemErrT[PhaseResultT[Id, ?], ?], QS](_)(lp))
       .toOption.run.copoint
 
-  val ejsonNull =
-    ejson.CommonEJson(ejson.Null[Fix[EJson]]()).embed
-
-  def ejsonInt(int: Int) =
-    ejson.ExtEJson(ejson.Int[Fix[EJson]](int)).embed
-
-  def ejsonStr(str: String) =
-    ejson.CommonEJson(ejson.Str[Fix[EJson]](str)).embed
-
-  def ejsonArr(elems: Fix[EJson]*) =
-    ejson.CommonEJson(ejson.Arr(elems.toList)).embed
-
-  def ejsonMap(elems: (Fix[EJson], Fix[EJson])*) =
-    ejson.ExtEJson(ejson.Map(elems.toList)).embed
-
-  val ejsonNullArr =
-    ejsonArr(ejson.CommonEJson(ejson.Null[Fix[EJson]]()).embed)
-
-  def ejsonJoin(l: Fix[EJson], r: Fix[EJson]) =
-    ejsonMap((
-      ejson.CommonEJson(ejson.Str[Fix[EJson]]("j")).embed,
-      ejsonArr(l, r)))
-
-  def ejsonProjectKey(key: Fix[EJson]) =
-    ejsonMap((ejson.CommonEJson(ejson.Str[Fix[EJson]]("f")).embed, key))
 }
 
 object QScriptHelpers extends QScriptHelpers

--- a/connector/src/test/scala/quasar/qscript/RenderQScriptDSLSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/RenderQScriptDSLSpec.scala
@@ -22,7 +22,7 @@ import quasar.fp._
 import matryoshka.Delay
 import matryoshka.data.Fix
 import org.specs2.execute.Result
-import quasar.ejson.{EJson, Extension, Fixed}
+import quasar.ejson.{EJson, Extension}
 import quasar.std.TemporalPart
 import quasar.qscript.RenderQScriptDSL.RenderQScriptDSL
 import quasar.common.{JoinType, SortDir}
@@ -72,8 +72,9 @@ class RenderQScriptDSLSpec extends quasar.Qspec with QScriptHelpers {
       |implicit def SRTD = Injectable.inject[SRTD, QT](QScriptHelpers.SRTD)
       |implicit def SRTF = Injectable.inject[SRTF, QT](QScriptHelpers.SRTF)
       |implicit def DET = Injectable.inject[DET, QT](QScriptHelpers.DET)
-      |val (func, free, fix) = construction.mkDefaults[Fix, QT]
+      |val dsl = construction.mkDefaults[Fix, QT]
       |val json = Fixed[Fix[EJson]]
+      |import dsl._
     """.stripMargin
 
   def testDSL[A: Equal: Show](in: List[A], rend: RenderQScriptDSL[A]): Result = {
@@ -81,8 +82,7 @@ class RenderQScriptDSLSpec extends quasar.Qspec with QScriptHelpers {
     (tb.eval(tb.parse(prefix + combined)).asInstanceOf[List[A]] must equal(in)).toResult
   }
 
-  val (func, free, fix) = construction.mkDefaults[Fix, QScriptTotal]
-  val json: Fixed[Fix[EJson]] = Fixed[Fix[EJson]]
+  import qstdsl._
 
   def freeMaps: List[FreeMap] = {
     val h = func.Hole

--- a/couchbase/src/test/scala/quasar/physical/couchbase/BasicQueryEnablementSpec.scala
+++ b/couchbase/src/test/scala/quasar/physical/couchbase/BasicQueryEnablementSpec.scala
@@ -25,7 +25,7 @@ import quasar.fp._
 import quasar.fp.ski.ι
 import quasar.frontend.logicalplan.LogicalPlan
 import quasar.Planner.PlannerError
-import quasar.qscript.{Map => _, Read => _, _}, MapFuncsCore._
+import quasar.qscript.{Map => _, Read => _, _}
 import quasar.sql._
 
 import scala.collection.JavaConverters._
@@ -137,14 +137,14 @@ class BasicQueryEnablementSpec
   "QScript to N1QL" should {
 
     "read followed by a map" in {
+      import qstdsl._
       // select (a + b) from foo
       val qs =
-        chain[Fix[QST], QST](
-          SRTF.inj(Const(ShiftedRead(rootDir </> file("foo"), ExcludeId))),
-          QCT.inj(qscript.Map((),
-            Free.roll(MFC(Add(
-              ProjectKeyR(HoleF, StrLit("a")),
-              ProjectKeyR(HoleF, StrLit("b"))))))))
+        fix.Map(
+          fix.ShiftedRead[AFile](rootDir </> file("foo"), ExcludeId),
+          func.Add(
+            func.ProjectKeyS(func.Hole, "a"),
+            func.ProjectKeyS(func.Hole, "b")))
 
       val n1ql = n1qlFromQS(qs)
 

--- a/marklogic/src/test/scala/quasar/physical/marklogic/qscript/ProjectPathSpec.scala
+++ b/marklogic/src/test/scala/quasar/physical/marklogic/qscript/ProjectPathSpec.scala
@@ -18,6 +18,7 @@ package quasar.physical.marklogic.qscript
 
 import slamdata.Predef._
 import quasar.contrib.pathy.ADir
+import quasar.ejson.{EJson, Fixed}
 import quasar.fp._
 import quasar.fp.free._
 import quasar.qscript.MapFuncsCore._
@@ -30,6 +31,8 @@ import pathy._, Path._
 import scalaz._, Scalaz._
 
 final class ProjectPathSpec extends quasar.Qspec {
+  val json = Fixed[Fix[EJson]]
+
   def projectKey[S[_]: Functor](src: Free[MapFunc[Fix, ?], Hole], str: String)(
     implicit I: MapFunc[Fix, ?] :<: S
   ): Free[S, Hole] =

--- a/marklogic/src/test/scala/quasar/physical/marklogic/qscript/RewriteNullSpec.scala
+++ b/marklogic/src/test/scala/quasar/physical/marklogic/qscript/RewriteNullSpec.scala
@@ -27,6 +27,8 @@ import matryoshka.data._
 import scalaz._, Scalaz._
 
 final class RewriteNullSpec extends quasar.Qspec {
+  val func = construction.Func[Fix]
+
   def eq[T[_[_]]: BirecursiveT, A](lhs: FreeMapA[T, A], rhs: FreeMapA[T, A]): FreeMapA[T, A] =
     Free.roll(MFC(Eq(lhs, rhs)))
 
@@ -44,19 +46,19 @@ final class RewriteNullSpec extends quasar.Qspec {
 
   "rewriteNullCheck" should {
     "rewrite Eq(Null, rhs) into Eq(TypeOf(rhs), 'null')" in {
-      rewrite(eq(NullLit(), expr)) must equal(eq(typeOf(expr), nullStr))
+      rewrite(func.Eq(NullLit(), expr)) must equal(func.Eq(func.TypeOf(expr), nullStr))
     }
 
     "rewrite Eq(lhs, Null) into Eq(TypeOf(lhs), 'null')" in {
-      rewrite(eq(expr, NullLit())) must equal(eq(typeOf(expr), nullStr))
+      rewrite(func.Eq(expr, NullLit())) must equal(func.Eq(func.TypeOf(expr), nullStr))
     }
 
     "rewrite Neq(Null, rhs) into Neq(TypeOf(rhs), 'null')" in {
-      rewrite(neq(NullLit(), expr)) must equal(neq(typeOf(expr), nullStr))
+      rewrite(func.Neq(NullLit(), expr)) must equal(func.Neq(func.TypeOf(expr), nullStr))
     }
 
     "rewrite Neq(lhs, Null) into Neq(TypeOf(lhs), 'null')" in {
-      rewrite(neq(expr, NullLit())) must equal(neq(typeOf(expr), nullStr))
+      rewrite(func.Neq(expr, NullLit())) must equal(func.Neq(func.TypeOf(expr), nullStr))
     }
   }
 }

--- a/mongodb/src/test/scala/quasar/physical/mongodb/PlannerQScriptSpec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/PlannerQScriptSpec.scala
@@ -93,8 +93,8 @@ class PlannerQScriptSpec extends
           Guard(
             ProjectKeyS(ProjectIndexI(Hole, 1), "parentid"),
             Type.Str,
-            Constant(ejs.bool(false)),
-            Constant(ejs.bool(true))))) must beWorkflow0(
+            Constant(json.bool(false)),
+            Constant(json.bool(true))))) must beWorkflow0(
         chain[Workflow](
           $read(collection("db", "zips")),
           $project(reshape("0" -> $arrayLit(List($field("_id"), $$ROOT)))),

--- a/mongodb/src/test/scala/quasar/physical/mongodb/PlannerQScriptSpec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/PlannerQScriptSpec.scala
@@ -44,10 +44,11 @@ class PlannerQScriptSpec extends
   import CollectionUtil._
   import Reshape.reshape
 
-  val (func, free, fix) =
+  val dsl =
     quasar.qscript.construction.mkDefaults[Fix, fs.MongoQScript[Fix, ?]]
+  import dsl._
 
-  val ejs = Fixed[Fix[EJson]]
+  val json = Fixed[Fix[EJson]]
 
   //TODO make this independent of MongoQScript and move to a place where all
   //     connector tests can refer to it
@@ -56,10 +57,10 @@ class PlannerQScriptSpec extends
       fix.Unreferenced,
       free.Filter(
         free.ShiftedRead[AFile](rootDir </> dir("db") </> file("zips"), qscript.ExcludeId),
-        func.Guard(func.Hole, Type.AnyObject, func.Constant(ejs.bool(true)), func.Constant(ejs.bool(false)))),
+        func.Guard(func.Hole, Type.AnyObject, func.Constant(json.bool(true)), func.Constant(json.bool(false)))),
       free.Filter(
         free.ShiftedRead[AFile](rootDir </> dir("db") </> file("smallZips"), qscript.ExcludeId),
-        func.Guard(func.Hole, Type.AnyObject, func.Constant(ejs.bool(true)), func.Constant(ejs.bool(false)))),
+        func.Guard(func.Hole, Type.AnyObject, func.Constant(json.bool(true)), func.Constant(json.bool(false)))),
       List((func.ProjectKeyS(func.Hole, "_id"), func.ProjectKeyS(func.Hole, "_id"))),
       JoinType.Inner,
       func.ProjectKeyS(func.RightSide, "city"))


### PR DESCRIPTION
Also reduced the use of tuples in `mkDefaults` because it makes the pretty printer more fragile.