### PR TITLE
comment out tracking in PlannerSpec for now

### DIFF
--- a/mongodb/src/test/scala/quasar/physical/mongodb/PlannerSpec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/PlannerSpec.scala
@@ -61,9 +61,9 @@ class PlannerSpec extends
         plan0 must beRight.which(cwf => notBrokenWithOps(cwf.op, expectedOps))
       }.pendingUntilFixed
 
-      s"track: $name" in {
-        plan0 must beRight.which(cwf => trackActual(cwf, testFile(s"plan $name")))
-      }
+      // s"track: $name" in {
+      //   plan0 must beRight.which(cwf => trackActual(cwf, testFile(s"plan $name")))
+      // }
     }
   }
 


### PR DESCRIPTION
Comment out tracking in PlannerSpec for now, so qscript devs won't have to deal with regenerating.  We can reenable once we are on polyrepo.