### PR TITLE
migrate join queries in mongo PlannerSpec

### DIFF
--- a/mongodb/src/test/resources/planner/plan_3-way_right_equi-join_(map-reduce).txt
+++ b/mongodb/src/test/resources/planner/plan_3-way_right_equi-join_(map-reduce).txt
@@ -1,12 +1,12 @@
 Chain
 ├─ $FoldLeftF
 │  ├─ Chain
-│  │  ├─ $ReadF(db; baz)
+│  │  ├─ $ReadF(db; ordered_items)
 │  │  ├─ $GroupF
 │  │  │  ├─ Grouped
 │  │  │  │  ╰─ Name("0" -> { "$push": "$$ROOT" })
 │  │  │  ╰─ By
-│  │  │     ╰─ Name("0" -> "$bar_id")
+│  │  │     ╰─ Name("0" -> "$order_key")
 │  │  ╰─ $ProjectF
 │  │     ├─ Name("_id" -> "$_id")
 │  │     ├─ Name("value")
@@ -17,12 +17,12 @@ Chain
 │  ╰─ Chain
 │     ├─ $FoldLeftF
 │     │  ├─ Chain
-│     │  │  ├─ $ReadF(db; foo)
+│     │  │  ├─ $ReadF(db; customers)
 │     │  │  ├─ $GroupF
 │     │  │  │  ├─ Grouped
 │     │  │  │  │  ╰─ Name("0" -> { "$push": "$$ROOT" })
 │     │  │  │  ╰─ By
-│     │  │  │     ╰─ Name("0" -> "$id")
+│     │  │  │     ╰─ Name("0" -> "$customer_key")
 │     │  │  ╰─ $ProjectF
 │     │  │     ├─ Name("_id" -> "$_id")
 │     │  │     ├─ Name("value")
@@ -31,9 +31,9 @@ Chain
 │     │  │     │  ╰─ Name("_id" -> "$_id")
 │     │  │     ╰─ IncludeId
 │     │  ╰─ Chain
-│     │     ├─ $ReadF(db; bar)
+│     │     ├─ $ReadF(db; orders)
 │     │     ├─ $MapF
-│     │     │  ├─ JavaScript(function (key, value) { return [{ "0": value.foo_id }, { "left": [], "right": [value] }] })
+│     │     │  ├─ JavaScript(function (key, value) { return [{ "0": value.customer_key }, { "left": [], "right": [value] }] })
 │     │     │  ╰─ Scope(Map())
 │     │     ╰─ $ReduceF
 │     │        ├─ JavaScript(function (key, values) {
@@ -75,7 +75,9 @@ Chain
 │     │     ╰─ Expr($0 -> Eq(Bool(true)))
 │     ├─ $MapF
 │     │  ├─ JavaScript(function (key, value) {
-│     │  │               return [{ "0": value.src.right.id }, { "right": [], "left": [value.src] }]
+│     │  │               return [
+│     │  │                 { "0": value.src.right.order_key },
+│     │  │                 { "right": [], "left": [value.src] }]
 │     │  │             })
 │     │  ╰─ Scope(Map())
 │     ╰─ $ReduceF
@@ -106,7 +108,7 @@ Chain
 ├─ $SimpleMapF
 │  ├─ Map
 │  │  ╰─ Obj
-│  │     ├─ Key(name)
+│  │     ├─ Key(last_name)
 │  │     │  ╰─ If
 │  │     │     ├─ BinOp(&&)
 │  │     │     │  ├─ Call
@@ -120,9 +122,9 @@ Chain
 │  │     │     │        ╰─ Obj
 │  │     │     │           ├─ Key(left: _.left.left)
 │  │     │     │           ╰─ Key(right: _.left.right)
-│  │     │     ├─ JsCore((isObject(_.left.left) && (! Array.isArray(_.left.left))) ? _.left.left.name : undefined)
+│  │     │     ├─ JsCore((isObject(_.left.left) && (! Array.isArray(_.left.left))) ? _.left.left.last_name : undefined)
 │  │     │     ╰─ Ident(undefined)
-│  │     ├─ Key(address)
+│  │     ├─ Key(purchase_date)
 │  │     │  ╰─ If
 │  │     │     ├─ BinOp(&&)
 │  │     │     │  ├─ Call
@@ -136,12 +138,12 @@ Chain
 │  │     │     │        ╰─ Obj
 │  │     │     │           ├─ Key(left: _.left.left)
 │  │     │     │           ╰─ Key(right: _.left.right)
-│  │     │     ├─ JsCore((isObject(_.left.right) && (! Array.isArray(_.left.right))) ? _.left.right.address : undefined)
+│  │     │     ├─ JsCore((isObject(_.left.right) && (! Array.isArray(_.left.right))) ? _.left.right.purchase_date : undefined)
 │  │     │     ╰─ Ident(undefined)
-│  │     ╰─ Key(zip: _.right.zip)
+│  │     ╰─ Key(qty: _.right.qty)
 │  ╰─ Scope(Map())
 ╰─ $ProjectF
-   ├─ Name("name" -> true)
-   ├─ Name("address" -> true)
-   ├─ Name("zip" -> true)
+   ├─ Name("last_name" -> true)
+   ├─ Name("purchase_date" -> true)
+   ├─ Name("qty" -> true)
    ╰─ ExcludeId

--- a/mongodb/src/test/resources/planner/plan_non-equi_join.txt
+++ b/mongodb/src/test/resources/planner/plan_non-equi_join.txt
@@ -52,7 +52,7 @@ Chain
 │  │     │  ╰─ Name("_id" -> "$_id")
 │  │     ╰─ IncludeId
 │  ╰─ Chain
-│     ├─ $ReadF(db; zips2)
+│     ├─ $ReadF(db; smallZips)
 │     ├─ $MatchF
 │     │  ╰─ Or
 │     │     ├─ Doc

--- a/mongodb/src/test/resources/planner/plan_simple_cross.txt
+++ b/mongodb/src/test/resources/planner/plan_simple_cross.txt
@@ -1,7 +1,7 @@
 Chain
 ├─ $FoldLeftF
 │  ├─ Chain
-│  │  ├─ $ReadF(db; zips)
+│  │  ├─ $ReadF(db; smallZips)
 │  │  ├─ $MatchF
 │  │  │  ╰─ Or
 │  │  │     ├─ Doc
@@ -52,7 +52,7 @@ Chain
 │  │     │  ╰─ Name("_id" -> "$_id")
 │  │     ╰─ IncludeId
 │  ╰─ Chain
-│     ├─ $ReadF(db; zips2)
+│     ├─ $ReadF(db; extraSmallZips)
 │     ├─ $MatchF
 │     │  ╰─ Or
 │     │     ├─ Doc

--- a/mongodb/src/test/scala/quasar/physical/mongodb/PlannerWorkflowHelpers.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/PlannerWorkflowHelpers.scala
@@ -298,20 +298,20 @@ trait PlannerWorkflowHelpers extends PlannerHelpers {
       case _ => Nil
     }) aka "dangling references"
 
-  def notBroken(wf: Workflow) = {
+  def notBroken(wf: Workflow, checkDanglingRefs: Boolean) = {
     noConsecutiveProjectOps(wf)
     noConsecutiveSimpleMapOps(wf)
-    danglingReferences(wf) must_== Nil
+    if (checkDanglingRefs) danglingReferences(wf) must_== Nil else ok
     brokenProjectOps(wf) must_== 0
   }
 
-  def notBrokenWithOps(wf: Workflow, expectedOps: IList[MongoOp]) = {
-    notBroken(wf)
+  def notBrokenWithOps(wf: Workflow, expectedOps: IList[MongoOp], checkDanglingRefs: Boolean = true) = {
+    notBroken(wf, checkDanglingRefs)
     ops(wf) must_== expectedOps
   }
 
-  def notBrokenWithOpsTree(wf: Workflow, expectedOps: Tree[MongoOp]) = {
-    notBroken(wf)
+  def notBrokenWithOpsTree(wf: Workflow, expectedOps: Tree[MongoOp], checkDanglingRefs: Boolean = true) = {
+    notBroken(wf, checkDanglingRefs)
     AsResult(Equal[Tree[MongoOp]].equal(opsTree(wf), expectedOps) must_=== true).updateMessage(s"Expected:\n${expectedOps.drawTree}\nActual:\n${opsTree(wf).drawTree}")
   }
 

--- a/mongodb/src/test/scala/quasar/physical/mongodb/PlannerWorkflowHelpers.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/PlannerWorkflowHelpers.scala
@@ -31,6 +31,8 @@ import matryoshka._
 import matryoshka.data.Fix
 import matryoshka.implicits._
 import org.scalacheck._
+import org.specs2.execute._
+import org.specs2.matcher.{Matcher, Expectable}
 import pathy.Path._
 import scalaz._, Scalaz._
 
@@ -183,6 +185,29 @@ trait PlannerWorkflowHelpers extends PlannerHelpers {
   case object SimpleMapOp extends MongoOp(MapReduce)
   case object ReduceOp extends MongoOp(MapReduce)
 
+  implicit val showMongoOp = Show.showFromToString[MongoOp]
+  implicit val equalMongoOp = Equal.equalRef[MongoOp]
+
+  val pureOp: MongoOp = PureOp
+  val readOp: MongoOp = ReadOp
+  val matchOp: MongoOp = MatchOp
+  val projectOp: MongoOp = ProjectOp
+  val redactOp: MongoOp = RedactOp
+  val limitOp: MongoOp = LimitOp
+  val skipOp: MongoOp = SkipOp
+  val unwindOp: MongoOp = UnwindOp
+  val groupOp: MongoOp = GroupOp
+  val sortOp: MongoOp = SortOp
+  val geoNearOp: MongoOp = GeoNearOp
+  val outOp: MongoOp = OutOp
+  val lookupOp: MongoOp = LookupOp
+  val sampleOp: MongoOp = SampleOp
+  val foldLeftOp: MongoOp = FoldLeftOp
+  val mapOp: MongoOp = MapOp
+  val flatMapOp: MongoOp = FlatMapOp
+  val simpleMapOp: MongoOp = SimpleMapOp
+  val reduceOp: MongoOp = ReduceOp
+
   def opAlg: Algebra[WorkflowF, IList[MongoOp]] = {
     case WC($PureF(_)) => IList(PureOp)
     case WC($ReadF(_)) => IList(ReadOp)
@@ -196,7 +221,7 @@ trait PlannerWorkflowHelpers extends PlannerHelpers {
     case WC($SortF(s, _)) => SortOp :: s
     case WC($GeoNearF(s, _, _, _, _, _, _, _, _, _)) => GeoNearOp :: s
     case WC($OutF(s, _)) => OutOp :: s
-    case WC($FoldLeftF(s1, s2)) => (FoldLeftOp :: s1) ::: s2.list.flatten
+    case WC($FoldLeftF(s1, s2)) => (FoldLeftOp :: s1) ++ s2.list.flatten
     case WC32($LookupF(s, _, _, _, _)) => LookupOp :: s
     case WC32($SampleF(s, _)) => SampleOp :: s
     case WC($MapF(s, _, _)) => MapOp :: s
@@ -205,7 +230,48 @@ trait PlannerWorkflowHelpers extends PlannerHelpers {
     case WC($ReduceF(s, _, _)) => ReduceOp :: s
   }
 
+  def opTreeAlg: Algebra[WorkflowF, Tree[MongoOp]] = {
+    case WC($PureF(_)) => pureOp.leaf
+    case WC($ReadF(_)) => readOp.leaf
+    case WC($MatchF(s, _)) => matchOp.node(s)
+    case WC($ProjectF(s, _, _)) => projectOp.node(s)
+    case WC($RedactF(s, _)) => redactOp.node(s)
+    case WC($LimitF(s, _)) => limitOp.node(s)
+    case WC($SkipF(s, _)) => skipOp.node(s)
+    case WC($UnwindF(s, _)) => unwindOp.node(s)
+    case WC($GroupF(s, _, _)) => groupOp.node(s)
+    case WC($SortF(s, _)) => sortOp.node(s)
+    case WC($GeoNearF(s, _, _, _, _, _, _, _, _, _)) => geoNearOp.node(s)
+    case WC($OutF(s, _)) => outOp.node(s)
+    case WC($FoldLeftF(s1, s2)) => foldLeftOp.node((s1 :: s2.list).toList : _*)
+    case WC32($LookupF(s, _, _, _, _)) => lookupOp.node(s)
+    case WC32($SampleF(s, _)) => sampleOp.node(s)
+    case WC($MapF(s, _, _)) => mapOp.node(s)
+    case WC($FlatMapF(s, _, _)) => flatMapOp.node(s)
+    case WC($SimpleMapF(s, _, _)) => simpleMapOp.node(s)
+    case WC($ReduceF(s, _, _)) => reduceOp.node(s)
+  }
+
   def ops(wf: Workflow): IList[MongoOp] = wf.cata(opAlg).reverse
+
+  def opsTree(wf: Workflow): Tree[MongoOp] = wf.cata(opTreeAlg)
+
+  def foldLeftJoinSubTree(fst: Tree[MongoOp], snd: Tree[MongoOp]): Tree[MongoOp] =
+    foldLeftOp.node(
+      projectOp.node(groupOp.node(fst)),
+      reduceOp.node(mapOp.node(snd)))
+
+  val stdFoldLeftJoinSubTree: Tree[MongoOp] = foldLeftJoinSubTree(readOp.leaf, readOp.leaf)
+
+  case class beOpsTree(expected: Tree[MongoOp]) extends Matcher[Tree[MongoOp]] {
+    def apply[S <: Tree[MongoOp]](actual: Expectable[S]) = {
+      result(expected === actual.value,
+             "\ntrees are equal:\n" + expected.drawTree,
+             "\ntrees are not equal:\nexpected\n" + expected.drawTree + "\nactual:\n" + actual.value.drawTree,
+             actual,
+             FailureDetails(actual.value.drawTree, expected.drawTree))
+    }
+  }
 
   def noConsecutiveProjectOps(wf: Workflow) =
     countOps(wf, { case WC($ProjectF(Embed(WC($ProjectF(_, _, _))), _, _)) => true }) aka "the occurrences of consecutive $project ops:" must_== 0
@@ -242,6 +308,11 @@ trait PlannerWorkflowHelpers extends PlannerHelpers {
   def notBrokenWithOps(wf: Workflow, expectedOps: IList[MongoOp]) = {
     notBroken(wf)
     ops(wf) must_== expectedOps
+  }
+
+  def notBrokenWithOpsTree(wf: Workflow, expectedOps: Tree[MongoOp]) = {
+    notBroken(wf)
+    AsResult(Equal[Tree[MongoOp]].equal(opsTree(wf), expectedOps) must_=== true).updateMessage(s"Expected:\n${expectedOps.drawTree}\nActual:\n${opsTree(wf).drawTree}")
   }
 
   def rootPushes(wf: Workflow) =


### PR DESCRIPTION
Migrate join queries in mongo PlannerSpec to test against pipeline ops instead of an exact workflow

Closes #3209 