### PR TITLE
Publish interface tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -487,6 +487,7 @@ lazy val interface = project
     skeleton,
     mimir)
   .settings(commonSettings)
+  .settings(publishTestsSettings)
   .settings(targetSettings)
   .settings(libraryDependencies ++= Dependencies.interface)
   .enablePlugins(AutomateHeaderPlugin)


### PR DESCRIPTION
Required for downstream consumption — slamdata/slamdata-backend#280