### PR TITLE
track plans that are erroring

### DIFF
--- a/mongodb/src/test/resources/planner/plan_unaggregated_field_when_grouping,_second_case.txt
+++ b/mongodb/src/test/resources/planner/plan_unaggregated_field_when_grouping,_second_case.txt
@@ -2,76 +2,125 @@ Chain
 ├─ $FoldLeftF
 │  ├─ Chain
 │  │  ├─ $ReadF(db; zips)
+│  │  ├─ $ProjectF
+│  │  │  ├─ Name("city" -> {
+│  │  │  │       "$cond": [
+│  │  │  │         {
+│  │  │  │           "$and": [
+│  │  │  │             { "$lte": [{ "$literal": {  } }, "$$ROOT"] },
+│  │  │  │             { "$lt": ["$$ROOT", { "$literal": [] }] }]
+│  │  │  │         },
+│  │  │  │         "$city",
+│  │  │  │         { "$literal": undefined }]
+│  │  │  │     })
+│  │  │  ├─ Name("state" -> {
+│  │  │  │       "$cond": [
+│  │  │  │         {
+│  │  │  │           "$and": [
+│  │  │  │             { "$lte": [{ "$literal": {  } }, "$$ROOT"] },
+│  │  │  │             { "$lt": ["$$ROOT", { "$literal": [] }] }]
+│  │  │  │         },
+│  │  │  │         "$state",
+│  │  │  │         { "$literal": undefined }]
+│  │  │  │     })
+│  │  │  ╰─ ExcludeId
 │  │  ├─ $GroupF
 │  │  │  ├─ Grouped
-│  │  │  │  ╰─ Name("0" -> {
-│  │  │  │          "$push": {
-│  │  │  │            "$let": {
-│  │  │  │              "vars": {
-│  │  │  │                "a": [
-│  │  │  │                  {
-│  │  │  │                    "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("0") }]
-│  │  │  │                  },
-│  │  │  │                  {
-│  │  │  │                    "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }]
-│  │  │  │                  }]
-│  │  │  │              },
-│  │  │  │              "in": "$$a"
-│  │  │  │            }
-│  │  │  │          }
-│  │  │  │        })
+│  │  │  │  ╰─ Name("0" -> { "$push": "$$ROOT" })
 │  │  │  ╰─ By({ "$literal": null })
 │  │  ╰─ $ProjectF
 │  │     ├─ Name("_id" -> "$_id")
 │  │     ├─ Name("value")
-│  │     │  ├─ Name("right" -> "$0")
-│  │     │  ├─ Name("left" -> { "$literal": [] })
+│  │     │  ├─ Name("left" -> "$0")
+│  │     │  ├─ Name("right" -> { "$literal": [] })
 │  │     │  ╰─ Name("_id" -> "$_id")
 │  │     ╰─ IncludeId
 │  ╰─ Chain
 │     ├─ $ReadF(db; zips)
-│     ├─ $ProjectF
-│     │  ├─ Name("0" -> [
-│     │  │       { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("0") }] },
-│     │  │       { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] }])
-│     │  ╰─ ExcludeId
-│     ├─ $SimpleMapF
-│     │  ├─ Map
-│     │  │  ╰─ Obj
-│     │  │     ╰─ Key(f0: ((isNumber(
-│     │  │            (isObject(_["0"][1]) && (! Array.isArray(_["0"][1]))) ? _["0"][1].pop : undefined) || ((((isObject(_["0"][1]) && (! Array.isArray(_["0"][1]))) ? _["0"][1].pop : undefined) instanceof NumberInt) || (((isObject(_["0"][1]) && (! Array.isArray(_["0"][1]))) ? _["0"][1].pop : undefined) instanceof NumberLong))) && (isObject(_["0"][1]) && (! Array.isArray(_["0"][1])))) ? _["0"][1].pop : undefined)
-│     │  ╰─ Scope(Map())
 │     ├─ $GroupF
 │     │  ├─ Grouped
-│     │  │  ╰─ Name("f0" -> { "$max": "$f0" })
+│     │  │  ╰─ Name("f0" -> {
+│     │  │          "$sum": {
+│     │  │            "$cond": [
+│     │  │              {
+│     │  │                "$and": [
+│     │  │                  {
+│     │  │                    "$lt": [
+│     │  │                      { "$literal": null },
+│     │  │                      {
+│     │  │                        "$cond": [
+│     │  │                          {
+│     │  │                            "$and": [
+│     │  │                              { "$lte": [{ "$literal": {  } }, "$$ROOT"] },
+│     │  │                              { "$lt": ["$$ROOT", { "$literal": [] }] }]
+│     │  │                          },
+│     │  │                          "$pop",
+│     │  │                          { "$literal": undefined }]
+│     │  │                      }]
+│     │  │                  },
+│     │  │                  {
+│     │  │                    "$lt": [
+│     │  │                      {
+│     │  │                        "$cond": [
+│     │  │                          {
+│     │  │                            "$and": [
+│     │  │                              { "$lte": [{ "$literal": {  } }, "$$ROOT"] },
+│     │  │                              { "$lt": ["$$ROOT", { "$literal": [] }] }]
+│     │  │                          },
+│     │  │                          "$pop",
+│     │  │                          { "$literal": undefined }]
+│     │  │                      },
+│     │  │                      { "$literal": "" }]
+│     │  │                  }]
+│     │  │              },
+│     │  │              {
+│     │  │                "$cond": [
+│     │  │                  {
+│     │  │                    "$and": [
+│     │  │                      { "$lte": [{ "$literal": {  } }, "$$ROOT"] },
+│     │  │                      { "$lt": ["$$ROOT", { "$literal": [] }] }]
+│     │  │                  },
+│     │  │                  "$pop",
+│     │  │                  { "$literal": undefined }]
+│     │  │              },
+│     │  │              { "$literal": undefined }]
+│     │  │          }
+│     │  │        })
 │     │  ╰─ By({ "$literal": null })
-│     ├─ $MapF
-│     │  ├─ JavaScript(function (key, value) { return [null, { "right": [], "left": [value.f0] }] })
-│     │  ╰─ Scope(Map())
+│     ├─ $ProjectF
+│     │  ├─ Name("2" -> "$f0")
+│     │  ╰─ ExcludeId
+│     ├─ $GroupF
+│     │  ├─ Grouped
+│     │  │  ╰─ Name("0" -> { "$push": "$$ROOT" })
+│     │  ╰─ By({ "$literal": null })
+│     ├─ $ProjectF
+│     │  ├─ Name("right" -> "$0")
+│     │  ├─ Name("left" -> { "$literal": [] })
+│     │  ├─ Name("_id" -> true)
+│     │  ╰─ IncludeId
 │     ╰─ $ReduceF
 │        ├─ JavaScript(function (key, values) {
-│        │               var result = { "right": [], "left": [] };
+│        │               var result = { "left": [], "right": [] };
 │        │               values.forEach(
 │        │                 function (value) {
-│        │                   result.right = result.right.concat(value.right);
-│        │                   result.left = result.left.concat(value.left)
+│        │                   result.left = result.left.concat(value.left);
+│        │                   result.right = result.right.concat(value.right)
 │        │                 });
 │        │               return result
 │        │             })
 │        ╰─ Scope(Map())
 ├─ $MatchF
 │  ╰─ Doc
-│     ├─ NotExpr($right -> Size(0))
-│     ╰─ NotExpr($left -> Size(0))
-├─ $UnwindF(DocField(BsonField.Name("left")))
+│     ├─ NotExpr($left -> Size(0))
+│     ╰─ NotExpr($right -> Size(0))
 ├─ $UnwindF(DocField(BsonField.Name("right")))
-├─ $SimpleMapF
-│  ├─ Map
-│  │  ╰─ Obj
-│  │     ├─ Key(0: _.left / 1000)
-│  │     ╰─ Key(pop: (isObject(_.right[1]) && (! Array.isArray(_.right[1]))) ? _.right[1].pop : undefined)
-│  ╰─ Scope(Map())
-╰─ $ProjectF
-   ├─ Name("0" -> true)
-   ├─ Name("pop" -> true)
-   ╰─ ExcludeId
+├─ $UnwindF(DocField(BsonField.Name("left")))
+╰─ $SimpleMapF
+   ├─ Map
+   │  ╰─ Obj
+   │     ╰─ Key(__quasar_mongodb_sigil)
+   │        ╰─ SpliceObjects
+   │           ├─ JsCore(_.left)
+   │           ╰─ JsCore(_.right)
+   ╰─ Scope(Map())

--- a/mongodb/src/test/resources/planner/plan_unify_flattened_fields.txt
+++ b/mongodb/src/test/resources/planner/plan_unify_flattened_fields.txt
@@ -1,0 +1,92 @@
+Chain
+├─ $ReadF(db; zips)
+├─ $ProjectF
+│  ├─ Name("identities" -> {
+│  │       "qsu1": { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("0") }] }
+│  │     })
+│  ├─ Name("value" -> { "$arrayElemAt": [["$_id", "$$ROOT"], { "$literal": NumberInt("1") }] })
+│  ╰─ ExcludeId
+├─ $ProjectF
+│  ├─ Name("s" -> "$$ROOT")
+│  ├─ Name("f" -> {
+│  │       "$cond": [
+│  │         {
+│  │           "$and": [
+│  │             {
+│  │               "$lte": [
+│  │                 { "$literal": [] },
+│  │                 {
+│  │                   "$cond": [
+│  │                     {
+│  │                       "$and": [
+│  │                         { "$lte": [{ "$literal": {  } }, "$value"] },
+│  │                         { "$lt": ["$value", { "$literal": [] }] }]
+│  │                     },
+│  │                     "$value.loc",
+│  │                     { "$literal": undefined }]
+│  │                 }]
+│  │             },
+│  │             {
+│  │               "$lt": [
+│  │                 {
+│  │                   "$cond": [
+│  │                     {
+│  │                       "$and": [
+│  │                         { "$lte": [{ "$literal": {  } }, "$value"] },
+│  │                         { "$lt": ["$value", { "$literal": [] }] }]
+│  │                     },
+│  │                     "$value.loc",
+│  │                     { "$literal": undefined }]
+│  │                 },
+│  │                 { "$literal": BinData(0, "") }]
+│  │             }]
+│  │         },
+│  │         {
+│  │           "$cond": [
+│  │             {
+│  │               "$and": [
+│  │                 { "$lte": [{ "$literal": {  } }, "$value"] },
+│  │                 { "$lt": ["$value", { "$literal": [] }] }]
+│  │             },
+│  │             "$value.loc",
+│  │             { "$literal": undefined }]
+│  │         },
+│  │         { "$literal": undefined }]
+│  │     })
+│  ╰─ ExcludeId
+├─ $SimpleMapF
+│  ├─ Flatten
+│  │  ╰─ JsCore(_.f)
+│  ├─ Map
+│  │  ╰─ Obj
+│  │     ├─ Key(identities)
+│  │     │  ╰─ SpliceObjects
+│  │     │     ├─ JsCore(_.s.identities)
+│  │     │     ╰─ JsCore(_.s.identities)
+│  │     ╰─ Key(value)
+│  │        ╰─ Obj
+│  │           ├─ Key(filter_source: (isObject(_.s.value) && (! Array.isArray(_.s.value))) ? _.s.value : undefined)
+│  │           ╰─ Key(filter_predicate: _.f < 0)
+│  ╰─ Scope(Map())
+├─ $MatchF
+│  ╰─ Doc
+│     ╰─ Expr($value.filter_predicate -> Eq(Bool(true)))
+├─ $ProjectF
+│  ├─ Name("0" -> {
+│  │       "$cond": [
+│  │         {
+│  │           "$and": [
+│  │             { "$lte": [{ "$literal": [] }, "$value.filter_source.loc"] },
+│  │             { "$lt": ["$value.filter_source.loc", { "$literal": BinData(0, "") }] }]
+│  │         },
+│  │         "$value.filter_source.loc",
+│  │         { "$literal": undefined }]
+│  │     })
+│  ╰─ ExcludeId
+├─ $SimpleMapF
+│  ├─ Flatten
+│  │  ╰─ JsCore(_["0"])
+│  ╰─ Scope(Map())
+╰─ $ProjectF
+   ├─ Name("__quasar_mongodb_sigil" -> "$0")
+   ╰─ ExcludeId


### PR DESCRIPTION
Went through the `pendingUntilFixed` tests and tests that were commented out in `PlannerSpec`. Some tests now don't error anymore and are now using `trackPending`. The ones that still error are tracked now by `trackPending(Err|Throw)`.