### PR TITLE
Added LeftShift type flag in qscript

### DIFF
--- a/connector/src/main/scala/quasar/qscript/ExtractPath.scala
+++ b/connector/src/main/scala/quasar/qscript/ExtractPath.scala
@@ -77,14 +77,14 @@ sealed abstract class ExtractPathInstances extends ExtractPathInstances0 {
   ): ExtractPath[QScriptCore[T, ?], P] =
     new ExtractPath[QScriptCore[T, ?], P] {
       def extractPath[G[_]: ApplicativePlus] = {
-        case Filter(paths, _)          => paths
-        case LeftShift(paths, _, _, _) => paths
-        case Map(paths, _)             => paths
-        case Reduce(paths, _, _, _)    => paths
-        case Sort(paths, _, _)         => paths
-        case Subset(paths, fm, _, ct)  => extractBranch[T, G, P](fm) <+> extractBranch[T, G, P](ct) <+> paths
-        case Union(paths, l, r)        => extractBranch[T, G, P](l)  <+> extractBranch[T, G, P](r)  <+> paths
-        case Unreferenced()            => mempty[G, P]
+        case Filter(paths, _)             => paths
+        case LeftShift(paths, _, _, _, _) => paths
+        case Map(paths, _)                => paths
+        case Reduce(paths, _, _, _)       => paths
+        case Sort(paths, _, _)            => paths
+        case Subset(paths, fm, _, ct)     => extractBranch[T, G, P](fm) <+> extractBranch[T, G, P](ct) <+> paths
+        case Union(paths, l, r)           => extractBranch[T, G, P](l)  <+> extractBranch[T, G, P](r)  <+> paths
+        case Unreferenced()               => mempty[G, P]
       }
     }
 

--- a/connector/src/main/scala/quasar/qscript/RenderQScriptDSL.scala
+++ b/connector/src/main/scala/quasar/qscript/RenderQScriptDSL.scala
@@ -311,9 +311,14 @@ object RenderQScriptDSL {
           case Map(src, f) =>
             DSLTree(base, "Map", (A(base, src).right :: freeMap(base, f).right :: Nil).some)
 
-          case LeftShift(src, struct, idStatus, repair) =>
+          case LeftShift(src, struct, idStatus, shiftType, repair) =>
             DSLTree(base, "LeftShift",
-              (A(base, src).right :: freeMap(base, struct).right :: idStatus.shows.left :: joinFunc(base, repair).right :: Nil).some)
+              (A(base, src).right ::
+                freeMap(base, struct).right ::
+                idStatus.shows.left ::
+                ("ShiftType." + shiftType.shows).left ::
+                joinFunc(base, repair).right ::
+                Nil).some)
 
           case Reduce(src, bucket, reducers, repair) =>
             val bucketArg = DSLTree("", "List", bucket.map(freeMap(base, _).right).some)

--- a/connector/src/main/scala/quasar/qscript/ShiftType.scala
+++ b/connector/src/main/scala/quasar/qscript/ShiftType.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript
+
+import quasar.RenderTree
+
+import scala.{Product, Serializable}
+import scalaz.{Equal, Show}
+
+sealed trait ShiftType extends Product with Serializable
+
+object ShiftType {
+  case object Array extends ShiftType
+  case object Map extends ShiftType
+
+  implicit def equal: Equal[ShiftType] = Equal.equalRef
+
+  implicit def renderTree: RenderTree[ShiftType] = RenderTree.fromShow("ShiftType")
+
+  implicit def show: Show[ShiftType] = Show.showFromToString
+}

--- a/connector/src/main/scala/quasar/qscript/UnaryFunctions.scala
+++ b/connector/src/main/scala/quasar/qscript/UnaryFunctions.scala
@@ -62,8 +62,8 @@ object UnaryFunctions {
             s match {
               case Map(src, fm) =>
                 (f(fm)).map(Map(src, _))
-              case LeftShift(src, struct, id, repair) =>
-                (f(struct)).map(LeftShift(src, _, id, repair))
+              case LeftShift(src, struct, id, stpe, repair) =>
+                (f(struct)).map(LeftShift(src, _, id, stpe, repair))
               case Reduce(src, bucket, red, repair) =>
                 (bucket.traverse(f) |@| red.traverse(_.traverse(f)))(Reduce(src, _, _, repair))
               case Sort(src, bucket, order) =>

--- a/connector/src/main/scala/quasar/qscript/analysis/Cardinality.scala
+++ b/connector/src/main/scala/quasar/qscript/analysis/Cardinality.scala
@@ -73,7 +73,7 @@ object Cardinality {
             case _ => c
           }
         }.point[M]
-        case LeftShift(card, struct, id, repair) => (card * 10).point[M]
+        case LeftShift(card, struct, id, stpe, repair) => (card * 10).point[M]
         case Union(card, lBranch, rBranch) => {
           val compile = Cardinality[QScriptTotal[T, ?]].calculate(pathCard)
           (lBranch.cataM(interpretM(κ(card.point[M]), compile)) |@| rBranch.cataM(interpretM(κ(card.point[M]), compile))) { _ + _}

--- a/connector/src/main/scala/quasar/qscript/analysis/Cost.scala
+++ b/connector/src/main/scala/quasar/qscript/analysis/Cost.scala
@@ -65,7 +65,7 @@ object Cost {
         case Sort((card, cost), bucket, orders) => (card + cost).point[M]
         case Filter((card, cost), f) => (card + cost).point[M]
         case Subset((card, cost), from, sel, count) => (card + cost).point[M]
-        case LeftShift((card, cost), struct, id, repair) => (card + cost).point[M]
+        case LeftShift((card, cost), struct, id, stpe, repair) => (card + cost).point[M]
         case Union((card, cost), lBranch, rBranch) => {
           val compileCardinality = Cardinality[QScriptTotal[T, ?]].calculate(pathCard)
           val compileCost = Cost[QScriptTotal[T, ?]].evaluate(pathCard)

--- a/connector/src/main/scala/quasar/qscript/analysis/DeepShape.scala
+++ b/connector/src/main/scala/quasar/qscript/analysis/DeepShape.scala
@@ -148,7 +148,7 @@ sealed abstract class DeepShapeInstances {
 
         case Map(shape, fm) => fm >> shape
 
-        case LeftShift(shape, struct, id, repair) =>
+        case LeftShift(shape, struct, id, stpe, repair) =>
           repair >>= {
             case LeftSide => shape
             case RightSide => freeShape[T](Shifting[T](id, struct >> shape))

--- a/connector/src/main/scala/quasar/qscript/analysis/Outline.scala
+++ b/connector/src/main/scala/quasar/qscript/analysis/Outline.scala
@@ -229,7 +229,7 @@ sealed abstract class OutlineInstances {
         case Map(inShape, fm) =>
           outlineF(fm)(κ(inShape))
 
-        case LeftShift(inShape, _, idStatus, repair) =>
+        case LeftShift(inShape, _, idStatus, shiftType, repair) =>
           outlineF(repair) {
             case LeftSide => inShape
             case RightSide => idStatus match {

--- a/connector/src/main/scala/quasar/qscript/construction.scala
+++ b/connector/src/main/scala/quasar/qscript/construction.scala
@@ -235,8 +235,9 @@ object construction {
     def LeftShift(src: R,
                   struct: FreeMap[T],
                   idStatus: IdStatus,
+                  shiftType: ShiftType,
                   repair: JoinFunc[T]): R =
-      core(qscript.LeftShift(src, struct, idStatus, repair))
+      core(qscript.LeftShift(src, struct, idStatus, shiftType, repair))
     def Reduce(src: R,
                bucket: List[FreeMap[T]],
                reducers: List[ReduceFunc[FreeMap[T]]],

--- a/connector/src/main/scala/quasar/qscript/qsu/Graduate.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/Graduate.scala
@@ -44,6 +44,7 @@ import quasar.qscript.{
   Reduce,
   ReduceFuncs,
   ReduceIndexF,
+  ShiftType,
   Sort,
   SrcHole,
   Subset,
@@ -196,7 +197,10 @@ final class Graduate[T[_[_]]: BirecursiveT: ShowT] private () extends QSUTTypes[
                 case QSU.LeftTarget() => (LeftSide: JoinSide).right
                 case QSU.RightTarget() => (RightSide: JoinSide).right
               }(κ(source.root))
-          } yield QCE(LeftShift[T, QSUGraph](source, struct, idStatus, resolvedRepair))
+
+            // TODO
+            shiftType = ShiftType.Array
+          } yield QCE(LeftShift[T, QSUGraph](source, struct, idStatus, shiftType, resolvedRepair))
 
         case QSU.QSSort(source, buckets, order) =>
           buckets traverse (resolveAccess(_)(_.left)(holeAs(source.root))) map { bs =>

--- a/connector/src/main/scala/quasar/qscript/qsu/Graduate.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/Graduate.scala
@@ -50,7 +50,8 @@ import quasar.qscript.{
   Subset,
   ThetaJoin,
   Union,
-  Unreferenced}
+  Unreferenced
+}
 import quasar.qscript.provenance.JoinKeys
 import quasar.qscript.qsu.{QScriptUniform => QSU}
 import quasar.qscript.qsu.QSUGraph.QSUPattern
@@ -187,7 +188,7 @@ final class Graduate[T[_[_]]: BirecursiveT: ShowT] private () extends QSUTTypes[
             QCE(Reduce[T, QSUGraph](source, bs, reducers, repair))
           }
 
-        case QSU.LeftShift(source, struct, idStatus, repair, _) =>
+        case QSU.LeftShift(source, struct, idStatus, repair, rot) =>
           for {
             // Access.value is already resolved, from ReifyIdentities.
             // this would be nicer with a tri-state Access type.
@@ -198,8 +199,13 @@ final class Graduate[T[_[_]]: BirecursiveT: ShowT] private () extends QSUTTypes[
                 case QSU.RightTarget() => (RightSide: JoinSide).right
               }(κ(source.root))
 
-            // TODO
-            shiftType = ShiftType.Array
+            shiftType = rot match {
+              case QSU.Rotation.FlattenArray | QSU.Rotation.ShiftArray =>
+                ShiftType.Array
+
+              case QSU.Rotation.FlattenMap | QSU.Rotation.ShiftMap =>
+                ShiftType.Map
+            }
           } yield QCE(LeftShift[T, QSUGraph](source, struct, idStatus, shiftType, resolvedRepair))
 
         case QSU.QSSort(source, buckets, order) =>

--- a/connector/src/main/scala/quasar/qscript/rewrites/Coalesce.scala
+++ b/connector/src/main/scala/quasar/qscript/rewrites/Coalesce.scala
@@ -486,13 +486,14 @@ class CoalesceT[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TType
               newRed,
               repair))
 
-        case LeftShift(Embed(src), struct, idStatus, repair) =>
+        case LeftShift(Embed(src), struct, idStatus, shiftType, repair) =>
           ((FToOut.get(src) >>= SR.prj) ⊛ eliminateRightSideProjUnary(struct) ⊛ eliminateRightSideProj(repair, LeftSide))(
             (sr, newStruct, newRepair) =>
             LeftShift(
               FToOut.reverseGet(SR.inj(Const[ShiftedRead[A], T[F]](ShiftedRead(sr.getConst.path, ExcludeId)))).embed,
               newStruct,
               idStatus,
+              shiftType,
               newRepair))
 
         case Subset(src, from, sel, count) =>

--- a/connector/src/main/scala/quasar/qscript/rewrites/Coalesce.scala
+++ b/connector/src/main/scala/quasar/qscript/rewrites/Coalesce.scala
@@ -283,9 +283,9 @@ class CoalesceT[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TType
         (FToOut: OUT ~> F)
         (implicit QC: QScriptCore :<: OUT)
           : QScriptCore[IT[F]] => Option[QScriptCore[IT[F]]] = {
-        case LeftShift(src, struct, id, repair) =>
+        case LeftShift(src, struct, id, stpe, repair) =>
           MapFuncCore.extractFilter(struct)(_.some) ∘ { case (f, m, _) =>
-            LeftShift(FToOut(QC.inj(Filter(src, f))).embed, m, id, repair)
+            LeftShift(FToOut(QC.inj(Filter(src, f))).embed, m, id, stpe, repair)
           }
         case Map(src, mf) =>
           MapFuncCore.extractFilter(mf)(_.some) ∘ { case (f, m, _) =>
@@ -310,8 +310,8 @@ class CoalesceT[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TType
           else s match {
             case Map(srcInner, mfInner) =>
               Map(srcInner, mf >> mfInner).some
-            case LeftShift(srcInner, struct, id, repair) =>
-              LeftShift(srcInner, struct, id, mf >> repair).some
+            case LeftShift(srcInner, struct, id, stpe, repair) =>
+              LeftShift(srcInner, struct, id, stpe, mf >> repair).some
             case Reduce(srcInner, bucket, funcs, repair) =>
               Reduce(srcInner, bucket, funcs, mf >> repair).some
             case Subset(innerSrc, lb, sel, rb) =>
@@ -347,23 +347,25 @@ class CoalesceT[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TType
 */
             case _ => None
           })
-        case LeftShift(Embed(src), struct, id, shiftRepair) =>
+        case LeftShift(Embed(src), struct, id, stpe, shiftRepair) =>
           FToOut.get(src) >>= QC.prj >>= {
-            case LeftShift(innerSrc, innerStruct, innerId, innerRepair)
+            case LeftShift(innerSrc, innerStruct, innerId, innerStpe, innerRepair)
                 if !shiftRepair.element(LeftSide) && !fmIsCondUndef(shiftRepair) && struct ≠ HoleF =>
               LeftShift(
                 FToOut.reverseGet(QC.inj(LeftShift(
                   innerSrc,
                   innerStruct,
                   innerId,
+                  innerStpe,
                   struct >> innerRepair))).embed,
                 HoleF,
                 id,
+                stpe,
                 shiftRepair).some
             // TODO: Should be able to apply this where there _is_ a `LeftSide`
             //       reference, but currently that breaks merging.
             case Map(innerSrc, mf) if !shiftRepair.element(LeftSide) =>
-              LeftShift(innerSrc, struct >> mf, id, shiftRepair).some
+              LeftShift(innerSrc, struct >> mf, id, stpe, shiftRepair).some
             case Reduce(srcInner, _, List(ReduceFuncs.UnshiftArray(elem)), redRepair)
                 if nm.freeMF(struct >> redRepair) ≟ Free.point(ReduceIndex(0.right)) =>
               rightOnly(elem)(shiftRepair) ∘ (Map(srcInner, _))
@@ -378,16 +380,16 @@ class CoalesceT[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TType
           }
         case Reduce(Embed(src), bucket, reducers, redRepair) =>
           FToOut.get(src) >>= QC.prj >>= {
-            case LeftShift(innerSrc, struct, id, shiftRepair)
+            case LeftShift(innerSrc, struct, id, stpe, shiftRepair)
                 if shiftRepair =/= RightSideF =>
               (bucket.traverse(b => rightOnly(HoleF)(nm.freeMF(b >> shiftRepair))) ⊛
                 reducers.traverse(_.traverse(mf => rightOnly(HoleF)(nm.freeMF(mf >> shiftRepair)))))((sb, sr) =>
                 Reduce(
-                  FToOut.reverseGet(QC.inj(LeftShift(innerSrc, struct, id, RightSideF))).embed,
+                  FToOut.reverseGet(QC.inj(LeftShift(innerSrc, struct, id, stpe, RightSideF))).embed,
                   sb,
                   sr,
                   redRepair))
-            case LeftShift(innerSrc, struct, id, shiftRepair) =>
+            case LeftShift(innerSrc, struct, id, stpe, shiftRepair) =>
               (bucket.traverse(b => rewrite.rewriteShift(id, nm.freeMF(b >> shiftRepair))).flatMap(sequenceBucket[IdStatus, JoinFunc]) ⊛
                 reducers.traverse(_.traverse(mf =>
                   rewrite.rewriteShift(id, nm.freeMF(mf >> shiftRepair)))).flatMap(_.traverse(sequenceReduce[IdStatus, JoinFunc]) >>= sequenceBucket[IdStatus, ReduceFunc[JoinFunc]])) {
@@ -399,7 +401,7 @@ class CoalesceT[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TType
                   (bucket.traverse(rightOnly(HoleF)) ⊛
                     (reducers.traverse(_.traverse(rightOnly(HoleF)))))((sb, sr) =>
                     Reduce(
-                      FToOut.reverseGet(QC.inj(LeftShift(innerSrc, struct, newId, RightSideF))).embed,
+                      FToOut.reverseGet(QC.inj(LeftShift(innerSrc, struct, newId, stpe, RightSideF))).embed,
                       sb,
                       sr,
                       redRepair))

--- a/connector/src/main/scala/quasar/qscript/rewrites/Normalizable.scala
+++ b/connector/src/main/scala/quasar/qscript/rewrites/Normalizable.scala
@@ -228,10 +228,10 @@ class NormalizableT[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends T
 
         makeNorm(bucket, order)(rebucket, _ => orderNormOpt)(Sort(src, _, _))
 
-      case Map(src, f)             => freeMFEq(f).map(Map(src, _))
-      case LeftShift(src, s, i, r) => makeNorm(s, r)(freeMFEq(_), freeMFEq(_))(LeftShift(src, _, i, _))
-      case Union(src, l, r)        => makeNorm(l, r)(freeTCEq(_), freeTCEq(_))(Union(src, _, _))
-      case Filter(src, f)          => freeMFEq(f).map(Filter(src, _))
+      case Map(src, f)                => freeMFEq(f).map(Map(src, _))
+      case LeftShift(src, s, i, t, r) => makeNorm(s, r)(freeMFEq(_), freeMFEq(_))(LeftShift(src, _, i, t, _))
+      case Union(src, l, r)           => makeNorm(l, r)(freeTCEq(_), freeTCEq(_))(Union(src, _, _))
+      case Filter(src, f)             => freeMFEq(f).map(Filter(src, _))
       case Subset(src, from, sel, count) => makeNorm(from, count)(freeTCEq(_), freeTCEq(_))(Subset(src, _, sel, _))
       case Unreferenced()          => None
     })

--- a/connector/src/main/scala/quasar/qscript/rewrites/PreferProjection.scala
+++ b/connector/src/main/scala/quasar/qscript/rewrites/PreferProjection.scala
@@ -157,16 +157,16 @@ sealed abstract class PreferProjectionInstances {
         case Map((srcShape, u), f) =>
           BtoF(Map(u, prjFreeMap(srcShape, f)))
 
-        case LeftShift((srcShape, u), struct, idStatus, repair) =>
+        case LeftShift((srcShape, u), struct, idStatus, shiftType, repair) =>
           // NB: This is necessary as srcShape gives us the input shape to the
           //     LeftShift, which is what we need to rewrite `struct`, however
           //     to rewrite `repair` we need any modifications that `LeftShift`
           //     makes to the shape, excluding `repair`'s own modifications.
           val prjRepair = projectComplement(repair) { joinSide =>
-            O.outlineƒ(LeftShift(srcShape, struct, idStatus, Free.point(joinSide)))
+            O.outlineƒ(LeftShift(srcShape, struct, idStatus, shiftType, Free.point(joinSide)))
           }
 
-          BtoF(LeftShift(u, prjFreeMap(srcShape, struct), idStatus, prjRepair))
+          BtoF(LeftShift(u, prjFreeMap(srcShape, struct), idStatus, shiftType, prjRepair))
 
         case Reduce((srcShape, u), buckets, reducers, repair) =>
           val prjBuckets = buckets map (prjFreeMap(srcShape, _))

--- a/connector/src/main/scala/quasar/qscript/rewrites/Rewrite.scala
+++ b/connector/src/main/scala/quasar/qscript/rewrites/Rewrite.scala
@@ -156,6 +156,7 @@ class Rewrite[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TTypes[
     def unifyMapRightSideShift(
       struct: FreeMap,
       status: IdStatus,
+      shiftType: ShiftType,
       repair: JoinFunc,
       shiftSrc: FreeMap,
       mapFn: FreeMap
@@ -168,12 +169,13 @@ class Rewrite[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TTypes[
             case RightSide => RightSideF
           }
         }).some
-      } (func => QC.inj(LeftShift(src, struct >> shiftSrc, status, func)).some)
+      } (func => QC.inj(LeftShift(src, struct >> shiftSrc, status, shiftType, func)).some)
 
     // Unify (LeftShift, Map)
     def unifyMapLeftSideShift(
       struct: FreeMap,
       status: IdStatus,
+      shiftType: ShiftType,
       repair: JoinFunc,
       shiftSrc: FreeMap,
       mapFn: FreeMap
@@ -186,19 +188,19 @@ class Rewrite[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TTypes[
           }
           case RightSide => mapFn >> LeftSideF  // references `src`
         }).some
-      } (func => QC.inj(LeftShift(src, struct >> shiftSrc, status, func)).some)
+      } (func => QC.inj(LeftShift(src, struct >> shiftSrc, status, shiftType, func)).some)
 
     (left.resumeTwice, right.resumeTwice) match {
       // left side is the data while the right side shifts the same data
       case (\/-(SrcHole), -\/(r)) => FI.project(r) >>= QC.prj match {
-        case Some(LeftShift(lshiftSrc, struct, status, repair)) =>
+        case Some(LeftShift(lshiftSrc, struct, status, shiftType, repair)) =>
           lshiftSrc match {
             case \/-(SrcHole) =>
-              unifyMapRightSideShift(struct, status, repair, HoleF, HoleF)
+              unifyMapRightSideShift(struct, status, shiftType, repair, HoleF, HoleF)
 
             case -\/(values) => FI.project(values) >>= QC.prj match {
               case Some(Map(mapSrc, srcFn)) if mapSrc ≟ HoleQS =>
-                unifyMapRightSideShift(struct, status, repair, srcFn, HoleF)
+                unifyMapRightSideShift(struct, status, shiftType, repair, srcFn, HoleF)
 
               case _ => NoneBranch[F, JoinSide, A]
             }
@@ -208,14 +210,14 @@ class Rewrite[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TTypes[
 
       // right side is the data while the left side shifts the same data
       case (-\/(l), \/-(SrcHole)) => FI.project(l) >>= QC.prj match {
-        case Some(LeftShift(lshiftSrc, struct, status, repair)) =>
+        case Some(LeftShift(lshiftSrc, struct, status, shiftType, repair)) =>
           lshiftSrc match {
             case \/-(SrcHole) =>
-              unifyMapLeftSideShift(struct, status, repair, HoleF, HoleF)
+              unifyMapLeftSideShift(struct, status, shiftType, repair, HoleF, HoleF)
 
             case -\/(values) => FI.project(values) >>= QC.prj match {
               case Some(Map(mapSrc, srcFn)) if mapSrc ≟ HoleQS =>
-                unifyMapLeftSideShift(struct, status, repair, srcFn, HoleF)
+                unifyMapLeftSideShift(struct, status, shiftType, repair, srcFn, HoleF)
 
               case _ => NoneBranch[F, JoinSide, A]
             }
@@ -225,28 +227,28 @@ class Rewrite[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TTypes[
 
       case (-\/(l), -\/(r)) => (l, r).uTraverse(m => FI.project(m) >>= QC.prj) collect {
         // left side maps over the data while the right side shifts the same data
-        case (Map(\/-(SrcHole), mapFn), LeftShift(lshiftSrc, struct, status, repair)) =>
+        case (Map(\/-(SrcHole), mapFn), LeftShift(lshiftSrc, struct, status, stpe, repair)) =>
           lshiftSrc match {
             case \/-(SrcHole) =>
-              unifyMapRightSideShift(struct, status, repair, HoleF, mapFn)
+              unifyMapRightSideShift(struct, status, stpe, repair, HoleF, mapFn)
 
             case -\/(values) => FI.project(values) >>= QC.prj match {
               case Some(Map(mapSrc, srcFn)) if mapSrc ≟ HoleQS =>
-                unifyMapRightSideShift(struct, status, repair, srcFn, mapFn)
+                unifyMapRightSideShift(struct, status, stpe, repair, srcFn, mapFn)
 
               case _ => NoneBranch[F, JoinSide, A]
             }
           }
 
         // right side maps over the data while the left side shifts the same data
-        case (LeftShift(lshiftSrc, struct, status, repair), Map(\/-(SrcHole), mapFn)) =>
+        case (LeftShift(lshiftSrc, struct, status, shiftType, repair), Map(\/-(SrcHole), mapFn)) =>
           lshiftSrc match {
             case \/-(SrcHole) =>
-              unifyMapLeftSideShift(struct, status, repair, HoleF, mapFn)
+              unifyMapLeftSideShift(struct, status, shiftType, repair, HoleF, mapFn)
 
             case -\/(values) => FI.project(values) >>= QC.prj match {
               case Some(Map(mapSrc, srcFn)) if mapSrc ≟ HoleQS =>
-                unifyMapLeftSideShift(struct, status, repair, srcFn, mapFn)
+                unifyMapLeftSideShift(struct, status, shiftType, repair, srcFn, mapFn)
 
               case _ => NoneBranch[F, JoinSide, A]
             }
@@ -402,7 +404,7 @@ class Rewrite[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TTypes[
   def compactLeftShift[F[_]: Functor]
       (QCToF: PrismNT[F, QScriptCore])
       : QScriptCore[T[F]] => Option[F[T[F]]] = {
-    case qs @ LeftShift(Embed(src), struct, ExcludeId, joinFunc) =>
+    case qs @ LeftShift(Embed(src), struct, ExcludeId, shiftType, joinFunc) =>
       (QCToF.get(src), struct.resume) match {
         // LeftShift(Map(_, MakeArray(_)), Hole, ExcludeId, _)
         case (Some(Map(innerSrc, fm)), \/-(SrcHole)) =>
@@ -426,8 +428,8 @@ class Rewrite[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TTypes[
   }
 
   val compactQC = λ[QScriptCore ~> (Option ∘ QScriptCore)#λ] {
-    case LeftShift(src, struct, id, repair) =>
-      rewriteShift(id, repair) ∘ (xy => LeftShift(src, struct, xy._1, xy._2))
+    case LeftShift(src, struct, id, stpe, repair) =>
+      rewriteShift(id, repair) ∘ (xy => LeftShift(src, struct, xy._1, stpe, xy._2))
 
     case Reduce(src, bucket, reducers, repair0) =>
       // `indices`: the indices into `reducers` that are used

--- a/connector/src/test/scala/quasar/qscript/RenderQScriptDSLSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/RenderQScriptDSLSpec.scala
@@ -178,7 +178,7 @@ class RenderQScriptDSLSpec extends quasar.Qspec with QScriptHelpers {
     List[FreeQS](
       free.Hole,
       free.Map(h, func.Undefined),
-      free.LeftShift(h, func.Undefined, ExcludeId, func.LeftSide),
+      free.LeftShift(h, func.Undefined, ExcludeId, ShiftType.Array, func.LeftSide),
       free.Reduce(h, Nil, Nil, func.ReduceIndex(1.right)),
       free.Sort(h, Nil, NonEmptyList((func.Hole, SortDir.Ascending))),
       free.Union(h, h, h),
@@ -204,7 +204,7 @@ class RenderQScriptDSLSpec extends quasar.Qspec with QScriptHelpers {
     val h = free.Hole
     List[Fix[QST]](
       fix.Map(u, func.Undefined),
-      fix.LeftShift(u, func.Undefined, ExcludeId, func.LeftSide),
+      fix.LeftShift(u, func.Undefined, ExcludeId, ShiftType.Array, func.LeftSide),
       fix.Reduce(u, Nil, Nil, func.ReduceIndex(1.right)),
       fix.Sort(u, Nil, NonEmptyList((func.Hole, SortDir.Ascending), (func.Hole, SortDir.Descending))),
       fix.Union(u, free.Hole, free.Hole),

--- a/connector/src/test/scala/quasar/qscript/analysis/CardinalitySpec.scala
+++ b/connector/src/test/scala/quasar/qscript/analysis/CardinalitySpec.scala
@@ -178,7 +178,7 @@ class CardinalitySpec extends quasar.Qspec with QScriptHelpers with DisjunctionM
           val fun: FreeMap =
             func.Eq(func.ProjectKeyS(func.Hole, "key"), func.Constant(json.str("value")))
           val joinFunc: JoinFunc = func.LeftSide
-          val leftShift = LeftShift(cardinality, fun, IdOnly, joinFunc)
+          val leftShift = LeftShift(cardinality, fun, IdOnly, ShiftType.Array, joinFunc)
           compile(leftShift) must_== cardinality * 10
         }
       }

--- a/connector/src/test/scala/quasar/qscript/analysis/DeepShapeSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/analysis/DeepShapeSpec.scala
@@ -60,7 +60,7 @@ final class DeepShapeSpec extends quasar.Qspec with QScriptHelpers with TTypes[F
             func.MakeArray(func.Add(func.LeftSide, IntLit(9))),
             func.MakeArray(func.Subtract(func.RightSide, IntLit(10))))
 
-        val qs = LeftShift(shape, struct, IdOnly, repair)
+        val qs = LeftShift(shape, struct, IdOnly, ShiftType.Array, repair)
 
         val expected: FreeShape[Fix] =
           func.ConcatArrays(
@@ -205,6 +205,7 @@ final class DeepShapeSpec extends quasar.Qspec with QScriptHelpers with TTypes[F
             func.ProjectKeyS(func.Hole, "foo")),
           func.Hole,
           IncludeId,
+          ShiftType.Array,
           func.RightSide)
 
       val rBranch: FreeQS =
@@ -214,6 +215,7 @@ final class DeepShapeSpec extends quasar.Qspec with QScriptHelpers with TTypes[F
             func.ProjectKeyS(func.Hole, "bar")),
           func.Hole,
           IncludeId,
+          ShiftType.Array,
           func.LeftSide)
 
       val combine: JoinFunc =

--- a/connector/src/test/scala/quasar/qscript/analysis/OutlineSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/analysis/OutlineSpec.scala
@@ -228,11 +228,11 @@ final class OutlineSpec extends quasar.Qspec with QScriptHelpers {
 
     "LeftShift(IncludeId) results in shape of repair applied to static array" >> prop { srcShape: Shape =>
       val r = rollS(CommonEJson(ejson.Arr(List(unknownF, unknownF))))
-      outlineQC(LeftShift(srcShape, func.Hole, IncludeId, joinFunc)) must_= modSides(srcShape, r)
+      outlineQC(LeftShift(srcShape, func.Hole, IncludeId, ShiftType.Array, joinFunc)) must_= modSides(srcShape, r)
     }
 
     "RightSide of repair is unknown when not IncludeId" >> prop { srcShape: Shape =>
-      outlineQC(LeftShift(srcShape, func.Hole, ExcludeId, joinFunc)) must_= modSides(srcShape, unknownF)
+      outlineQC(LeftShift(srcShape, func.Hole, ExcludeId, ShiftType.Array, joinFunc)) must_= modSides(srcShape, unknownF)
     }
 
     "Reduce tracks static input shape through buckets" >> prop { srcShape: Shape =>

--- a/connector/src/test/scala/quasar/qscript/qsu/GraduateSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/GraduateSpec.scala
@@ -25,15 +25,16 @@ import quasar.ejson.{EJson, Fixed}
 import quasar.fp._
 import quasar.qscript.{
   construction,
-  Hole, 
-  HoleF, 
-  IncludeId, 
-  JoinSide, 
-  ReduceFunc, 
-  ReduceFuncs, 
-  ReduceIndex, 
-  ReduceIndexF, 
-  SrcHole, 
+  Hole,
+  HoleF,
+  IncludeId,
+  JoinSide,
+  ReduceFunc,
+  ReduceFuncs,
+  ReduceIndex,
+  ReduceIndexF,
+  ShiftType,
+  SrcHole,
   Take
 }
 import quasar.qscript.MapFuncsCore.IntLit
@@ -123,7 +124,7 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
             func.MakeArray(func.RightSide)))
 
         val qgraph: Fix[QSU] = qsu.leftShift(qsu.read(afile), struct, IncludeId, arepair, Rotation.ShiftArray)
-        val qscript: Fix[QSE] = qse.LeftShift(qse.Read[AFile](afile), struct, IncludeId, repair)
+        val qscript: Fix[QSE] = qse.LeftShift(qse.Read[AFile](afile), struct, IncludeId, ShiftType.Array, repair)
 
         qgraph must graduateAs(qscript)
       }
@@ -201,6 +202,7 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
           fqse.Read(root </> file("zips")),
           HoleF[Fix],
           IncludeId,
+          ShiftType.Array,
           concatArr)
 
       val rhs: Free[QSE, Hole] =

--- a/connector/src/test/scala/quasar/qscript/qsu/LPtoQSSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/LPtoQSSpec.scala
@@ -70,7 +70,7 @@ object LPtoQSSpec extends Qspec with CompilerHelpers with QSUTTypes[Fix] {
         qs.Read(afoo),
         HoleF[Fix],
         ExcludeId,
-        ShiftType.Array,
+        ShiftType.Map,
         RightSideF[Fix])
 
       lp must compileTo(expected)
@@ -88,7 +88,7 @@ object LPtoQSSpec extends Qspec with CompilerHelpers with QSUTTypes[Fix] {
           qs.Read(afoo),
           HoleF[Fix],
           ExcludeId,
-          ShiftType.Array,
+          ShiftType.Map,
           RightSideF[Fix]),
         Nil,
         List(ReduceFuncs.Count(HoleF[Fix])),
@@ -108,8 +108,8 @@ object LPtoQSSpec extends Qspec with CompilerHelpers with QSUTTypes[Fix] {
       case \/-(compiled) =>
         (
           Equal[Fix[QScriptEducated]].equal(compiled, qs),
-          s"\n${lp.render.shows}\n\n compiled to:\n\n ${qs.render.shows}",
-          s"\n${lp.render.shows}\n\n compiled to:\n\n ${qs.render.shows}\n\n expected:\n\n ${qs.render.shows}")
+          s"\n${lp.render.shows}\n\n compiled to:\n\n ${compiled.render.shows}",
+          s"\n${lp.render.shows}\n\n compiled to:\n\n ${compiled.render.shows}\n\n expected:\n\n ${qs.render.shows}")
     }
   }
 }

--- a/connector/src/test/scala/quasar/qscript/qsu/LPtoQSSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/LPtoQSSpec.scala
@@ -24,7 +24,7 @@ import quasar.ejson.{EJson, Fixed}
 import quasar.fp._
 import quasar.frontend.logicalplan.LogicalPlan
 import quasar.qscript.construction
-import quasar.qscript.{ExcludeId, HoleF, ReduceFuncs, ReduceIndex, RightSideF}
+import quasar.qscript.{ExcludeId, HoleF, ReduceFuncs, ReduceIndex, RightSideF, ShiftType}
 import quasar.sql.CompilerHelpers
 import quasar.std.{AggLib, IdentityLib}
 import slamdata.Predef._
@@ -70,6 +70,7 @@ object LPtoQSSpec extends Qspec with CompilerHelpers with QSUTTypes[Fix] {
         qs.Read(afoo),
         HoleF[Fix],
         ExcludeId,
+        ShiftType.Array,
         RightSideF[Fix])
 
       lp must compileTo(expected)
@@ -87,6 +88,7 @@ object LPtoQSSpec extends Qspec with CompilerHelpers with QSUTTypes[Fix] {
           qs.Read(afoo),
           HoleF[Fix],
           ExcludeId,
+          ShiftType.Array,
           RightSideF[Fix]),
         Nil,
         List(ReduceFuncs.Count(HoleF[Fix])),

--- a/connector/src/test/scala/quasar/qscript/rewrites/PreferProjectionSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/rewrites/PreferProjectionSpec.scala
@@ -105,6 +105,7 @@ final class PreferProjectionSpec extends quasar.Qspec with QScriptHelpers {
         fix.Read[AFile](rootDir </> dir("foo") </> file("bar")),
         func.Hole,
         ExcludeId,
+        ShiftType.Array,
         MapFuncCore.StaticMap(List(
           json.str("a") -> func.ProjectIndex(func.RightSide, func.Constant(json.int(0))),
           json.str("b") -> func.ProjectIndex(func.RightSide, func.Constant(json.int(2))),
@@ -135,6 +136,7 @@ final class PreferProjectionSpec extends quasar.Qspec with QScriptHelpers {
           base,
           func.DeleteKeyS(func.Hole, "c"),
           IncludeId,
+          ShiftType.Array,
           MapFuncCore.StaticArray(List(
             func.DeleteKeyS(func.DeleteKeyS(func.LeftSide, "a"), "b"),
             func.RightSide)))
@@ -144,6 +146,7 @@ final class PreferProjectionSpec extends quasar.Qspec with QScriptHelpers {
           base,
           prjFrom(func.Hole, "a", "b"),
           IncludeId,
+          ShiftType.Array,
           MapFuncCore.StaticArray(List(
             prjFrom(func.LeftSide, "c"),
             func.RightSide)))

--- a/connector/src/test/scala/quasar/qscript/rewrites/RewriteSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/rewrites/RewriteSpec.scala
@@ -408,6 +408,7 @@ class RewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           fix.ShiftedRead[AFile](sampleFile, IncludeId),
           func.ProjectKeyS(func.ProjectIndexI(func.Hole, 1), "foo"),
           ExcludeId,
+          ShiftType.Map,
           func.ConcatMaps(
             func.MakeMapS("a", func.ProjectKeyS(func.ProjectIndexI(func.LeftSide, 1), "quux")),
             func.MakeMapS("b", func.RightSide)))
@@ -417,6 +418,7 @@ class RewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           fix.ShiftedRead[AFile](sampleFile, ExcludeId),
           func.ProjectKeyS(func.Hole, "foo"),
           ExcludeId,
+          ShiftType.Map,
           func.ConcatMaps(
             func.MakeMapS("a", func.ProjectKeyS(func.LeftSide, "quux")),
             func.MakeMapS("b", func.RightSide)))

--- a/connector/src/test/scala/quasar/qscript/rewrites/RewriteSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/rewrites/RewriteSpec.scala
@@ -103,6 +103,7 @@ class RewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
             func.Constant(json.bool(true))),
           func.Hole,
           ExcludeId,
+          ShiftType.Array,
           func.RightSide).unFix
 
       Coalesce[Fix, QScriptCore, QScriptCore].coalesceQC(idPrism).apply(exp) must
@@ -111,6 +112,7 @@ class RewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           fix.Unreferenced,
           func.Constant(json.bool(true)),
           ExcludeId,
+          ShiftType.Array,
           func.RightSide).unFix.some)
     }
 
@@ -200,6 +202,7 @@ class RewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
               func.ProjectKey(func.Hole, func.Constant(json.str("city")))),
             func.Hole,
             IncludeId,
+            ShiftType.Array,
             func.ConcatArrays(
               func.MakeArray(func.LeftSide),
               func.MakeArray(func.RightSide))),
@@ -221,6 +224,7 @@ class RewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           fix.LeftShift(_,
             func.ProjectKey(func.Hole, func.Constant(json.str("city"))),
             ExcludeId,
+            ShiftType.Array,
             func.ProjectKey(func.RightSide, func.Constant(json.str("name"))))))
     }
 
@@ -256,6 +260,7 @@ class RewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
               free.Hole,
               func.Hole,
               IncludeId,
+              ShiftType.Array,
               func.ConcatArrays(
                 func.MakeArray(func.LeftSide),
                 func.MakeArray(func.RightSide))),
@@ -280,6 +285,7 @@ class RewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
             fix.Root,
             func.Hole,
             IncludeId,
+            ShiftType.Array,
             func.ConcatArrays(
               func.Constant(json.arr(List(json.str("name")))),
               func.MakeArray(
@@ -427,6 +433,7 @@ class RewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
             func.MakeArray(func.Add(func.Hole, func.Constant(json.int(3))))),
           func.Hole,
           ExcludeId,
+          ShiftType.Array,
           func.ConcatMaps(
             func.MakeMap(func.Constant(json.str("right")), func.RightSide),
             func.MakeMap(func.Constant(json.str("left")), func.LeftSide)))
@@ -450,6 +457,7 @@ class RewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
             func.Add(func.Hole, func.Constant(json.int(3)))),
           func.MakeArray(func.Subtract(func.Hole, func.Constant(json.int(5)))),
           ExcludeId,
+          ShiftType.Array,
           func.ConcatMaps(
             func.MakeMap(func.Constant(json.str("right")), func.RightSide),
             func.MakeMap(func.Constant(json.str("left")), func.LeftSide)))

--- a/connector/src/test/scala/quasar/qscript/rewrites/ShiftReadSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/rewrites/ShiftReadSpec.scala
@@ -39,7 +39,7 @@ class ShiftReadSpec extends quasar.Qspec with QScriptHelpers with TreeMatchers {
       val qScript: Fix[QS] =
         chainQS(
           qsdsl.fix.Read[AFile](sampleFile),
-          qsdsl.fix.LeftShift(_, qsdsl.func.Hole, ExcludeId, qsdsl.func.RightSide))
+          qsdsl.fix.LeftShift(_, qsdsl.func.Hole, ExcludeId, ShiftType.Array, qsdsl.func.RightSide))
 
       val newQScript: Fix[QST] =
         qScript.codyna(
@@ -59,6 +59,7 @@ class ShiftReadSpec extends quasar.Qspec with QScriptHelpers with TreeMatchers {
           qsdsl.fix.Read[AFile](rootDir </> dir("foo") </> file("bar")),
           qsdsl.func.Hole,
           ExcludeId,
+          ShiftType.Array,
           qsdsl.func.RightSide),
         Nil,
         List(ReduceFuncs.Count(qsdsl.func.Hole)),

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/QScriptCorePlanner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/QScriptCorePlanner.scala
@@ -79,7 +79,7 @@ final class QScriptCorePlanner[
         groupBy = none,
         orderBy = nil).embed
 
-    case LeftShift(src, struct, id, repair) =>
+    case LeftShift(src, struct, id, _, repair) =>
       for {
         id1 <- genId[T[N1QL], F]
         id2 <- genId[T[N1QL], F]

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/QScriptCorePlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/QScriptCorePlanner.scala
@@ -66,7 +66,7 @@ private[qscript] final class QScriptCorePlanner[
 
     // TODO: Use type information from `Guard` when available to determine
     //       if `ext` is being treated as an array or an object.
-    case LeftShift(src0, struct, id, repair) =>
+    case LeftShift(src0, struct, id, _, repair) =>
       for {
         l       <- freshName[F]
         ext     <- freshName[F]

--- a/mimir/src/main/scala/quasar/mimir/Mimir.scala
+++ b/mimir/src/main/scala/quasar/mimir/Mimir.scala
@@ -453,7 +453,7 @@ object Mimir extends BackendModule with Logging with DefaultAnalyzeModule {
           }
         } yield Repr(src.P)(table)
 
-      case qscript.LeftShift(src, struct, idStatus, repair) =>
+      case qscript.LeftShift(src, struct, idStatus, _, repair) =>
         import src.P.trans._
 
         for {

--- a/mongodb/src/main/scala/quasar/physical/mongodb/MongoDbPlanner.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/MongoDbPlanner.scala
@@ -892,7 +892,7 @@ object MongoDbPlanner {
             ev3: EX :<: ExprOp) = {
           case qscript.Map(src, f) =>
             getExprBuilder[T, M, WF, EX](cfg.funcHandler, cfg.staticHandler)(src, f)
-          case LeftShift(src, struct0, id, repair) => {
+          case LeftShift(src, struct0, id, _, repair) => {
             val rewriteUndefined: CoMapFuncR[T, Hole] => Option[CoMapFuncR[T, Hole]] = {
               case CoEnv(\/-(MFC(Guard(exp, tpe @ Type.FlexArr(_, _, _), exp0, Embed(CoEnv(\/-(MFC(Undefined())))))))) =>
                 rollMF[T, Hole](MFC(Guard(exp, tpe, exp0, Free.roll(MFC(MakeArray(Free.roll(MFC(Undefined())))))))).some

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/assumeReadType.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/assumeReadType.scala
@@ -132,10 +132,10 @@ def apply[T[_[_]]: BirecursiveT: EqualT, F[_]: Functor, M[_]: Monad: MonadFsErr]
                 case h :: t => GtoF.reverseGet(
                   QC(Filter(src, t.foldLeft[FreeMap[T]](h)((acc, e) => Free.roll(MFC(MapFuncsCore.And(acc, e)))))))
               })
-        case QC(LeftShift(src, struct, id, repair))
+        case QC(LeftShift(src, struct, id, stpe, repair))
           if (isRewrite[T, F, G, A](GtoF, src.project)) =>
             elide(struct) ∘
-            (s => GtoF.reverseGet(QC(LeftShift(src, s, id, repair))))
+            (s => GtoF.reverseGet(QC(LeftShift(src, s, id, stpe, repair))))
         case QC(qscript.Map(src, mf))
           if (isRewrite[T, F, G, A](GtoF, src.project)) =>
             elide(mf) ∘

--- a/mongodb/src/test/scala/quasar/physical/mongodb/PlannerQScriptSpec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/PlannerQScriptSpec.scala
@@ -383,6 +383,7 @@ class PlannerQScriptSpec extends
               func.ProjectKey(func.Hole, func.Constant(json.str("loc"))),
               func.Undefined),
             qscript.ExcludeId,
+            qscript.ShiftType.Array,
             func.ConcatMaps(
               func.MakeMap(func.Constant(json.str("city")),
                 func.ProjectKey(func.LeftSide, func.Constant(json.str("city")))),
@@ -422,6 +423,7 @@ class PlannerQScriptSpec extends
               func.ProjectKey(func.Hole, func.Constant(json.str("loc"))),
               func.Undefined),
             qscript.ExcludeId,
+            qscript.ShiftType.Array,
             func.RightSide),
           func.Lt(func.Hole, func.Constant(json.int(-165))))) must beWorkflow0(
         chain[Workflow](
@@ -482,12 +484,14 @@ class PlannerQScriptSpec extends
               func.ProjectKey(func.Hole, func.Constant(json.str("loc"))),
               func.Undefined),
             qscript.ExcludeId,
+            qscript.ShiftType.Array,
             func.Guard(func.RightSide,
               Type.FlexArr(0, None, Type.Top),
               func.RightSide,
               func.Undefined)),
           func.Hole,
           qscript.ExcludeId,
+          qscript.ShiftType.Array,
           func.RightSide)) must beWorkflow0(
         chain[Workflow](
           $read(collection("db", "zips")),
@@ -523,6 +527,7 @@ class PlannerQScriptSpec extends
             func.ProjectKey(func.Hole, func.Constant(json.str("loc"))),
             func.Undefined),
           qscript.ExcludeId,
+          qscript.ShiftType.Array,
           func.ConcatMaps(
             func.MakeMap(func.Constant(json.str("city")),
               func.ProjectKey(func.LeftSide, func.Constant(json.str("city")))),

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/QScriptCorePlanner.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/QScriptCorePlanner.scala
@@ -256,7 +256,7 @@ class QScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, S[_]]
           case Sample => (i: Index, c: Count) => i < c
         })
 
-    case LeftShift(src, struct, id, repair) =>
+    case LeftShift(src, struct, id, _, repair) =>
 
       val structFunc: PlannerError \/ (Data => Data) =
         CoreMap.changeFreeMap(struct)

--- a/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/PlannerSpec.scala
+++ b/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/PlannerSpec.scala
@@ -439,7 +439,7 @@ class PlannerSpec
           def struct: FreeMap = func.ProjectKeyS(func.Hole, "countries")
           def repair: JoinFunc = func.RightSide
 
-          val leftShift = quasar.qscript.LeftShift(src, struct, ExcludeId, repair)
+          val leftShift = quasar.qscript.LeftShift(src, struct, ExcludeId, ShiftType.Array, repair)
 
           val program: SparkState[Task, RDD[Data]] = compile(leftShift)
           program.eval(sc).run.map(result => result must beRightDisjunction.like{


### PR DESCRIPTION
This adds a flag to the `LeftShift` node so that we know what type of shift we're performing.  The `Guard` nodes are still included.  Note that this enables a future refinement for mimir, where we can literally eliminate all `Guard` nodes.  More importantly though, this makes it much simpler for mongo to optimize certain things.