### PR TITLE
Serialize module SQL properly so it can be parsed again

### DIFF
--- a/core/src/test/scala/quasar/fs/mount/MountConfigSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/MountConfigSpec.scala
@@ -19,8 +19,12 @@ package quasar.fs.mount
 import slamdata.Predef._
 import quasar.{Variables, VarName, VarValue}
 import quasar.sql._
+import quasar.sql.StatementArbitrary._
+
+import scala.Predef.$conforms
 
 import argonaut._, Argonaut._, JsonScalaz._
+import matryoshka.data.Fix
 import scalaz.Scalaz._
 
 class MountConfigSpec extends quasar.Qspec {
@@ -83,6 +87,13 @@ class MountConfigSpec extends quasar.Qspec {
         viewJson("sql2:///?q=%F%28select+*+from+zips%29")
           .as[MountConfig].toEither.leftMap(_._1) must beLeft
       }
+    }
+  }
+
+  "Module Config" should {
+    "be able to parse any printed module" >> prop { module: List[Statement[Fix[Sql]]] =>
+      val str = module.pprint
+      fixParser.parseModule(str) must_=== module.right
     }
   }
 }

--- a/frontend/src/main/scala/quasar/sql/ParsingError.scala
+++ b/frontend/src/main/scala/quasar/sql/ParsingError.scala
@@ -31,4 +31,9 @@ final case class ParsingPathError(error: PathError) extends ParsingError {
 
 object ParsingError {
   implicit val parsingErrorShow: Show[ParsingError] = Show.showFromToString
+  implicit val equal: Equal[ParsingError] = Equal.equal {
+    case (GenericParsingError(m1), GenericParsingError(m2)) => m1 ≟ m2
+    case (ParsingPathError(e1), ParsingPathError(e2))       => e1 ≟ e2
+    case _                                                  => false
+  }
 }

--- a/frontend/src/test/scala/quasar/sql/SqlParserSpec.scala
+++ b/frontend/src/test/scala/quasar/sql/SqlParserSpec.scala
@@ -613,6 +613,11 @@ class SQLParserSpec extends quasar.Qspec {
         fixParser.parseModule(moduleString) must_===
           \/-(List(FunctionDecl(CIName("foo"), List(CIName("foo")), sqlE":foo")))
       }
+      "functions with escaped param names" in {
+        val moduleString = "CREATE FUNCTION FOO(:`foo`) BEGIN :`foo` END;"
+        fixParser.parseModule(moduleString) must_===
+          \/-(List(FunctionDecl(CIName("foo"), List(CIName("foo")), sqlE":foo")))
+      }
     }
 
     "parse scopedExpr" in {

--- a/frontend/src/test/scala/quasar/sql/StatementArbitrary.scala
+++ b/frontend/src/test/scala/quasar/sql/StatementArbitrary.scala
@@ -42,7 +42,7 @@ trait StatementArbitrary {
     for {
       body <- Arbitrary.arbitrary[Fix[Sql]]
       name <- nonEmptyNameGen
-      args <- Gen.listOf(nonEmptyNameGen)
+      args <- Gen.listOf(Arbitrary.arbitrary[String].map(CIName(_)))
     } yield FunctionDecl(name, args, body)
 
   val nonEmptyNameGen: Gen[CIName] = Gen.identifier.map(CIName(_))

--- a/frontend/src/test/scala/quasar/sql/StatementSpec.scala
+++ b/frontend/src/test/scala/quasar/sql/StatementSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.sql
+
+import slamdata.Predef._
+
+import scalaz.Scalaz._
+
+class StatementSpec extends quasar.Qspec {
+  "Statement" >> {
+    "pretty print" >> {
+      "escape param names that need to escaped" >> {
+        val funcDef = FunctionDecl(
+          name = CIName("FOO"),
+          args = List(CIName("what!?(")),
+          body = sqlE"select * from :`what!?(`")
+        funcDef.pprintF must_= "CREATE FUNCTION FOO(:`what!?(`)\n  BEGIN\n    (select * from :`what!?(`)\n  END"
+      }
+    }
+  }
+}

--- a/web/src/test/scala/quasar/api/services/MountServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/MountServiceSpec.scala
@@ -187,7 +187,7 @@ class MountServiceSpec extends quasar.Qspec with Http4s {
       "succeed with correct SQL Statements" >> prop { d: ADir =>
         runTest { service =>
           val cfg = MountConfig.moduleConfig(sampleStatements)
-          val cfgStr = EncodeJson.of[MountConfig].encode(cfg)
+          val cfgJson = EncodeJson.of[MountConfig].encode(cfg)
 
           for {
             _    <- M.mountModule(d, sampleStatements)
@@ -195,7 +195,7 @@ class MountServiceSpec extends quasar.Qspec with Http4s {
             (res, _) = r
             body <- lift(res.as[Json]).into[Eff]
           } yield {
-            (body must_== cfgStr) and (res.status must_== Ok)
+            (body must_=== cfgJson) and (res.status must_=== Ok)
           }
         }
       }


### PR DESCRIPTION
Fixes #3027 

- escape function param names that need to be escaped
- Add round-trip test for modules
- Add test to make sure we parse function with escaped param names properly
- Rename `_qq` to `escape`
- Add `Equal` instance to `ParsingError`
- Add convenience `pprintF` on `Statement` for common use case