### PR TITLE
Improve LeftShift Mongo plans

### DIFF
--- a/mongodb/src/main/scala/quasar/physical/mongodb/MongoDbPlanner.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/MongoDbPlanner.scala
@@ -905,31 +905,22 @@ object MongoDbPlanner {
               struct match {
                 case Embed(CoEnv(\/-(MFC(Guard(exp, Type.FlexArr(_, _, _), exp0, _))))) if exp0 === exp => {
                   val struct0 = handleFreeMap[T, M, EX](cfg.funcHandler, cfg.staticHandler, struct)
-                  val exprMerge0 = getMerge[T, M, EX](cfg.funcHandler, cfg.staticHandler)(repair, DocField(BsonField.Name("s")), DocField(BsonField.Name("f")))
-                  val jsMerge0 = getJsMerge[T, M](repair, jscore.Select(jscore.Ident(JsFn.defaultName), "s"), jscore.Select(jscore.Ident(JsFn.defaultName), "f"))
+                  val exprMerge: JoinFunc[T] => M[Fix[ExprOp]] =
+                    getExprMerge[T, M, EX](cfg.funcHandler, cfg.staticHandler)(_, DocField(BsonField.Name("s")), DocField(BsonField.Name("f")))
+                  val jsMerge: JoinFunc[T] => M[JsFn] =
+                    getJsMerge[T, M](_, jscore.Select(jscore.Ident(JsFn.defaultName), "s"), jscore.Select(jscore.Ident(JsFn.defaultName), "f"))
 
-                  (struct0 |@| exprMerge0 |@| jsMerge0) { (expr, exprMerge, jsMerge) =>
-                    exprMerge.fold(
-                      ExprBuilder(
-                        FlatteningBuilder(
-                          DocBuilder(
-                            src,
-                            ListMap(
-                              BsonField.Name("s") -> docVarToExpr(DocVar.ROOT()),
-                              BsonField.Name("f") -> expr)),
-                          // TODO: Handle arrays properly
-                          Set(StructureType.Object(DocField(BsonField.Name("f")), id))),
-                        -\&/(jsMerge))
-                    )( mrg =>
-                      ExprBuilder(
-                        FlatteningBuilder(
-                          DocBuilder(
-                            src,
-                            ListMap(
-                              BsonField.Name("s") -> docVarToExpr(DocVar.ROOT()),
-                              BsonField.Name("f") -> expr)),
-                          Set(StructureType.Array(DocField(BsonField.Name("f")), id))), \&/-(mrg)))
-                  }
+                  val planMerge: JoinFunc[T] => M[Expr] = exprOrJs(_)(exprMerge, jsMerge)
+
+                  struct0 >>= (expr =>
+                    getBuilder[T, M, WF, EX, JoinSide](planMerge(_))(
+                      FlatteningBuilder(
+                        DocBuilder(
+                          src,
+                          ListMap(
+                            BsonField.Name("s") -> docVarToExpr(DocVar.ROOT()),
+                            BsonField.Name("f") -> expr)),
+                        Set(StructureType.Array(DocField(BsonField.Name("f")), id))), repair))
                 }
                 case _ =>
                   (handleFreeMap[T, M, EX](cfg.funcHandler, cfg.staticHandler, struct) ⊛
@@ -1186,13 +1177,6 @@ object MongoDbPlanner {
       case LeftSide => a1
       case RightSide => a2
     } ∘ (JsFn(JsFn.defaultName, _))
-
-  def getMerge[T[_[_]]: BirecursiveT: ShowT, M[_]: Monad: MonadFsErr: ExecTimeR, EX[_]: Traverse]
-    (funcHandler: MapFunc[T, ?] ~> OptionFree[EX, ?], staticHandler: StaticHandler[T, EX])
-    (jf: JoinFunc[T], a1: DocVar, a2: DocVar)
-    (implicit inj: EX :<: ExprOp)
-      : M[Option[Fix[ExprOp]]] =
-    handleErr(getExprMerge[T, M, EX](funcHandler, staticHandler)(jf, a1, a2).map(_.some))(_ => none[Fix[ExprOp]].point[M])
 
   def getExprMerge[T[_[_]]: BirecursiveT: ShowT, M[_]: Monad: MonadFsErr: ExecTimeR, EX[_]: Traverse]
     (funcHandler: MapFunc[T, ?] ~> OptionFree[EX, ?], staticHandler: StaticHandler[T, EX])

--- a/mongodb/src/test/scala/quasar/physical/mongodb/PlannerQScriptSpec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/PlannerQScriptSpec.scala
@@ -401,14 +401,10 @@ class PlannerQScriptSpec extends
                 $field("loc"),
                 $arrayLit(List($literal(Bson.Undefined)))))),
           $unwind(DocField("f")),
+          $match(Selector.Doc((BsonField.Name("f")) -> Selector.Lt(Bson.Int32(-165)))),
           $project(reshape(
-            "0" -> $objectLit(
-              ListMap(
-                BsonField.Name("city") -> $field("s", "city"),
-                BsonField.Name("loc") -> $field("f"))))),
-          $match(Selector.Doc(
-            (BsonField.Name("0") \ BsonField.Name("loc")) -> Selector.Lt(Bson.Int32(-165)))),
-          $project(reshape(sigil.Quasar -> $field("0")))))
+            "city" -> $field("s", "city"),
+            "loc" -> $field("f")))))
     }
 
     "plan with flatenning in filter predicate without reference to LeftSide" in {
@@ -541,10 +537,8 @@ class PlannerQScriptSpec extends
                 $arrayLit(List($literal(Bson.Undefined)))))),
           $unwind(DocField("f")),
           $project(reshape(
-            sigil.Quasar -> $objectLit(
-              ListMap(
-                BsonField.Name("city") -> $field("s", "city"),
-                BsonField.Name("loc") -> $field("f")))))))
+            "city" -> $field("s", "city"),
+            "loc" -> $field("f")))))
     }
   }
 }

--- a/mongodb/src/test/scala/quasar/physical/mongodb/PlannerSpec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/PlannerSpec.scala
@@ -246,6 +246,8 @@ class PlannerSpec extends
       "unify flattened fields",
       plan(sqlE"select loc[*] from zips where loc[*] < 0"),
       // actual: IList(ReadOp, ProjectOp, UnwindOp, ProjectOp, MatchOp, ProjectOp, UnwindOp, ProjectOp))
+      //         The QScript contains two LeftShift (i.e flattens) which are not unified as they should,
+      //         hence the two `UnwindOp`s
       IList(ReadOp, ProjectOp, UnwindOp, MatchOp, ProjectOp))
 
     trackPendingErr(
@@ -254,11 +256,10 @@ class PlannerSpec extends
       IList(ReadOp, ProjectOp, UnwindOp, GroupOp, ProjectOp),
       { case QScriptPlanningFailed(_) => ok })
 
-    trackPending(
-      "unify flattened fields with unflattened field",
-      plan(sqlE"select `_id` as zip, loc[*] from zips order by loc[*]"),
-      // actual: IList(ReadOp, ProjectOp, UnwindOp, ProjectOp, SortOp, ProjectOp))
-      IList(ReadOp, ProjectOp, UnwindOp, SortOp))
+    "unify flattened fields with unflattened field" in {
+      plan(sqlE"select `_id` as zip, loc[*] from zips order by loc[*]") must
+        beRight.which(cwf => notBrokenWithOps(cwf.op, IList(ReadOp, ProjectOp, UnwindOp, ProjectOp, SortOp)))
+    }
 
     trackPending(
       "unify flattened with double-flattened",


### PR DESCRIPTION
This is a second implementation that allows for parts of the `LeftShift`'s `repair` function to be planned in `mapReduce` while planning the rest of the `repair` in aggregation. I expected some more tests to become green.