### PR TITLE
Generalized dimensional coalescence to arbitrarily-nested shifts

### DIFF
--- a/connector/src/main/scala/quasar/qscript/qsu/LPtoQS.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/LPtoQS.scala
@@ -17,7 +17,7 @@
 package quasar.qscript.qsu
 
 import slamdata.Predef._
-import quasar.NameGenerator
+import quasar.{NameGenerator, RenderTreeT}
 import quasar.Planner.PlannerErrorME
 import quasar.frontend.logicalplan.LogicalPlan
 
@@ -26,7 +26,7 @@ import scalaz.{Applicative, Functor, Kleisli => K, Monad}
 import scalaz.syntax.applicative._
 import scalaz.syntax.show._
 
-final class LPtoQS[T[_[_]]: BirecursiveT: EqualT: ShowT] extends QSUTTypes[T] {
+final class LPtoQS[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends QSUTTypes[T] {
   import LPtoQS.MapSyntax
   import ApplyProvenance.AuthenticatedQSU
 
@@ -80,7 +80,7 @@ final class LPtoQS[T[_[_]]: BirecursiveT: EqualT: ShowT] extends QSUTTypes[T] {
 }
 
 object LPtoQS {
-  def apply[T[_[_]]: BirecursiveT: EqualT: ShowT]: LPtoQS[T] = new LPtoQS[T]
+  def apply[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT]: LPtoQS[T] = new LPtoQS[T]
 
   final implicit class MapSyntax[F[_], A](val self: F[A]) extends AnyVal {
     def >-[B](f: A => B)(implicit F: Functor[F]): F[B] =

--- a/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
@@ -221,7 +221,7 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends 
                           rebuiltFM).liftM[OptionT]
                     }
 
-                    back <- OptionT(minimizer[G](qgraph, candidates2, fm))
+                    back <- OptionT(minimizer[G](qgraph, simplifiedSource, candidates2, fm))
                   } yield back
 
                   backM.run

--- a/connector/src/main/scala/quasar/qscript/qsu/QSUGraph.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/QSUGraph.scala
@@ -280,7 +280,7 @@ object QSUGraph extends QSUGraphInstances {
 
       back <- reverse.get(node) match {
         case Some(sym) =>
-          QSUGraph[T](root = sym, SMap()).point[F]
+          QSUGraph[T](root = sym, SMap(sym -> node)).point[F]
 
         case None =>
           for {

--- a/connector/src/main/scala/quasar/qscript/qsu/minimizers/MergeReductions.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/minimizers/MergeReductions.scala
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.qsu
+package minimizers
+
+import quasar.{NameGenerator, Planner}, Planner.PlannerErrorME
+import quasar.contrib.matryoshka._
+import quasar.contrib.scalaz.MonadState_
+import quasar.ejson.implicits._
+import quasar.fp._
+import quasar.fp.ski.κ
+import quasar.qscript.{
+  construction,
+  Hole,
+  HoleF,
+  ReduceIndex
+}
+import quasar.qscript.qsu.{QScriptUniform => QSU}
+import slamdata.Predef._
+
+import matryoshka.{delayEqual, BirecursiveT, EqualT}
+import matryoshka.data.free._
+import scalaz.{Free, Monad, Scalaz}, Scalaz._
+
+final class MergeReductions[T[_[_]]: BirecursiveT: EqualT] private () extends Minimizer[T] {
+  import MinimizeAutoJoins._
+  import QSUGraph.Extractors._
+
+  private val func = construction.Func[T]
+
+  def couldApplyTo(candidates: List[QSUGraph]): Boolean = {
+    candidates forall {
+      case QSReduce(_, _, _, _) => true
+      case _ => false
+    }
+  }
+
+  def extract[
+      G[_]: Monad: NameGenerator: PlannerErrorME: MonadState_[?[_], RevIdx]: MonadState_[?[_], MinimizationState[T]]](
+      qgraph: QSUGraph): Option[(QSUGraph, (QSUGraph, FreeMap) => G[QSUGraph])] = qgraph match {
+
+    case qgraph @ QSReduce(src, buckets, reducers, repair) =>
+      def rebuild(src: QSUGraph, fm: FreeMap): G[QSUGraph] = {
+        def rewriteBucket(bucket: Access[Hole]): FreeMapA[Access[Hole]] = bucket match {
+          case v @ Access.Value(_) => fm.map(κ(v))
+          case other => Free.pure[MapFunc, Access[Hole]](other)
+        }
+
+        val buckets2 = buckets.map(_.flatMap(rewriteBucket))
+        val reducers2 = reducers.map(_.map(_.flatMap(κ(fm))))
+
+        updateGraph[T, G](QSU.QSReduce(src.root, buckets2, reducers2, repair)) map { rewritten =>
+          qgraph.overwriteAtRoot(rewritten.vertices(rewritten.root)) :++ rewritten :++ src
+        }
+      }
+
+      Some((src, rebuild _))
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+  def apply[
+      G[_]: Monad: NameGenerator: PlannerErrorME: MonadState_[?[_], RevIdx]: MonadState_[?[_], MinimizationState[T]]](
+      qgraph: QSUGraph, candidates: List[QSUGraph], fm: FreeMapA[Int]): G[Option[(QSUGraph, QSUGraph)]] = {
+
+    val reducerAttempt = candidates collect {
+      case g @ QSReduce(source, buckets, reducers, repair) =>
+        (source, buckets, reducers, repair)
+    }
+
+    val (source, buckets, _, _) = reducerAttempt.head
+
+    val sourceCheck = reducerAttempt filter {
+      case (cSrc, cBuckets, _, _) =>
+        cSrc.root === source.root && cBuckets === buckets
+    }
+
+    if (sourceCheck.lengthCompare(candidates.length) === 0) {
+      val lifted = reducerAttempt.zipWithIndex map {
+        case ((_, buckets, reducers, repair), i) =>
+          (
+            buckets,
+            reducers,
+            // we use maps here to avoid definedness issues in reduction results
+            func.MakeMapS(i.toString, repair))
+      }
+
+      // this is fine, because we can't be here if candidates is empty
+      // doing it this way avoids an extra (and useless) Option state in the fold
+      val (_, lhreducers, lhrepair) = lifted.head
+
+      // squish all the reducers down into lhead
+      val (_, (reducers, repair)) =
+        lifted.tail.foldLeft((lhreducers.length, (lhreducers, lhrepair))) {
+          case ((roffset, (lreducers, lrepair)), (_, rreducers, rrepair)) =>
+            val reducers = lreducers ::: rreducers
+
+            val roffset2 = roffset + rreducers.length
+
+            val repair = func.ConcatMaps(
+              lrepair,
+              rrepair map {
+                case ReduceIndex(e) =>
+                  ReduceIndex(e.rightMap(_ + roffset))
+              })
+
+            (roffset2, (reducers, repair))
+        }
+
+      // 107.7, All chiropractors, all the time
+      val adjustedFM = fm flatMap { i =>
+        // get the value back OUT of the map
+        func.ProjectKeyS(HoleF[T], i.toString)
+      }
+
+      val redPat = QSU.QSReduce[T, Symbol](source.root, buckets, reducers, repair)
+
+      updateGraph[T, G](redPat) map { rewritten =>
+        val back = qgraph.overwriteAtRoot(QSU.Map[T, Symbol](rewritten.root, adjustedFM)) :++ rewritten
+
+        Some((rewritten, back))
+      }
+    } else {
+      (None: Option[(QSUGraph, QSUGraph)]).point[G]
+    }
+  }
+}
+
+object MergeReductions {
+  def apply[T[_[_]]: BirecursiveT: EqualT]: MergeReductions[T] =
+    new MergeReductions[T]
+}

--- a/connector/src/main/scala/quasar/qscript/qsu/minimizers/MergeReductions.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/minimizers/MergeReductions.scala
@@ -74,14 +74,17 @@ final class MergeReductions[T[_[_]]: BirecursiveT: EqualT] private () extends Mi
   @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
   def apply[
       G[_]: Monad: NameGenerator: PlannerErrorME: MonadState_[?[_], RevIdx]: MonadState_[?[_], MinimizationState[T]]](
-      qgraph: QSUGraph, candidates: List[QSUGraph], fm: FreeMapA[Int]): G[Option[(QSUGraph, QSUGraph)]] = {
+      qgraph: QSUGraph,
+      source: QSUGraph,
+      candidates: List[QSUGraph],
+      fm: FreeMapA[Int]): G[Option[(QSUGraph, QSUGraph)]] = {
 
     val reducerAttempt = candidates collect {
       case g @ QSReduce(source, buckets, reducers, repair) =>
         (source, buckets, reducers, repair)
     }
 
-    val (source, buckets, _, _) = reducerAttempt.head
+    val (_, buckets, _, _) = reducerAttempt.head
 
     val sourceCheck = reducerAttempt filter {
       case (cSrc, cBuckets, _, _) =>

--- a/connector/src/main/scala/quasar/qscript/qsu/minimizers/Minimizer.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/minimizers/Minimizer.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.qsu
+package minimizers
+
+import quasar.{NameGenerator, Planner}, Planner.PlannerErrorME
+import quasar.contrib.scalaz.MonadState_
+import slamdata.Predef._
+
+import scalaz.Monad
+
+trait Minimizer[T[_[_]]] extends QSUTTypes[T] {
+  import MinimizeAutoJoins.MinimizationState
+
+  def couldApplyTo(candidates: List[QSUGraph]): Boolean
+
+  def extract[
+      G[_]: Monad: NameGenerator: PlannerErrorME: MonadState_[?[_], RevIdx]: MonadState_[?[_], MinimizationState[T]]](
+      qgraph: QSUGraph): Option[(QSUGraph, (QSUGraph, FreeMap) => G[QSUGraph])]
+
+  // the first component of the tuple is the rewrite target on any provenance association
+  // the second component is the root of the resulting graph
+  def apply[
+      G[_]: Monad: NameGenerator: PlannerErrorME: MonadState_[?[_], RevIdx]: MonadState_[?[_], MinimizationState[T]]](
+      qgraph: QSUGraph, candidates: List[QSUGraph], fm: FreeMapA[Int]): G[Option[(QSUGraph, QSUGraph)]]
+}

--- a/connector/src/main/scala/quasar/qscript/qsu/minimizers/Minimizer.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/minimizers/Minimizer.scala
@@ -36,5 +36,8 @@ trait Minimizer[T[_[_]]] extends QSUTTypes[T] {
   // the second component is the root of the resulting graph
   def apply[
       G[_]: Monad: NameGenerator: PlannerErrorME: MonadState_[?[_], RevIdx]: MonadState_[?[_], MinimizationState[T]]](
-      qgraph: QSUGraph, candidates: List[QSUGraph], fm: FreeMapA[Int]): G[Option[(QSUGraph, QSUGraph)]]
+      qgraph: QSUGraph,
+      singleSource: QSUGraph,
+      candidates: List[QSUGraph],
+      fm: FreeMapA[Int]): G[Option[(QSUGraph, QSUGraph)]]
 }

--- a/connector/src/main/scala/quasar/qscript/qsu/minimizers/ShiftProjectBelow.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/minimizers/ShiftProjectBelow.scala
@@ -43,8 +43,11 @@ final class ShiftProjectBelow[T[_[_]]: BirecursiveT: EqualT] private () extends 
   import QSUGraph.Extractors._
 
   def couldApplyTo(candidates: List[QSUGraph]): Boolean = candidates match {
+    case LeftShift(_, _, _, _, _) :: LeftShift(_, _, _, _, _) :: Nil => false
+
     case LeftShift(_, _, _, _, _) :: _ :: Nil => true
     case _ :: LeftShift(_, _, _, _, _) :: Nil => true
+
     case _ => false
   }
 

--- a/connector/src/main/scala/quasar/qscript/qsu/minimizers/ShiftProjectBelow.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/minimizers/ShiftProjectBelow.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.qsu
+package minimizers
+
+import quasar.{NameGenerator, Planner}, Planner.PlannerErrorME
+import quasar.contrib.matryoshka._
+import quasar.contrib.scalaz.MonadState_
+import quasar.ejson.implicits._
+import quasar.fp._
+import quasar.fp.ski.κ
+import quasar.qscript.{
+  HoleF,
+  JoinSide,
+  LeftSide,
+  LeftSideF,
+  RightSide,
+  RightSideF
+}
+import quasar.qscript.qsu.{QScriptUniform => QSU}
+import slamdata.Predef._
+
+import matryoshka.{delayEqual, BirecursiveT, EqualT}
+import matryoshka.data.free._
+import scalaz.{Monad, Scalaz}, Scalaz._
+
+final class ShiftProjectBelow[T[_[_]]: BirecursiveT: EqualT] private () extends Minimizer[T] {
+  import MinimizeAutoJoins._
+  import QSUGraph.Extractors._
+
+  def couldApplyTo(candidates: List[QSUGraph]): Boolean = candidates match {
+    case LeftShift(_, _, _, _, _) :: _ :: Nil => true
+    case _ :: LeftShift(_, _, _, _, _) :: Nil => true
+    case _ => false
+  }
+
+  def extract[
+      G[_]: Monad: NameGenerator: PlannerErrorME: MonadState_[?[_], RevIdx]: MonadState_[?[_], MinimizationState[T]]](
+      qgraph: QSUGraph): Option[(QSUGraph, (QSUGraph, FreeMap) => G[QSUGraph])] = qgraph match {
+
+    case qgraph @ LeftShift(src, struct, idStatus, repair, rot) =>
+      def rebuild(src: QSUGraph, fm: FreeMap): G[QSUGraph] = {
+        val struct2 = struct.flatMap(κ(fm))
+
+        val repair2 = repair flatMap {
+          case LeftSide => fm.map(κ(LeftSide: JoinSide))
+          case RightSide => RightSideF[T]
+        }
+
+        updateGraph[T, G](QSU.LeftShift(src.root, struct2, idStatus, repair2, rot)) map { rewritten =>
+          qgraph.overwriteAtRoot(rewritten.vertices(rewritten.root)) :++ rewritten :++ src
+        }
+      }
+
+      Some((src, rebuild _))
+
+    // we're potentially defined for all sides so long as there's a left shift around
+    case qgraph =>
+      def rebuild(src: QSUGraph, fm: FreeMap): G[QSUGraph] = {
+        if (fm === HoleF[T]) {
+          src.point[G]
+        } else {
+          // this case should never happen
+          updateGraph[T, G](QSU.Map(src.root, fm)) map { rewritten =>
+            qgraph.overwriteAtRoot(rewritten.vertices(rewritten.root)) :++ rewritten :++ src
+          }
+        }
+      }
+
+      Some((qgraph, rebuild _))
+  }
+
+  def apply[
+      G[_]: Monad: NameGenerator: PlannerErrorME: MonadState_[?[_], RevIdx]: MonadState_[?[_], MinimizationState[T]]](
+      qgraph: QSUGraph, candidates: List[QSUGraph], fm: FreeMapA[Int]): G[Option[(QSUGraph, QSUGraph)]] = {
+
+    val extraction = candidates match {
+      case LeftShift(src1, struct, idStatus, repair, rot) :: src2 :: Nil if src1.root === src2.root =>
+        Some((src1, struct, idStatus, repair, rot, true))
+
+      case src1 :: LeftShift(src2, struct, idStatus, repair, rot) :: Nil if src1.root === src2.root =>
+        Some((src1, struct, idStatus, repair, rot, false))
+
+      case _ => None
+    }
+
+    extraction traverse {
+      case (src, struct, idStatus, repair, rot, leftToRight) =>
+        val fm2 = if (leftToRight)
+          fm
+        else
+          fm.map(1 - _)   // we know the domain is {0, 1}, so we invert the indices
+
+        val repair2 = fm2 flatMap {
+          case 0 => repair
+          case 1 => LeftSideF[T]
+        }
+
+        updateGraph[T, G](QSU.LeftShift[T, Symbol](src.root, struct, idStatus, repair2, rot)) map { rewritten =>
+          val back = qgraph.overwriteAtRoot(rewritten.vertices(rewritten.root)) :++ rewritten
+
+          (back, back)
+        }
+    }
+  }
+}
+
+object ShiftProjectBelow {
+  def apply[T[_[_]]: BirecursiveT: EqualT]: ShiftProjectBelow[T] =
+    new ShiftProjectBelow[T]
+}

--- a/connector/src/main/scala/quasar/qscript/qsu/minimizers/ShiftProjectBelow.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/minimizers/ShiftProjectBelow.scala
@@ -86,7 +86,10 @@ final class ShiftProjectBelow[T[_[_]]: BirecursiveT: EqualT] private () extends 
 
   def apply[
       G[_]: Monad: NameGenerator: PlannerErrorME: MonadState_[?[_], RevIdx]: MonadState_[?[_], MinimizationState[T]]](
-      qgraph: QSUGraph, candidates: List[QSUGraph], fm: FreeMapA[Int]): G[Option[(QSUGraph, QSUGraph)]] = {
+      qgraph: QSUGraph,
+      singleSource: QSUGraph,
+      candidates: List[QSUGraph],
+      fm: FreeMapA[Int]): G[Option[(QSUGraph, QSUGraph)]] = {
 
     val extraction = candidates match {
       case LeftShift(src1, struct, idStatus, repair, rot) :: src2 :: Nil if src1.root === src2.root =>

--- a/connector/src/main/scala/quasar/qscript/qsu/minimizers/ShiftProjectBelow.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/minimizers/ShiftProjectBelow.scala
@@ -17,30 +17,34 @@
 package quasar.qscript.qsu
 package minimizers
 
-import quasar.{NameGenerator, Planner}, Planner.PlannerErrorME
+import quasar.{NameGenerator, Planner, RenderTreeT}, Planner.PlannerErrorME
 import quasar.contrib.matryoshka._
 import quasar.contrib.scalaz.MonadState_
 import quasar.ejson.implicits._
 import quasar.fp._
 import quasar.fp.ski.κ
 import quasar.qscript.{
+  construction,
   HoleF,
   JoinSide,
   LeftSide,
-  LeftSideF,
-  RightSide,
-  RightSideF
+  RightSide
 }
 import quasar.qscript.qsu.{QScriptUniform => QSU}
+import quasar.qscript.rewrites.NormalizableT
 import slamdata.Predef._
 
-import matryoshka.{delayEqual, BirecursiveT, EqualT}
+import matryoshka.{delayEqual, BirecursiveT, EqualT, ShowT}
 import matryoshka.data.free._
-import scalaz.{Monad, Scalaz}, Scalaz._
+import scalaz.{Monad, NonEmptyList => NEL, Scalaz}, Scalaz._
 
-final class ShiftProjectBelow[T[_[_]]: BirecursiveT: EqualT] private () extends Minimizer[T] {
+final class ShiftProjectBelow[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] private () extends Minimizer[T] {
   import MinimizeAutoJoins._
   import QSUGraph.Extractors._
+
+  private val func = construction.Func[T]
+
+  private val N = new NormalizableT[T]
 
   def couldApplyTo(candidates: List[QSUGraph]): Boolean = candidates match {
     case LeftShift(_, _, _, _, _) :: LeftShift(_, _, _, _, _) :: Nil => false
@@ -55,18 +59,33 @@ final class ShiftProjectBelow[T[_[_]]: BirecursiveT: EqualT] private () extends 
       G[_]: Monad: NameGenerator: PlannerErrorME: MonadState_[?[_], RevIdx]: MonadState_[?[_], MinimizationState[T]]](
       qgraph: QSUGraph): Option[(QSUGraph, (QSUGraph, FreeMap) => G[QSUGraph])] = qgraph match {
 
-    case qgraph @ LeftShift(src, struct, idStatus, repair, rot) =>
+    case ConsecutiveLeftShifts(src, shifts) =>
       def rebuild(src: QSUGraph, fm: FreeMap): G[QSUGraph] = {
+        val reversed = shifts.reverse
+
+        val QSU.LeftShift(_, struct, idStatus, repair, rot) = reversed.head
+        val rest = reversed.tail
+
         val struct2 = struct.flatMap(κ(fm))
 
         val repair2 = repair flatMap {
           case LeftSide => fm.map(κ(LeftSide: JoinSide))
-          case RightSide => RightSideF[T]
+          case RightSide => func.RightSide
         }
 
-        updateGraph[T, G](QSU.LeftShift(src.root, struct2, idStatus, repair2, rot)) map { rewritten =>
-          qgraph.overwriteAtRoot(rewritten.vertices(rewritten.root)) :++ rewritten :++ src
-        }
+        for {
+          init <-
+            updateGraph[T, G](QSU.LeftShift(src.root, struct2, idStatus, repair2, rot)) map { rewritten =>
+              rewritten :++ src
+            }
+
+          back <- rest.foldLeftM[G, QSUGraph](init) {
+            case (src, QSU.LeftShift(_, struct, idStatus, repair, rot)) =>
+              updateGraph[T, G](QSU.LeftShift(src.root, struct, idStatus, repair, rot)) map { rewritten =>
+                rewritten :++ src
+              }
+          }
+        } yield qgraph.overwriteAtRoot(back.vertices(back.root)) :++ back
       }
 
       Some((src, rebuild _))
@@ -90,42 +109,107 @@ final class ShiftProjectBelow[T[_[_]]: BirecursiveT: EqualT] private () extends 
   def apply[
       G[_]: Monad: NameGenerator: PlannerErrorME: MonadState_[?[_], RevIdx]: MonadState_[?[_], MinimizationState[T]]](
       qgraph: QSUGraph,
-      singleSource: QSUGraph,
+      src: QSUGraph,
       candidates: List[QSUGraph],
       fm: FreeMapA[Int]): G[Option[(QSUGraph, QSUGraph)]] = {
 
     val extraction = candidates match {
-      case LeftShift(src1, struct, idStatus, repair, rot) :: src2 :: Nil if src1.root === src2.root =>
-        Some((src1, struct, idStatus, repair, rot, true))
-
-      case src1 :: LeftShift(src2, struct, idStatus, repair, rot) :: Nil if src1.root === src2.root =>
-        Some((src1, struct, idStatus, repair, rot, false))
-
+      case ConsecutiveLeftShifts(_, shifts) :: _ :: Nil => Some((shifts, true))
+      case _ :: ConsecutiveLeftShifts(_, shifts) :: Nil => Some((shifts, false))
       case _ => None
     }
 
     extraction traverse {
-      case (src, struct, idStatus, repair, rot, leftToRight) =>
+      case (shifts, leftToRight) =>
+        val reversed = shifts.reverse
+
         val fm2 = if (leftToRight)
           fm
         else
           fm.map(1 - _)   // we know the domain is {0, 1}, so we invert the indices
 
-        val repair2 = fm2 flatMap {
-          case 0 => repair
-          case 1 => LeftSideF[T]
-        }
+        val QSU.LeftShift(_, struct, idStatus, repair, rot) = reversed.head
+        val rest = reversed.tail
 
-        updateGraph[T, G](QSU.LeftShift[T, Symbol](src.root, struct, idStatus, repair2, rot)) map { rewritten =>
-          val back = qgraph.overwriteAtRoot(rewritten.vertices(rewritten.root)) :++ rewritten
+        if (rest.isEmpty) {
+          val repair2 = fm2 flatMap {
+            case 0 => repair
+            case 1 => func.LeftSide
+          }
 
-          (back, back)
+          // TODO I'm pretty sure this messes up dimension names
+          updateGraph[T, G](QSU.LeftShift[T, Symbol](src.root, struct, idStatus, repair2, rot)) map { rewritten =>
+            val back = qgraph.overwriteAtRoot(rewritten.vertices(rewritten.root)) :++ rewritten
+
+            (back, back)
+          }
+        } else {
+          val repair2 = func.ConcatMaps(
+            func.MakeMapS("original", func.LeftSide),
+            func.MakeMapS("results", repair))
+
+          for {
+            init2 <- updateGraph[T, G](
+              QSU.LeftShift[T, Symbol](src.root, struct, idStatus, repair2, rot))
+
+            reconstructed <- rest.foldLeftM[G, QSUGraph](init2) {
+              case (src, QSU.LeftShift(_, struct, idStatus, repair, rot)) =>
+                val struct2 = struct.flatMap(κ(func.ProjectKeyS(func.Hole, "results")))
+
+                val repair2 = repair flatMap {
+                  case LeftSide => func.ProjectKeyS(func.LeftSide, "results")
+                  case RightSide => func.RightSide
+                }
+
+                // we use right-biased map concat to our advantage here and overwrite results
+                val repair3 = func.ConcatMaps(
+                  func.LeftSide,
+                  func.MakeMapS("results", func.RightSide))
+
+                updateGraph[T, G](QSU.LeftShift[T, Symbol](src.root, struct2, idStatus, repair3, rot)) map { rewritten =>
+                  rewritten :++ src
+                }
+            }
+
+            // TODO this creates some unnecessary structure (we create the results map, only to deconstruct it again)
+            rewritten = reconstructed match {
+              case reconstructed @ LeftShift(src, struct, idStatus, repair, rot) =>
+                val repair2 = fm2 flatMap {
+                  case 0 => func.ProjectKeyS(repair, "results")
+                  case 1 => func.ProjectKeyS(repair, "original")
+                }
+
+                val repairN = N.freeMF(repair2)
+
+                reconstructed.overwriteAtRoot(
+                  QSU.LeftShift(src.root, struct, idStatus, repairN, rot))
+
+              case reconstructed => reconstructed
+            }
+
+            back = qgraph.overwriteAtRoot(rewritten.vertices(rewritten.root)) :++ rewritten
+          } yield (back, back)
         }
+    }
+  }
+
+  object ConsecutiveLeftShifts {
+
+    @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
+    def unapply(qgraph: QSUGraph): Option[(QSUGraph, NEL[QSU.LeftShift[T, QSUGraph]])] = qgraph match {
+      case LeftShift(oparent @ ConsecutiveLeftShifts(parent, inners), struct, idStatus, repair, rot) =>
+        Some((parent, QSU.LeftShift[T, QSUGraph](oparent, struct, idStatus, repair, rot) <:: inners))
+
+      case LeftShift(parent, struct, idStatus, repair, rot) =>
+        Some((parent, NEL(QSU.LeftShift[T, QSUGraph](parent, struct, idStatus, repair, rot))))
+
+      case _ =>
+        None
     }
   }
 }
 
 object ShiftProjectBelow {
-  def apply[T[_[_]]: BirecursiveT: EqualT]: ShiftProjectBelow[T] =
+  def apply[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT]: ShiftProjectBelow[T] =
     new ShiftProjectBelow[T]
 }

--- a/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
@@ -23,6 +23,7 @@ import quasar.fp._
 import quasar.qscript.{
   construction,
   ExcludeId,
+  IncludeId,
   Hole,
   HoleF,
   LeftSide,
@@ -545,7 +546,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
             qsu.leftShift(
               qsu.read(afile),
               HoleF[Fix],
-              ExcludeId,
+              IncludeId,
               RightSideF[Fix],
               Rotation.ShiftArray),
             HoleF[Fix],
@@ -560,7 +561,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
           LeftShift(
             Read(`afile`),
             structInner,
-            ExcludeId,
+            IncludeId,
             repairInner,
             _),
           structOuter,
@@ -596,13 +597,13 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
               qsu.leftShift(
                 qsu.read(afile),
                 HoleF[Fix],
-                ExcludeId,
+                IncludeId,
                 RightSideF[Fix],
                 Rotation.ShiftArray),
               HoleF[Fix],
               ExcludeId,
               RightSideF[Fix],
-              Rotation.ShiftArray),
+              Rotation.ShiftMap),
             HoleF[Fix],
             ExcludeId,
             RightSideF[Fix],
@@ -616,17 +617,17 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
             LeftShift(
               Read(`afile`),
               structInnerInner,
-              ExcludeId,
+              IncludeId,
               repairInnerInner,
-              _),
+              Rotation.ShiftArray),
             structInner,
             ExcludeId,
             repairInner,
-            _),
+            Rotation.ShiftMap),
           structOuter,
           ExcludeId,
           repairOuter,
-          _) =>
+          Rotation.ShiftArray) =>
 
           structInnerInner must beTreeEqual(func.Hole)
 

--- a/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
@@ -242,30 +242,11 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
 
           // must_=== doesn't work
           h1 must beTreeEqual(
-            func.ProjectKeyS(
-              func.ConcatMaps(
-                func.MakeMapS(
-                  "0",
-                  func.ConcatArrays(
-                    HoleF,
-                    func.Constant(J.str("hey")))),
-                func.MakeMapS(
-                  "1",
-                  func.Hole)),
-              "0"))
+            func.ConcatArrays(
+              HoleF,
+              func.Constant(J.str("hey"))))
 
-          h2 must beTreeEqual(
-            func.ProjectKeyS(
-              func.ConcatMaps(
-                func.MakeMapS(
-                  "0",
-                  func.ConcatArrays(
-                    HoleF,
-                    func.Constant(J.str("hey")))),
-                func.MakeMapS(
-                  "1",
-                  func.Hole)),
-              "1"))
+          h2 must beTreeEqual(func.Hole)
 
           repair must beTreeEqual(
             func.ConcatMaps(
@@ -369,7 +350,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
               func.ProjectKey(HoleF, func.Constant(J.str("0"))),
               func.ProjectKey(HoleF, func.Constant(J.str("1")))))
       }
-    }.pendingUntilFixed
+    }
 
     "remap coalesced bucket references in dimensions" in {
       val aqsu = QScriptUniform.AnnotatedDsl[Fix, Symbol]
@@ -400,7 +381,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
       val ds = runOn_(qgraph).dims
 
       (ds(remap('n2)) must_= expDims) and (ds(remap('n3)) must_= expDims)
-    }.pendingUntilFixed
+    }
 
     "leave uncoalesced reductions of different bucketing" in {
       val qgraph = QSUGraph.fromTree[Fix](

--- a/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
@@ -262,7 +262,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
               func.ProjectKey(HoleF, func.Constant(J.str("0"))),
               func.ProjectKey(HoleF, func.Constant(J.str("1")))))
       }
-    }
+    }.pendingUntilFixed
 
     "rewrite filter into cond only to avoid join" in {
       val qgraph = QSUGraph.fromTree[Fix](
@@ -350,7 +350,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
               func.ProjectKey(HoleF, func.Constant(J.str("0"))),
               func.ProjectKey(HoleF, func.Constant(J.str("1")))))
       }
-    }
+    }.pendingUntilFixed
 
     "remap coalesced bucket references in dimensions" in {
       val aqsu = QScriptUniform.AnnotatedDsl[Fix, Symbol]

--- a/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
@@ -376,7 +376,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
         QSUGraph.fromAnnotatedTree(atree map (_.some))
 
       val expDims =
-        IList(qprov.prov.value(Access.bucket('qsu0, 0, 'qsu0).point[FreeMapA]))
+        IList(qprov.prov.value(Access.bucket('qsu2, 0, 'qsu2).point[FreeMapA]))
 
       val ds = runOn_(qgraph).dims
 

--- a/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/MinimizeAutoJoinsSpec.scala
@@ -242,11 +242,30 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
 
           // must_=== doesn't work
           h1 must beTreeEqual(
-            func.ConcatArrays(
-              HoleF,
-              func.Constant(J.str("hey"))))
+            func.ProjectKeyS(
+              func.ConcatMaps(
+                func.MakeMapS(
+                  "0",
+                  func.ConcatArrays(
+                    HoleF,
+                    func.Constant(J.str("hey")))),
+                func.MakeMapS(
+                  "1",
+                  func.Hole)),
+              "0"))
 
-          h2 must beTreeEqual(HoleF[Fix])
+          h2 must beTreeEqual(
+            func.ProjectKeyS(
+              func.ConcatMaps(
+                func.MakeMapS(
+                  "0",
+                  func.ConcatArrays(
+                    HoleF,
+                    func.Constant(J.str("hey")))),
+                func.MakeMapS(
+                  "1",
+                  func.Hole)),
+              "1"))
 
           repair must beTreeEqual(
             func.ConcatMaps(
@@ -262,7 +281,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
               func.ProjectKey(HoleF, func.Constant(J.str("0"))),
               func.ProjectKey(HoleF, func.Constant(J.str("1")))))
       }
-    }.pendingUntilFixed
+    }
 
     "rewrite filter into cond only to avoid join" in {
       val qgraph = QSUGraph.fromTree[Fix](
@@ -381,7 +400,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
       val ds = runOn_(qgraph).dims
 
       (ds(remap('n2)) must_= expDims) and (ds(remap('n3)) must_= expDims)
-    }
+    }.pendingUntilFixed
 
     "leave uncoalesced reductions of different bucketing" in {
       val qgraph = QSUGraph.fromTree[Fix](
@@ -450,7 +469,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
           repair,
           _) =>
 
-          struct must_=== HoleF[Fix]
+          struct must beTreeEqual(HoleF[Fix])
 
           repair must beTreeEqual(func.Add(RightSideF, LeftSideF))
       }
@@ -476,8 +495,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
           repair,
           _) =>
 
-          struct must_=== HoleF[Fix]
-
+          struct must beTreeEqual(HoleF[Fix])
           repair must beTreeEqual(func.Add(LeftSideF, RightSideF))
       }
     }


### PR DESCRIPTION
This generalizes #3287 to arbitrary nestings (e.g. `a[*][*] + b`).  Depends on #3297.  Affects #3222.  This PR is actually just the single `HEAD` commit.

Assigning to @wemrysi.  Can you take a close look at the way that I'm rewriting root at the end of the shift chains?  Which is to say, lines 141 and 190.  Note that `updateGraph` calls `withName`, updates dimensions, and then returns that node.