### PR TITLE
Nonmappable sort keys

### DIFF
--- a/connector/src/main/scala/quasar/qscript/qsu/ExtractFreeMap.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ExtractFreeMap.scala
@@ -83,50 +83,58 @@ final class ExtractFreeMap[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T
         case ((\/-(sym), _)) => sym
       }
 
-      def autojoinVerts(initial: Symbol): F[(Symbol, QSUVerts[T])] =
-        nonmappable.foldLeftM((initial, graph.vertices)) {
-          case ((src, verts), sym) =>
-            freshName[F].map { joinRoot =>
-              val join: QSU[Symbol] =
-	            AutoJoin2(src, sym, func.ConcatMaps(func.LeftSide, func.MakeMapS(sym.name, func.RightSide)))
-	          (joinRoot, verts.updated(joinRoot, join))
-            }
-        }
+      def autojoinVerts(head: Symbol, tail: List[Symbol]): F[(Symbol, QSUVerts[T])] = {
+        freshName[F].flatMap { joinRoot =>
+          val join: QSU[Symbol] = AutoJoin2(src.root, head,
+            func.ConcatMaps(func.MakeMapS("sort_source", func.LeftSide), func.MakeMapS(head.name, func.RightSide)))
 
-      if (nonmappable.isEmpty) {
-        keys traverse { case (k, sortDir) =>
-          MappableRegion.unaryOf(src.root, graph refocus k.root).strengthR(sortDir) match {
-            case Some(pair) => pair.point[F]
-            case None =>
-              PlannerErrorME[F].raiseError[(FreeMap, SortDir)](
-                InternalError(s"Invalid sort key, $k, must be a mappable function of $src.", None))
+	      val updated: QSUVerts[T] = graph.vertices.updated(joinRoot, join)
+
+          tail.foldLeftM((joinRoot, updated)) {
+            case ((prev, verts), sym) =>
+              freshName[F].map { innerRoot =>
+                val join: QSU[Symbol] =
+	              AutoJoin2(prev, sym, func.ConcatMaps(func.LeftSide, func.MakeMapS(sym.name, func.RightSide)))
+
+	            (innerRoot, verts.updated(innerRoot, join))
+              }
           }
-        } map { nel => graph.overwriteAtRoot(QSSort(src.root, Nil, nel)) }
-      } else {
-        for {
-          sortRoot <- freshName[F]
-          interRoot <- freshName[F]
-          joined <- autojoinVerts(sortRoot)
-        } yield {
-          val (joinRoot, verts) = joined
-
-          val order: NEL[(FreeMap, SortDir)] =
-            access.map(_.leftMap {
-              case -\/(fm) => fm >> func.ProjectKey(func.Hole, StrLit("sort_source"))
-              case \/-(sym) => func.ProjectKey(func.Hole, StrLit(sym.name))
-            })
-
-          val sortSrc: QSU[Symbol] = Map(joinRoot, func.MakeMapS("sort_source", func.Hole))
-          val sort: QSU[Symbol] = QSSort(sortRoot, Nil, order)
-          val result: QSU[Symbol] = Map(interRoot, func.ProjectKey(func.Hole, StrLit("sort_source")))
-
-          val newVerts: QSUVerts[T] = verts
-            .updated(sortRoot, sortSrc)
-            .updated(interRoot, sort)
-            .updated(graph.root, result)
-
-          QSUGraph(graph.root, newVerts)
         }
+      }
+
+      nonmappable match {
+        case Nil =>
+          keys traverse { case (k, sortDir) =>
+            MappableRegion.unaryOf(src.root, graph refocus k.root).strengthR(sortDir) match {
+              case Some(pair) => pair.point[F]
+              case None =>
+                PlannerErrorME[F].raiseError[(FreeMap, SortDir)](
+                  InternalError(s"Invalid sort key, $k, must be a mappable function of $src.", None))
+            }
+          } map { nel => graph.overwriteAtRoot(QSSort(src.root, Nil, nel)) }
+
+        case head :: tail =>
+          for {
+            interRoot <- freshName[F]
+            joined <- autojoinVerts(head, tail)
+          } yield {
+            val (joinRoot, verts) = joined
+
+            val order: NEL[(FreeMap, SortDir)] =
+              access.map(_.leftMap {
+                case -\/(fm) => fm >> func.ProjectKey(func.Hole, StrLit("sort_source"))
+                case \/-(sym) => func.ProjectKey(func.Hole, StrLit(sym.name))
+              })
+
+            val sort: QSU[Symbol] = QSSort(joinRoot, Nil, order)
+            val result: QSU[Symbol] = Map(interRoot, func.ProjectKey(func.Hole, StrLit("sort_source")))
+
+            val newVerts: QSUVerts[T] = verts
+              .updated(interRoot, sort)
+              .updated(graph.root, result)
+
+            QSUGraph(graph.root, newVerts)
+          }
       }
     }
 

--- a/connector/src/main/scala/quasar/qscript/qsu/ExtractFreeMap.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ExtractFreeMap.scala
@@ -142,6 +142,8 @@ final class ExtractFreeMap[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T
       : F[QSUGraph] =
     graph.rewriteM[F](extract[F])
 
+  ////
+
   private def autojoinFreeMap[F[_]: Applicative: NameGenerator: PlannerErrorME]
     (graph: QSUGraph, src: Symbol, target: Symbol)
     (srcName: String, targetName: String)

--- a/connector/src/main/scala/quasar/qscript/qsu/ExtractFreeMap.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ExtractFreeMap.scala
@@ -122,12 +122,12 @@ final class ExtractFreeMap[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T
 
             val order: NEL[(FreeMap, SortDir)] =
               access.map(_.leftMap {
-                case -\/(fm) => fm >> func.ProjectKey(func.Hole, StrLit("sort_source"))
-                case \/-(sym) => func.ProjectKey(func.Hole, StrLit(sym.name))
+                case -\/(fm) => fm >> func.ProjectKeyS(func.Hole, "sort_source")
+                case \/-(sym) => func.ProjectKeyS(func.Hole, sym.name)
               })
 
             val sort: QSU[Symbol] = QSSort(joinRoot, Nil, order)
-            val result: QSU[Symbol] = Map(interRoot, func.ProjectKey(func.Hole, StrLit("sort_source")))
+            val result: QSU[Symbol] = Map(interRoot, func.ProjectKeyS(func.Hole, "sort_source"))
 
             val newVerts: QSUVerts[T] = verts
               .updated(interRoot, sort)
@@ -161,8 +161,8 @@ final class ExtractFreeMap[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T
               func.MakeMap(StrLit(targetName), func.RightSide))
 
             val join: QSU[Symbol] = AutoJoin2(src, target, combine)
-            val inter: QSU[Symbol] = makeQSU(joinRoot, func.ProjectKey(func.Hole, StrLit(targetName)))
-            val result: QSU[Symbol] = Map(interRoot, func.ProjectKey(func.Hole, StrLit(srcName)))
+            val inter: QSU[Symbol] = makeQSU(joinRoot, func.ProjectKeyS(func.Hole, targetName))
+            val result: QSU[Symbol] = Map(interRoot, func.ProjectKeyS(func.Hole, srcName))
 
             val QSUGraph(origRoot, origVerts) = graph
 

--- a/connector/src/test/scala/quasar/qscript/qsu/ExtractFreeMapSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/ExtractFreeMapSpec.scala
@@ -45,8 +45,7 @@ object ExtractFreeMapSpec extends Qspec with QSUTTypes[Fix] {
   val qsu = QScriptUniform.DslT[Fix]
   val func = construction.Func[Fix]
 
-  def projectStrKey(key: String): FreeMap =
-    func.ProjectKey(func.Hole, func.Constant(ejs.str(key)))
+  def projectStrKey(key: String): FreeMap = func.ProjectKeyS(func.Hole, key)
 
   val orders: AFile = Path.rootDir </> Path.dir("client") </> Path.file("orders")
 

--- a/connector/src/test/scala/quasar/qscript/qsu/ExtractFreeMapSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/ExtractFreeMapSpec.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.qsu
+
+import slamdata.Predef._
+import quasar.Qspec
+import quasar.Planner.PlannerError
+import quasar.contrib.matryoshka._
+import quasar.contrib.pathy.AFile
+import quasar.ejson.{EJson, Fixed}
+import quasar.ejson.implicits._
+import quasar.fp._
+import quasar.qscript.construction
+
+import matryoshka._
+import matryoshka.data._
+import matryoshka.data.free._
+import pathy.Path
+import scalaz.{\/, \/-, EitherT, Need, StateT}
+
+object ExtractFreeMapSpec extends Qspec with QSUTTypes[Fix] {
+  import QScriptUniform.DTrans
+  import QSUGraph.Extractors._
+
+  type F[A] = EitherT[StateT[Need, Long, ?], PlannerError, A]
+  type QSU[A] = QScriptUniform[A]
+
+  val ejs = Fixed[Fix[EJson]]
+  val qsu = QScriptUniform.DslT[Fix]
+  val func = construction.Func[Fix]
+
+  val orders: AFile = Path.rootDir </> Path.dir("client") </> Path.file("orders")
+
+  def extractFM(graph: QSUGraph) = ExtractFreeMap[Fix, F](graph)
+
+  "extracting mappable region" should {
+
+    "convert mappable filter" >> {
+      val predicate = func.ProjectKey(func.Hole, func.Constant(ejs.str("foo")))
+
+      val graph = QSUGraph.fromTree[Fix](
+        qsu.lpFilter(
+          qsu.read(orders),
+          qsu.map(qsu.read(orders), predicate)))
+
+      evaluate(extractFM(graph)) must beLike {
+        case \/-(QSFilter(Read(`orders`), fm)) => fm must_= predicate
+      }
+    }
+
+    "convert mappable group key" >> {
+      val predicate = func.ProjectKey(func.Hole, func.Constant(ejs.str("foo")))
+
+      val graph = QSUGraph.fromTree[Fix](
+        qsu.groupBy(
+          qsu.read(orders),
+          qsu.map(qsu.read(orders), predicate)))
+
+      evaluate(extractFM(graph)) must beLike {
+        case \/-(DimEdit(Read(`orders`), DTrans.Group(fm))) => fm must_= predicate
+      }
+    }
+  }
+
+  def evaluate[A](fa: F[A]): PlannerError \/ A = fa.run.eval(0L).value
+}

--- a/connector/src/test/scala/quasar/qscript/qsu/ExtractFreeMapSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/ExtractFreeMapSpec.scala
@@ -84,13 +84,12 @@ object ExtractFreeMapSpec extends Qspec with QSUTTypes[Fix] {
                 autojoinCondition),
               filterPredicate),
             valueAccess)) =>
-          (fm must_= predicate) and
-            (filterPredicate must_= projectStrKey("filter_predicate")) and
-            (valueAccess must_= projectStrKey("filter_source")) and
-            (autojoinCondition must_= func.ConcatMaps(
-              func.MakeMap(func.Constant(ejs.str("filter_source")), func.LeftSide),
-              func.MakeMap(func.Constant(ejs.str("filter_predicate")), func.RightSide)))
-
+          fm must_= predicate
+          filterPredicate must_= projectStrKey("filter_predicate")
+          valueAccess must_= projectStrKey("filter_source")
+          autojoinCondition must_= func.ConcatMaps(
+            func.MakeMap(func.Constant(ejs.str("filter_source")), func.LeftSide),
+            func.MakeMap(func.Constant(ejs.str("filter_predicate")), func.RightSide))
       }
     }
 
@@ -124,12 +123,12 @@ object ExtractFreeMapSpec extends Qspec with QSUTTypes[Fix] {
                 autojoinCondition),
               DTrans.Group(groupKey)),
             valueAccess)) =>
-          (fm must_= key) and
-            (groupKey must_= projectStrKey("group_key")) and
-            (valueAccess must_= projectStrKey("group_source")) and
-            (autojoinCondition must_= func.ConcatMaps(
-              func.MakeMap(func.Constant(ejs.str("group_source")), func.LeftSide),
-              func.MakeMap(func.Constant(ejs.str("group_key")), func.RightSide)))
+          fm must_= key
+          groupKey must_= projectStrKey("group_key")
+          valueAccess must_= projectStrKey("group_source")
+          autojoinCondition must_= func.ConcatMaps(
+           func.MakeMap(func.Constant(ejs.str("group_source")), func.LeftSide),
+           func.MakeMap(func.Constant(ejs.str("group_key")), func.RightSide))
 
       }
     }
@@ -150,7 +149,8 @@ object ExtractFreeMapSpec extends Qspec with QSUTTypes[Fix] {
             Read(`orders`),
             Nil,
             NEL((fm1, SortDir.Ascending), ICons((fm2, SortDir.Descending), INil())))) =>
-          (fm1 must_= key1) and (fm2 must_= key2)
+          fm1 must_= key1
+          fm2 must_= key2
       }
     }
 
@@ -175,13 +175,13 @@ object ExtractFreeMapSpec extends Qspec with QSUTTypes[Fix] {
               Nil,
               NEL((fm1, SortDir.Ascending), ICons((fm2, SortDir.Descending), INil()))),
             valueAccess)) =>   // FIXME don't explicitly test for generated names
-          (fm must_= key2) and
-          (fm1 must_= key1 >> projectStrKey("sort_source")) and
-          (fm2 must_= projectStrKey("__fromTree3")) and
-          (valueAccess must_= projectStrKey("sort_source")) and
-          (autojoinCondition must_= func.ConcatMaps(
+          fm must_= key2
+          fm1 must_= key1 >> projectStrKey("sort_source")
+          fm2 must_= projectStrKey("__fromTree3")
+          valueAccess must_= projectStrKey("sort_source")
+          autojoinCondition must_= func.ConcatMaps(
             func.MakeMap(func.Constant(ejs.str("sort_source")), func.LeftSide),
-            func.MakeMap(func.Constant(ejs.str("__fromTree3")), func.RightSide)))
+            func.MakeMap(func.Constant(ejs.str("__fromTree3")), func.RightSide))
       }
     }
 
@@ -214,19 +214,19 @@ object ExtractFreeMapSpec extends Qspec with QSUTTypes[Fix] {
               NEL(
                 (fm1, SortDir.Ascending), ICons((fm2, SortDir.Descending), ICons((fm3, SortDir.Descending), ICons((fm4, SortDir.Ascending), INil()))))),
             valueAccess)) =>  // FIXME don't explicitly test for generated names
-          (innerFM must_= key2) and
-          (outerFM must_= key4) and
-          (fm1 must_= key1 >> projectStrKey("sort_source")) and
-          (fm2 must_= projectStrKey("__fromTree3")) and
-          (fm3 must_= key3 >> projectStrKey("sort_source")) and
-          (fm4 must_= projectStrKey("__fromTree6")) and
-          (valueAccess must_= projectStrKey("sort_source")) and
-          (innerAutojoinCondition must_= func.ConcatMaps(
+          innerFM must_= key2
+          outerFM must_= key4
+          fm1 must_= key1 >> projectStrKey("sort_source")
+          fm2 must_= projectStrKey("__fromTree3")
+          fm3 must_= key3 >> projectStrKey("sort_source")
+          fm4 must_= projectStrKey("__fromTree6")
+          valueAccess must_= projectStrKey("sort_source")
+          innerAutojoinCondition must_= func.ConcatMaps(
             func.MakeMap(func.Constant(ejs.str("sort_source")), func.LeftSide),
-            func.MakeMap(func.Constant(ejs.str("__fromTree3")), func.RightSide))) and
-          (outerAutojoinCondition must_= func.ConcatMaps(
+            func.MakeMap(func.Constant(ejs.str("__fromTree3")), func.RightSide))
+          outerAutojoinCondition must_= func.ConcatMaps(
             func.LeftSide,
-            func.MakeMap(func.Constant(ejs.str("__fromTree6")), func.RightSide)))
+            func.MakeMap(func.Constant(ejs.str("__fromTree6")), func.RightSide))
       }
     }
   }

--- a/connector/src/test/scala/quasar/qscript/qsu/ExtractFreeMapSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/ExtractFreeMapSpec.scala
@@ -47,6 +47,11 @@ object ExtractFreeMapSpec extends Qspec with QSUTTypes[Fix] {
 
   def projectStrKey(key: String): FreeMap = func.ProjectKeyS(func.Hole, key)
 
+  def makeMap(left: String, right: String): JoinFunc =
+    func.ConcatMaps(
+      func.MakeMapS(left, func.LeftSide),
+      func.MakeMapS(right, func.RightSide))
+
   val orders: AFile = Path.rootDir </> Path.dir("client") </> Path.file("orders")
 
   def extractFM(graph: QSUGraph) = ExtractFreeMap[Fix, F](graph)
@@ -86,9 +91,7 @@ object ExtractFreeMapSpec extends Qspec with QSUTTypes[Fix] {
           fm must_= predicate
           filterPredicate must_= projectStrKey("filter_predicate")
           valueAccess must_= projectStrKey("filter_source")
-          autojoinCondition must_= func.ConcatMaps(
-            func.MakeMap(func.Constant(ejs.str("filter_source")), func.LeftSide),
-            func.MakeMap(func.Constant(ejs.str("filter_predicate")), func.RightSide))
+          autojoinCondition must_= makeMap("filter_source", "filter_predicate")
       }
     }
 
@@ -125,10 +128,7 @@ object ExtractFreeMapSpec extends Qspec with QSUTTypes[Fix] {
           fm must_= key
           groupKey must_= projectStrKey("group_key")
           valueAccess must_= projectStrKey("group_source")
-          autojoinCondition must_= func.ConcatMaps(
-           func.MakeMap(func.Constant(ejs.str("group_source")), func.LeftSide),
-           func.MakeMap(func.Constant(ejs.str("group_key")), func.RightSide))
-
+          autojoinCondition must_= makeMap("group_source", "group_key")
       }
     }
 
@@ -178,9 +178,7 @@ object ExtractFreeMapSpec extends Qspec with QSUTTypes[Fix] {
           fm1 must_= key1 >> projectStrKey("sort_source")
           fm2 must_= projectStrKey("__fromTree3")
           valueAccess must_= projectStrKey("sort_source")
-          autojoinCondition must_= func.ConcatMaps(
-            func.MakeMap(func.Constant(ejs.str("sort_source")), func.LeftSide),
-            func.MakeMap(func.Constant(ejs.str("__fromTree3")), func.RightSide))
+          autojoinCondition must_= makeMap("sort_source", "__fromTree3")
       }
     }
 
@@ -220,9 +218,7 @@ object ExtractFreeMapSpec extends Qspec with QSUTTypes[Fix] {
           fm3 must_= key3 >> projectStrKey("sort_source")
           fm4 must_= projectStrKey("__fromTree6")
           valueAccess must_= projectStrKey("sort_source")
-          innerAutojoinCondition must_= func.ConcatMaps(
-            func.MakeMap(func.Constant(ejs.str("sort_source")), func.LeftSide),
-            func.MakeMap(func.Constant(ejs.str("__fromTree3")), func.RightSide))
+          innerAutojoinCondition must_= makeMap("sort_source", "__fromTree3")
           outerAutojoinCondition must_= func.ConcatMaps(
             func.LeftSide,
             func.MakeMap(func.Constant(ejs.str("__fromTree6")), func.RightSide))

--- a/it/src/main/resources/tests/sortKeyFlatten.test
+++ b/it/src/main/resources/tests/sortKeyFlatten.test
@@ -1,0 +1,22 @@
+{
+    "name": "sort with a flattened key",
+
+     "backends": {
+         "couchbase": "ignoreFieldOrder",
+         "marklogic_json": "ignoreFieldOrder",
+         "mimir": "ignoreFieldOrder"
+     },
+
+    "data": "zips.data",
+
+    "query": "select city, state, loc from zips order by loc[*] desc",
+
+    "predicate": "initial",
+
+    "expected": [
+       { "city": "BARROW",      "state": "AK", "loc": [ -156.817409, 71.234637] },
+       { "city": "WAINWRIGHT",  "state": "AK", "loc": [ -160.012532, 70.620064] },
+       { "city": "NUIQSUT",     "state": "AK", "loc": [ -150.997119, 70.192737] },
+       { "city": "PRUDHOE BAY", "state": "AK", "loc": [ -148.559636, 70.070057] },
+       { "city": "KAKTOVIK",    "state": "AK", "loc": [ -143.631329, 70.042889] } ]
+}


### PR DESCRIPTION
Part of #3021

Provide support for nonmappable sort keys.

Add tests for `ExtractFreeMap`.