### PR TITLE
Tests Diff (aka Reversed Batman)

### DIFF
--- a/ejson/src/main/scala/quasar/contrib/argonaut/package.scala
+++ b/ejson/src/main/scala/quasar/contrib/argonaut/package.scala
@@ -17,6 +17,7 @@
 package quasar.contrib
 
 import quasar.ejson
+import quasar.RenderTree
 
 import scala.collection.immutable.ListMap
 
@@ -56,4 +57,6 @@ package object argonaut {
           case OJ(ejson.Obj(o))  => jObject(JsonObject.fromTraversableOnce(o))
         }
     }
+
+  implicit def jsonRenderTree: RenderTree[Json] = RenderTree.recursive[Json, ejson.Json]
 }


### PR DESCRIPTION
I call this PR "Reversed Batman" because it is PR that we both deserve and need

With this change we get nice diff of RenderedTrees between expected
and actual.

Previously, if test was failing you got this:

```
[error] x olympic_search_step1 [./demo/olympic_search_step1.test] (10 seconds, 86 ms)
[error]  ; {"city":"Turin","event":"15km mass start","year":2006,"country":"NOR","sport":"Biathlon","discipline":"Biathlon","type":"Bronze","gender":"M"} does not match {"city":"Turin","event":"15km mass start2","year":2006,"country":"NOR","sport":"Biathlon","discipline":"Biathlon","type":"Bronze","gender":"M"} (file:1)
```

and now you get this

```
[error] x olympic_search_step1 [./demo/olympic_search_step1.test] (11 seconds, 937 ms)
[error]  ; Actual result does not match expected value. 
[error]  
[error]   Diff: 
[error]   Obj
[error]  ╰─ Map
[error]     ├─ Key("discipline")
[error]     │  ├─ >>> Str("Biathlon")
[error]     │  ╰─ <<< Str("Biathlofsd;lfdn")
[error]     ├─ Key("city")
[error]     │  ╰─ Str("Turin")
[error]     ├─ Key("gender")
[error]     │  ╰─ Str("M")
[error]     ├─ Key("country")
[error]     │  ╰─ Str("NOR")
[error]     ├─ Key("year")
[error]     │  ╰─ Dec(2006)
[error]     ├─ Key("sport")
[error]     │  ╰─ Str("Biathlon")
[error]     ├─ Key("type")
[error]     │  ╰─ Str("Bronze")
[error]     ╰─ Key("event")
[error]        ╰─ Str("10km")  (file:1)
```