### PR TITLE
Encapsulate and standardize QSU rewrite application

### DIFF
--- a/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
@@ -157,8 +157,7 @@ final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT] private () {
   }
 
   private def unexpectedError[F[_]: PlannerErrorME, A](nodeName: String, id: Symbol): F[A] =
-    PlannerErrorME[F].raiseError(
-      InternalError(s"ComputeProvenance: Encountered unexpected $nodeName[$id].", None))
+    PlannerErrorME[F].raiseError(InternalError(s"Encountered unexpected $nodeName[$id].", None))
 }
 
 object ApplyProvenance {
@@ -167,7 +166,7 @@ object ApplyProvenance {
       F[_]: Monad: PlannerErrorME]
       (graph: QSUGraph[T])
       : F[AuthenticatedQSU[T]] =
-    new ApplyProvenance[T].apply[F](graph)
+    taggedInternalError("ApplyProvenance", new ApplyProvenance[T].apply[F](graph))
 
   def computeProvenanceƒ[
       T[_[_]]: BirecursiveT: EqualT,

--- a/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
@@ -36,7 +36,7 @@ import scalaz.syntax.foldable1._
 import scalaz.syntax.monad._
 import scalaz.syntax.show._
 
-final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT] {
+final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT] private () {
   import ApplyProvenance._
   import QScriptUniform._
 
@@ -162,8 +162,18 @@ final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT] {
 }
 
 object ApplyProvenance {
-  def apply[T[_[_]]: BirecursiveT: EqualT]: ApplyProvenance[T] =
-    new ApplyProvenance[T]
+  def apply[
+      T[_[_]]: BirecursiveT: EqualT,
+      F[_]: Monad: PlannerErrorME]
+      (graph: QSUGraph[T])
+      : F[AuthenticatedQSU[T]] =
+    new ApplyProvenance[T].apply[F](graph)
+
+  def computeProvenanceƒ[
+      T[_[_]]: BirecursiveT: EqualT,
+      F[_]: Monad: PlannerErrorME]
+      : AlgebraM[F, QSUGraph.QSUPattern[T, ?], (Symbol, Dimensions[QProv.P[T]])] =
+    new ApplyProvenance[T].computeProvenanceƒ[F]
 
   final case class AuthenticatedQSU[T[_[_]]](
       graph: QSUGraph[T],

--- a/connector/src/main/scala/quasar/qscript/qsu/EliminateUnary.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/EliminateUnary.scala
@@ -16,21 +16,19 @@
 
 package quasar.qscript.qsu
 
+import quasar.qscript.FreeMapA
 import quasar.qscript.qsu.{QScriptUniform => QSU}
 
 import matryoshka.BirecursiveT
 import scalaz.Free
 import scalaz.syntax.applicative._
 
-final class EliminateUnary[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T] {
+object EliminateUnary {
   import QSUGraph.Extractors._
 
-  def apply(qgraph: QSUGraph): QSUGraph = qgraph rewrite {
-    case qgraph @ Unary(source, mf) =>
-      qgraph.overwriteAtRoot(QSU.Map(source.root, Free.roll(mf.map(_.point[FreeMapA]))))
-  }
-}
-
-object EliminateUnary {
-  def apply[T[_[_]]: BirecursiveT]: EliminateUnary[T] = new EliminateUnary[T]
+  def apply[T[_[_]]: BirecursiveT](qgraph: QSUGraph[T]): QSUGraph[T] =
+    qgraph rewrite {
+      case qgraph @ Unary(source, mf) =>
+        qgraph.overwriteAtRoot(QSU.Map(source.root, Free.roll(mf.map(_.point[FreeMapA[T, ?]]))))
+    }
 }

--- a/connector/src/main/scala/quasar/qscript/qsu/ExtractFreeMap.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ExtractFreeMap.scala
@@ -32,7 +32,7 @@ import scalaz.{Applicative, Functor, Monad, Scalaz}, Scalaz._
   * to be a function of one or more sibling arguments and creating an
   * autojoin if not.
   */
-final class ExtractFreeMap[T[_[_]]: BirecursiveT] extends QSUTTypes[T] {
+final class ExtractFreeMap[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T] {
   import QScriptUniform._
   import QSUGraph.Extractors
 
@@ -132,6 +132,10 @@ final class ExtractFreeMap[T[_[_]]: BirecursiveT] extends QSUTTypes[T] {
 }
 
 object ExtractFreeMap {
-  def apply[T[_[_]]: BirecursiveT]: ExtractFreeMap[T] =
-    new ExtractFreeMap[T]
+  def apply[
+      T[_[_]]: BirecursiveT,
+      F[_]: Monad: NameGenerator: PlannerErrorME]
+      (graph: QSUGraph[T])
+      : F[QSUGraph[T]] =
+    new ExtractFreeMap[T].apply[F](graph)
 }

--- a/connector/src/main/scala/quasar/qscript/qsu/ExtractFreeMap.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ExtractFreeMap.scala
@@ -137,5 +137,5 @@ object ExtractFreeMap {
       F[_]: Monad: NameGenerator: PlannerErrorME]
       (graph: QSUGraph[T])
       : F[QSUGraph[T]] =
-    new ExtractFreeMap[T].apply[F](graph)
+    taggedInternalError("ExtractFreeMap", new ExtractFreeMap[T].apply[F](graph))
 }

--- a/connector/src/main/scala/quasar/qscript/qsu/Graduate.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/Graduate.scala
@@ -32,6 +32,7 @@ import quasar.qscript.{
   LeftShift,
   Map,
   QCE,
+  QScriptEducated,
   Read,
   Reduce,
   ReduceFuncs,
@@ -44,6 +45,7 @@ import quasar.qscript.{
   Unreferenced}
 import quasar.qscript.qsu.{QScriptUniform => QSU}
 import quasar.qscript.qsu.QSUGraph.QSUPattern
+import quasar.qscript.qsu.ReifyIdentities.ResearchedQSU
 
 import matryoshka.{Corecursive, CorecursiveT, CoalgebraM, Recursive}
 import matryoshka.data.free._
@@ -51,8 +53,7 @@ import matryoshka.patterns.CoEnv
 import scalaz.{~>, -\/, \/-, Const, Inject, Monad, NaturalTransformation, ReaderT}
 import scalaz.Scalaz._
 
-final class Graduate[T[_[_]]: CorecursiveT] extends QSUTTypes[T] {
-  import ReifyIdentities.ResearchedQSU
+final class Graduate[T[_[_]]: CorecursiveT] private () extends QSUTTypes[T] {
 
   type QSE[A] = QScriptEducated[A]
 
@@ -253,6 +254,10 @@ final class Graduate[T[_[_]]: CorecursiveT] extends QSUTTypes[T] {
 }
 
 object Graduate {
-  def apply[T[_[_]]: CorecursiveT]: Graduate[T] =
-    new Graduate[T]
+  def apply[
+      T[_[_]]: CorecursiveT,
+      F[_]: Monad: PlannerErrorME: NameGenerator]
+      (rqsu: ResearchedQSU[T])
+      : F[T[QScriptEducated[T, ?]]] =
+    new Graduate[T].apply[F](rqsu)
 }

--- a/connector/src/main/scala/quasar/qscript/qsu/Graduate.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/Graduate.scala
@@ -259,5 +259,5 @@ object Graduate {
       F[_]: Monad: PlannerErrorME: NameGenerator]
       (rqsu: ResearchedQSU[T])
       : F[T[QScriptEducated[T, ?]]] =
-    new Graduate[T].apply[F](rqsu)
+    taggedInternalError("Graduate", new Graduate[T].apply[F](rqsu))
 }

--- a/connector/src/main/scala/quasar/qscript/qsu/LPtoQS.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/LPtoQS.scala
@@ -34,27 +34,27 @@ final class LPtoQS[T[_[_]]: BirecursiveT: EqualT: ShowT] extends QSUTTypes[T] {
       : F[T[QScriptEducated]] = {
 
     val lpToQs =
-      K(ReadLP[T].apply[F])            >=>
-      debugG("ReadLP: ")               >==>
-      RewriteGroupByArrays[T].apply[F] >=>
-      debugG("RewriteGBArrays: ")      >-
-      EliminateUnary[T].apply          >=>
-      debugG("EliminateUnary: ")       >-
-      RecognizeDistinct[T].apply       >=>
-      debugG("RecognizeDistinct: ")    >==>
-      ExtractFreeMap[T].apply[F]       >=>
-      debugG("ExtractFreeMap: ")       >==>
-      ApplyProvenance[T].apply[F]      >=>
-      debugAG("ApplyProv: ")           >==>
-      ReifyBuckets[T, F]               >=>
-      debugAG("ReifyBuckets: ")        >==>
-      MinimizeAutoJoins[T].apply[F]    >=>
-      debugAG("MinimizeAJ: ")          >==>
-      ReifyAutoJoins[T].apply[F]       >=>
-      debugAG("ReifyAutoJoins: ")      >-
-      (_.graph)                        >==>
-      ReifyIdentities[T].apply[F]      >==>
-      Graduate[T].apply[F]
+      K(ReadLP[T, F])               >=>
+      debugG("ReadLP: ")            >==>
+      RewriteGroupByArrays[T, F]    >=>
+      debugG("RewriteGBArrays: ")   >-
+      EliminateUnary[T]             >=>
+      debugG("EliminateUnary: ")    >-
+      RecognizeDistinct[T]          >=>
+      debugG("RecognizeDistinct: ") >==>
+      ExtractFreeMap[T, F]          >=>
+      debugG("ExtractFreeMap: ")    >==>
+      ApplyProvenance[T, F]         >=>
+      debugAG("ApplyProv: ")        >==>
+      ReifyBuckets[T, F]            >=>
+      debugAG("ReifyBuckets: ")     >==>
+      MinimizeAutoJoins[T, F]       >=>
+      debugAG("MinimizeAJ: ")       >==>
+      ReifyAutoJoins[T, F]          >=>
+      debugAG("ReifyAutoJoins: ")   >-
+      (_.graph)                     >==>
+      ReifyIdentities[T, F]         >==>
+      Graduate[T, F]
 
     lpToQs(lp)
   }

--- a/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
@@ -326,5 +326,5 @@ object MinimizeAutoJoins {
       F[_]: Monad: NameGenerator: PlannerErrorME]
       (agraph: AuthenticatedQSU[T])
       : F[AuthenticatedQSU[T]] =
-    new MinimizeAutoJoins[T].apply[F](agraph)
+    taggedInternalError("MinimizeAutoJoins", new MinimizeAutoJoins[T].apply[F](agraph))
 }

--- a/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
@@ -16,6 +16,7 @@
 
 package quasar.qscript.qsu
 
+import slamdata.Predef.{Map => SMap, _}
 import quasar.{NameGenerator, Planner}, Planner.PlannerErrorME
 import quasar.contrib.matryoshka._
 import quasar.contrib.scalaz.MonadState_
@@ -36,22 +37,19 @@ import quasar.qscript.{
   SrcHole
 }
 import quasar.qscript.qsu.{QScriptUniform => QSU}
-import slamdata.Predef.{Map => SMap, _}
+import quasar.qscript.qsu.ApplyProvenance.AuthenticatedQSU
 
 import matryoshka.{delayEqual, BirecursiveT, EqualT}
 import matryoshka.data.free._
 import scalaz.{Equal, Free, Monad, Scalaz, StateT}, Scalaz._   // sigh, monad/traverse conflict
 
 final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends QSUTTypes[T] {
-  import ApplyProvenance.AuthenticatedQSU
   import QSUGraph.Extractors._
 
   private val func = construction.Func[T]
   private val srcHole: Hole = SrcHole   // wtb smart constructor
 
   private val J = Fixed[T[EJson]]
-
-  private val AP = ApplyProvenance[T]
   private val QP = QProv[T]
 
   // needed to avoid bug in implicit search!  don't import QP.prov._
@@ -311,7 +309,7 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends 
       qgraph <- QSUGraph.withName[T, G](pat)
 
       state <- MonadState_[G, MinimizationState].get
-      computed <- AP.computeProvenanceƒ[G].apply(
+      computed <- ApplyProvenance.computeProvenanceƒ[T, G].apply(
         QSUGraph.QSUPattern(qgraph.root, pat.map(s => (s, state.dims(s)))))
 
       dims2 = state.dims + (qgraph.root -> computed._2)
@@ -323,6 +321,10 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends 
 }
 
 object MinimizeAutoJoins {
-  def apply[T[_[_]]: BirecursiveT: EqualT]: MinimizeAutoJoins[T] =
-    new MinimizeAutoJoins[T]
+  def apply[
+      T[_[_]]: BirecursiveT: EqualT,
+      F[_]: Monad: NameGenerator: PlannerErrorME]
+      (agraph: AuthenticatedQSU[T])
+      : F[AuthenticatedQSU[T]] =
+    new MinimizeAutoJoins[T].apply[F](agraph)
 }

--- a/connector/src/main/scala/quasar/qscript/qsu/ReadLP.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ReadLP.scala
@@ -282,5 +282,10 @@ final class ReadLP[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T] {
 }
 
 object ReadLP {
-  def apply[T[_[_]]: BirecursiveT]: ReadLP[T] = new ReadLP[T]
+  def apply[
+      T[_[_]]: BirecursiveT,
+      F[_]: Monad: PlannerErrorME: NameGenerator]
+      (plan: T[lp.LogicalPlan])
+      : F[QSUGraph[T]] =
+    new ReadLP[T].apply[F](plan)
 }

--- a/connector/src/main/scala/quasar/qscript/qsu/ReadLP.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ReadLP.scala
@@ -287,5 +287,5 @@ object ReadLP {
       F[_]: Monad: PlannerErrorME: NameGenerator]
       (plan: T[lp.LogicalPlan])
       : F[QSUGraph[T]] =
-    new ReadLP[T].apply[F](plan)
+    taggedInternalError("ReadLP", new ReadLP[T].apply[F](plan))
 }

--- a/connector/src/main/scala/quasar/qscript/qsu/RecognizeDistinct.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/RecognizeDistinct.scala
@@ -23,18 +23,15 @@ import quasar.qscript.qsu.{QScriptUniform => QSU}
 import matryoshka.BirecursiveT
 import scalaz.syntax.equal._
 
-final class RecognizeDistinct[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T] {
+object RecognizeDistinct {
   import QSUGraph.Extractors._
 
   // pattern from compileDistinct in compiler.scala
   // TODO this is dumb; we shouldn't be replicating patterns like this
-  def apply(qgraph: QSUGraph): QSUGraph = qgraph rewrite {
-    case qgraph @ LPReduce(GroupBy(orig1, orig2), ReduceFuncs.Arbitrary(()))
-        if orig1.root === orig2.root =>
-      qgraph.overwriteAtRoot(QSU.Distinct(orig1.root))
-  }
-}
-
-object RecognizeDistinct {
-  def apply[T[_[_]]: BirecursiveT]: RecognizeDistinct[T] = new RecognizeDistinct[T]
+  def apply[T[_[_]]: BirecursiveT](qgraph: QSUGraph[T]): QSUGraph[T] =
+    qgraph rewrite {
+      case qgraph @ LPReduce(GroupBy(orig1, orig2), ReduceFuncs.Arbitrary(()))
+          if orig1.root === orig2.root =>
+        qgraph.overwriteAtRoot(QSU.Distinct(orig1.root))
+    }
 }

--- a/connector/src/main/scala/quasar/qscript/qsu/ReifyAutoJoins.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ReifyAutoJoins.scala
@@ -32,14 +32,14 @@ import quasar.qscript.{
   RightSideF}
 import quasar.qscript.provenance.Dimensions
 import quasar.qscript.MapFuncsCore.StrLit
+import quasar.qscript.qsu.ApplyProvenance.AuthenticatedQSU
 
 import matryoshka._
 import matryoshka.data.free._
 import scalaz.{Monad, WriterT}
 import scalaz.Scalaz._
 
-final class ReifyAutoJoins[T[_[_]]: BirecursiveT: EqualT] extends QSUTTypes[T] {
-  import ApplyProvenance.AuthenticatedQSU
+final class ReifyAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends QSUTTypes[T] {
   import QSUGraph.Extractors._
 
   def apply[F[_]: Monad: NameGenerator](qsu: AuthenticatedQSU[T])
@@ -122,6 +122,10 @@ final class ReifyAutoJoins[T[_[_]]: BirecursiveT: EqualT] extends QSUTTypes[T] {
 }
 
 object ReifyAutoJoins {
-  def apply[T[_[_]]: BirecursiveT: EqualT]: ReifyAutoJoins[T] =
-    new ReifyAutoJoins[T]
+  def apply[
+      T[_[_]]: BirecursiveT: EqualT,
+      F[_]: Monad: NameGenerator]
+      (qsu: AuthenticatedQSU[T])
+      : F[AuthenticatedQSU[T]] =
+    new ReifyAutoJoins[T].apply[F](qsu)
 }

--- a/connector/src/main/scala/quasar/qscript/qsu/ReifyBuckets.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ReifyBuckets.scala
@@ -39,7 +39,7 @@ object ReifyBuckets {
   def apply[T[_[_]]: BirecursiveT: EqualT, F[_]: Monad: PlannerErrorME](aqsu: AuthenticatedQSU[T])
       : F[AuthenticatedQSU[T]] = {
 
-    val prov = new QProv[T]
+    val prov = QProv[T]
     val qsu  = QScriptUniform.Optics[T]
     val LF   = Traverse[List].compose[FreeMapA[T, ?]]
     val LFA  = LF.compose[Access]
@@ -57,7 +57,7 @@ object ReifyBuckets {
 
             region getOrElseF {
               PlannerErrorME[F].raiseError(InternalError(
-                s"ReifyBuckets: Expected to find a mappable region in ${source.root} based on one of ${syms}.",
+                s"[ReifyBuckets] Expected to find a mappable region in ${source.root} based on one of ${syms}.",
                 None))
             }
           }

--- a/connector/src/main/scala/quasar/qscript/qsu/ReifyIdentities.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ReifyIdentities.scala
@@ -43,7 +43,7 @@ import monocle.Lens
 import scalaz.{Foldable, Free, Functor, IMap, ISet, Monad, NonEmptyList, StateT, Traverse}
 import scalaz.Scalaz._
 
-final class ReifyIdentities[T[_[_]]: BirecursiveT] extends QSUTTypes[T] {
+final class ReifyIdentities[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T] {
   import ReifyIdentities.ResearchedQSU
 
   def apply[F[_]: Monad: NameGenerator](graph: QSUGraph): F[ResearchedQSU[T]] =
@@ -443,6 +443,8 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT] extends QSUTTypes[T] {
 object ReifyIdentities {
   final case class ResearchedQSU[T[_[_]]](refs: References[T], graph: QSUGraph[T])
 
-  def apply[T[_[_]]: BirecursiveT]: ReifyIdentities[T] =
-    new ReifyIdentities[T]
+  def apply[T[_[_]]: BirecursiveT, F[_]: Monad: NameGenerator]
+      (graph: QSUGraph[T])
+      : F[ResearchedQSU[T]] =
+    new ReifyIdentities[T].apply[F](graph)
 }

--- a/connector/src/main/scala/quasar/qscript/qsu/RewriteGroupByArrays.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/RewriteGroupByArrays.scala
@@ -66,5 +66,10 @@ final class RewriteGroupByArrays[T[_[_]]: BirecursiveT: ShowT] private () extend
 }
 
 object RewriteGroupByArrays {
-  def apply[T[_[_]]: BirecursiveT: ShowT]: RewriteGroupByArrays[T] = new RewriteGroupByArrays[T]
+  def apply[
+      T[_[_]]: BirecursiveT: ShowT,
+      F[_]: Monad: NameGenerator](
+      qgraph: QSUGraph[T])
+      : F[QSUGraph[T]] =
+    new RewriteGroupByArrays[T].apply[F](qgraph)
 }

--- a/connector/src/main/scala/quasar/qscript/qsu/package.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/package.scala
@@ -17,6 +17,7 @@
 package quasar.qscript
 
 import slamdata.Predef.{Map => SMap, _}
+import quasar.Planner.{InternalError, PlannerErrorME}
 import quasar.fp._
 import quasar.qscript.provenance.Dimensions
 
@@ -47,4 +48,10 @@ package object qsu {
         "\n]"
       }
   }
+
+  def taggedInternalError[F[_]: PlannerErrorME, A](tag: String, fa: F[A]): F[A] =
+    PlannerErrorME[F].handleError(fa)(e => PlannerErrorME[F].raiseError(e match {
+      case InternalError(msg, cause) => InternalError(s"[$tag] $msg", cause)
+      case other => other
+    }))
 }

--- a/connector/src/test/scala/quasar/qscript/qsu/ApplyProvenanceSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/ApplyProvenanceSpec.scala
@@ -53,7 +53,7 @@ object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
   val qsu = QScriptUniform.AnnotatedDsl[Fix, Symbol]
   val func = construction.Func[Fix]
 
-  val app = ApplyProvenance[Fix]
+  val app = ApplyProvenance[Fix, F] _
   val qprov = QProv[Fix]
 
   val root = Path.rootDir[Sandboxed]
@@ -123,7 +123,7 @@ object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
             (renames(k), newP)
           }
 
-        val actual: PlannerError \/ AuthenticatedQSU[Fix] = app[F](inputGraph)
+        val actual: PlannerError \/ AuthenticatedQSU[Fix] = app(inputGraph)
 
         actual.bimap[MatchResult[S], MatchResult[S]](
         { err =>

--- a/connector/src/test/scala/quasar/qscript/qsu/EliminateUnarySpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/EliminateUnarySpec.scala
@@ -36,7 +36,7 @@ object EliminateUnarySpec extends Qspec with QSUTTypes[Fix] {
   import QSUGraph.Extractors._
 
   val qsu = QScriptUniform.DslT[Fix]
-  val elim = EliminateUnary[Fix]
+  val elim = EliminateUnary[Fix] _
 
   val IC = Inject[MapFuncCore, MapFunc]
 

--- a/connector/src/test/scala/quasar/qscript/qsu/GraduateSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/GraduateSpec.scala
@@ -57,8 +57,8 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
   type QSU[A] = QScriptUniform[A]
   type QSE[A] = QScriptEducated[A]
 
-  val researched = ReifyIdentities[Fix]
-  val grad = Graduate[Fix]
+  val researched = ReifyIdentities[Fix, F] _
+  val grad = Graduate[Fix, F] _
 
   val qsu = QScriptUniform.DslT[Fix]
 
@@ -216,7 +216,7 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
     new Matcher[Fix[QSU]] {
       def apply[S <: Fix[QSU]](s: Expectable[S]): MatchResult[S] = {
         val actual: PlannerError \/ Fix[QSE] =
-          evaluate(researched[F](QSUGraph.fromTree[Fix](s.value)) >>= grad[F])
+          evaluate(researched(QSUGraph.fromTree[Fix](s.value)) >>= grad)
 
         actual.bimap[MatchResult[S], MatchResult[S]](
         { err =>
@@ -237,7 +237,7 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
     new Matcher[Fix[QSU]] {
       def apply[S <: Fix[QSU]](s: Expectable[S]): MatchResult[S] = {
         val actual: PlannerError \/ Fix[QSE] =
-          evaluate(researched[F](QSUGraph.fromTree[Fix](s.value)) >>= grad[F])
+          evaluate(researched(QSUGraph.fromTree[Fix](s.value)) >>= grad)
 
         // TODO better equality checking for PlannerError
         actual.bimap[MatchResult[S], MatchResult[S]](

--- a/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
@@ -51,7 +51,6 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
 
   val qsu = QScriptUniform.DslT[Fix]
   val func = construction.Func[Fix]
-  val maj = MinimizeAutoJoins[Fix]
   val qprov = QProv[Fix]
 
   val J = Fixed[Fix[EJson]]
@@ -418,9 +417,9 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
 
   def runOn_(qgraph: QSUGraph): AuthenticatedQSU[Fix] = {
     val resultsF = for {
-      agraph0 <- ApplyProvenance[Fix].apply[F](qgraph)
+      agraph0 <- ApplyProvenance[Fix, F](qgraph)
       agraph <- ReifyBuckets[Fix, F](agraph0)
-      back <- maj[F](agraph)
+      back <- MinimizeAutoJoins[Fix, F](agraph)
     } yield back
 
     val results = resultsF.run.eval(0L).value.toEither

--- a/connector/src/test/scala/quasar/qscript/qsu/ReadLPSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/ReadLPSpec.scala
@@ -60,7 +60,7 @@ object ReadLPSpec extends Qspec with CompilerHelpers with DataArbitrary with QSU
 
   type F[A] = EitherT[StateT[Need, Long, ?], PlannerError, A]
 
-  val reader = ReadLP[Fix]
+  val reader = ReadLP[Fix, F] _
   val root = Path.rootDir[Sandboxed]
 
   val IC = Inject[MapFuncCore, MapFunc]
@@ -283,7 +283,7 @@ object ReadLPSpec extends Qspec with CompilerHelpers with DataArbitrary with QSU
     }
 
     "compress redundant first- and second-order nodes" in {
-      val qgraphM = reader[F](lpf.invoke2(SetLib.Filter, read("foo"), read("foo")))
+      val qgraphM = reader(lpf.invoke2(SetLib.Filter, read("foo"), read("foo")))
       val result = evaluate(qgraphM).toOption
 
       result must beSome
@@ -395,7 +395,7 @@ object ReadLPSpec extends Qspec with CompilerHelpers with DataArbitrary with QSU
   def readQsuAs(pf: PartialFunction[QSUGraph, MatchResult[_]]): Matcher[Fix[LogicalPlan]] = {
     new Matcher[Fix[LogicalPlan]] {
       def apply[S <: Fix[LogicalPlan]](s: Expectable[S]): MatchResult[S] = {
-        val resulted = evaluate(reader[F](s.value)) leftMap { err =>
+        val resulted = evaluate(reader(s.value)) leftMap { err =>
           failure(s"reading produced planner error: ${err.shows}", s)
         }
 

--- a/connector/src/test/scala/quasar/qscript/qsu/ReifyBucketsSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/ReifyBucketsSpec.scala
@@ -38,7 +38,7 @@ object ReifyBucketsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
   val func = construction.Func[Fix]
 
   def reifyBuckets(qsu: Fix[QScriptUniform]): PlannerError \/ QSUGraph =
-    ApplyProvenance[Fix].apply[PlannerError \/ ?](QSUGraph.fromTree(qsu))
+    ApplyProvenance[Fix, PlannerError \/ ?](QSUGraph.fromTree(qsu))
       .flatMap(ReifyBuckets[Fix, PlannerError \/ ?])
       .map(_.graph)
 

--- a/connector/src/test/scala/quasar/qscript/qsu/RewriteGroupByArraysSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/RewriteGroupByArraysSpec.scala
@@ -30,7 +30,7 @@ object RewriteGroupByArraysSpec extends Qspec with QSUTTypes[Fix] {
   type F[A] = StateT[Need, Long, A]
 
   val qsu = QScriptUniform.DslT[Fix]
-  val rw = RewriteGroupByArrays[Fix]
+  val rw = RewriteGroupByArrays[Fix, F] _
 
   val afile = Path.rootDir[Sandboxed] </> Path.file("afile")
   val afile2 = Path.rootDir[Sandboxed] </> Path.file("afile2")
@@ -46,7 +46,7 @@ object RewriteGroupByArraysSpec extends Qspec with QSUTTypes[Fix] {
             qsu.cstr("foo"),
             _(MapFuncsCore.ProjectKey(_, _))))))
 
-      eval(rw[F](qgraph)) must beLike {
+      eval(rw(qgraph)) must beLike {
         case GroupBy(
           Unreferenced(),
           AutoJoin2C(
@@ -75,7 +75,7 @@ object RewriteGroupByArraysSpec extends Qspec with QSUTTypes[Fix] {
               MFC(MapFuncsCore.MakeArray[Fix, Hole](SrcHole))),
             _(MapFuncsCore.ConcatArrays(_, _))))))
 
-      eval(rw[F](qgraph)) must beLike {
+      eval(rw(qgraph)) must beLike {
         case GroupBy(
           GroupBy(
             Read(`afile`),
@@ -122,7 +122,7 @@ object RewriteGroupByArraysSpec extends Qspec with QSUTTypes[Fix] {
               MFC(MapFuncsCore.MakeArray[Fix, Hole](SrcHole))),
             _(MapFuncsCore.ConcatArrays(_, _))))))
 
-      eval(rw[F](qgraph)) must beLike {
+      eval(rw(qgraph)) must beLike {
         case GroupBy(
           GroupBy(    // s2
             GroupBy(   // s1


### PR DESCRIPTION
Some minor refactoring to avoid publicly exposing the implementation classes for QSU rewrites as well as tagging any internal errors they produce with the name of the rewrite to make them easier to identify.