### PR TITLE
Reimplemented Filter => Cond rewrite to apply more conservatively

### DIFF
--- a/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
@@ -97,7 +97,7 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends 
 
       fms = branches.zipWithIndex map {
         case (g, i) =>
-          expandSecondOrder(MappableRegion[T](state.failed, g)).map(g => (g, i))
+          MappableRegion[T](state.failed, g).map(g => (g, i))
       }
 
       (remap, candidates) = minimizeSources(fms.flatMap(_.toList))
@@ -110,23 +110,26 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends 
 
   // attempt to extend by seeing through constructs like filter (mostly just filter)
   @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
-  private def expandSecondOrder(fm: FreeMapA[QSUGraph]): FreeMapA[QSUGraph] = {
-    fm
+  private def expandSecondOrder(fm: FreeMapA[Int], candidates: List[QSUGraph]): Option[(FreeMapA[Int], List[QSUGraph])] = {
+    val (fm2, candidates2, changed) = candidates.zipWithIndex.foldRight((fm, List[QSUGraph](), false)) {
+      case ((QSFilter(source, predicate), i), (fm, candidates, _)) =>
+        val fm2 = fm flatMap { i2 =>
+          if (i2 === i)
+            func.Cond(predicate.map(κ(i)), i.point[FreeMapA], func.Undefined[Int])
+          else
+            i2.point[FreeMapA]
+        }
 
-    // TODO the use of this function is incorrect right now
-    // it will be employed even when joins are avoidable in
-    // other ways (e.g. by eliminating Unreferenced())
+        (fm2, source :: candidates, true)
 
-    /*fm flatMap {
-      case QSFilter(source, predicate) =>
-        // tune into 102.5 FM, The Source
-        val sourceFM = expandSecondOrder(MappableRegion.maximal(source))
-        func.Cond(predicate.flatMap(κ(sourceFM)), sourceFM, func.Undefined[QSUGraph])
+      case ((node, _), (fm, candidates, changed)) =>
+        (fm, node :: candidates, changed)
+    }
 
-      // TODO should we handle LPFilter here just for completion sake?
-
-      case g => Free.pure(g)
-    }*/
+    if (changed)
+      Some((fm2, candidates2))
+    else
+      None
   }
 
   // attempts to reduce the set of candidates to a single Map node, given a FreeMap[Int]
@@ -150,122 +153,129 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends 
       qgraph.overwriteAtRoot(QSU.Map[T, Symbol](single.root, fm.map(κ(srcHole)))).point[G]
 
     case candidates =>
-      val reducerAttempt = candidates collect {
-        case g @ QSReduce(source, buckets, reducers, repair) =>
-          (source, buckets, reducers, repair)
-      }
+      expandSecondOrder(fm, candidates) match {
+        case Some((fm, candidates)) =>
+          // we need to re-expand and re-minimize, and we might end up doing additional second-order expansions
+          coalesceToMap[G](qgraph, candidates, fm)
 
-      // candidates.forall(_ ~= QSReduce)
-      if (reducerAttempt.lengthCompare(candidates.length) === 0) {
-        for {
-          // apply coalescence recursively to our sources
-          extended <- reducerAttempt traverse {
-            case desc @ (source, buckets, reducers, repair) =>
-              // TODO this is a weird use of the function, but it should work
-              // we're just trying to run ourselves recursively to extend the sources
-              // this isn't likely to be a common case
-              coalesceToMap[G](source, List(source), Free.pure(0)) map {
-                // coalesceToMap is always going to return... a Map, but
-                // what we care about is the source and the fm, not the
-                // node itself.  so we pull it apart (this is what's weird, btw)
-                //
-                // TODO short circuit this a bit if fm === Free.pure(Hole)
-                // I'm pretty sure the fallthrough case will never be hit
-                case Map(source2, fm) =>
-                  def rewriteBucket(bucket: Access[Hole]): FreeMapA[Access[Hole]] = bucket match {
-                    case v @ Access.Value(_) => fm.map(κ(v))
-                    case other => Free.pure[MapFunc, Access[Hole]](other)
-                  }
-
-                  (
-                    source2,
-                    buckets.map(_.flatMap(rewriteBucket)),
-                    reducers.map(_.map(_.flatMap(κ(fm)))),
-                    repair)
-
-                case _ => desc
-              }
+        case None =>
+          val reducerAttempt = candidates collect {
+            case g @ QSReduce(source, buckets, reducers, repair) =>
+              (source, buckets, reducers, repair)
           }
 
-          // we know we're non-empty by structure of outer match
-          (source, buckets, _, _) = extended.head
+          // candidates.forall(_ ~= QSReduce)
+          if (reducerAttempt.lengthCompare(candidates.length) === 0) {
+            for {
+              // apply coalescence recursively to our sources
+              extended <- reducerAttempt traverse {
+                case desc @ (source, buckets, reducers, repair) =>
+                  // TODO this is a weird use of the function, but it should work
+                  // we're just trying to run ourselves recursively to extend the sources
+                  // this isn't likely to be a common case
+                  coalesceToMap[G](source, List(source), Free.pure(0)) map {
+                    // coalesceToMap is always going to return... a Map, but
+                    // what we care about is the source and the fm, not the
+                    // node itself.  so we pull it apart (this is what's weird, btw)
+                    //
+                    // TODO short circuit this a bit if fm === Free.pure(Hole)
+                    // I'm pretty sure the fallthrough case will never be hit
+                    case Map(source2, fm) =>
+                      def rewriteBucket(bucket: Access[Hole]): FreeMapA[Access[Hole]] = bucket match {
+                        case v @ Access.Value(_) => fm.map(κ(v))
+                        case other => Free.pure[MapFunc, Access[Hole]](other)
+                      }
 
-          state <- MonadState_[G, MinimizationState].get
-          dims = state.dims
+                      (
+                        source2,
+                        buckets.map(_.flatMap(rewriteBucket)),
+                        reducers.map(_.map(_.flatMap(κ(fm)))),
+                        repair)
 
-          // do we have the same provenance at our roots?
-          rootProvCheck = extended.forall(t => dims(t._1.root) === dims(source.root))
-
-          // we need a stricter check than just provenance, since we have to inline maps
-          back <- if (rootProvCheck
-              && extended.forall(_._2 === buckets)
-              && extended.forall(_._1.root === source.root)) {
-
-            val lifted = extended.zipWithIndex map {
-              case ((_, buckets, reducers, repair), i) =>
-                (
-                  buckets,
-                  reducers,
-                  // we use maps here to avoid definedness issues in reduction results
-                  func.MakeMap(func.Constant(J.str(i.toString)), repair))
-            }
-
-            // this is fine, because we can't be here if candidates is empty
-            // doing it this way avoids an extra (and useless) Option state in the fold
-            val (_, lhreducers, lhrepair) = lifted.head
-
-            // squish all the reducers down into lhead
-            val (_, (reducers, repair)) =
-              lifted.tail.foldLeft((lhreducers.length, (lhreducers, lhrepair))) {
-                case ((roffset, (lreducers, lrepair)), (_, rreducers, rrepair)) =>
-                  val reducers = lreducers ::: rreducers
-
-                  val roffset2 = roffset + rreducers.length
-
-                  val repair = func.ConcatMaps(
-                    lrepair,
-                    rrepair map {
-                      case ReduceIndex(e) =>
-                        ReduceIndex(e.rightMap(_ + roffset))
-                    })
-
-                  (roffset2, (reducers, repair))
+                    case _ => desc
+                  }
               }
 
-            // 107.7, All chiropractors, all the time
-            val adjustedFM = fm flatMap { i =>
-              // get the value back OUT of the map
-              func.ProjectKey(HoleF[T], func.Constant(J.str(i.toString)))
-            }
+              // we know we're non-empty by structure of outer match
+              (source, buckets, _, _) = extended.head
 
-            val redPat = QSU.QSReduce[T, Symbol](source.root, buckets, reducers, repair)
+              state <- MonadState_[G, MinimizationState].get
+              dims = state.dims
 
-            for {
-              red <- updateGraph[G](redPat)
-              back = qgraph.overwriteAtRoot(QSU.Map[T, Symbol](red.root, adjustedFM)) :++ red
+              // do we have the same provenance at our roots?
+              rootProvCheck = extended.forall(t => dims(t._1.root) === dims(source.root))
 
-              _ <- MonadState_[G, MinimizationState] modify { state =>
-                val dims2 = state.dims map {
-                  case (key, value) =>
-                    val value2 = candidates.foldLeft(value) { (value, c) =>
-                      if (c.root =/= red.root)
-                        QP.rename(c.root, red.root, value)
-                      else
-                        value
-                    }
+              // we need a stricter check than just provenance, since we have to inline maps
+              back <- if (rootProvCheck
+                  && extended.forall(_._2 === buckets)
+                  && extended.forall(_._1.root === source.root)) {
 
-                    key -> value2
+                val lifted = extended.zipWithIndex map {
+                  case ((_, buckets, reducers, repair), i) =>
+                    (
+                      buckets,
+                      reducers,
+                      // we use maps here to avoid definedness issues in reduction results
+                      func.MakeMap(func.Constant(J.str(i.toString)), repair))
                 }
 
-                state.copy(dims = dims2)
+                // this is fine, because we can't be here if candidates is empty
+                // doing it this way avoids an extra (and useless) Option state in the fold
+                val (_, lhreducers, lhrepair) = lifted.head
+
+                // squish all the reducers down into lhead
+                val (_, (reducers, repair)) =
+                  lifted.tail.foldLeft((lhreducers.length, (lhreducers, lhrepair))) {
+                    case ((roffset, (lreducers, lrepair)), (_, rreducers, rrepair)) =>
+                      val reducers = lreducers ::: rreducers
+
+                      val roffset2 = roffset + rreducers.length
+
+                      val repair = func.ConcatMaps(
+                        lrepair,
+                        rrepair map {
+                          case ReduceIndex(e) =>
+                            ReduceIndex(e.rightMap(_ + roffset))
+                        })
+
+                      (roffset2, (reducers, repair))
+                  }
+
+                // 107.7, All chiropractors, all the time
+                val adjustedFM = fm flatMap { i =>
+                  // get the value back OUT of the map
+                  func.ProjectKey(HoleF[T], func.Constant(J.str(i.toString)))
+                }
+
+                val redPat = QSU.QSReduce[T, Symbol](source.root, buckets, reducers, repair)
+
+                for {
+                  red <- updateGraph[G](redPat)
+                  back = qgraph.overwriteAtRoot(QSU.Map[T, Symbol](red.root, adjustedFM)) :++ red
+
+                  _ <- MonadState_[G, MinimizationState] modify { state =>
+                    val dims2 = state.dims map {
+                      case (key, value) =>
+                        val value2 = candidates.foldLeft(value) { (value, c) =>
+                          if (c.root =/= red.root)
+                            QP.rename(c.root, red.root, value)
+                          else
+                            value
+                        }
+
+                        key -> value2
+                    }
+
+                    state.copy(dims = dims2)
+                  }
+                } yield back
+              } else {
+                failure[G](qgraph)
               }
             } yield back
           } else {
             failure[G](qgraph)
           }
-        } yield back
-      } else {
-        failure[G](qgraph)
       }
   }
 

--- a/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
@@ -280,7 +280,23 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
                 HoleF[Fix],
                 func.Undefined)))
       }
-    }.pendingUntilFixed
+    }
+
+    "not rewrite filter acting as upstream source" in {
+      val qgraph = QSUGraph.fromTree[Fix](
+        qsu.autojoin2((
+          qsu.qsFilter(
+            qsu.read(afile),
+            func.Eq(HoleF[Fix], func.Constant(J.str("foo")))),
+          qsu.cint(42),
+          _(MapFuncsCore.Add(_, _)))))
+
+      runOn(qgraph) must beLike {
+        case Map(QSFilter(_, _), fm) =>
+          fm must beTreeEqual(
+            func.Add(HoleF[Fix], func.Constant(J.int(42))))
+      }
+    }
 
     "coalesce two summed bucketing reductions, inlining functions into the buckets" in {
       val readAndThings =

--- a/it/src/main/resources/tests/demo/conditional_input_step2.test
+++ b/it/src/main/resources/tests/demo/conditional_input_step2.test
@@ -2,10 +2,11 @@
     "name": "conditional_input_step2",
     "data": "patients.data",
     "backends": {
-       "couchbase":         "ignoreFieldOrder",
+       "couchbase":         "skip",
        "marklogic_json":    "ignoreFieldOrder",
        "mimir":             "ignoreFieldOrder"
     },
+    "NB": "skipped on couchbase because loading is flaky",
     "query": "SELECT first_name, last_name, gender FROM patients WHERE state = \"CO\" AND (CASE \"both\" WHEN \"male\" THEN gender = \"male\" WHEN \"female\" THEN gender = \"female\" WHEN \"both\" THEN gender IN (\"male\", \"female\") END) AND (CASE WHEN 40 > 0 THEN age >= 40 ELSE age > 0 END) AND (CASE WHEN 55 > 0 THEN age <= 55 ELSE age > 0 END) ORDER BY last_name LIMIT 10",
     "predicate": "exactly",
     "expected": [

--- a/it/src/main/resources/tests/demo/geo_markers_step1.test
+++ b/it/src/main/resources/tests/demo/geo_markers_step1.test
@@ -2,7 +2,7 @@
     "name": "geo_markers_step1",
     "data": "patients.data",
     "backends": {
-       "couchbase":         "ignoreFieldOrder",
+       "couchbase":         "skip",
        "marklogic_json":    "ignoreFieldOrder",
        "mimir":             "ignoreFieldOrder"
     },

--- a/mimir/src/main/scala/quasar/mimir/MapFuncCorePlanner.scala
+++ b/mimir/src/main/scala/quasar/mimir/MapFuncCorePlanner.scala
@@ -168,6 +168,8 @@ final class MapFuncCorePlanner[T[_[_]]: RecursiveT, F[_]: Applicative]
         Infix.Or.spec(a1, a2).point[F]
       case MapFuncsCore.Between(a1, a2, a3) =>
         (MapN(OuterArrayConcat(WrapArray(a1), WrapArray(a2), WrapArray(a3)), between): TransSpec[A]).point[F]
+      case MapFuncsCore.Cond(a1, a2, a3) if a3 == undefined(id) =>
+        (Filter(a1, a2): TransSpec[A]).point[F]
       case MapFuncsCore.Cond(a1, a2, a3) =>
         (Cond(a1, a2, a3): TransSpec[A]).point[F]
 

--- a/mimir/src/main/scala/quasar/mimir/MapFuncCorePlanner.scala
+++ b/mimir/src/main/scala/quasar/mimir/MapFuncCorePlanner.scala
@@ -169,7 +169,7 @@ final class MapFuncCorePlanner[T[_[_]]: RecursiveT, F[_]: Applicative]
       case MapFuncsCore.Between(a1, a2, a3) =>
         (MapN(OuterArrayConcat(WrapArray(a1), WrapArray(a2), WrapArray(a3)), between): TransSpec[A]).point[F]
       case MapFuncsCore.Cond(a1, a2, a3) if a3 == undefined(id) =>
-        (Filter(a1, a2): TransSpec[A]).point[F]
+        (Filter(a2, a1): TransSpec[A]).point[F]
       case MapFuncsCore.Cond(a1, a2, a3) =>
         (Cond(a1, a2, a3): TransSpec[A]).point[F]
 


### PR DESCRIPTION
We can now eliminate autojoins even in cases where common sources are being obscured by filters.  We do this by rewriting the `Filter` to a `Cond` within the autojoin heritage (we don't eliminate the node, obviously, so other descendants will continue to see it as a `Filter`).  This optimization applies recursively and can open the door to other collapsing.

I wish we had a `Scan` `MapFunc`; if we had that, I could do something similar with `Subset`.