### PR TITLE
Corrected invalid freemaps generated by MinimizeAutoJoins

### DIFF
--- a/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
@@ -102,7 +102,7 @@ final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT] {
 
       case QSFilter(src, _) => src.point[F]
 
-      case QSReduce(src, _, _, _) => unexpectedError("QSReduce", gpf.root)
+      case QSReduce(src, _, _, _) => dims.bucketAccess(gpf.root, dims.reduce(src)).point[F]
 
       case QSSort(src, _, _) => src.point[F]
 

--- a/connector/src/main/scala/quasar/qscript/qsu/LPtoQS.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/LPtoQS.scala
@@ -62,15 +62,21 @@ final class LPtoQS[T[_[_]]: BirecursiveT: EqualT: ShowT] extends QSUTTypes[T] {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   private def debugG[F[_]: Applicative](prefix: String): K[F, QSUGraph, QSUGraph] =
     K { g =>
-      println("\n\n" + prefix + g.shows)    // uh... yeah do better
+      maybePrint("\n\n" + prefix + g.shows)    // uh... yeah do better
       g.point[F]
     }
 
   private def debugAG[F[_]: Applicative](prefix: String): K[F, AuthenticatedQSU[T], AuthenticatedQSU[T]] =
     K { aqsu =>
-      println("\n\n" + prefix + aqsu.graph.shows + "\n" + aqsu.dims.shows)
+      maybePrint("\n\n" + prefix + aqsu.graph.shows + "\n" + aqsu.dims.shows)
       aqsu.point[F]
     }
+
+  private def maybePrint(str: String): Unit = {
+    // println(str)
+
+    ()
+  }
 }
 
 object LPtoQS {

--- a/connector/src/main/scala/quasar/qscript/qsu/LPtoQS.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/LPtoQS.scala
@@ -50,7 +50,7 @@ final class LPtoQS[T[_[_]]: BirecursiveT: EqualT: ShowT] extends QSUTTypes[T] {
       ReifyBuckets[T]                >=>
       debugAG("ReifyBuckets: ")      >==>
       MinimizeAutoJoins[T].apply[F]  >=>
-      debugAG("MinimizeAJ: ")         >==>
+      debugAG("MinimizeAJ: ")        >==>
       ReifyAutoJoins[T].apply[F]     >=>
       debugAG("ReifyAutoJoins: ")    >-
       (_.graph)                      >==>

--- a/connector/src/main/scala/quasar/qscript/qsu/LPtoQS.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/LPtoQS.scala
@@ -45,12 +45,12 @@ final class LPtoQS[T[_[_]]: BirecursiveT: EqualT: ShowT] extends QSUTTypes[T] {
       debugG("RecognizeDistinct: ")  >==>
       ExtractFreeMap[T, F]           >=>
       debugG("ExtractFM: ")          >==>
-      MinimizeAutoJoins[T].apply[F]  >=>
-      debugG("MinimizeAJ: ")         >==>
       ApplyProvenance[T].apply[F]    >=>
       debugAG("ApplyProv: ")         >-
       ReifyBuckets[T]                >=>
       debugAG("ReifyBuckets: ")      >==>
+      MinimizeAutoJoins[T].apply[F]  >=>
+      debugAG("MinimizeAJ: ")         >==>
       ReifyAutoJoins[T].apply[F]     >=>
       debugAG("ReifyAutoJoins: ")    >-
       (_.graph)                      >==>

--- a/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
@@ -18,98 +18,210 @@ package quasar.qscript.qsu
 
 import quasar.NameGenerator
 import quasar.contrib.scalaz.MonadState_
+import quasar.ejson.{EJson, Fixed}
+import quasar.fp._
+import quasar.fp.ski.κ
 import quasar.qscript.{
+  construction,
   Center,
   Hole,
+  HoleF,
   LeftSide,
   LeftSide3,
+  ReduceIndex,
   RightSide,
   RightSide3,
   SrcHole
 }
 import quasar.qscript.qsu.{QScriptUniform => QSU}
-import slamdata.Predef._
+import slamdata.Predef.{Map => SMap, _}
 
 import matryoshka.BirecursiveT
-import scalaz.{Free, Monad, StateT}
-import scalaz.syntax.foldable._
-import scalaz.syntax.monad._
+import scalaz.{Free, Monad, Scalaz, StateT}, Scalaz._   // sigh, monad/traverse conflict
 
 final class MinimizeAutoJoins[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T] {
   import QSUGraph.Extractors._
+
+  private val func = construction.Func[T]
+  private val srcHole: Hole = SrcHole   // wtb smart constructor
+
+  private val J = Fixed[T[EJson]]
 
   def apply[F[_]: Monad: NameGenerator](qgraph: QSUGraph): F[QSUGraph] = {
     type G[A] = StateT[F, RevIdx, A]
 
     val back = qgraph rewriteM {
       case qgraph @ AutoJoin2(left, right, combiner) =>
-        val fml = MappableRegion.maximal(left)
-        val fmr = MappableRegion.maximal(right)
-
-        val minimized = minimizeSources(fml.toList ::: fmr.toList)
-
-        lazy val extended = combiner map {
-          case LeftSide => fml.map(_ => SrcHole: Hole)
-          case RightSide => fmr.map(_ => SrcHole: Hole)
+        val combiner2 = combiner map {
+          case LeftSide => 0
+          case RightSide => 1
         }
 
-        attemptCoalesce[G](qgraph, minimized, extended)
+        coalesceToMap[G](qgraph, List(left, right), Free.liftF[MapFunc, Int](combiner2))
 
       case qgraph @ AutoJoin3(left, center, right, combiner) =>
-        val fml = MappableRegion.maximal(left)
-        val fmc = MappableRegion.maximal(center)
-        val fmr = MappableRegion.maximal(right)
-
-        val minimized =
-          minimizeSources(fml.toList ::: fmc.toList ::: fmr.toList)
-
-        lazy val extended = combiner map {
-          case LeftSide3 => fml.map(_ => SrcHole: Hole)
-          case Center => fmc.map(_ => SrcHole: Hole)
-          case RightSide3 => fmr.map(_ => SrcHole: Hole)
+        val combiner2 = combiner map {
+          case LeftSide3 => 0
+          case Center => 1
+          case RightSide3 => 2
         }
 
-        attemptCoalesce[G](qgraph, minimized, extended)
+        coalesceToMap[G](qgraph, List(left, center, right), Free.liftF[MapFunc, Int](combiner2))
     }
 
     back.eval(qgraph.generateRevIndex)
   }
 
-  private def attemptCoalesce[G[_]: Monad: NameGenerator: MonadState_[?[_], RevIdx]](
+  // the Ints are indices into branches
+  private def coalesceToMap[G[_]: Monad: NameGenerator: MonadState_[?[_], RevIdx]](
       qgraph: QSUGraph,
-      minimized: List[QSUGraph],
-      extended: => MapFunc[FreeMap]): G[QSUGraph] = {
+      branches: List[QSUGraph],
+      combiner: FreeMapA[Int]): G[QSUGraph] = {
 
-    lazy val fm = Free.roll[MapFunc, Hole](extended)
+    val fms = branches.zipWithIndex map {
+      case (g, i) =>
+        expandSecondOrder(MappableRegion.maximal(g)).map(g => (g, i))
+    }
 
-    minimized match {
-      case Nil =>
-        QSUGraph.withName[T, G](QSU.Unreferenced[T, Symbol]()) map { unref =>
-          qgraph.overwriteAtRoot(QSU.Map[T, Symbol](unref.root, fm)) :++ unref
-        }
+    val (remap, candidates) = minimizeSources(fms.flatMap(_.toList))
 
-      case single :: Nil =>
-        qgraph.overwriteAtRoot(QSU.Map[T, Symbol](single.root, fm)).point[G]
+    lazy val fm = combiner.flatMap(i => fms(i).map(κ(remap(i))))
 
-      case minimized =>
-        // TODO implement coalesce heuristics here
-        qgraph.point[G]
+    coalesceRoots[G](qgraph, fm, candidates)
+  }
+
+  // attempt to extend by seeing through constructs like filter (mostly just filter)
+  @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
+  private def expandSecondOrder(fm: FreeMapA[QSUGraph]): FreeMapA[QSUGraph] = {
+    fm flatMap {
+      case QSFilter(source, predicate) =>
+        // tune into 102.5 FM, The Source
+        val sourceFM = expandSecondOrder(MappableRegion.maximal(source))
+        func.Cond(sourceFM, sourceFM, func.Undefined[QSUGraph])
+
+      // TODO should we handle LPFilter here just for completion sake?
+
+      case g => Free.pure(g)
     }
   }
 
-  private def minimizeSources(sources: List[QSUGraph]): List[QSUGraph] = {
-    val (_, minimized) = sources.foldRight((Set[Symbol](), List[QSUGraph]())) {
-      // just drop unreferenced sources entirely
-      case (Unreferenced(), pair) => pair
+  // attempts to reduce the set of candidates to a single Map node, given a FreeMap[Int]
+  // the Int indexes into the final number of distinct roots
+  @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+  private def coalesceRoots[G[_]: Monad: NameGenerator: MonadState_[?[_], RevIdx]](
+      qgraph: QSUGraph,
+      fm: => FreeMapA[Int],
+      candidates: List[QSUGraph]): G[QSUGraph] = candidates match {
 
-      case (g, (mask, acc)) =>
-        if (mask(g.root))
-          (mask, acc)
-        else
-          (mask + g.root, g :: acc)
-    }
+    case Nil =>
+      QSUGraph.withName[T, G](QSU.Unreferenced[T, Symbol]()) map { unref =>
+        qgraph.overwriteAtRoot(QSU.Map[T, Symbol](unref.root, fm.map(κ(srcHole)))) :++ unref
+      }
 
-    minimized
+    case single :: Nil =>
+      // if this is false, it's an assertion error
+      // lazy val sanityCheck = fm.toList.forall(0 ==)
+
+      qgraph.overwriteAtRoot(QSU.Map[T, Symbol](single.root, fm.map(κ(srcHole)))).point[G]
+
+    case candidates =>
+      val reducerAttempt = candidates collect {
+        case g @ QSReduce(source, buckets, reducers, repair) =>
+          (source, buckets, reducers, repair)
+      }
+
+      if (reducerAttempt.lengthCompare(candidates.length) === 0) {
+        for {
+          extended <- reducerAttempt traverse {
+            case desc @ (source, buckets, reducers, repair) =>
+              // TODO this is a weird use of the function, but it should work
+              // we're just trying to run ourselves recursively to extend the sources
+              // this isn't likely to be a common case
+              coalesceToMap[G](source, List(source), Free.pure(0)) map {
+                case Map(source2, fm) =>
+                  (
+                    source2,
+                    buckets.map(_.flatMap(κ(fm))),
+                    reducers.map(_.map(_.flatMap(κ(fm)))),
+                    repair)
+
+                case _ => desc
+              }
+          }
+
+          // we know we're non-empty by structure of outer match
+          (source, _, _, _) = extended.head
+
+          back <- if (extended.forall(_._1.root === source.root)) {
+            val lifted = extended.zipWithIndex map {
+              case ((_, buckets, reducers, repair), i) =>
+                (
+                  buckets,
+                  reducers,
+                  // we use maps here to avoid definedness issues in reduction results
+                  func.MakeMap(repair, func.Constant(J.str(i.toString))))
+            }
+
+            val lhead = lifted.head
+
+            val (_, (buckets, reducers, repair)) =
+              lifted.tail.foldLeft((lhead._1.length, lhead)) {
+                case ((offset, (lbuckets, lreducers, lrepair)), (rbuckets, rreducers, rrepair)) =>
+                  val buckets = lbuckets ::: rbuckets
+                  val reducers = lreducers ::: rreducers
+                  val offset2 = offset + rbuckets.length
+
+                  val repair = func.ConcatMaps(
+                    lrepair,
+                    rrepair map {
+                      case ReduceIndex(e) =>
+                        ReduceIndex(e.bimap(_ + offset, _ + offset))
+                    })
+
+                  (offset2, (buckets, reducers, repair))
+              }
+
+            // 107.7, All chiropractors, all the time
+            val adjustedFM = fm flatMap { i =>
+              // get the value back OUT of the map
+              func.ProjectKey(HoleF, func.Constant(J.str(i.toString)))
+            }
+
+            val redPat = QSU.QSReduce[T, Symbol](source.root, buckets, reducers, repair)
+
+            QSUGraph.withName[T, G](redPat) map { red =>
+              qgraph.overwriteAtRoot(QSU.Map[T, Symbol](red.root, adjustedFM))
+            }
+          } else {
+            qgraph.point[G]
+          }
+        } yield back
+      } else {
+        qgraph.point[G]
+      }
+  }
+
+  // we return a remap function along with a minimized list
+  // the remapper can be used to determine which input indices
+  // collapsed into what output indices
+  // note that if everything is Unreferenced, remap will be κ(-1),
+  // which is weird but harmless
+  private def minimizeSources(sources: List[(QSUGraph, Int)]): (Int => Int, List[QSUGraph]) = {
+    val (_, remap, _, minimized) =
+      sources.foldRight((Set[Symbol](), SMap[Int, Int](), 0, List[QSUGraph]())) {
+        // just drop unreferenced sources entirely
+        case ((Unreferenced(), i), (mask, remap, offset, acc)) =>
+          (mask, remap + (i -> offset), offset, acc)
+
+        case ((g, i), (mask, remap, offset, acc)) =>
+          if (mask(g.root))
+            (mask, remap + (i -> offset), offset, acc)
+          else
+            (mask + g.root, remap + (i -> offset), offset + 1, g :: acc)
+      }
+
+    // if we're asking for a non-existent remap index, it's because it isn't referenced
+    (i => remap.getOrElse(i, -1), minimized)
   }
 }
 

--- a/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
@@ -186,7 +186,7 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends 
                   buckets,
                   reducers,
                   // we use maps here to avoid definedness issues in reduction results
-                  func.MakeMap(repair, func.Constant(J.str(i.toString))))
+                  func.MakeMap(func.Constant(J.str(i.toString)), repair))
             }
 
             // this is fine, because we can't be here if candidates is empty

--- a/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
@@ -109,7 +109,7 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends 
       case QSFilter(source, predicate) =>
         // tune into 102.5 FM, The Source
         val sourceFM = expandSecondOrder(MappableRegion.maximal(source))
-        func.Cond(sourceFM, sourceFM, func.Undefined[QSUGraph])
+        func.Cond(predicate.flatMap(κ(sourceFM)), sourceFM, func.Undefined[QSUGraph])
 
       // TODO should we handle LPFilter here just for completion sake?
 

--- a/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
@@ -105,7 +105,13 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends 
   // attempt to extend by seeing through constructs like filter (mostly just filter)
   @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
   private def expandSecondOrder(fm: FreeMapA[QSUGraph]): FreeMapA[QSUGraph] = {
-    fm flatMap {
+    fm
+
+    // TODO the use of this function is incorrect right now
+    // it will be employed even when joins are avoidable in
+    // other ways (e.g. by eliminating Unreferenced())
+
+    /*fm flatMap {
       case QSFilter(source, predicate) =>
         // tune into 102.5 FM, The Source
         val sourceFM = expandSecondOrder(MappableRegion.maximal(source))
@@ -114,7 +120,7 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends 
       // TODO should we handle LPFilter here just for completion sake?
 
       case g => Free.pure(g)
-    }
+    }*/
   }
 
   // attempts to reduce the set of candidates to a single Map node, given a FreeMap[Int]

--- a/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.qsu
+
+import quasar.{Planner, Qspec, TreeMatchers, Type}, Planner.PlannerError
+import quasar.ejson.{EJson, Fixed}
+import quasar.fp._
+import quasar.qscript.{
+  construction,
+  Hole,
+  HoleF,
+  MapFuncsCore
+}
+import slamdata.Predef._
+
+import matryoshka._
+import matryoshka.data.Fix
+import pathy.Path, Path.Sandboxed
+import scalaz.{EitherT, Need, StateT}
+
+object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix] {
+  import QSUGraph.Extractors._
+
+  type F[A] = EitherT[StateT[Need, Long, ?], PlannerError, A]
+
+  val qsu = QScriptUniform.Dsl[Fix]
+  val func = construction.Func[Fix]
+  val maj = MinimizeAutoJoins[Fix]
+
+  val J = Fixed[Fix[EJson]]
+
+  val afile = Path.rootDir[Sandboxed] </> Path.file("afile")
+
+  "unary node elimination" should {
+    "linearize .foo + .bar" in {
+      val qgraph = QSUGraph.fromTree[Fix](
+        qsu.autojoin2(
+          qsu.map(
+            qsu.read(afile),
+            func.ProjectKey(HoleF, func.Constant(J.str("foo")))),
+          qsu.map(
+            qsu.read(afile),
+            func.ProjectKey(HoleF, func.Constant(J.str("bar")))),
+          _(MapFuncsCore.Add(_, _))))
+
+      runOn(qgraph) must beLike {
+        case Map(Read(_), fm) =>
+          // must_=== doesn't work
+          fm must beTreeEqual(
+            func.Add(
+              func.ProjectKey(HoleF, func.Constant(J.str("foo"))),
+              func.ProjectKey(HoleF, func.Constant(J.str("bar")))))
+      }
+    }
+
+    "convert Typecheck to a Map(_, Guard)" in {
+      val qgraph = QSUGraph.fromTree[Fix](
+        qsu.autojoin3(
+          qsu.read(afile),
+          qsu.read(afile),
+          qsu.map1(
+            qsu.unreferenced(),
+            MapFuncsCore.Undefined[Fix, Hole](): MapFuncCore[Hole]),
+          _(MapFuncsCore.Guard(_, Type.AnyObject, _, _))))
+
+      runOn(qgraph) must beLike {
+        case Map(Read(_), fm) =>
+          // must_=== doesn't work
+          fm must beTreeEqual(func.Guard(HoleF, Type.AnyObject, HoleF, func.Undefined))
+      }
+    }
+  }
+
+  def runOn(qgraph: QSUGraph): QSUGraph = {
+    val results = maj[F](qgraph).run.eval(0L).value.toEither
+    results must beRight
+
+    results.right.get
+  }
+}

--- a/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
@@ -185,7 +185,12 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
   }
 
   def runOn(qgraph: QSUGraph): QSUGraph = {
-    val results = maj[F](qgraph).run.eval(0L).value.toEither
+    val resultsF = for {
+      agraph <- ApplyProvenance[Fix].apply[F](qgraph)
+      back <- maj[F](agraph)
+    } yield back.graph
+
+    val results = resultsF.run.eval(0L).value.toEither
     results must beRight
 
     results.right.get

--- a/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
@@ -117,11 +117,11 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
           repair must beTreeEqual(
             func.ConcatMaps(
               func.MakeMap(
-                Free.pure[MapFunc, ReduceIndex](ReduceIndex(\/-(0))),
-                func.Constant(J.str("0"))),
+                func.Constant(J.str("0")),
+                Free.pure[MapFunc, ReduceIndex](ReduceIndex(\/-(0)))),
               func.MakeMap(
-                Free.pure[MapFunc, ReduceIndex](ReduceIndex(\/-(1))),
-                func.Constant(J.str("1")))))
+                func.Constant(J.str("1")),
+                Free.pure[MapFunc, ReduceIndex](ReduceIndex(\/-(1))))))
 
           fm must beTreeEqual(
             func.Add(
@@ -170,11 +170,11 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
           repair must beTreeEqual(
             func.ConcatMaps(
               func.MakeMap(
-                Free.pure[MapFunc, ReduceIndex](ReduceIndex(\/-(0))),
-                func.Constant(J.str("0"))),
+                func.Constant(J.str("0")),
+                Free.pure[MapFunc, ReduceIndex](ReduceIndex(\/-(0)))),
               func.MakeMap(
-                Free.pure[MapFunc, ReduceIndex](ReduceIndex(\/-(1))),
-                func.Constant(J.str("1")))))
+                func.Constant(J.str("1")),
+                Free.pure[MapFunc, ReduceIndex](ReduceIndex(\/-(1))))))
 
           fm must beTreeEqual(
             func.Add(

--- a/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
@@ -202,7 +202,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
                 HoleF[Fix],
                 func.Undefined)))
       }
-    }
+    }.pendingUntilFixed
   }
 
   def runOn(qgraph: QSUGraph): QSUGraph = {

--- a/foundation/src/main/scala/quasar/contrib/scalaz/MonadState_.scala
+++ b/foundation/src/main/scala/quasar/contrib/scalaz/MonadState_.scala
@@ -18,7 +18,8 @@ package quasar.contrib.scalaz
 
 import slamdata.Predef._
 
-import scalaz.{Bind, Functor, MonadState}
+import scalaz.{Bind, Functor, Monad, MonadState, StateT}
+import scalaz.syntax.monad._
 
 /** A version of MonadState that doesn't extend Monad to avoid ambiguous
   * implicits in the presence of multiple "mtl" constraints.
@@ -42,5 +43,12 @@ object MonadState_ {
     new MonadState_[F, S] {
       def get = F.get
       def put(s: S) = F.put(s)
+    }
+
+  implicit def monadStateWithinState[F[_]: Monad, S1, S2](implicit F: MonadState_[F, S1])
+      : MonadState_[StateT[F, S2, ?], S1] =
+    new MonadState_[StateT[F, S2, ?], S1] {
+      def get = F.get.liftM[StateT[?[_], S2, ?]]
+      def put(s: S1) = F.put(s).liftM[StateT[?[_], S2, ?]]
     }
 }


### PR DESCRIPTION
Depends on #3131

I had to turn off second-order minimization for now.  So we're no longer doing Filter => Cond rewriting.  This was because the rewrite is currently done in the wrong place, and is over-aggressive (it happens even when it's unnecessary).  I think I have a decent idea how to restore it, but I'm putting that off for the moment.