### PR TITLE
Add explain to integration tests

### DIFF
--- a/it/src/test/scala/quasar/regression/RegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/RegressionTest.scala
@@ -27,12 +27,13 @@ import pathy.argonaut.PosixCodecJson._
 import scalaz._, Scalaz._
 
 case class RegressionTest(
-  name:      String,
-  backends:  Directives,
-  data:      List[RelFile[Unsandboxed]],
-  query:     String,
-  variables: Map[String, String],
-  expected:  ExpectedResult
+  name:          String,
+  backends:      Directives,
+  data:          List[RelFile[Unsandboxed]],
+  query:         String,
+  variables:     Map[String, String],
+  expected:      ExpectedResult,
+  explainQuery : Boolean
 )
 
 object RegressionTest {
@@ -61,9 +62,10 @@ object RegressionTest {
       ignoredFields     <- orElse(c --\ "ignoredFields", List.empty[String])
       ignoreFieldOrder  <- orElse(c --\ "ignoreFieldOrder", false)
       ignoreResultOrder <- orElse(c --\ "ignoreResultOrder", false)
+      explainQuery <- orElse(c --\ "explainQuery", false)
       rows              <- (c --\ "expected").as[List[Json]]
       predicate         <- (c --\ "predicate").as[Predicate]
     } yield RegressionTest(
       name, backends, data, query, variables,
-      ExpectedResult(rows, predicate, ignoredFields, ignoreFieldOrder, ignoreResultOrder, backends)))
+      ExpectedResult(rows, predicate, ignoredFields, ignoreFieldOrder, ignoreResultOrder, backends), explainQuery))
 }


### PR DESCRIPTION
With this change you can add flag `"explainQuery": true,` to your integration tests, like this:

```
{
  "name": "select with wildcard",
  "data": "basic.data",
  "query": "select * from basic",
  "predicate": "exactly",
  "ignoreResultOrder": true,
  "ignoredFields": ["_id"],
  "ignoreFieldOrder": true,

  "explainQuery": true,

  "expected": [
    {"name": {"first": "John", "last": "Smith"}, "num": 4},
    {"name": {"first": "Janina", "last": "Kowalska"}, "num": 42}
  ]
}

```

so when you run your integration tests, you will get the explanation of your physical plan. Below example for spark

```
> it/testOnly **.StreamingQueryRegressionSpec -- -ex wild --
[info] Compiling 1 Scala source to /Users/rabbit/projects/quasar/.targets/it/scala-2.11/test-classes...
Running Streaming Queries [.....................................................................helllo!!!!
ExecutionPlan[FileSystemType(spark-local)](inputs = ISet(rootDir </> dir("regression") </> dir("postgres") </> file("basic")))

(2) MapPartitionsRDD[3] at map at QScriptCorePlanner.scala:145 []
 |  MapPartitionsRDD[2] at map at SparkLocal.scala:129 []
 |  /Users/rabbit/temp/t/run6340e4df/regression/postgres/basic MapPartitionsRDD[1] at textFile at SparkLocal.scala:128 []
 |  /Users/rabbit/temp/t/run6340e4df/regression/postgres/basic HadoopRDD[0] at textFile at SparkLocal.scala:128 []
.................................................................................................................................................................................]
[info] StreamingQueryRegressionSpec
[info] 
```