### PR TITLE
PostgreSQL: Allow creating schemas concurrently

### DIFF
--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/postgres/PostgresCreate.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/postgres/PostgresCreate.scala
@@ -34,6 +34,7 @@ trait PostgresCreate extends RdbmsCreate {
       if (s.isRoot)
         ().point[ConnectionIO]
       else
+        fr"LOCK TABLE pg_catalog.pg_namespace".update.run *>
         (fr"CREATE SCHEMA IF NOT EXISTS" ++ Fragment.const(s.shows)).update.run.void
     }.void
   }


### PR DESCRIPTION
There are problems with calling `CREATE SCHEMA IF EXISTS` concurrently. Since schemas represent directories, such situation often happens in integration tests which try to create parent `__regression` directories multiple times.
This fix solves the problem by adding an explicit lock on the system `pg_namespace` table.
The lock is released automatically when transaction ends.

Reference: https://stackoverflow.com/questions/29900845/create-schema-if-not-exists-raises-duplicate-key-error