### PR TITLE
Fix Mimir returning `NotFound` on root if empty

### DIFF
--- a/core/src/test/scala/quasar/fs/mount/HierarchicalFileSystemSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/HierarchicalFileSystemSpec.scala
@@ -222,6 +222,11 @@ class HierarchicalFileSystemSpec extends quasar.Qspec with FileSystemFixture {
           runMntd(query.ls(rootDir </> dir("bar")).run)
             .eval(emptyMS) must_=== mnts.right
         }
+
+        "of empty mount should return empty set" >> {
+          runMntd(query.ls(rootDir </> dir("bar") </> dir("mntA")).run)
+            .eval(emptyMS) must_=== Set().right
+        }
       }
     }
 

--- a/it/src/test/scala/quasar/TestConfig.scala
+++ b/it/src/test/scala/quasar/TestConfig.scala
@@ -130,7 +130,7 @@ object TestConfig {
 
     TestConfig.testDataPrefix flatMap { prefix =>
       TestConfig.backendRefs.toIList
-        .traverse(r => lookupFileSystem(r, prefix).run.map(SupportedFs(r.ref,_)))
+        .traverse(r => lookupFileSystem(r, prefix).run.map(fsUT => SupportedFs(r.ref,fsUT, fsUT.map(_.copy(testDir = rootDir)))))
     }
   }
 
@@ -192,11 +192,15 @@ object TestConfig {
     confStrM flatMap { confStr =>
       import java.io.File
 
-      val backends = IList(confStr.split(";"): _*) map { backend =>
-        val List(name, classpath) = backend.split("=").toList
+      val backends =
+        if (confStr.isEmpty) IList.empty[(scala.Predef.String, scala.collection.Seq[java.io.File])]
+        else {
+          IList(confStr.split(";"): _*) map { backend =>
+            val List(name, classpath) = backend.split("=").toList
 
-        name -> classpath.split(":").map(new File(_)).toSeq
-      }
+            name -> classpath.split(":").map(new File(_)).toSeq
+          }
+        }
 
       BackendConfig.fromBackends(backends)
     }

--- a/it/src/test/scala/quasar/fs/QueryFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/QueryFilesSpec.scala
@@ -55,7 +55,7 @@ class QueryFilesSpec extends FileSystemTest[BackendEffect](FileSystemTest.allFsU
           lpr.read(src),
           lpr.constant(Data._str(from)))))
 
-  fileSystemShould { (fs, _) =>
+  fileSystemShould { (fs, nonChFs) =>
     "Querying Files" should {
       step(deleteForQuery(fs.setupInterpM).runVoid)
 
@@ -102,10 +102,8 @@ class QueryFilesSpec extends FileSystemTest[BackendEffect](FileSystemTest.allFsU
           .runEither must beRight(containTheSameElementsAs(expectedNodes))
       }
 
-      // TODO: Our chrooting prevents this from working, maybe we need a
-      //       spec that does no chrooting and writes no files?
-      "listing root dir should succeed" >> pending {
-        runT(fs.testInterpM)(query.ls(rootDir)).runEither must beRight
+      "listing root dir should always succeed even if mount is completely empty" >> {
+        runT(nonChFs.testInterpM)(query.ls(rootDir)).runEither must beRight
       }
 
       "listing nonexistent directory returns dir NotFound" >> pendingFor(fs)(Set("mimir")) {

--- a/it/testing.conf.example
+++ b/it/testing.conf.example
@@ -9,3 +9,4 @@
 #spark_cassandra   ="spark://<spark_host>:<spark_port>?cassandraHost=<host>t&cassandraPort=<port>&rootPath=<rootPath>"
 #marklogic         ="xcc://<username>:<password>@<host>:<port>/<database>"
 #couchbase         ="couchbase://<host>[:<port>]/<bucket-name>?password=<password>&docTypeKey=<type>[&queryTimeoutSeconds=<seconds>]"
+#mimir              ="<path_to_folder>"

--- a/web/src/test/scala/quasar/api/services/MetadataServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/MetadataServiceSpec.scala
@@ -83,7 +83,7 @@ class MetadataServiceSpec extends quasar.Qspec with FileSystemFixture with Http4
     }
 
     "respond with OK" >> {
-      "and empty list for existing empty directory" >> {
+      "and empty list if root is empty" >> {
         service(InMemState.empty, Map())(Request(uri = Uri(path = "/")))
           .as[Json].unsafePerformSync must_== Json("children" -> jEmptyArray)
       }

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/vfs.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/vfs.scala
@@ -214,7 +214,12 @@ object FreeVFS {
 
   def exists[F[_]: Monad](path: APath): StateT[F, VFS, Boolean] = {
     Path.refineType(path).fold(
-      dir => StateTContrib.get[F, VFS].map(_.index.contains(dir)),
+      dir =>
+        if (dir ≟ Path.rootDir)
+          true.point[StateT[F, VFS, ?]] // root directory always exists
+        else {
+          StateTContrib.get[F, VFS].map(_.index.contains(dir))
+        },
       file => StateTContrib.get[F, VFS].map(_.paths.contains(file)))
   }
 


### PR DESCRIPTION
Fix #2473

- Add test for `HierarchicalFS` to make sure it handles the root of a mount properly
- Remove `pending` from "root dir" test for connectors
- Fix `externalFileSystems` to provide "non-chrooted" interpreters to it tests
- Fix `testBackendConfig` to avoid crashing when there are no external connectors to test
- Add `mimir` to `testing.conf.example`