### PR TITLE
[#3145] Fix how rewrites are applied during ApplyProvenance

### DIFF
--- a/connector/src/main/scala/quasar/qscript/qsu/LPtoQS.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/LPtoQS.scala
@@ -19,13 +19,10 @@ package quasar.qscript.qsu
 import slamdata.Predef._
 import quasar.NameGenerator
 import quasar.Planner.PlannerErrorME
-import quasar.fp.{coproductShow, symbolShow}
 import quasar.frontend.logicalplan.LogicalPlan
 
 import matryoshka.{delayShow, showTShow, BirecursiveT, EqualT, ShowT}
-import matryoshka.data._
 import scalaz.{Applicative, Functor, Kleisli => K, Monad}
-import scalaz.std.map._
 import scalaz.syntax.applicative._
 import scalaz.syntax.show._
 
@@ -69,7 +66,7 @@ final class LPtoQS[T[_[_]]: BirecursiveT: EqualT: ShowT] extends QSUTTypes[T] {
 
   private def debugAG[F[_]: Applicative](prefix: String): K[F, AuthenticatedQSU[T], AuthenticatedQSU[T]] =
     K { aqsu =>
-      maybePrint("\n\n" + prefix + aqsu.graph.shows + "\n" + aqsu.dims.shows)
+      maybePrint("\n\n" + prefix + aqsu.shows)
       aqsu.point[F]
     }
 

--- a/connector/src/main/scala/quasar/qscript/qsu/package.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/package.scala
@@ -17,10 +17,28 @@
 package quasar.qscript
 
 import slamdata.Predef.{Map => SMap, _}
+import quasar.fp._
 import quasar.qscript.provenance.Dimensions
+
+import matryoshka._
+import matryoshka.data.free._
+import scalaz.Show
+import scalaz.std.list._
+import scalaz.std.string._
+import scalaz.syntax.foldable._
+import scalaz.syntax.show._
 
 package object qsu {
   type FreeAccess[T[_[_]], A] = FreeMapA[T, Access[A]]
   type QSUDims[T[_[_]]] = SMap[Symbol, Dimensions[QProv.P[T]]]
   type QSUVerts[T[_[_]]] = SMap[Symbol, QScriptUniform[T, Symbol]]
+
+  object QSUDims {
+    def show[T[_[_]]: ShowT]: Show[QSUDims[T]] =
+      Show.shows { dims =>
+        "QSUDims[\n" +
+        dims.toList.map({ case (k, v) => s"  ${k.shows} -> ${v.shows}"}).intercalate("\n") +
+        "\n]"
+      }
+  }
 }

--- a/connector/src/test/scala/quasar/qscript/qsu/ApplyProvenanceSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/ApplyProvenanceSpec.scala
@@ -22,26 +22,35 @@ import quasar.Qspec
 import quasar.Planner.PlannerError
 import quasar.contrib.pathy.AFile
 import quasar.ejson.{EJson, Fixed}
+import quasar.ejson.implicits._
+import quasar.fp._
 import quasar.qscript.construction
 import quasar.qscript.provenance.Dimensions
-import quasar.qscript.HoleF
+import quasar.qscript.{HoleF, ReduceFuncs}
 import quasar.qscript.MapFuncsCore.IntLit
 
+import matryoshka._
 import matryoshka.data.Fix
+import matryoshka.data.free._
 import org.specs2.matcher.{Expectable, Matcher, MatchResult}
 import pathy.Path, Path.{file, Sandboxed}
-import scalaz.{\/, Cofree, IList}
+import scalaz.{\/, Cofree, Equal, IList}
+import scalaz.syntax.applicative._
+import scalaz.syntax.equal._
+import scalaz.syntax.show._
+import scalaz.std.map._
 
 object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
 
   import ApplyProvenance.AuthenticatedQSU
+  import QScriptUniform.DTrans
 
   type F[A] = PlannerError \/ A
   type QSU[A] = QScriptUniform[A]
 
   val J = Fixed[Fix[EJson]]
 
-  val qsu = QScriptUniform.AnnotatedDsl[Fix, String]
+  val qsu = QScriptUniform.AnnotatedDsl[Fix, Symbol]
   val func = construction.Func[Fix]
 
   val app = ApplyProvenance[Fix]
@@ -50,50 +59,81 @@ object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
   val root = Path.rootDir[Sandboxed]
   val afile: AFile = root </> file("foobar")
 
+  // FIXME: Figure out how to get this to resolve normally.
+  implicit val eqP: Equal[qprov.P] =
+    qprov.prov.provenanceEqual(Equal[qprov.D], Equal[FreeMapA[Access[Symbol]]])
+
   "provenance application" should {
 
     "produce provenance for map" in {
 
       val fm: FreeMap = func.Add(HoleF, IntLit(17))
 
-      val tree: Cofree[QSU, String] =
-        qsu.map("name0",
-          (qsu.read("name1", afile), fm))
+      val tree: Cofree[QSU, Symbol] =
+        qsu.map('name0,
+          (qsu.read('name1, afile), fm))
 
-      val dims: SMap[String, Dimensions[qprov.P]] = SMap(
-        "name0" -> IList(qprov.prov.proj(J.str("foobar"))),
-        "name1" -> IList(qprov.prov.proj(J.str("foobar"))))
+      val dims: SMap[Symbol, Dimensions[qprov.P]] = SMap(
+        'name0 -> IList(qprov.prov.proj(J.str("foobar"))),
+        'name1 -> IList(qprov.prov.proj(J.str("foobar"))))
 
       tree must haveDimensions(dims)
+    }
+
+    "compute correct provenance nested dimEdits" >> {
+      val tree =
+        qsu.lpReduce('n4, (
+          qsu.map('n3, (
+            qsu.dimEdit('n2, (
+              qsu.dimEdit('n1, (
+                qsu.read('n0, afile),
+                DTrans.Group(func.ProjectKeyS(func.Hole, "x")))),
+              DTrans.Group(func.ProjectKeyS(func.Hole, "y")))),
+            func.ProjectKeyS(func.Hole, "pop"))),
+          ReduceFuncs.Sum(())))
+
+      tree must haveDimensions(SMap(
+        'n4 -> IList(
+          qprov.prov.value(Access.bucket('n4, 1, 'n4).point[FreeMapA])
+        , qprov.prov.value(Access.bucket('n4, 0, 'n4).point[FreeMapA]))
+      , 'n3 -> IList(
+          qprov.prov.proj(J.str("foobar"))
+        , qprov.prov.value(func.ProjectKeyS(Access.value('n0).point[FreeMapA], "y"))
+        , qprov.prov.value(func.ProjectKeyS(Access.value('n0).point[FreeMapA], "x")))
+      , 'n0 -> IList(
+          qprov.prov.proj(J.str("foobar"))
+        , qprov.prov.value(func.ProjectKeyS(Access.value('n0).point[FreeMapA], "y"))
+        , qprov.prov.value(func.ProjectKeyS(Access.value('n0).point[FreeMapA], "x")))
+      ))
     }
   }
 
   // checks the expected dimensions
-  // checks that the graph has not changed
-  def haveDimensions(expected: SMap[String, Dimensions[qprov.P]])
-      : Matcher[Cofree[QSU, String]] =
-    new Matcher[Cofree[QSU, String]] {
-      def apply[S <: Cofree[QSU, String]](s: Expectable[S]): MatchResult[S] = {
+  def haveDimensions(expected: SMap[Symbol, Dimensions[qprov.P]])
+      : Matcher[Cofree[QSU, Symbol]] =
+    new Matcher[Cofree[QSU, Symbol]] {
+      def apply[S <: Cofree[QSU, Symbol]](s: Expectable[S]): MatchResult[S] = {
 
         val (renames, inputGraph): (QSUGraph.Renames, QSUGraph) =
-          QSUGraph.fromAnnotatedTree[Fix](s.value.map(v => Some(Symbol(v))))
+          QSUGraph.fromAnnotatedTree[Fix](s.value.map(Some(_)))
 
-	// TODO map over values too
         val expectedDims: QSUDims[Fix] =
-	  expected.map { case (k, v) => (renames(Symbol(k)), v) }
+          expected.map { case (k, v) =>
+            val newP = renames.foldLeft(v)((p, t) => qprov.rename(t._1, t._2, p))
+            (renames(k), newP)
+          }
 
-	val actual: PlannerError \/ AuthenticatedQSU[Fix] = app[F](inputGraph)
+        val actual: PlannerError \/ AuthenticatedQSU[Fix] = app[F](inputGraph)
 
-	// TODO use Show
         actual.bimap[MatchResult[S], MatchResult[S]](
         { err =>
           failure(s"provenance application produced unexpected planner error: ${err}", s)
         },
         { case auth @ AuthenticatedQSU(resultGraph, resultDims) =>
           result(
-            (resultGraph == inputGraph) && (resultDims == expectedDims), // TODO better equals
-            s"received expected authenticated QSU:\n${auth}",
-            s"received unexpected authenticated QSU:\n${auth}\nexpected:\n${expected}",
+            resultDims ≟ expectedDims,
+            s"received expected authenticated QSU:\n${auth.shows}",
+            s"received unexpected authenticated QSU:\n${auth.shows}\nexpected:\n${QSUDims.show[Fix].shows(expected)}",
             s)
         }).merge
       }

--- a/it/src/main/resources/tests/nestedSelectWithFilter.test
+++ b/it/src/main/resources/tests/nestedSelectWithFilter.test
@@ -2,16 +2,10 @@
     "name": "nested select with filter",
     "backends": {
         "couchbase":         "pending",
-        "marklogic_json":    "pending",
-        "marklogic_xml":     "pending",
         "mimir":             "pending",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
-        "mongodb_3_2":       "pending",
-        "mongodb_3_4":       "pending",
         "mongodb_read_only": "pending",
-        "spark_hdfs":        "pending",
-        "spark_local":       "pending",
         "spark_cassandra":   "pending"
     },
     "data": "olympics.data",

--- a/it/src/main/resources/tests/nestedSelectWithFilter.test
+++ b/it/src/main/resources/tests/nestedSelectWithFilter.test
@@ -5,7 +5,6 @@
         "mimir":             "pending",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
-        "mongodb_read_only": "pending",
         "spark_cassandra":   "pending"
     },
     "data": "olympics.data",


### PR DESCRIPTION
Updates how symbol rewrites are applied in `ApplyProvenance` to be correct in the presence of nested `DimEdit`s. 

Fixes #3145.
Fixes #3182.