### PR TITLE
Fixed mistaken assumption about group keys always being array-wrapped

### DIFF
--- a/it/src/main/resources/tests/groupBySimpleExpression.test
+++ b/it/src/main/resources/tests/groupBySimpleExpression.test
@@ -3,7 +3,7 @@
     "backends": {
         "couchbase":         "pending",
         "marklogic_json":    "pending",
-        "mimir":             "pending",
+        "mimir":             "ignoreFieldOrder",
         "mongodb_3_2":       "ignoreFieldOrder",
         "mongodb_3_4":       "ignoreFieldOrder",
         "mongodb_read_only": "pending"

--- a/it/src/main/resources/tests/subqueryGroupBy.test
+++ b/it/src/main/resources/tests/subqueryGroupBy.test
@@ -4,7 +4,7 @@
         "couchbase":         "skip",
         "marklogic_json":    "pendingIgnoreFieldOrder",
         "marklogic_xml":     "timeout",
-        "mimir":             "pendingIgnoreFieldOrder",
+        "mimir":             "ignoreFieldOrder",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
         "mongodb_3_2":       "pending",

--- a/it/src/main/resources/tests/unsupportedTests.test
+++ b/it/src/main/resources/tests/unsupportedTests.test
@@ -3,7 +3,6 @@
     "backends": {
         "couchbase": "skip",
         "marklogic_json": "pending",
-        "mimir": "pending",
         "mongodb_2_6": "pending",
         "mongodb_3_0": "pending",
         "mongodb_3_2": "pending",

--- a/mimir/src/main/scala/quasar/mimir/Mimir.scala
+++ b/mimir/src/main/scala/quasar/mimir/Mimir.scala
@@ -284,7 +284,7 @@ object Mimir extends BackendModule with Logging with DefaultAnalyzeModule {
       if (specs.isEmpty)
         TransSpec1.Id
       else if (specs.lengthCompare(1) == 0)
-        specs.head
+        WrapArray(specs.head)
       else
         OuterArrayConcat(specs.map(WrapArray(_): TransSpec1) : _*)
     }
@@ -405,6 +405,7 @@ object Mimir extends BackendModule with Logging with DefaultAnalyzeModule {
               for {
                 // ok this isn't working right now because we throw away the key when we reduce; need to fold in a First reducer to carry along the key
                 red <- megaReduction(bucketed)(table.transform(megaSpec(bucketed)))
+
                 trans <- repair.cataM[Future, TransSpec1](
                   // note that .0 is the partition key
                   // and .1 is the value (if bucketed)


### PR DESCRIPTION
Affects #3272

As mentioned on the issue, I'm guessing mongo has a similar problem.