### PR TITLE
Minimize autojoins in dimensional 1-2 cases

### DIFF
--- a/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
@@ -76,11 +76,11 @@ final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT] private () {
         _ <- RenameT[F].tell(DList(deId -> srcId))
       } yield (srcId, qdims + (srcId -> updDims))
 
-    case ((_, tdims), GPF(tid, Transpose((srcId, srcDims), retain, _))) =>
+    case ((_, tdims), GPF(tid, Transpose((srcId, srcDims), retain, rot))) =>
       GStateM[F].modify(
         QSUGraph.vertices.modify(_.updated(
           tid,
-          LeftShift(srcId, HoleF, retain.fold[IdStatus](IdOnly, ExcludeId), RightSideF))))
+          LeftShift(srcId, HoleF, retain.fold[IdStatus](IdOnly, ExcludeId), RightSideF, rot))))
         .as((tid, srcDims + (tid -> tdims)))
 
     case ((_, nodeDims), GPF(nodeId, node)) =>
@@ -105,7 +105,7 @@ final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT] private () {
 
         case JoinSideRef(_) => unexpectedError("JoinSideRef", root)
 
-        case LeftShift(_, _, _, _) => unexpectedError("LeftShift", root)
+        case LeftShift(_, _, _, _, _) => unexpectedError("LeftShift", root)
 
         case LPFilter(_, _) => unexpectedError("LPFilter", root)
 

--- a/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
@@ -27,7 +27,7 @@ import quasar.fp._
 import quasar.qscript.{ExcludeId, HoleF, IdOnly, IdStatus, RightSideF}
 import quasar.qscript.provenance._
 
-import matryoshka._
+import matryoshka.{Hole => _, _}
 import matryoshka.data.free._
 import matryoshka.implicits._
 import pathy.Path
@@ -105,7 +105,12 @@ final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT] private () {
 
         case JoinSideRef(_) => unexpectedError("JoinSideRef", root)
 
-        case LeftShift(_, _, _, _, _) => unexpectedError("LeftShift", root)
+        case LeftShift((_, src), _, _, _, rot) =>
+          val tid: dims.I = Free.pure(Access.identity(root, root))
+          (rot match {
+            case Rotation.ShiftMap   | Rotation.ShiftArray   => dims.lshift(tid, src)
+            case Rotation.FlattenMap | Rotation.FlattenArray => dims.flatten(tid, src)
+          }).point[F]
 
         case LPFilter(_, _) => unexpectedError("LPFilter", root)
 

--- a/connector/src/main/scala/quasar/qscript/qsu/Graduate.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/Graduate.scala
@@ -167,7 +167,7 @@ final class Graduate[T[_[_]]: CorecursiveT] private () extends QSUTTypes[T] {
             QCE(Reduce[T, QSUGraph](source, bs, reducers, repair))
           }
 
-        case QSU.LeftShift(source, struct, idStatus, repair) =>
+        case QSU.LeftShift(source, struct, idStatus, repair, _) =>
           QCE(LeftShift[T, QSUGraph](source, struct, idStatus, repair)).point[F]
 
         case QSU.QSSort(source, buckets, order) =>

--- a/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
@@ -168,12 +168,12 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends 
           // candidates.forall(_ ~= QSReduce)
           lazy val reducerCheck = reducerAttempt.lengthCompare(candidates.length) === 0
 
-          lazy val leftShift12Extract = candidates match {
-            case (ls @ LeftShift(src1, _, _, _, _)) :: src2 :: Nil if src1.root === src2.root =>
-              Some((ls.unfold, true))
+          lazy val leftShift12Extract: Option[(QSU.LeftShift[T, QSUGraph], Boolean)] = candidates match {
+            case (ls @ LeftShift(src1, struct, idStatus, repair, rot)) :: src2 :: Nil if src1.root === src2.root =>
+              Some((QSU.LeftShift(src1, struct, idStatus, repair, rot), true))
 
-            case src2 :: (ls @ LeftShift(src1, _, _, _, _)) :: Nil if src1.root === src2.root =>
-              Some((ls.unfold, false))
+            case src2 :: (ls @ LeftShift(src1, struct, idStatus, repair, rot)) :: Nil if src1.root === src2.root =>
+              Some((QSU.LeftShift(src1, struct, idStatus, repair, rot), false))
 
             case _ => None
           }
@@ -273,8 +273,7 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends 
               }
             } yield back
           } else {
-            // this has to be @unchecked because otherwise scalac chokes
-            (leftShift12Extract: @unchecked) match {
+            leftShift12Extract match {
               case Some((QSU.LeftShift(src, struct, idStatus, repair, rot), leftToRight)) =>
                 val fm2 = if (leftToRight)
                   fm

--- a/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
@@ -31,6 +31,7 @@ import quasar.qscript.{
   HoleF,
   LeftSide,
   LeftSide3,
+  LeftSideF,
   ReduceIndex,
   RightSide,
   RightSide3,
@@ -41,7 +42,7 @@ import quasar.qscript.qsu.ApplyProvenance.AuthenticatedQSU
 
 import matryoshka.{delayEqual, BirecursiveT, EqualT}
 import matryoshka.data.free._
-import scalaz.{Equal, Free, Monad, Scalaz, StateT}, Scalaz._   // sigh, monad/traverse conflict
+import scalaz.{Bind, Equal, Free, Monad, Scalaz, StateT}, Scalaz._   // sigh, monad/traverse conflict
 
 final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends QSUTTypes[T] {
   import QSUGraph.Extractors._
@@ -159,13 +160,25 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends 
           coalesceToMap[G](qgraph, candidates, fm)
 
         case None =>
-          val reducerAttempt = candidates collect {
+          lazy val reducerAttempt = candidates collect {
             case g @ QSReduce(source, buckets, reducers, repair) =>
               (source, buckets, reducers, repair)
           }
 
           // candidates.forall(_ ~= QSReduce)
-          if (reducerAttempt.lengthCompare(candidates.length) === 0) {
+          lazy val reducerCheck = reducerAttempt.lengthCompare(candidates.length) === 0
+
+          lazy val leftShift12Extract = candidates match {
+            case (ls @ LeftShift(src1, _, _, _)) :: src2 :: Nil if src1.root === src2.root =>
+              Some((ls.unfold, true))
+
+            case src2 :: (ls @ LeftShift(src1, _, _, _)) :: Nil if src1.root === src2.root =>
+              Some((ls.unfold, false))
+
+            case _ => None
+          }
+
+          if (reducerCheck) {
             for {
               // apply coalescence recursively to our sources
               extended <- reducerAttempt traverse {
@@ -253,28 +266,36 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends 
                   red <- updateGraph[G](redPat)
                   back = qgraph.overwriteAtRoot(QSU.Map[T, Symbol](red.root, adjustedFM)) :++ red
 
-                  _ <- MonadState_[G, MinimizationState] modify { state =>
-                    val dims2 = state.dims map {
-                      case (key, value) =>
-                        val value2 = candidates.foldLeft(value) { (value, c) =>
-                          if (c.root =/= red.root)
-                            QP.rename(c.root, red.root, value)
-                          else
-                            value
-                        }
-
-                        key -> value2
-                    }
-
-                    state.copy(dims = dims2)
-                  }
+                  _ <- updateForCoalesce[G](candidates, red.root)
                 } yield back
               } else {
                 failure[G](qgraph)
               }
             } yield back
           } else {
-            failure[G](qgraph)
+            // this has to be @unchecked because otherwise scalac chokes
+            (leftShift12Extract: @unchecked) match {
+              case Some((QSU.LeftShift(src, struct, idStatus, repair), leftToRight)) =>
+                val fm2 = if (leftToRight)
+                  fm
+                else
+                  fm.map(1 - _)   // we know the domain is {0, 1}, so we invert the indices
+
+                val repair2 = fm2 flatMap {
+                  case 0 => repair
+                  case 1 => LeftSideF[T]
+                }
+
+
+                for {
+                  back <- qgraph.overwriteAtRoot(
+                    QSU.LeftShift[T, Symbol](src.root, struct, idStatus, repair2)).point[G]
+
+                  _ <- updateForCoalesce[G](candidates, qgraph.root)
+                } yield back
+              case None =>
+                failure[G](qgraph)
+            }
           }
       }
   }
@@ -288,6 +309,27 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends 
     }
 
     change.map(_ => graph)
+  }
+
+  private def updateForCoalesce[G[_]: Bind: MonadState_[?[_], MinimizationState]](
+      candidates: List[QSUGraph],
+      newRoot: Symbol): G[Unit] = {
+
+    MonadState_[G, MinimizationState] modify { state =>
+      val dims2 = state.dims map {
+        case (key, value) =>
+          val value2 = candidates.foldLeft(value) { (value, c) =>
+            if (c.root =/= newRoot)
+              QP.rename(c.root, newRoot, value)
+            else
+              value
+          }
+
+          key -> value2
+      }
+
+      state.copy(dims = dims2)
+    }
   }
 
   // we return a remap function along with a minimized list

--- a/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
@@ -169,10 +169,10 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends 
           lazy val reducerCheck = reducerAttempt.lengthCompare(candidates.length) === 0
 
           lazy val leftShift12Extract = candidates match {
-            case (ls @ LeftShift(src1, _, _, _)) :: src2 :: Nil if src1.root === src2.root =>
+            case (ls @ LeftShift(src1, _, _, _, _)) :: src2 :: Nil if src1.root === src2.root =>
               Some((ls.unfold, true))
 
-            case src2 :: (ls @ LeftShift(src1, _, _, _)) :: Nil if src1.root === src2.root =>
+            case src2 :: (ls @ LeftShift(src1, _, _, _, _)) :: Nil if src1.root === src2.root =>
               Some((ls.unfold, false))
 
             case _ => None
@@ -275,7 +275,7 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends 
           } else {
             // this has to be @unchecked because otherwise scalac chokes
             (leftShift12Extract: @unchecked) match {
-              case Some((QSU.LeftShift(src, struct, idStatus, repair), leftToRight)) =>
+              case Some((QSU.LeftShift(src, struct, idStatus, repair, rot), leftToRight)) =>
                 val fm2 = if (leftToRight)
                   fm
                 else
@@ -289,7 +289,7 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends 
 
                 for {
                   back <- qgraph.overwriteAtRoot(
-                    QSU.LeftShift[T, Symbol](src.root, struct, idStatus, repair2)).point[G]
+                    QSU.LeftShift[T, Symbol](src.root, struct, idStatus, repair2, rot)).point[G]
 
                   _ <- updateForCoalesce[G](candidates, qgraph.root)
                 } yield back

--- a/connector/src/main/scala/quasar/qscript/qsu/ReifyIdentities.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ReifyIdentities.scala
@@ -217,14 +217,14 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT] private () extends QSUTTypes[
       case g @ E.Distinct(source) =>
         preserveIV(source, g) as g
 
-      case g @ E.LeftShift(source, struct, IdOnly, repair) =>
+      case g @ E.LeftShift(source, struct, IdOnly, repair, rot) =>
         emitsIVMap(source).tuple(isReferenced(Access.identity(g.root, g.root))) flatMap {
           case (true, true) =>
             onNeedsIV(g) as {
               val newRepair =
                 updateIV(func.LeftSide, makeI1(g.root, func.RightSide), srcIVRepair(repair))
 
-              g.overwriteAtRoot(O.leftShift(source.root, rebaseV(struct), IdOnly, newRepair))
+              g.overwriteAtRoot(O.leftShift(source.root, rebaseV(struct), IdOnly, newRepair, rot))
             }
 
           case (true, false) =>
@@ -232,20 +232,20 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT] private () extends QSUTTypes[
               val newRepair =
                 makeIV(lookupIdentities >> func.LeftSide, srcIVRepair(repair))
 
-              g.overwriteAtRoot(O.leftShift(source.root, rebaseV(struct), IdOnly, newRepair))
+              g.overwriteAtRoot(O.leftShift(source.root, rebaseV(struct), IdOnly, newRepair, rot))
             }
 
           case (false, true) =>
             onNeedsIV(g) as {
               val newRepair = makeIV(makeI1(g.root, func.RightSide), repair)
-              g.overwriteAtRoot(O.leftShift(source.root, struct, IdOnly, newRepair))
+              g.overwriteAtRoot(O.leftShift(source.root, struct, IdOnly, newRepair, rot))
             }
 
           case (false, false) =>
             setStatus(g.root, false) as g
         }
 
-      case g @ E.LeftShift(source, struct, ExcludeId, repair) =>
+      case g @ E.LeftShift(source, struct, ExcludeId, repair, rot) =>
         emitsIVMap(source).tuple(isReferenced(Access.identity(g.root, g.root))) flatMap {
           case (true, true) =>
             onNeedsIV(g) as {
@@ -255,7 +255,7 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT] private () extends QSUTTypes[
                   makeI1(g.root, func.ProjectIndex(func.RightSide, func.Constant(EJson.int(0)))),
                   includeIdRepair(repair, rebaseV(func.LeftSide)))
 
-              g.overwriteAtRoot(O.leftShift(source.root, rebaseV(struct), IncludeId, newRepair))
+              g.overwriteAtRoot(O.leftShift(source.root, rebaseV(struct), IncludeId, newRepair, rot))
             }
 
           case (true, false) =>
@@ -263,7 +263,7 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT] private () extends QSUTTypes[
               val newRepair =
                 makeIV(lookupIdentities >> func.LeftSide, srcIVRepair(repair))
 
-              g.overwriteAtRoot(O.leftShift(source.root, rebaseV(struct), ExcludeId, newRepair))
+              g.overwriteAtRoot(O.leftShift(source.root, rebaseV(struct), ExcludeId, newRepair, rot))
             }
 
           case (false, true) =>
@@ -273,7 +273,7 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT] private () extends QSUTTypes[
                   makeI1(g.root, func.ProjectIndex(func.RightSide, func.Constant(EJson.int(0)))),
                   includeIdRepair(repair, func.LeftSide))
 
-              g.overwriteAtRoot(O.leftShift(source.root, struct, IncludeId, newRepair))
+              g.overwriteAtRoot(O.leftShift(source.root, struct, IncludeId, newRepair, rot))
             }
 
           case (false, false) =>

--- a/connector/src/test/scala/quasar/qscript/qsu/GraduateSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/GraduateSpec.scala
@@ -51,6 +51,7 @@ import scalaz.{\/, \/-, EitherT, Free, Need, NonEmptyList => NEL, StateT}
 import scalaz.Scalaz._
 
 object GraduateSpec extends Qspec with QSUTTypes[Fix] {
+  import QScriptUniform.Rotation
 
   type F[A] = EitherT[StateT[Need, Long, ?], PlannerError, A]
 
@@ -114,7 +115,7 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
         val struct: FreeMap = func.Add(HoleF, IntLit(17))
         val repair: JoinFunc = func.ConcatArrays(func.MakeArray(LeftSideF), func.MakeArray(RightSideF))
 
-        val qgraph: Fix[QSU] = qsu.leftShift(qsu.read(afile), struct, IncludeId, repair)
+        val qgraph: Fix[QSU] = qsu.leftShift(qsu.read(afile), struct, IncludeId, repair, Rotation.ShiftArray)
         val qscript: Fix[QSE] = qse.LeftShift(qse.Read[AFile](afile), struct, IncludeId, repair)
 
         qgraph must graduateAs(qscript)
@@ -173,7 +174,8 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
               qsu.read(root </> file("zips")),
               HoleF[Fix],
               IncludeId,
-              concatArr),
+              concatArr,
+              Rotation.ShiftArray),
             qsu.cint(1),
             Free.roll[MapFunc, Access[JoinSide]](
               MFC(MapFuncsCore.Constant[Fix, FreeAccess[JoinSide]](

--- a/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
@@ -452,6 +452,32 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
 
           struct must_=== HoleF[Fix]
 
+          repair must beTreeEqual(func.Add(RightSideF, LeftSideF))
+      }
+    }
+
+    "coalesce an autojoin on a single leftshift on a shared source (RTL)" in {
+      val qgraph = QSUGraph.fromTree[Fix](
+        qsu.autojoin2((
+          qsu.read(afile),
+          qsu.leftShift(
+            qsu.read(afile),
+            HoleF[Fix],
+            ExcludeId,
+            RightSideF[Fix],
+            Rotation.ShiftArray),
+          _(MapFuncsCore.Add(_, _)))))
+
+      runOn(qgraph) must beLike {
+        case LeftShift(
+          Read(`afile`),
+          struct,
+          ExcludeId,
+          repair,
+          _) =>
+
+          struct must_=== HoleF[Fix]
+
           repair must beTreeEqual(func.Add(LeftSideF, RightSideF))
       }
     }

--- a/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
@@ -48,7 +48,7 @@ import scalaz.syntax.std.option._
 object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix] {
   import QSUGraph.Extractors._
   import ApplyProvenance.AuthenticatedQSU
-  import QScriptUniform.DTrans
+  import QScriptUniform.{DTrans, Rotation}
 
   type F[A] = EitherT[StateT[Need, Long, ?], PlannerError, A]
 
@@ -437,7 +437,8 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
             qsu.read(afile),
             HoleF[Fix],
             ExcludeId,
-            RightSideF[Fix]),
+            RightSideF[Fix],
+            Rotation.ShiftArray),
           qsu.read(afile),
           _(MapFuncsCore.Add(_, _)))))
 
@@ -446,7 +447,8 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
           Read(`afile`),
           struct,
           ExcludeId,
-          repair) =>
+          repair,
+          _) =>
 
           struct must_=== HoleF[Fix]
 

--- a/connector/src/test/scala/quasar/qscript/qsu/ReifyBucketsSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/ReifyBucketsSpec.scala
@@ -63,7 +63,7 @@ object ReifyBucketsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
 
       reifyBuckets(tree) must beLike {
         case \/-(QSReduce(
-            LeftShift(Read(_), _, ExcludeId, _),
+            LeftShift(Read(_), _, ExcludeId, _, _),
             List(b),
             List(ReduceFuncs.Sum(r)),
             _)) =>
@@ -88,7 +88,7 @@ object ReifyBucketsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
       reifyBuckets(tree) must beLike {
         case \/-(
           QSReduce(
-            Map(LeftShift(Read(_), _, ExcludeId, _), fm),
+            Map(LeftShift(Read(_), _, ExcludeId, _, _), fm),
             Nil,
             List(ReduceFuncs.Sum(r)),
             _)) =>
@@ -118,7 +118,7 @@ object ReifyBucketsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
       reifyBuckets(tree) must beLike {
         case \/-(
           QSReduce(
-            Map(LeftShift(Read(_), _, ExcludeId, _), fm),
+            Map(LeftShift(Read(_), _, ExcludeId, _, _), fm),
             List(b),
             List(ReduceFuncs.Sum(r)),
             _)) =>


### PR DESCRIPTION
Example:

```sql
select a[*] + b from foo
```

This is pretty narrowly tailored, but it does address part of #3222 