### PR TITLE
Fix #3162: Add regular equals and hashCode to ColumnDesc

### DIFF
--- a/rdbms/src/main/scala/quasar/physical/rdbms/model/TableModel.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/model/TableModel.scala
@@ -33,7 +33,17 @@ case object StringCol extends ColumnType
 case object IntCol extends ColumnType
 case object NullCol extends ColumnType
 
-final case class ColumnDesc(name: String, tpe: ColumnType)
+final case class ColumnDesc(name: String, tpe: ColumnType) {
+
+  override def equals(other: scala.Any): Boolean = {
+    other match {
+      case other@ColumnDesc(_, _) => TableModel.columnDescEq.equal(this, other)
+      case _                      => false
+    }
+  }
+
+  override def hashCode: Int = name.hashCode
+}
 
 sealed trait TableModel
 

--- a/rdbms/src/test/scala/quasar/physical/rdbms/model/TableModelTest.scala
+++ b/rdbms/src/test/scala/quasar/physical/rdbms/model/TableModelTest.scala
@@ -63,6 +63,14 @@ class TableModelTest extends Spec  with ScalazMatchers {
   checkAll(propz.equal.laws[TableModel])
   checkAll(propz.monoid.laws[TableModel])
 
+  "ColumnDesc must" >> {
+    "Define equality and hashcode in terms of its name (#3162)" >> {
+      prop { (col: ColumnDesc) =>
+        Set(col, col.copy(tpe = IntCol)) must_=== Set(col)
+      }
+    }
+  }
+
   "Table Model Monoid must" >> {
     "be commutative" >> {
       prop { (x: TableModel, y: TableModel) =>


### PR DESCRIPTION
The issue was caused by multiple `ColumnDesc` with the same column name present in a `TableModel`. 