### PR TITLE
Allow 'null' values in MongoDB distinct results

### DIFF
--- a/it/src/main/resources/tests/nullableDistinct.test
+++ b/it/src/main/resources/tests/nullableDistinct.test
@@ -1,0 +1,21 @@
+{
+  "name": "distinct of a nullable field",
+
+  "backends": {
+  },
+
+  "data": "nullable_distinct.data",
+
+  "query": "select distinct foo from nullable_distinct",
+
+  "predicate": "exactly",
+  "ignoreResultOrder": true,
+
+  "expected": [
+    "a"
+  , null
+  , "b"
+  , "c"
+  , "d"
+  ]
+}

--- a/it/src/main/resources/tests/nullable_distinct.data
+++ b/it/src/main/resources/tests/nullable_distinct.data
@@ -1,0 +1,9 @@
+{ "_id": 1, "foo": "a" }
+{ "_id": 2, "foo": null }
+{ "_id": 3, "foo": "b" }
+{ "_id": 4, "foo": "c" }
+{ "_id": 5, "foo": "b" }
+{ "_id": 6, "foo": "c" }
+{ "_id": 7, "foo": null }
+{ "_id": 8, "foo": "a" }
+{ "_id": 9, "foo": "d" }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutor.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutor.scala
@@ -66,9 +66,11 @@ private[mongodb] final class JavaScriptWorkflowExecutor
   }
 
   protected def distinct(src: Collection, cfg: Distinct, field: BsonField.Name) = {
+    val filter =
+      cfg.query.map(_.bson.toJs).toList
+
     val distinct0 =
-      foldExpr(cfg.query)((q, js) => Call(Select(js, "filter"), List(q.bson.toJs)))
-        .exec(Call(Select(toJsRef(src), "distinct"), List(Str(cfg.field.asText))))
+      Call(Select(toJsRef(src), "distinct"), List(Str(cfg.field.asText)) ::: filter)
 
     tell(Call(
       Select(distinct0, "map"),

--- a/mongodb/src/main/scala/quasar/physical/mongodb/MongoDbIOWorkflowExecutor.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/MongoDbIOWorkflowExecutor.scala
@@ -31,7 +31,7 @@ import scala.Predef.classOf
 import com.mongodb._
 import com.mongodb.async.client._
 import com.mongodb.client.model.CountOptions
-import org.bson.{BsonDocument, BsonValue}
+import org.bson.{BsonDocument, BsonNull, BsonValue}
 import scalaz._, Scalaz._
 
 /** Implementation class for a WorkflowExecutor in the `MongoDbIO` monad. */
@@ -66,8 +66,10 @@ private[mongodb] final class MongoDbIOWorkflowExecutor
     type DIT = DistinctIterable[BsonValue]
     type MIT = MongoIterable[BsonDocument]
 
+    // Fun fact: Even though BSON has a `null` type, the MongoDB java driver emits
+    // BSON nulls as Java `null`, because reasons.
     val wrapVal: BsonValue => BsonDocument =
-      new BsonDocument(field.asText, _)
+      bv => new BsonDocument(field.asText, Option(bv) getOrElse new BsonNull())
 
     val distinct0 =
       foldS(cfg.query)((q, dit: DIT) => dit.filter(q.bson))

--- a/mongodb/src/test/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutionSpec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutionSpec.scala
@@ -172,7 +172,7 @@ class JavaScriptWorkflowExecutionSpec extends quasar.Qspec {
           ExcludeId))
 
       toJS(wf) must beRightDisjunction(
-        """db.zips.distinct("city").filter({ "pop": { "$gte": NumberLong("1000") } }).map(
+        """db.zips.distinct("city", { "pop": { "$gte": NumberLong("1000") } }).map(
           |  function (elem) { return { "c": elem } });
           |""".stripMargin)
     }


### PR DESCRIPTION
Fixes an issue where `null` values in the results of a `db.collection.distinct(...)` query would throw an exception.