### PR TITLE
QSU Group Key Reification

### DIFF
--- a/connector/src/main/scala/quasar/qscript/MapFuncCore.scala
+++ b/connector/src/main/scala/quasar/qscript/MapFuncCore.scala
@@ -398,6 +398,8 @@ object MapFuncCore {
 
       case ConcatMaps(Embed(lhs), Embed(StaticMap(Nil))) => lhs.some
 
+      case ConcatMaps(Embed(lhs), Embed(rhs)) if lhs ≟ rhs => lhs.some
+
       case _ => none
     }
 

--- a/connector/src/main/scala/quasar/qscript/provenance/Dimension.scala
+++ b/connector/src/main/scala/quasar/qscript/provenance/Dimension.scala
@@ -68,7 +68,7 @@ trait Dimension[D, I, P] {
 
   /** Collapses all dimensions into a single one. */
   def squash(ds: Dimensions[P]): Dimensions[P] =
-    ds.toNel.fold(ds)(nel => IList(nel.foldLeft1(thenn(_, _))))
+    ds.toNel.fold(ds)(nel => IList(nel.foldRight1(thenn(_, _))))
 
   /** Swaps the dimensions at the nth and mth indices. */
   def swap(idxN: Int, idxM: Int, ds: Dimensions[P]): Dimensions[P] = {

--- a/connector/src/main/scala/quasar/qscript/provenance/Prov.scala
+++ b/connector/src/main/scala/quasar/qscript/provenance/Prov.scala
@@ -141,13 +141,13 @@ trait Prov[D, I, P] {
     })
   }
 
-  // eliminate duplicates within contiguous Both/OneOf and reassociate to the left
+  // eliminate duplicates within contiguous Both/OneOf and reassociate to the right
   def normalize(p: P)(implicit eqD: Equal[D], eqI: Equal[I]): P = {
     def normalize0(alternates: NEL[NEL[P]]): P =
       alternates
-        .map(_.distinctE1.foldLeft1(both(_, _)))
+        .map(_.distinctE1.foldRight1(both(_, _)))
         .distinctE1
-        .foldLeft1(oneOf(_, _))
+        .foldRight1(oneOf(_, _))
 
     val normalizeƒ: Algebra[PF, NEL[NEL[P]]] = {
       case Both(l, r)  => (l |@| r)(_ append _)

--- a/connector/src/main/scala/quasar/qscript/qsu/Access.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/Access.scala
@@ -16,105 +16,82 @@
 
 package quasar.qscript.qsu
 
-import slamdata.Predef._
+import slamdata.Predef.{StringContext, Symbol}
 import quasar.RenderTree
-import quasar.fp.symbolOrder
 
-import monocle.{PLens, Prism, Traversal}
-import scalaz.{Applicative, Apply, Equal, Order, Show, Traverse1}
-import scalaz.std.anyVal._
+import monocle.{Lens, PLens, Prism}
+import scalaz.{Apply, Equal, Order, Show, Traverse1}
+import scalaz.syntax.show._
 import scalaz.std.option._
 import scalaz.std.tuple._
-import scalaz.syntax.applicative._
-import scalaz.syntax.show._
 
-/** Describes access to the value and identity of `A`. */
-sealed abstract class Access[A] {
-  /** Surfaces symbols accessed, using the provided function in the `Value`
-    * case.
-    */
-  def symbolic(value: A => Symbol): Access[Symbol] =
+sealed abstract class Access[D, A] {
+  def symbolic(value: A => Symbol): Access[D, Symbol] =
     this match {
-      case Access.Bucket(s, i, _) => Access.bucket(s, i, s)
-      case Access.Identity(s, _)  => Access.identity(s, s)
-      case Access.Value(a)        => Access.value(value(a))
+      case Access.Id(i, a) =>
+        IdAccess.symbols[D]
+          .headOption(i)
+          .fold(Access.id(i, value(a)))(Access.id(i, _))
+
+      case Access.Value(a) =>
+        Access.value(value(a))
     }
 }
 
 object Access extends AccessInstances {
-  final case class Bucket[A](of: Symbol, idx: Int, src: A) extends Access[A]
-  final case class Identity[A](of: Symbol, src: A) extends Access[A]
-  final case class Value[A](src: A) extends Access[A]
+  final case class Id[D, A](idAccess: IdAccess[D], src: A) extends Access[D, A]
+  final case class Value[D, A](src: A) extends Access[D, A]
 
-  def bucket[A]: Prism[Access[A], (Symbol, Int, A)] =
-    Prism.partial[Access[A], (Symbol, Int, A)] {
-      case Bucket(s, i, a) => (s, i, a)
-    } { case (s, i, a) => Bucket(s, i, a) }
+  def id[D, A]: Prism[Access[D, A], (IdAccess[D], A)] =
+    Prism.partial[Access[D, A], (IdAccess[D], A)] {
+      case Id(i, a) => (i, a)
+    } { case (i, a) => Id(i, a) }
 
-  def identity[A]: Prism[Access[A], (Symbol, A)] =
-    Prism.partial[Access[A], (Symbol, A)] {
-      case Identity(s, a) => (s, a)
-    } { case (s, a) => Identity(s, a) }
-
-  def src[A, B]: PLens[Access[A], Access[B], A, B] =
-    PLens[Access[A], Access[B], A, B] {
-      case Bucket(_, _, a) => a
-      case Identity(_, a)  => a
-      case Value(a)        => a
-    } { b => {
-      case Bucket(s, i, _) => Bucket(s, i, b)
-      case Identity(s, _)  => Identity(s, b)
-      case Value(_)        => Value(b)
-    }}
-
-  def symbols[A]: Traversal[Access[A], Symbol] =
-    new Traversal[Access[A], Symbol] {
-      def modifyF[F[_]: Applicative](f: Symbol => F[Symbol])(a: Access[A]) =
-        a match {
-          case Bucket(s, i, a) => f(s) map (Bucket(_, i, a))
-          case Identity(s, a)  => f(s) map (Identity(_, a))
-          case Value(a)        => value(a).point[F]
-        }
-    }
-
-  def value[A]: Prism[Access[A], A] =
-    Prism.partial[Access[A], A] {
+  def value[D, A]: Prism[Access[D, A], A] =
+    Prism.partial[Access[D, A], A] {
       case Value(a) => a
     } (Value(_))
+
+  def src[D, A]: Lens[Access[D, A], A] =
+    srcP[D, A, A]
+
+  def srcP[D, A, B]: PLens[Access[D, A], Access[D, B], A, B] =
+    PLens[Access[D, A], Access[D, B], A, B] {
+      case Id(_, a) => a
+      case Value(a) => a
+    } { b => {
+      case Id(i, _) => id(i, b)
+      case Value(_) => value(b)
+    }}
 }
 
 sealed abstract class AccessInstances extends AccessInstances0 {
-  import Access._
+  implicit def traverse1[D]: Traverse1[Access[D, ?]] =
+    new Traverse1[Access[D, ?]] {
+      def traverse1Impl[G[_]: Apply, A, B](fa: Access[D, A])(f: A => G[B]) =
+        Access.srcP[D, A, B].modifyF(f)(fa)
 
-  implicit val traverse1: Traverse1[Access] =
-    new Traverse1[Access] {
-      def foldMapRight1[A, B](fa: Access[A])(z: A => B)(f: (A, => B) => B) =
-        z(src[A, B].get(fa))
-
-      def traverse1Impl[F[_]: Apply, A, B](fa: Access[A])(f: A => F[B]) =
-        src[A, B].modifyF(f)(fa)
+      def foldMapRight1[A, B](fa: Access[D, A])(z: A => B)(f: (A, => B) => B) =
+        z(Access.src[D, A] get fa)
     }
 
-  implicit def order[A: Order]: Order[Access[A]] =
-    Order.orderBy(generic(_))
+  implicit def order[D: Order, A: Order]: Order[Access[D, A]] =
+    Order.orderBy(generic)
 
-  implicit def renderTree[A: Show]: RenderTree[Access[A]] =
+  implicit def renderTree[D: Show, A: Show]: RenderTree[Access[D, A]] =
     RenderTree.fromShowAsType("Access")
 
-  implicit def show[A: Show]: Show[Access[A]] =
+  implicit def show[D: Show, A: Show]: Show[Access[D, A]] =
     Show.shows {
-      case Bucket(s, i, a) => s"Bucket($s[$i], ${a.shows})"
-      case Identity(s, a)  => s"Identity($s, ${a.shows})"
-      case Value(a)        => s"Value(${a.shows})"
+      case Access.Id(i, a) => s"Id(${i.shows}, ${a.shows})"
+      case Access.Value(a) => s"Value(${a.shows})"
     }
 }
 
 sealed abstract class AccessInstances0 {
-  import Access._
+  implicit def equal[D: Equal, A: Equal]: Equal[Access[D, A]] =
+    Equal.equalBy(generic)
 
-  implicit def equal[A: Equal]: Equal[Access[A]] =
-    Equal.equalBy(generic(_))
-
-  protected def generic[A](a: Access[A]) =
-    (bucket.getOption(a), identity.getOption(a), value.getOption(a))
+  protected def generic[D, A](a: Access[D, A]) =
+    (Access.id.getOption(a), Access.value.getOption(a))
 }

--- a/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
@@ -16,181 +16,235 @@
 
 package quasar.qscript.qsu
 
-import slamdata.Predef.{Map => SMap, _}
+import slamdata.Predef._
 
 import quasar.Planner.{PlannerErrorME, InternalError}
-import quasar.contrib.scalaz.{MonadState_, MonadTell_}
+import quasar.contrib.scalaz.MonadState_
 import quasar.ejson
 import quasar.ejson.EJson
 import quasar.ejson.implicits._
 import quasar.fp._
+import quasar.fp.ski.ι
 import quasar.qscript.{ExcludeId, HoleF, IdOnly, IdStatus, RightSideF}
-import quasar.qscript.provenance._
 
-import matryoshka.{Hole => _, _}
-import matryoshka.data.free._
+import matryoshka._
 import matryoshka.implicits._
 import pathy.Path
-import scalaz.{DList, Free, IList, Monad, Show, StateT, WriterT}
-import scalaz.syntax.foldable1._
-import scalaz.syntax.monad._
-import scalaz.syntax.show._
+import scalaz.{Applicative, Functor, IList, Monad, Show, StateT, ValidationNel}
+import scalaz.Scalaz._
 
-final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT] private () {
+final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT: ShowT] private () extends QSUTTypes[T] {
   import ApplyProvenance._
   import QScriptUniform._
+  import QSUGraph.Extractors
 
-  type P = QProv.P[T]
-  type Dims = Dimensions[P]
-  type QSU[A] = QScriptUniform[T, A]
+  type QSU[A] = QScriptUniform[A]
 
-  type GPF[A] = QSUGraph.QSUPattern[T, A]
-  val GPF = QSUGraph.QSUPattern
+  type QAuthS[F[_]] = MonadState_[F, QAuth]
+  def QAuthS[F[_]](implicit ev: QAuthS[F]): QAuthS[F] = ev
 
-  type GStateM[F[_]] = MonadState_[F, QSUGraph[T]]
-  def GStateM[F[_]](implicit ev: GStateM[F]): GStateM[F] = ev
-
-  type RenameT[F[_]] = MonadTell_[F, DList[(Symbol, Symbol)]]
-  def RenameT[F[_]](implicit ev: RenameT[F]): RenameT[F] = ev
+  private type V[F[_], A] = F[ValidationNel[Symbol, A]]
+  implicit def V[F[_]: Applicative] = Applicative[F].compose[ValidationNel[Symbol, ?]]
 
   val dims = QProv[T]
 
-  def apply[F[_]: Monad: PlannerErrorME](graph: QSUGraph[T]): F[AuthenticatedQSU[T]] = {
-    type X[A] = WriterT[StateT[F, QSUGraph[T], ?], DList[(Symbol, Symbol)], A]
+  def apply[F[_]: Monad: PlannerErrorME](graph: QSUGraph): F[AuthenticatedQSU[T]] = {
+    type X[A] = StateT[F, QAuth, A]
 
-    def applyRenames(renames: IList[(Symbol, Symbol)], ds: Dimensions[P]): Dimensions[P] =
-      renames.foldLeft(ds)((ds0, t) => dims.rename(t._1, t._2, ds0))
+    val authGraph = graph.rewriteM[X] {
+      case g @ Extractors.DimEdit(src, _) =>
+        for {
+          _ <- computeProvenance[X](g)
+          _ <- QAuthS[X].modify(_.rename(src.root, g.root))
+        } yield g.overwriteAtRoot(src.unfold map (_.root))
 
-    graph.elgotZygoM(computeProvenanceƒ[X], applyProvenanceƒ[X])
-      .run
-      .run(graph)
-      .map { case (g, (renames, (_, ds))) =>
-        AuthenticatedQSU(g, ds mapValues (applyRenames(renames.toIList, _)))
-      }
+      case g @ Extractors.Transpose(src, retain, rot) =>
+        computeProvenance[X](g) as g.overwriteAtRoot {
+          LeftShift(src.root, HoleF, retain.fold[IdStatus](IdOnly, ExcludeId), RightSideF, rot)
+        }
+
+      case other =>
+        computeProvenance[X](other) as other
+    }
+
+    authGraph.run(QAuth.empty[T]) map {
+      case (qauth, graph) => AuthenticatedQSU(graph, qauth)
+    }
   }
 
-  def applyProvenanceƒ[F[_]: Monad: GStateM: RenameT]: ElgotAlgebraM[((Symbol, Dims), ?), F, GPF, (Symbol, QSUDims[T])] = {
-    case ((_, updDims), GPF(deId, DimEdit((srcId, qdims), _))) =>
-      for {
-        _ <- GStateM[F].modify(_.replace(deId, srcId))
-        _ <- RenameT[F].tell(DList(deId -> srcId))
-      } yield (srcId, qdims + (srcId -> updDims))
+  def computeProvenance[F[_]: Monad: PlannerErrorME: QAuthS](g: QSUGraph): F[QDims] = {
+    def flattened =
+      s"${g.root} @ ${g.unfold.map(_.root).shows}"
 
-    case ((_, tdims), GPF(tid, Transpose((srcId, srcDims), retain, rot))) =>
-      GStateM[F].modify(
-        QSUGraph.vertices.modify(_.updated(
-          tid,
-          LeftShift(srcId, HoleF, retain.fold[IdStatus](IdOnly, ExcludeId), RightSideF, rot))))
-        .as((tid, srcDims + (tid -> tdims)))
+    def unexpectedError: F[QDims] =
+      PlannerErrorME[F].raiseError(
+        InternalError(s"Encountered unexpected $flattened.", None))
 
-    case ((_, nodeDims), GPF(nodeId, node)) =>
-      (nodeId, node.foldRight[QSUDims[T]](SMap(nodeId -> nodeDims))(_._2 ++ _)).point[F]
-  }
+    g.unfold match {
+      case AutoJoin2(left, right, _) =>
+        compute2[F](g, left, right)(dims.join(_, _))
 
-  def computeProvenanceƒ[F[_]: Monad: PlannerErrorME]: AlgebraM[F, GPF, (Symbol, Dims)] = {
-    case GPF(root, qsu) =>
-      val computedDims: F[Dims] = qsu match {
-        case AutoJoin2((_, left), (_, right), _) => dims.join(left, right).point[F]
+      case AutoJoin3(left, center, right, _) =>
+        compute3[F](g, left, center, right) { (l, c, r) =>
+          dims.join(dims.join(l, c), r)
+        }
 
-        case AutoJoin3((_, left), (_, center), (_, right), _) => dims.join(dims.join(left, center), right).point[F]
+      case QSAutoJoin(left, right, _, _) =>
+        compute2[F](g, left, right)(dims.join(_, _))
 
-        case DimEdit((_, src), DTrans.Squash()) => dims.squash(src).point[F]
+      case DimEdit(src, DTrans.Squash()) =>
+        compute1[F](g, src)(dims.squash)
 
-        case DimEdit((name, src), DTrans.Group(k)) =>
-          dims.swap(0, 1, dims.lshift(k as Access.value(name), src)).point[F]
+      case DimEdit(src, DTrans.Group(k)) =>
+        handleMissingDims(dimsFor[F](src)) flatMap { sdims =>
+          val nextIdx = dims.nextGroupKeyIndex(src.root, sdims)
+          val idAccess = IdAccess.groupKey[dims.D](src.root, nextIdx)
+          val nextDims = dims.swap(0, 1, dims.lshift(idAccess, sdims))
 
-        case Distinct((_, src)) => src.point[F]
+          QAuthS[F].modify(
+            _.addDims(src.root, nextDims)
+              .addGroupKey(src.root, nextIdx, k))
+            .as(nextDims)
+        }
 
-        case GroupBy(_, _) => unexpectedError("GroupBy", root)
+      case Distinct(src) =>
+        compute1[F](g, src)(ι)
 
-        case JoinSideRef(_) => unexpectedError("JoinSideRef", root)
+      case GroupBy(_, _) => unexpectedError
 
-        case LeftShift((_, src), _, _, _, rot) =>
-          val tid: dims.I = Free.pure(Access.identity(root, root))
-          (rot match {
-            case Rotation.ShiftMap   | Rotation.ShiftArray   => dims.lshift(tid, src)
-            case Rotation.FlattenMap | Rotation.FlattenArray => dims.flatten(tid, src)
-          }).point[F]
+      case JoinSideRef(_) => unexpectedError
 
-        case LPFilter(_, _) => unexpectedError("LPFilter", root)
+      case LeftShift(src, _, _, _, rot) =>
+        val tid = IdAccess.identity[dims.D](g.root)
+        compute1[F](g, src) { sdims =>
+          rot match {
+            case Rotation.ShiftMap   | Rotation.ShiftArray   => dims.lshift(tid, sdims)
+            case Rotation.FlattenMap | Rotation.FlattenArray => dims.flatten(tid, sdims)
+          }
+        }
 
-        case LPJoin(_, _, _, _, _, _) => unexpectedError("LPJoin", root)
+      case LPFilter(_, _) => unexpectedError
 
-        case LPReduce((_, src), _) => dims.bucketAccess(root, dims.reduce(src)).point[F]
+      case LPJoin(_, _, _, _, _, _) => unexpectedError
 
-        case LPSort(_, _) => unexpectedError("LPSort", root)
+      case LPReduce(src, _) =>
+        compute1[F](g, src) { sdims =>
+          dims.bucketAccess(g.root, dims.reduce(sdims))
+        }
 
-        case QSFilter((_, src), _) => src.point[F]
+      case LPSort(_, _) => unexpectedError
 
-        case QSReduce((_, src), _, _, _) => dims.bucketAccess(root, dims.reduce(src)).point[F]
+      case QSFilter(src, _) =>
+        compute1[F](g, src)(ι)
 
-        case QSSort((_, src), _, _) => src.point[F]
+      case QSReduce(src, _, _, _) =>
+        compute1[F](g, src) { sdims =>
+          dims.bucketAccess(g.root, dims.reduce(sdims))
+        }
 
-        case Unary(_, _) => unexpectedError("Unary", root)
+      case QSSort(src, _, _) =>
+        compute1[F](g, src)(ι)
 
-        case Map((_, src), _) => src.point[F]
+      case Unary(_, _) => unexpectedError
 
-        case Read(file) => dims.squash(segments(file).map(projStr).reverse).point[F]
+      case Map(src, _) =>
+        compute1[F](g, src)(ι)
 
-        case Subset((_, from), _, (_, count)) => dims.join(from, count).point[F]
+      case Read(file) =>
+        val rdims = dims.squash(segments(file).map(projStr).reverse)
+        QAuthS[F].modify(_.addDims(g.root, rdims)) as rdims
 
-        case ThetaJoin((_, left), (_, right), _, _, _) => dims.join(left, right).point[F]
+      case Subset(from, _, count) =>
+        compute2[F](g, from, count)(dims.join(_, _))
 
-        case Transpose((_, src), _, rot) =>
-          val tid: dims.I = Free.pure(Access.identity(root, root))
-          (rot match {
-            case Rotation.ShiftMap   | Rotation.ShiftArray   => dims.lshift(tid, src)
-            case Rotation.FlattenMap | Rotation.FlattenArray => dims.flatten(tid, src)
-          }).point[F]
+      case ThetaJoin(left, right, _, _, _) =>
+        compute2[F](g, left, right)(dims.join(_, _))
 
-        case Union((_, left), (_, right)) => dims.union(left, right).point[F]
+      case Transpose(src, _, rot) =>
+        val tid = IdAccess.identity[dims.D](g.root)
+        compute1[F](g, src) { sdims =>
+          rot match {
+            case Rotation.ShiftMap   | Rotation.ShiftArray   => dims.lshift(tid, sdims)
+            case Rotation.FlattenMap | Rotation.FlattenArray => dims.flatten(tid, sdims)
+          }
+        }
 
-        case Unreferenced() => dims.empty.point[F]
-      }
+      case Union(left, right) =>
+        compute2[F](g, left, right)(dims.union(_, _))
 
-      computedDims strengthL root
+      case Unreferenced() =>
+        QAuthS[F].modify(_.addDims(g.root, dims.empty)) as dims.empty
+    }
   }
 
   ////
 
-  private def projStr(s: String): P =
+  private def compute1[F[_]: Monad: PlannerErrorME: QAuthS]
+      (g: QSUGraph, src: QSUGraph)
+      (f: QDims => QDims)
+      : F[QDims] =
+    handleMissingDims(dimsFor[F](src)) flatMap { sdims =>
+      val gdims = f(sdims)
+      QAuthS.modify(_.addDims(g.root, gdims)) as gdims
+    }
+
+  private def compute2[F[_]: Monad: PlannerErrorME: QAuthS]
+      (g: QSUGraph, l: QSUGraph, r: QSUGraph)
+      (f: (QDims, QDims) => QDims)
+      : F[QDims] =
+    handleMissingDims((dimsFor[F](l) |@| dimsFor(r))(f)) flatMap { ds =>
+      QAuthS.modify(_.addDims(g.root, ds)) as ds
+    }
+
+  private def compute3[F[_]: Monad: PlannerErrorME: QAuthS]
+      (g: QSUGraph, l: QSUGraph, c: QSUGraph, r: QSUGraph)
+      (f: (QDims, QDims, QDims) => QDims)
+      : F[QDims] =
+    handleMissingDims((dimsFor[F](l) |@| dimsFor[F](c) |@| dimsFor[F](r))(f)) flatMap { ds =>
+      QAuthS.modify(_.addDims(g.root, ds)) as ds
+    }
+
+  private def dimsFor[F[_]: Functor: QAuthS](g: QSUGraph): V[F, QDims] =
+    QAuthS[F].gets(_ lookupDims g.root toSuccessNel g.root)
+
+  private def handleMissingDims[F[_]: Monad: PlannerErrorME, A](v: V[F, A]): F[A] =
+    (v: F[ValidationNel[Symbol, A]]).flatMap { v0 =>
+      v0.map(_.point[F]) valueOr { syms =>
+        PlannerErrorME[F].raiseError[A](
+          InternalError(s"Dependent dimensions not found: ${syms.show}.", None))
+      }
+    }
+
+  private def projStr(s: String): QProv.P[T] =
     dims.prov.proj(ejson.CommonEJson(ejson.Str[T[EJson]](s)).embed)
 
   private def segments(p: Path[_, _, _]): IList[String] = {
     val segs = Path.flatten[IList[String]](IList(), IList(), IList(), IList(_), IList(_), p)
     (segs.head :: segs.tail).join
   }
-
-  private def unexpectedError[F[_]: PlannerErrorME, A](nodeName: String, id: Symbol): F[A] =
-    PlannerErrorME[F].raiseError(InternalError(s"Encountered unexpected $nodeName[$id].", None))
 }
 
 object ApplyProvenance {
   def apply[
-      T[_[_]]: BirecursiveT: EqualT,
+      T[_[_]]: BirecursiveT: EqualT: ShowT,
       F[_]: Monad: PlannerErrorME]
       (graph: QSUGraph[T])
       : F[AuthenticatedQSU[T]] =
     taggedInternalError("ApplyProvenance", new ApplyProvenance[T].apply[F](graph))
 
-  def computeProvenanceƒ[
-      T[_[_]]: BirecursiveT: EqualT,
-      F[_]: Monad: PlannerErrorME]
-      : AlgebraM[F, QSUGraph.QSUPattern[T, ?], (Symbol, Dimensions[QProv.P[T]])] =
-    new ApplyProvenance[T].computeProvenanceƒ[F]
+  def computeProvenance[
+      T[_[_]]: BirecursiveT: EqualT: ShowT,
+      F[_]: Monad: PlannerErrorME: MonadState_[?[_], QAuth[T]]]
+      (graph: QSUGraph[T])
+      : F[QDims[T]] =
+    new ApplyProvenance[T].computeProvenance[F](graph)
 
-  final case class AuthenticatedQSU[T[_[_]]](
-      graph: QSUGraph[T],
-      dims: QSUDims[T])
+  final case class AuthenticatedQSU[T[_[_]]](graph: QSUGraph[T], auth: QAuth[T])
 
   object AuthenticatedQSU {
     implicit def show[T[_[_]]: ShowT]: Show[AuthenticatedQSU[T]] =
-      Show.shows { case AuthenticatedQSU(g, d) =>
-        s"AuthenticatedQSU {\n" +
-        g.shows +
-        "\n\n" +
-        QSUDims.show[T].shows(d) +
-        "\n}"
+      Show.shows { case AuthenticatedQSU(g, a) =>
+        s"AuthenticatedQSU {\n${g.shows}\n\n${a.shows}\n}"
       }
   }
 }

--- a/connector/src/main/scala/quasar/qscript/qsu/ExtractFreeMap.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ExtractFreeMap.scala
@@ -62,7 +62,7 @@ final class ExtractFreeMap[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T
           func.MakeMap(StrLit[T, JoinSide](JoinDir.Right.name), func.RightSide))
 
       MappableRegion.funcOf(replaceRefs(graph, lref, rref), graph refocus cond.root)
-        .map(jf => ThetaJoin(left.root, right.root, jf map (Access.value(_)), jtype, combiner)) match {
+        .map(jf => ThetaJoin(left.root, right.root, jf, jtype, combiner)) match {
           case Some(qs) =>
             graph.overwriteAtRoot(qs).point[F]
           case None =>

--- a/connector/src/main/scala/quasar/qscript/qsu/Graduate.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/Graduate.scala
@@ -20,16 +20,21 @@ import slamdata.Predef._
 
 import quasar.NameGenerator
 import quasar.Planner.{InternalError, PlannerErrorME}
+import quasar.common.JoinType
 import quasar.contrib.pathy.AFile
 import quasar.contrib.scalaz.MonadReader_
+import quasar.ejson.EJson
+import quasar.ejson.implicits._
 import quasar.fp._
 import quasar.fp.ski.κ
 import quasar.qscript.{
+  construction,
   educatedToTotal,
   Filter,
   Hole,
   HoleF,
   LeftShift,
+  JoinSide,
   Map,
   QCE,
   QScriptEducated,
@@ -43,17 +48,18 @@ import quasar.qscript.{
   ThetaJoin,
   Union,
   Unreferenced}
+import quasar.qscript.provenance.JoinKeys
 import quasar.qscript.qsu.{QScriptUniform => QSU}
 import quasar.qscript.qsu.QSUGraph.QSUPattern
 import quasar.qscript.qsu.ReifyIdentities.ResearchedQSU
 
-import matryoshka.{Corecursive, CorecursiveT, CoalgebraM, Recursive}
+import matryoshka.{Corecursive, BirecursiveT, CoalgebraM, Recursive}
 import matryoshka.data.free._
 import matryoshka.patterns.CoEnv
 import scalaz.{~>, -\/, \/-, Const, Inject, Monad, NaturalTransformation, ReaderT}
 import scalaz.Scalaz._
 
-final class Graduate[T[_[_]]: CorecursiveT] private () extends QSUTTypes[T] {
+final class Graduate[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T] {
 
   type QSE[A] = QScriptEducated[A]
 
@@ -73,6 +79,8 @@ final class Graduate[T[_[_]]: CorecursiveT] private () extends QSUTTypes[T] {
   private type RefsR[F[_]] = MonadReader_[F, References]
 
   private final case class SrcMerge[A, B](src: A, lval: B, rval: B)
+
+  private val func = construction.Func[T]
 
   private def mergeSources[F[_]: Monad: PlannerErrorME: NameGenerator: RefsR](
       left: QSUGraph,
@@ -152,6 +160,14 @@ final class Graduate[T[_[_]]: CorecursiveT] private () extends QSUTTypes[T] {
       def resolveAccess[A](fa: FreeAccess[A])(f: A => Symbol): F[FreeMapA[A]] =
         MR.asks(_.resolveAccess(name, fa)(f))
 
+      def eqCond(lroot: Symbol, rroot: Symbol): JoinKeys.JoinKey[QIdAccess] => F[JoinFunc] = {
+        case JoinKeys.JoinKey(l, r) =>
+          for {
+            lside <- resolveAccess(func.Hole as Access.id(l, lroot))(κ(lroot))
+            rside <- resolveAccess(func.Hole as Access.id(r, rroot))(κ(rroot))
+          } yield func.Eq(lside >> func.LeftSide, rside >> func.RightSide)
+      }
+
       qsu match {
         case QSU.Read(path) =>
           Inject[Const[Read[AFile], ?], QSE].inj(Const(Read(path))).point[F]
@@ -189,7 +205,7 @@ final class Graduate[T[_[_]]: CorecursiveT] private () extends QSUTTypes[T] {
 
         // TODO distinct should be its own node in qscript proper
         case QSU.Distinct(source) =>
-          resolveAccess(HoleF map (Access.value(_)))(holeAs(source.root)) map { fm =>
+          resolveAccess(HoleF map (Access.value[T[EJson], Hole](_)))(holeAs(source.root)) map { fm =>
             QCE(Reduce[T, QSUGraph](
               source,
               // Bucket by the value
@@ -202,13 +218,23 @@ final class Graduate[T[_[_]]: CorecursiveT] private () extends QSUTTypes[T] {
         case QSU.Unreferenced() =>
           QCE(Unreferenced[T, QSUGraph]()).point[F]
 
-        case QSU.ThetaJoin(left, right, condition, joinType, combiner) =>
-          val qsCondition = resolveAccess(condition)(_.fold(left.root, right.root))
+        case QSU.QSAutoJoin(left, right, joinKeys, combiner) =>
+          val condition = joinKeys.keys.toNel.fold(func.Constant[JoinSide](EJson.bool(true)).point[F]) { jks =>
+            val (l, r) = (left.root, right.root)
+            jks.foldMapLeft1(eqCond(l, r))((fm, k) => (eqCond(l, r)(k) |@| fm)(func.And(_, _)))
+          }
 
-          (mergeSources[F](left, right) |@| qsCondition) { (srcs, cond) =>
-            val SrcMerge(source, lBranch, rBranch) = srcs
-            Inject[ThetaJoin, QSE].inj(
-              ThetaJoin[T, QSUGraph](source, lBranch, rBranch, cond, joinType, combiner))
+          (mergeSources[F](left, right) |@| condition) {
+            case (SrcMerge(source, lBranch, rBranch), cond) =>
+              Inject[ThetaJoin, QSE].inj(
+                ThetaJoin[T, QSUGraph](source, lBranch, rBranch, cond, JoinType.Inner, combiner))
+          }
+
+        case QSU.ThetaJoin(left, right, condition, joinType, combiner) =>
+          mergeSources[F](left, right) map {
+            case SrcMerge(source, lBranch, rBranch) =>
+              Inject[ThetaJoin, QSE].inj(
+                ThetaJoin[T, QSUGraph](source, lBranch, rBranch, condition, joinType, combiner))
           }
 
         case qsu =>
@@ -255,7 +281,7 @@ final class Graduate[T[_[_]]: CorecursiveT] private () extends QSUTTypes[T] {
 
 object Graduate {
   def apply[
-      T[_[_]]: CorecursiveT,
+      T[_[_]]: BirecursiveT,
       F[_]: Monad: PlannerErrorME: NameGenerator]
       (rqsu: ResearchedQSU[T])
       : F[T[QScriptEducated[T, ?]]] =

--- a/connector/src/main/scala/quasar/qscript/qsu/IdAccess.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/IdAccess.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.qsu
+
+import slamdata.Predef._
+import quasar.RenderTree
+import quasar.fp.symbolOrder
+
+import matryoshka._
+import monocle.{Prism, PPrism, Traversal}
+import scalaz.{Applicative, Equal, Order, Show, Traverse}
+import scalaz.std.anyVal._
+import scalaz.std.option._
+import scalaz.std.tuple._
+import scalaz.syntax.applicative._
+import scalaz.syntax.either._
+import scalaz.syntax.show._
+
+/** Describes access to the various forms of ids. */
+sealed abstract class IdAccess[D]
+
+object IdAccess extends IdAccessInstances {
+  final case class Bucket[D](of: Symbol, idx: Int) extends IdAccess[D]
+  final case class GroupKey[D](of: Symbol, idx: Int) extends IdAccess[D]
+  final case class Identity[D](of: Symbol) extends IdAccess[D]
+  final case class Static[D](data: D) extends IdAccess[D]
+
+  def bucket[D]: Prism[IdAccess[D], (Symbol, Int)] =
+    Prism.partial[IdAccess[D], (Symbol, Int)] {
+      case Bucket(s, i) => (s, i)
+    } { case (s, i) => Bucket(s, i) }
+
+  def groupKey[D]: Prism[IdAccess[D], (Symbol, Int)] =
+    Prism.partial[IdAccess[D], (Symbol, Int)] {
+      case GroupKey(s, i) => (s, i)
+    } { case (s, i) => GroupKey(s, i) }
+
+  def identity[D]: Prism[IdAccess[D], Symbol] =
+    Prism.partial[IdAccess[D], Symbol] {
+      case Identity(s) => s
+    } (Identity(_))
+
+  def static[D]: Prism[IdAccess[D], D] =
+    staticP[D, D]
+
+  def staticP[D, E]: PPrism[IdAccess[D], IdAccess[E], D, E] =
+    PPrism[IdAccess[D], IdAccess[E], D, E] {
+      case Bucket(s, i)   => bucket[E](s, i).left
+      case GroupKey(s, i) => groupKey[E](s, i).left
+      case Identity(s)    => identity[E](s).left
+      case Static(d)      => d.right
+    } (Static(_))
+
+  def symbols[D]: Traversal[IdAccess[D], Symbol] =
+    new Traversal[IdAccess[D], Symbol] {
+      def modifyF[F[_]: Applicative](f: Symbol => F[Symbol])(s: IdAccess[D]) =
+        s match {
+          case Bucket(s, i)   => f(s) map (bucket(_, i))
+          case GroupKey(s, i) => f(s) map (groupKey(_, i))
+          case Identity(s)    => f(s) map (identity(_))
+          case Static(d)      => static(d).point[F]
+        }
+    }
+}
+
+sealed abstract class IdAccessInstances extends IdAccessInstances0 {
+  import IdAccess._
+
+  implicit def traverse: Traverse[IdAccess] =
+    new Traverse[IdAccess] {
+      def traverseImpl[F[_]: Applicative, A, B](a: IdAccess[A])(f: A => F[B]) =
+        staticP[A, B].modifyF(f)(a)
+    }
+
+  implicit def order[D: Order]: Order[IdAccess[D]] =
+    Order.orderBy(generic(_))
+
+  implicit def renderTree[D: Show]: RenderTree[IdAccess[D]] =
+    RenderTree.fromShowAsType("IdAccess")
+
+  implicit def show[D: Show]: Show[IdAccess[D]] =
+    Show.shows {
+      case Bucket(s, i)   => s"Bucket($s[$i])"
+      case GroupKey(s, i) => s"GroupKey($s[$i])"
+      case Identity(s)    => s"Identity($s)"
+      case Static(d)      => s"Static(${d.shows})"
+    }
+}
+
+sealed abstract class IdAccessInstances0 {
+  import IdAccess.{bucket, groupKey, identity, static}
+
+  implicit def equal[D: Equal]: Equal[IdAccess[D]] =
+    Equal.equalBy(generic(_))
+
+  protected def generic[D](a: IdAccess[D]) =
+    (bucket.getOption(a), groupKey.getOption(a), identity.getOption(a), static.getOption(a))
+}

--- a/connector/src/main/scala/quasar/qscript/qsu/LPtoQS.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/LPtoQS.scala
@@ -50,8 +50,7 @@ final class LPtoQS[T[_[_]]: BirecursiveT: EqualT: ShowT] extends QSUTTypes[T] {
       MinimizeAutoJoins[T, F]      >=>
       debug("MinimizeAJ: ")        >==>
       ReifyAutoJoins[T, F]         >=>
-      debug("ReifyAutoJoins: ")    >-
-      (_.graph)                    >==>
+      debug("ReifyAutoJoins: ")    >==>
       ReifyIdentities[T, F]        >=>
       debug("ReifyIdentities: ")   >==>
       Graduate[T, F]

--- a/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
@@ -339,7 +339,7 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT: ShowT] private () e
     MinStateM[G] modify { state =>
       val auth2 = candidates.foldLeft(state.auth) { (auth, c) =>
         if (c.root =/= newRoot)
-          auth.rename(c.root, newRoot)
+          auth.supplant(c.root, newRoot)
         else
           auth
       }

--- a/connector/src/main/scala/quasar/qscript/qsu/QAuth.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/QAuth.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.qsu
+
+import slamdata.Predef._
+import quasar.Planner.{InternalError, PlannerErrorME}
+import quasar.ejson.implicits._
+import quasar.fp.{coproductEqual, coproductShow, symbolOrder, symbolShow}
+import quasar.qscript.FreeMap
+
+import matryoshka._
+import matryoshka.data.free._
+import scalaz.{Applicative, Equal, Monoid, Show}
+import scalaz.std.anyVal._
+import scalaz.std.map._
+import scalaz.std.tuple._
+import scalaz.syntax.equal._
+import scalaz.syntax.std.option._
+
+final case class QAuth[T[_[_]]](
+    dims: Map[Symbol, QDims[T]],
+    groupKeys: Map[(Symbol, Int), FreeMap[T]]) {
+
+  def ++ (other: QAuth[T]): QAuth[T] =
+    QAuth(dims ++ other.dims, groupKeys ++ other.groupKeys)
+
+  def addDims(vertex: Symbol, qdims: QDims[T]): QAuth[T] =
+    copy(dims = dims + (vertex -> qdims))
+
+  def addGroupKey(vertex: Symbol, idx: Int, key: FreeMap[T]): QAuth[T] =
+    copy(groupKeys = groupKeys + ((vertex, idx) -> key))
+
+  def lookupDims(vertex: Symbol): Option[QDims[T]] =
+    dims get vertex
+
+  def lookupDimsE[F[_]: Applicative: PlannerErrorME](vertex: Symbol): F[QDims[T]] =
+    lookupDims(vertex) getOrElseF PlannerErrorME[F].raiseError[QDims[T]] {
+      InternalError(s"Dimensions for $vertex not found.", None)
+    }
+
+  def lookupGroupKey(vertex: Symbol, idx: Int): Option[FreeMap[T]] =
+    groupKeys get ((vertex, idx))
+
+  def lookupGroupKeyE[F[_]: Applicative: PlannerErrorME](vertex: Symbol, idx: Int): F[FreeMap[T]] =
+    lookupGroupKey(vertex, idx) getOrElseF PlannerErrorME[F].raiseError[FreeMap[T]] {
+      InternalError(s"GroupKey[$idx] for $vertex not found.", None)
+    }
+
+  def rename
+      (from: Symbol, to: Symbol)
+      (implicit T0: BirecursiveT[T], T1: EqualT[T])
+      : QAuth[T] = {
+
+    val qp = QProv[T]
+
+    def rename0(sym: Symbol): Symbol =
+      if (sym === from) to else sym
+
+    val rnDims = dims map {
+      case (k, v) => rename0(k) -> qp.rename(from, to, v)
+    }
+
+    val rnKeys = groupKeys map {
+      case ((s, i), v) => ((rename0(s), i) -> v)
+    }
+
+    QAuth(rnDims, rnKeys)
+  }
+}
+
+object QAuth extends QAuthInstances {
+  def empty[T[_[_]]]: QAuth[T] =
+    QAuth(Map(), Map())
+}
+
+sealed abstract class QAuthInstances {
+  implicit def monoid[T[_[_]]]: Monoid[QAuth[T]] =
+    Monoid.instance(_ ++ _, QAuth.empty[T])
+
+  implicit def equal[T[_[_]]: BirecursiveT: EqualT]: Equal[QAuth[T]] = {
+    implicit val eqP: Equal[QProv.P[T]] = QProv[T].prov.provenanceEqual
+    Equal.equalBy(qa => (qa.dims, qa.groupKeys))
+  }
+
+  implicit def show[T[_[_]]: ShowT]: Show[QAuth[T]] =
+    Show.shows { case QAuth(dims, keys) =>
+      "QAuth\n" +
+      "=====\n" +
+      "Dimensions[\n" + printMultiline(dims) + "\n]\n\n" +
+      "GroupKeys[\n" + printMultiline(keys) + "\n]\n" +
+      "====="
+    }
+}

--- a/connector/src/main/scala/quasar/qscript/qsu/QAuth.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/QAuth.scala
@@ -26,6 +26,7 @@ import matryoshka._
 import matryoshka.data.free._
 import scalaz.{Applicative, Equal, Monoid, Show}
 import scalaz.std.anyVal._
+import scalaz.std.list._
 import scalaz.std.map._
 import scalaz.std.tuple._
 import scalaz.syntax.equal._
@@ -100,8 +101,8 @@ sealed abstract class QAuthInstances {
     Show.shows { case QAuth(dims, keys) =>
       "QAuth\n" +
       "=====\n" +
-      "Dimensions[\n" + printMultiline(dims) + "\n]\n\n" +
-      "GroupKeys[\n" + printMultiline(keys) + "\n]\n" +
+      "Dimensions[\n" + printMultiline(dims.toList) + "\n]\n\n" +
+      "GroupKeys[\n" + printMultiline(keys.toList) + "\n]\n" +
       "====="
     }
 }

--- a/connector/src/main/scala/quasar/qscript/qsu/QProv.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/QProv.scala
@@ -91,6 +91,10 @@ final class QProv[T[_[_]]: BirecursiveT: EqualT]
     MaxVal.unsubst(dims foldMap maxIndex)
   }
 
+  /** Returns new dimensions where all identities have been modified by `f`. */
+  def modifyIdentities(dims: Dimensions[P])(f: I => I): Dimensions[P] =
+    canonicalize(dims map (_.transCata[P](pfo.value modify f)))
+
   /** The index of the next group key for `of`. */
   def nextGroupKeyIndex(of: Symbol, dims: Dimensions[P]): SInt =
     maxGroupKeyIndex(of, dims).fold(0)(_ + 1)
@@ -100,10 +104,7 @@ final class QProv[T[_[_]]: BirecursiveT: EqualT]
     def rename0(sym: Symbol): Symbol =
       (sym === from) ? to | sym
 
-    val renameAccess =
-      IdAccess.symbols[D].modify(rename0)
-
-    canonicalize(dims map (_.transCata[P](pfo.value modify renameAccess)))
+    modifyIdentities(dims)(IdAccess.symbols[D].modify(rename0))
   }
 
   ////

--- a/connector/src/main/scala/quasar/qscript/qsu/QProv.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/QProv.scala
@@ -26,11 +26,13 @@ import quasar.qscript.provenance._
 import matryoshka.{Hole => _, _}
 import matryoshka.implicits._
 import matryoshka.data._
-import scalaz.{Lens => _, _}, Scalaz._, Tags.{MaxVal, LastVal}
+import scalaz.{Lens => _, _}, Scalaz._, Tags.MaxVal
 
 final class QProv[T[_[_]]: BirecursiveT: EqualT]
     extends Dimension[T[EJson], IdAccess[T[EJson]], QProv.P[T]]
     with QSUTTypes[T] {
+
+  import QProv.BucketsState
 
   type D     = T[EJson]
   type I     = IdAccess[D]
@@ -40,47 +42,44 @@ final class QProv[T[_[_]]: BirecursiveT: EqualT]
   val prov: Prov[D, I, P] =
     Prov[D, I, P](IdAccess.static(_))
 
-  /** Returns a position map of the identities present in the given provenance
-    * and a new provenance where the identities have been replaced with the
+  type BucketsM[F[_]] = MonadState_[F, BucketsState[I]]
+  def BucketsM[F[_]](implicit ev: BucketsM[F]): BucketsM[F] = ev
+
+  /** Returns provenance where the identities have been replaced with the
     * appropriate bucket references.
     */
-  def bucketedIds[M[_]: Monad: MonadState_[?[_], SInt]](src: Symbol, p: P): M[(P, SInt ==>> I)] =
+  def bucketedIds[M[_]: Monad: BucketsM](src: Symbol, p: P): M[P] =
     p.cataM(bucketedIdsƒ[M](src))
 
-  def bucketedIdsƒ[M[_]: Monad](src: Symbol)(implicit M: MonadState_[M, SInt]): AlgebraM[M, PF, (P, SInt ==>> I)] = {
-    def children
-        (l: (P, SInt ==>> I), r: (P, SInt ==>> I))
-        (f: (P, P) => P)
-        : M[(P, SInt ==>> I)] =
-      (l, r) match {
-        case ((lp, lg), (rp, rg)) => (f(lp, rp), lg union rg).point[M]
-      }
+  def bucketedIdsƒ[M[_]: Monad](src: Symbol)(implicit M: BucketsM[M]): AlgebraM[M, PF, P] = {
+    case ProvF.Value(i) =>
+      for {
+        s <- M.get
 
-    {
-      case ProvF.Value(i) =>
-        for {
-          idx <- M.get
-          _   <- M.put(idx + 1)
-          b   =  IdAccess.bucket[D](src, idx)
-        } yield (prov.value(b), IMap.singleton(idx, i))
+        idx <- s.buckets.lookup(i) getOrElseF {
+          M.put(BucketsState(
+            s.nextIdx + 1,
+            s.buckets + (i -> s.nextIdx)
+          )) as s.nextIdx
+        }
 
-      case ProvF.Nada()      => (prov.nada(), IMap.empty[SInt, I]).point[M]
-      case ProvF.Proj(ejs)   => (prov.proj(ejs), IMap.empty[SInt, I]).point[M]
-      case ProvF.Both(l, r)  => children(l, r)(prov.both(_, _))
-      case ProvF.OneOf(l, r) => children(l, r)(prov.oneOf(_, _))
-      case ProvF.Then(l, r)  => children(l, r)(prov.thenn(_, _))
-    }
+        b = IdAccess.bucket[D](src, idx)
+      } yield prov.value(b)
+
+    case other =>
+      other.embed.point[M]
   }
 
   /** Converts identity access in `dims` to bucket access of `src`. */
   def bucketAccess(src: Symbol, dims: Dimensions[P]): Dimensions[P] =
-    bucketedDims(src, dims)._1
+    bucketedDims(src, dims)._2
 
   /** Reifies the identities in the given `Dimensions`. */
-  def buckets(dims: Dimensions[P]): List[I] = {
-    val maps = bucketedDims(Symbol(""), dims)._2
-    LastVal.unsubst(maps.foldMap(LastVal.subst(_))).values
-  }
+  def buckets(dims: Dimensions[P]): List[I] =
+    bucketedDims(Symbol(""), dims)._1
+      .toList
+      .sortBy(_._2)
+      .map(_._1)
 
   /** The greatest index of group keys for `of` or None if none exist. */
   def maxGroupKeyIndex(of: Symbol, dims: Dimensions[P]): Option[SInt] = {
@@ -112,18 +111,19 @@ final class QProv[T[_[_]]: BirecursiveT: EqualT]
   private val pfo = ProvF.Optics[D, I]
   private val groupKey = prov.value composePrism IdAccess.groupKey[D]
 
-  // NB: Computed together to ensure indices align properly.
-  private def bucketedDims(src: Symbol, dims: Dimensions[P]): (Dimensions[P], IList[SInt ==>> I]) =
+  private def bucketedDims(src: Symbol, dims: Dimensions[P]): (I ==>> SInt, Dimensions[P]) =
     dims.reverse
-      .traverse(bucketedIds[State[SInt, ?]](src, _))
-      .eval(0)
-      .unzip
-      .leftMap(_.reverse)
+      .traverse(bucketedIds[State[BucketsState[I], ?]](src, _))
+      .map(_.reverse)
+      .run(BucketsState(0, IMap.empty))
+      .leftMap(_.buckets)
 }
 
 object QProv {
   type PF[T[_[_]], A] = ProvF[T[EJson], IdAccess[T[EJson]], A]
   type P[T[_[_]]]     = T[PF[T, ?]]
+
+  final case class BucketsState[I](nextIdx: SInt, buckets: I ==>> SInt)
 
   def apply[T[_[_]]: BirecursiveT: EqualT]: QProv[T] =
     new QProv[T]

--- a/connector/src/main/scala/quasar/qscript/qsu/QSUGraph.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/QSUGraph.scala
@@ -367,6 +367,13 @@ object QSUGraph extends QSUGraphInstances {
       }
     }
 
+    object QSAutoJoin {
+      def unapply[T[_[_]]](g: QSUGraph[T]) = g.unfold match {
+        case g: QSU.QSAutoJoin[T, QSUGraph[T]] => QSU.QSAutoJoin.unapply(g)
+        case _ => None
+      }
+    }
+
     object GroupBy {
       def unapply[T[_[_]]](g: QSUGraph[T]) = g.unfold match {
         case g: QSU.GroupBy[T, QSUGraph[T]] => QSU.GroupBy.unapply(g)
@@ -604,7 +611,7 @@ sealed abstract class QSUGraphInstances extends QSUGraphInstances0 {
       val assocs = g.foldMapUp(sg => DList((sg.root, sg.vertices(sg.root))))
 
       s"QSUGraph(${g.root.shows})[\n" +
-      assocs.toList.map({ case (k, v) => s"  ${k.shows} -> ${v.shows}" }).intercalate("\n") +
+      printMultiline(assocs.toList.toMap) +
       "\n]"
     }
 }

--- a/connector/src/main/scala/quasar/qscript/qsu/QSUGraph.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/QSUGraph.scala
@@ -280,7 +280,7 @@ object QSUGraph extends QSUGraphInstances {
 
       back <- reverse.get(node) match {
         case Some(sym) =>
-          QSUGraph[T](root = sym, SMap()).point[F]
+          QSUGraph[T](root = sym, SMap(sym -> node)).point[F]
 
         case None =>
           for {

--- a/connector/src/main/scala/quasar/qscript/qsu/QSUGraph.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/QSUGraph.scala
@@ -611,7 +611,7 @@ sealed abstract class QSUGraphInstances extends QSUGraphInstances0 {
       val assocs = g.foldMapUp(sg => DList((sg.root, sg.vertices(sg.root))))
 
       s"QSUGraph(${g.root.shows})[\n" +
-      printMultiline(assocs.toList.toMap) +
+      printMultiline(assocs.toList) +
       "\n]"
     }
 }

--- a/connector/src/main/scala/quasar/qscript/qsu/QSUTTypes.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/QSUTTypes.scala
@@ -16,13 +16,18 @@
 
 package quasar.qscript.qsu
 
+import quasar.ejson.EJson
 import quasar.qscript.TTypes
 
 trait QSUTTypes[T[_[_]]] extends TTypes[T] {
+  type QAuth = quasar.qscript.qsu.QAuth[T]
+  type QDims = quasar.qscript.qsu.QDims[T]
+  type QIdAccess = quasar.qscript.qsu.QIdAccess[T]
+  type QAccess[A] = quasar.qscript.qsu.QAccess[T, A]
   type FreeAccess[A] = quasar.qscript.qsu.FreeAccess[T, A]
   type QSUGraph = quasar.qscript.qsu.QSUGraph[T]
   type RevIdx = quasar.qscript.qsu.QSUGraph.RevIdx[T]
-  type References = quasar.qscript.qsu.References[T]
+  type References = quasar.qscript.qsu.References[T, T[EJson]]
   type QScriptUniform[A] = quasar.qscript.qsu.QScriptUniform[T, A]
   type QScriptEducated[A] = quasar.qscript.QScriptEducated[T, A]
 }

--- a/connector/src/main/scala/quasar/qscript/qsu/QScriptUniform.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/QScriptUniform.scala
@@ -738,6 +738,12 @@ object QScriptUniform {
     def tread1(name: String): T[QSU] =
       tread(Path.rootDir </> Path.file(name))
 
+    // undefined
+    val undefined: Prism[T[QSU], Unit] =
+      Prism[T[QSU], Unit](map.getOption(_) collect {
+        case (Unreferenced(), Embed(CoEnv(\/-(MFC(MapFuncsCore.Undefined()))))) => ()
+      })(_ => map(unreferenced(), Free.roll(mfc[FreeMap](MapFuncsCore.Undefined()))))
+
     // constants
     val constant: Prism[T[QSU], T[EJson]] =
       Prism[T[QSU], T[EJson]](map.getOption(_) collect {

--- a/connector/src/main/scala/quasar/qscript/qsu/ReifyBuckets.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ReifyBuckets.scala
@@ -19,67 +19,86 @@ package quasar.qscript.qsu
 import slamdata.Predef._
 
 import quasar.Planner.{InternalError, PlannerErrorME}
-import quasar.fp.ski.κ
 import quasar.fp.symbolOrder
-import quasar.qscript.{FreeMap, FreeMapA, Hole, HoleF, ReduceIndexF, SrcHole}
+import quasar.fp.ski.ι
+import quasar.qscript.{Hole, HoleF, ReduceIndexF, SrcHole}
+import ApplyProvenance.AuthenticatedQSU
 
 import matryoshka._
-import scalaz.{Id, ISet, Monad, Traverse}
-import scalaz.std.list._
-import scalaz.std.option._
-import scalaz.syntax.either._
-import scalaz.syntax.foldable._
-import scalaz.syntax.monad._
-import scalaz.syntax.std.option._
+import scalaz.{Id, ISet, Monad, Scalaz}, Scalaz._
 
-object ReifyBuckets {
+final class ReifyBuckets[T[_[_]]: BirecursiveT: EqualT: ShowT] private () extends QSUTTypes[T] {
   import QSUGraph.Extractors._
-  import ApplyProvenance.AuthenticatedQSU
 
-  def apply[T[_[_]]: BirecursiveT: EqualT, F[_]: Monad: PlannerErrorME](aqsu: AuthenticatedQSU[T])
+  val prov = QProv[T]
+  val qsu  = QScriptUniform.Optics[T]
+
+  def apply[F[_]: Monad: PlannerErrorME](aqsu: AuthenticatedQSU[T])
       : F[AuthenticatedQSU[T]] = {
 
-    val prov = QProv[T]
-    val qsu  = QScriptUniform.Optics[T]
-    val LF   = Traverse[List].compose[FreeMapA[T, ?]]
-    val LFA  = LF.compose[Access]
-
-    val bucketsReified = aqsu.graph rewriteM {
+    val bucketsReified = aqsu.graph.rewriteM[F] {
       case g @ LPReduce(source, reduce) =>
-        val buckets = prov.buckets(prov.reduce(aqsu.dims(source.root)))
-        val srcs = LF.foldMap(buckets)(a => ISet.fromFoldable(Access.value.getOption(a))).toIList
+        for {
+          res <- bucketsFor[F](aqsu.auth, source.root)
 
-        val discovered: F[(Symbol, FreeMap[T])] =
-          srcs.toNel.fold((source.root, HoleF[T]).point[F]) { syms =>
+          (srcs, buckets) = res
+
+          discovered <- srcs.toList.toNel.fold((source.root, HoleF[T]).point[F]) { syms =>
             val region =
-              syms.findMapM[Id.Id, (Symbol, FreeMap[T])](
+              syms.findMapM[Id.Id, (Symbol, FreeMap)](
                 s => MappableRegion.unaryOf(s, source) strengthL s)
 
-            region getOrElseF {
-              PlannerErrorME[F].raiseError(InternalError(
-                s"[ReifyBuckets] Expected to find a mappable region in ${source.root} based on one of ${syms}.",
+            region getOrElseF PlannerErrorME[F].raiseError(
+              InternalError(
+                s"Expected to find a mappable region in ${source.root} based on one of ${syms}.",
                 None))
-            }
           }
 
-        discovered map { case (newSrc, fm) =>
+          (newSrc, fm) = discovered
+
+        } yield {
           g.overwriteAtRoot(qsu.qsReduce(
             newSrc,
-            LFA.map(buckets)(κ(SrcHole : Hole)),
+            buckets,
             List(reduce as fm),
             ReduceIndexF[T](0.right)))
         }
 
       case g @ QSSort(source, Nil, keys) =>
         val src = source.root
-        val buckets = prov.buckets(prov.reduce(aqsu.dims(src)))
 
-        g.overwriteAtRoot(qsu.qsSort(
-          src,
-          LFA.map(buckets)(κ(SrcHole : Hole)),
-          keys)).point[F]
+        bucketsFor[F](aqsu.auth, src) map { case (_, buckets) =>
+          g.overwriteAtRoot(qsu.qsSort(src, buckets, keys))
+        }
     }
 
     bucketsReified map (g => aqsu.copy(graph = g))
   }
+
+  ////
+
+  private def bucketsFor[F[_]: Monad: PlannerErrorME]
+      (qauth: QAuth, vertex: Symbol)
+      : F[(ISet[Symbol], List[FreeAccess[Hole]])] =
+    for {
+      vdims <- qauth.lookupDimsE[F](vertex)
+
+      ids = prov.buckets(prov.reduce(vdims)).toList
+
+      res <- ids traverse {
+        case id @ IdAccess.GroupKey(s, i) =>
+          qauth.lookupGroupKeyE[F](s, i)
+            .map(fm => (ISet.singleton(s), fm as Access.value[prov.D, Hole](SrcHole)))
+
+        case other =>
+          (ISet.empty[Symbol], HoleF[T] as Access.id[prov.D, Hole](other, SrcHole)).point[F]
+      }
+    } yield res.unfzip leftMap (_.foldMap(ι))
+}
+
+object ReifyBuckets {
+  def apply[T[_[_]]: BirecursiveT: EqualT: ShowT, F[_]: Monad: PlannerErrorME]
+      (aqsu: AuthenticatedQSU[T])
+      : F[AuthenticatedQSU[T]] =
+    taggedInternalError("ReifyBuckets", new ReifyBuckets[T].apply[F](aqsu))
 }

--- a/connector/src/main/scala/quasar/qscript/qsu/ReifyIdentities.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ReifyIdentities.scala
@@ -40,9 +40,9 @@ import quasar.qscript.MapFuncCore.{EmptyMap, StaticMap}
 import quasar.qscript.provenance.JoinKeys.JoinKey
 import quasar.qscript.qsu.{QScriptUniform => QSU}
 
-import matryoshka.BirecursiveT
+import matryoshka.{showTShow, BirecursiveT, ShowT}
 import monocle.Lens
-import scalaz.{Foldable, Free, Functor, IList, IMap, ISet, Monad, NonEmptyList, StateT, Traverse}
+import scalaz.{Foldable, Free, Functor, IList, IMap, ISet, Monad, NonEmptyList, Show, StateT, Traverse}
 import scalaz.Scalaz._
 
 final class ReifyIdentities[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T] {
@@ -475,6 +475,13 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT] private () extends QSUTTypes[
 
 object ReifyIdentities {
   final case class ResearchedQSU[T[_[_]]](refs: References[T, T[EJson]], graph: QSUGraph[T])
+
+  object ResearchedQSU {
+    implicit def show[T[_[_]]: ShowT]: Show[ResearchedQSU[T]] =
+      Show.shows { rqsu =>
+        s"ResearchedQSU\n======\n${rqsu.graph.shows}\n\n${rqsu.refs.shows}\n======"
+      }
+  }
 
   def apply[T[_[_]]: BirecursiveT, F[_]: Monad: NameGenerator]
       (graph: QSUGraph[T])

--- a/connector/src/main/scala/quasar/qscript/qsu/package.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/package.scala
@@ -23,10 +23,9 @@ import quasar.fp._
 import quasar.qscript.provenance.Dimensions
 
 import matryoshka._
-import scalaz.{Free, Show}
-import scalaz.std.list._
+import scalaz.{Free, Show, Traverse}
 import scalaz.std.string._
-import scalaz.syntax.foldable._
+import scalaz.syntax.traverse._
 import scalaz.syntax.show._
 
 package object qsu {
@@ -42,10 +41,8 @@ package object qsu {
   def AccessValueHoleF[T[_[_]]]: FreeAccess[T, Hole] =
     AccessValueF[T, Hole](SrcHole)
 
-  def printMultiline[K: Show, V: Show](m: SMap[K, V]): String =
-    m.toList
-      .map({ case (k, v) => s"  ${k.shows} -> ${v.shows}"})
-      .intercalate("\n")
+  def printMultiline[F[_]: Traverse, K: Show, V: Show](fkv: F[(K, V)]): String =
+    fkv map { case (k, v) => s"  ${k.shows} -> ${v.shows}" } intercalate "\n"
 
   def taggedInternalError[F[_]: PlannerErrorME, A](tag: String, fa: F[A]): F[A] =
     PlannerErrorME[F].handleError(fa)(e => PlannerErrorME[F].raiseError(e match {

--- a/connector/src/test/scala/quasar/qscript/qsu/ApplyProvenanceSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/ApplyProvenanceSpec.scala
@@ -35,6 +35,7 @@ import pathy.Path, Path.{file, Sandboxed}
 import scalaz.{\/, Cofree, Equal, IList}
 import scalaz.syntax.equal._
 import scalaz.syntax.show._
+import scalaz.std.list._
 import scalaz.std.map._
 
 object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
@@ -130,7 +131,8 @@ object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
           result(
             qauth.dims ≟ expectedDims,
             s"received expected authenticated QSU:\n${aqsu.shows}",
-            s"received unexpected authenticated QSU:\n${aqsu.shows}\nexpected:\n[\n${printMultiline(expected)}\n]",
+            s"received unexpected authenticated QSU:\n${aqsu.shows}\n" +
+            s"expected:\n[\n${printMultiline(expected.toList)}\n]",
             s)
         }).merge
       }

--- a/connector/src/test/scala/quasar/qscript/qsu/ApplyProvenanceSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/ApplyProvenanceSpec.scala
@@ -25,17 +25,14 @@ import quasar.ejson.{EJson, Fixed}
 import quasar.ejson.implicits._
 import quasar.fp._
 import quasar.qscript.construction
-import quasar.qscript.provenance.Dimensions
 import quasar.qscript.{HoleF, ReduceFuncs}
 import quasar.qscript.MapFuncsCore.IntLit
 
 import matryoshka._
 import matryoshka.data.Fix
-import matryoshka.data.free._
 import org.specs2.matcher.{Expectable, Matcher, MatchResult}
 import pathy.Path, Path.{file, Sandboxed}
 import scalaz.{\/, Cofree, Equal, IList}
-import scalaz.syntax.applicative._
 import scalaz.syntax.equal._
 import scalaz.syntax.show._
 import scalaz.std.map._
@@ -61,7 +58,7 @@ object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
 
   // FIXME: Figure out how to get this to resolve normally.
   implicit val eqP: Equal[qprov.P] =
-    qprov.prov.provenanceEqual(Equal[qprov.D], Equal[FreeMapA[Access[Symbol]]])
+    qprov.prov.provenanceEqual(Equal[qprov.D], Equal[QIdAccess])
 
   "provenance application" should {
 
@@ -73,7 +70,7 @@ object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
         qsu.map('name0,
           (qsu.read('name1, afile), fm))
 
-      val dims: SMap[Symbol, Dimensions[qprov.P]] = SMap(
+      val dims: SMap[Symbol, QDims] = SMap(
         'name0 -> IList(qprov.prov.proj(J.str("foobar"))),
         'name1 -> IList(qprov.prov.proj(J.str("foobar"))))
 
@@ -94,22 +91,22 @@ object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
 
       tree must haveDimensions(SMap(
         'n4 -> IList(
-          qprov.prov.value(Access.bucket('n4, 1, 'n4).point[FreeMapA])
-        , qprov.prov.value(Access.bucket('n4, 0, 'n4).point[FreeMapA]))
+          qprov.prov.value(IdAccess.bucket('n4, 1))
+        , qprov.prov.value(IdAccess.bucket('n4, 0)))
       , 'n3 -> IList(
           qprov.prov.proj(J.str("foobar"))
-        , qprov.prov.value(func.ProjectKeyS(Access.value('n0).point[FreeMapA], "y"))
-        , qprov.prov.value(func.ProjectKeyS(Access.value('n0).point[FreeMapA], "x")))
-      , 'n0 -> IList(
+        , qprov.prov.value(IdAccess.groupKey('n2, 1))
+        , qprov.prov.value(IdAccess.groupKey('n2, 0)))
+      , 'n2 -> IList(
           qprov.prov.proj(J.str("foobar"))
-        , qprov.prov.value(func.ProjectKeyS(Access.value('n0).point[FreeMapA], "y"))
-        , qprov.prov.value(func.ProjectKeyS(Access.value('n0).point[FreeMapA], "x")))
+        , qprov.prov.value(IdAccess.groupKey('n2, 1))
+        , qprov.prov.value(IdAccess.groupKey('n2, 0)))
       ))
     }
   }
 
   // checks the expected dimensions
-  def haveDimensions(expected: SMap[Symbol, Dimensions[qprov.P]])
+  def haveDimensions(expected: SMap[Symbol, QDims])
       : Matcher[Cofree[QSU, Symbol]] =
     new Matcher[Cofree[QSU, Symbol]] {
       def apply[S <: Cofree[QSU, Symbol]](s: Expectable[S]): MatchResult[S] = {
@@ -117,7 +114,7 @@ object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
         val (renames, inputGraph): (QSUGraph.Renames, QSUGraph) =
           QSUGraph.fromAnnotatedTree[Fix](s.value.map(Some(_)))
 
-        val expectedDims: QSUDims[Fix] =
+        val expectedDims: SMap[Symbol, QDims] =
           expected.map { case (k, v) =>
             val newP = renames.foldLeft(v)((p, t) => qprov.rename(t._1, t._2, p))
             (renames(k), newP)
@@ -129,11 +126,11 @@ object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
         { err =>
           failure(s"provenance application produced unexpected planner error: ${err}", s)
         },
-        { case auth @ AuthenticatedQSU(resultGraph, resultDims) =>
+        { case aqsu @ AuthenticatedQSU(resultGraph, qauth) =>
           result(
-            resultDims ≟ expectedDims,
-            s"received expected authenticated QSU:\n${auth.shows}",
-            s"received unexpected authenticated QSU:\n${auth.shows}\nexpected:\n${QSUDims.show[Fix].shows(expected)}",
+            qauth.dims ≟ expectedDims,
+            s"received expected authenticated QSU:\n${aqsu.shows}",
+            s"received unexpected authenticated QSU:\n${aqsu.shows}\nexpected:\n[\n${printMultiline(expected)}\n]",
             s)
         }).merge
       }

--- a/connector/src/test/scala/quasar/qscript/qsu/GraduateSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/GraduateSpec.scala
@@ -31,8 +31,6 @@ import quasar.qscript.{
   IncludeId,
   JoinSide,
   LeftSideF,
-  MapFuncsCore,
-  MFC,
   ReduceFunc,
   ReduceFuncs,
   ReduceIndex,
@@ -101,7 +99,7 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
 
       "convert QSReduce" in {
         val buckets: List[FreeMap] = List(func.Add(HoleF, IntLit(17)))
-        val abuckets: List[FreeAccess[Hole]] = buckets.map(_.map(Access.value(_)))
+        val abuckets: List[FreeAccess[Hole]] = buckets.map(_.map(Access.value[Fix[EJson], Hole](_)))
         val reducers: List[ReduceFunc[FreeMap]] = List(ReduceFuncs.Count(HoleF))
         val repair: FreeMapA[ReduceIndex] = ReduceIndexF(\/-(0))
 
@@ -123,7 +121,7 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
 
       "convert QSSort" in {
         val buckets: List[FreeMap] = List(func.Add(HoleF, IntLit(17)))
-        val abuckets: List[FreeAccess[Hole]] = buckets.map(_.map(Access.value(_)))
+        val abuckets: List[FreeAccess[Hole]] = buckets.map(_.map(Access.value[Fix[EJson], Hole](_)))
         val order: NEL[(FreeMap, SortDir)] = NEL(HoleF -> SortDir.Descending)
 
         val qgraph: Fix[QSU] = qsu.qsSort(qsu.read(afile), abuckets, order)
@@ -177,9 +175,7 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
               concatArr,
               Rotation.ShiftArray),
             qsu.cint(1),
-            Free.roll[MapFunc, Access[JoinSide]](
-              MFC(MapFuncsCore.Constant[Fix, FreeAccess[JoinSide]](
-                Fixed[Fix[EJson]].bool(true)))),
+            func.Constant[JoinSide](Fixed[Fix[EJson]].bool(true)),
             JoinType.Inner,
             projectIdx),
           Take,

--- a/connector/src/test/scala/quasar/qscript/qsu/GraduateSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/GraduateSpec.scala
@@ -40,6 +40,7 @@ import quasar.qscript.{
   Take
 }
 import quasar.qscript.MapFuncsCore.IntLit
+import quasar.qscript.qsu.ApplyProvenance.AuthenticatedQSU
 
 import matryoshka.EqualT
 import matryoshka.data.Fix, Fix._
@@ -213,8 +214,8 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
   def graduateAs(expected: Fix[QSE]): Matcher[Fix[QSU]] = {
     new Matcher[Fix[QSU]] {
       def apply[S <: Fix[QSU]](s: Expectable[S]): MatchResult[S] = {
-        val actual: PlannerError \/ Fix[QSE] =
-          evaluate(researched(QSUGraph.fromTree[Fix](s.value)) >>= grad)
+        val authd = AuthenticatedQSU[Fix](QSUGraph.fromTree[Fix](s.value), QAuth.empty)
+        val actual: PlannerError \/ Fix[QSE] = evaluate(researched(authd) >>= grad)
 
         actual.bimap[MatchResult[S], MatchResult[S]](
         { err =>
@@ -234,8 +235,8 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
   def notGraduate: Matcher[Fix[QSU]] = {
     new Matcher[Fix[QSU]] {
       def apply[S <: Fix[QSU]](s: Expectable[S]): MatchResult[S] = {
-        val actual: PlannerError \/ Fix[QSE] =
-          evaluate(researched(QSUGraph.fromTree[Fix](s.value)) >>= grad)
+        val authd = AuthenticatedQSU[Fix](QSUGraph.fromTree[Fix](s.value), QAuth.empty)
+        val actual: PlannerError \/ Fix[QSE] = evaluate(researched(authd) >>= grad)
 
         // TODO better equality checking for PlannerError
         actual.bimap[MatchResult[S], MatchResult[S]](

--- a/connector/src/test/scala/quasar/qscript/qsu/ReifyBucketsSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/ReifyBucketsSpec.scala
@@ -21,10 +21,11 @@ import slamdata.Predef.{List, Nil}
 import quasar.{Qspec, TreeMatchers}
 import quasar.Planner.PlannerError
 import quasar.ejson.{EJson, Fixed}
-import quasar.fp.coproductEqual
+import quasar.ejson.implicits._
+import quasar.fp.{coproductEqual, coproductShow}
 import quasar.qscript.{construction, ExcludeId, Hole, ReduceFuncs}
 
-import matryoshka.delayEqual
+import matryoshka.{delayEqual, delayShow, showTShow}
 import matryoshka.data.Fix
 import matryoshka.data.free._
 import scalaz.{\/, \/-}
@@ -56,7 +57,7 @@ object ReifyBucketsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
           ReduceFuncs.Sum(()))
 
       val expBucket =
-        func.ProjectKeyS(func.Hole, "state") map (Access.value(_))
+        func.ProjectKeyS(func.Hole, "state") map (Access.value[Fix[EJson], Hole](_))
 
       val expReducer =
         func.ProjectKeyS(func.Hole, "pop")
@@ -69,6 +70,36 @@ object ReifyBucketsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
             _)) =>
 
           (b must beTreeEqual(expBucket)) and
+          (r must beTreeEqual(expReducer))
+      }
+    }
+
+    "extract func even when constant buckets" >> {
+      // select sum(pop) from zips group by 7
+      val tree =
+        qsu.lpReduce(
+          qsu.map(
+            qsu.dimEdit(
+              qsu.tread1("zips"),
+              DTrans.Group(func.Constant(J.int(7)))),
+            func.ProjectKeyS(func.Hole, "pop")),
+          ReduceFuncs.Sum(()))
+
+      val expB =
+        func.Constant[Access[Fix[EJson], Hole]](J.int(7))
+
+      val expReducer =
+        func.ProjectKeyS(func.Hole, "pop")
+
+      reifyBuckets(tree) must beLike {
+        case \/-(
+          QSReduce(
+            LeftShift(Read(_), _, ExcludeId, _, _),
+            List(b),
+            List(ReduceFuncs.Sum(r)),
+            _)) =>
+
+          (b must beTreeEqual(expB)) and
           (r must beTreeEqual(expReducer))
       }
     }
@@ -94,37 +125,6 @@ object ReifyBucketsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
             _)) =>
 
           (fm must beTreeEqual(expFm)) and
-          (r must beTreeEqual(func.Hole))
-      }
-    }
-
-    "leave source untouched when constant buckets" >> {
-      // select sum(pop) from zips group by 7
-      val tree =
-        qsu.lpReduce(
-          qsu.map(
-            qsu.dimEdit(
-              qsu.tread1("zips"),
-              DTrans.Group(func.Constant(J.int(7)))),
-            func.ProjectKeyS(func.Hole, "pop")),
-          ReduceFuncs.Sum(()))
-
-      val expFm =
-        func.ProjectKeyS(func.Hole, "pop")
-
-      val expB =
-        func.Constant[Access[Hole]](J.int(7))
-
-      reifyBuckets(tree) must beLike {
-        case \/-(
-          QSReduce(
-            Map(LeftShift(Read(_), _, ExcludeId, _, _), fm),
-            List(b),
-            List(ReduceFuncs.Sum(r)),
-            _)) =>
-
-          (fm must beTreeEqual(expFm)) and
-          (b must beTreeEqual(expB)) and
           (r must beTreeEqual(func.Hole))
       }
     }

--- a/it/src/main/resources/tests/demo/groupedSelectOfNestedReduction.test
+++ b/it/src/main/resources/tests/demo/groupedSelectOfNestedReduction.test
@@ -1,0 +1,23 @@
+{
+    "name": "select unreduced grouped values from nested select with reduction",
+    "backends": {
+        "couchbase":         "skip",
+        "marklogic_json":    "ignoreFieldOrder"
+    },
+    "NB": "disabled on couchbase due to lack of general join",
+    "data": "patients.data",
+    "query": "select city, cnt as c from (select city, count(*) as cnt from patients where state = \"NY\" group by city order by count(*) desc, city limit 10) group by city order by c desc, city",
+    "predicate": "exactly",
+    "expected": [
+      { "city": "NEW YORK",     "c": 9 }
+    , { "city": "ROCHESTER",    "c": 8 }
+    , { "city": "ALBANY",       "c": 6 }
+    , { "city": "BRONX",        "c": 2 }
+    , { "city": "BROOKLYN",     "c": 2 }
+    , { "city": "BROWNVILLE",   "c": 2 }
+    , { "city": "BUFFALO",      "c": 2 }
+    , { "city": "GARDEN CITY",  "c": 2 }
+    , { "city": "MOUNT VERNON", "c": 2 }
+    , { "city": "OLD BETHPAGE", "c": 2 }
+    ]
+}

--- a/it/src/main/resources/tests/demo/nestedSelectWithReduce.test
+++ b/it/src/main/resources/tests/demo/nestedSelectWithReduce.test
@@ -5,14 +5,13 @@
         "marklogic_json":    "ignoreFieldOrder"
 
     },
-    "NB": "pending on mimir due to sorting issue (should be pendingIgnoreFieldOrder, but that breaks because the predicate is buggy)",
     "NB": "disabled on couchbase due to lack of general join",
     "data": "otherpatients.data",
     "query": "SELECT AVG(cnt) as measure, state as category FROM
                 (SELECT COUNT(*) as cnt, state, gender FROM otherpatients
                 WHERE codes[*].desc LIKE \"%flu%\"
                 GROUP BY state, gender
-                ORDER BY COUNT(*) DESC, state ASC) as meh",
+                ORDER BY COUNT(*) DESC, state ASC)",
     "predicate": "initial",
     "expected": [{ "measure": 1.238095238095, "category": "NE" },
                  { "measure": 1.238095238095, "category": "AL" },

--- a/it/src/main/resources/tests/different-flattens.test
+++ b/it/src/main/resources/tests/different-flattens.test
@@ -1,18 +1,18 @@
 {
     "name": "merge differently-nested flattens",
     "backends": {
-        "couchbase":         "pending",
-        "marklogic_json":    "pending",
-        "marklogic_xml":     "pending",
-        "mimir":             "pending",
-        "mongodb_2_6":       "pending",
-        "mongodb_3_0":       "pending",
-        "mongodb_3_2":       "pending",
-        "mongodb_3_4":       "pending",
-        "mongodb_read_only": "pending",
-        "spark_hdfs":        "pending",
-        "spark_local":       "pending",
-        "spark_cassandra":   "pending"
+        "couchbase":         "skip",
+        "marklogic_json":    "skip",
+        "marklogic_xml":     "skip",
+        "mimir":             "skip",
+        "mongodb_2_6":       "skip",
+        "mongodb_3_0":       "skip",
+        "mongodb_3_2":       "skip",
+        "mongodb_3_4":       "skip",
+        "mongodb_read_only": "skip",
+        "spark_hdfs":        "skip",
+        "spark_local":       "skip",
+        "spark_cassandra":   "skip"
     },
     "data": "user_comments.data",
     "query": "select profile from user_comments where (

--- a/it/src/main/resources/tests/flattenGroupedObject.test
+++ b/it/src/main/resources/tests/flattenGroupedObject.test
@@ -9,7 +9,6 @@
         "mongodb_3_2":       "pending",
         "mongodb_3_4":       "pending",
         "mongodb_read_only": "pending",
-        "spark_hdfs":        "pending",
         "spark_cassandra":   "pending"
     },
 

--- a/it/src/main/resources/tests/flattenGroupedObject.test
+++ b/it/src/main/resources/tests/flattenGroupedObject.test
@@ -10,7 +10,6 @@
         "mongodb_3_4":       "pending",
         "mongodb_read_only": "pending",
         "spark_hdfs":        "pending",
-        "spark_local":       "pending",
         "spark_cassandra":   "pending"
     },
 

--- a/it/src/main/resources/tests/flattenGroupedObject.test
+++ b/it/src/main/resources/tests/flattenGroupedObject.test
@@ -4,7 +4,6 @@
         "couchbase":         "pending",
         "marklogic_json":    "pending",
         "marklogic_xml":     "pending",
-        "mimir":             "pending",
         "mongodb_2_6":       "pending",
         "mongodb_3_0":       "pending",
         "mongodb_3_2":       "pending",

--- a/it/src/main/resources/tests/multistageFlatten.test
+++ b/it/src/main/resources/tests/multistageFlatten.test
@@ -1,18 +1,18 @@
 {
     "name": "multi-flatten with fields at various depths",
     "backends": {
-        "couchbase":           "pending",
-        "marklogic_json":      "pending",
-        "marklogic_xml":       "pending",
-        "mimir":               "pendingIgnoreFieldOrder",
-        "mongodb_2_6":         "pending",
-        "mongodb_3_0":         "pending",
-        "mongodb_3_2":         "pending",
-        "mongodb_3_4":         "pending",
-        "mongodb_read_only":   "pending",
-        "spark_local":         "pending",
-        "spark_hdfs":          "pending",
-        "spark_cassandra":     "pending"
+        "couchbase":           "skip",
+        "marklogic_json":      "skip",
+        "marklogic_xml":       "skip",
+        "mimir":               "skip",
+        "mongodb_2_6":         "skip",
+        "mongodb_3_0":         "skip",
+        "mongodb_3_2":         "skip",
+        "mongodb_3_4":         "skip",
+        "mongodb_read_only":   "skip",
+        "spark_local":         "skip",
+        "spark_hdfs":          "skip",
+        "spark_cassandra":     "skip"
     },
     "data": "nested_foo.data",
     "query": "select * from nested_foo where (

--- a/it/src/main/resources/tests/multitypeFlatten.test
+++ b/it/src/main/resources/tests/multitypeFlatten.test
@@ -1,18 +1,18 @@
 {
     "name": "flatten a single field as both object and array",
     "backends": {
-        "couchbase":         "pending",
-        "marklogic_json":    "pending",
-        "marklogic_xml":     "pending",
-        "mimir":             "pendingIgnoreFieldOrder",
-        "mongodb_2_6":       "pending",
-        "mongodb_3_0":       "pending",
-        "mongodb_3_2":       "pending",
-        "mongodb_3_4":       "pending",
-        "mongodb_read_only": "pending",
-        "spark_hdfs":        "pending",
-        "spark_local":       "pending",
-        "spark_cassandra":   "pending"
+        "couchbase":         "skip",
+        "marklogic_json":    "skip",
+        "marklogic_xml":     "skip",
+        "mimir":             "skip",
+        "mongodb_2_6":       "skip",
+        "mongodb_3_0":       "skip",
+        "mongodb_3_2":       "skip",
+        "mongodb_3_4":       "skip",
+        "mongodb_read_only": "skip",
+        "spark_hdfs":        "skip",
+        "spark_local":       "skip",
+        "spark_cassandra":   "skip"
     },
     "data": "nested_foo.data",
     "query": "select * from nested_foo where (


### PR DESCRIPTION
Group keys are now first-class identities along side shift ids and reducer buckets. This allows them to be properly reified when referenced in an autojoin.

Fixes #3170.
Fixes #3252.