### PR TITLE
Generate ExecutionIDs, record and dump basic timing information (fixes qz-3343)

### DIFF
--- a/effect/src/main/scala/quasar/effect/TimingScope.scala
+++ b/effect/src/main/scala/quasar/effect/TimingScope.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.effect
+
+import slamdata.Predef._
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import scala.collection.immutable.TreeMap
+import quasar.fp._
+import quasar.fp.numeric.Natural
+
+import scalaz._, Scalaz._
+import scalaz.concurrent.Task
+
+/** Represents the ability to create an execution scope, within which timing scopes can be created.
+  */
+trait ScopeExecution[F[_], T] {
+  def newExecution[A](executionId: ExecutionId, action: ScopeTiming[F, T] => F[A]): F[A]
+}
+
+/** Represents the ability to create a timing scope.
+  */
+trait ScopeTiming[F[_], T] {
+  def newScope[A](scopeId: String, fa: => F[A]): F[A]
+}
+
+final case class ExecutionId(index: Long, startTime: Instant)
+object ExecutionId {
+  import scala.Ordering
+  implicit val executionIdOrdering: Ordering[ExecutionId] = Ordering.ordered[Instant](x => x).on(_.startTime)
+  implicit val executionIdShow: Show[ExecutionId] = Show.shows {
+    case ExecutionId(index, start) => s"Query execution $index began at $start"
+  }
+  def ofRef(ref: TaskRef[Long]): Task[ExecutionId] =
+    for {
+      i <- ref.modify(_ + 1)
+      now <- Task.delay(Instant.now())
+    } yield ExecutionId(i, now)
+}
+
+final case class ExecutionTimings(timings: Map[String, (Instant, Instant)])
+object ExecutionTimings {
+  implicit val executionTimingsShow: Show[ExecutionTimings] = Show.show {
+    executionTimings =>
+      executionTimings.timings.map {
+        case (identifier, (start, end)) =>
+          val millisBetween = start.until(end, ChronoUnit.MILLIS)
+          Cord("phase ") ++
+          Cord(identifier) ++
+          Cord(": ") ++
+          millisBetween.show ++
+          Cord(" ms")
+      }.mkString("\n")
+  }
+}
+final case class TimingRepository(recordedExecutions: Natural, repo: TaskRef[TreeMap[ExecutionId, ExecutionTimings]]) {
+  def addScope(executionId: ExecutionId, scopeId: String, start: Instant, end: Instant): Task[Unit] = {
+    repo.modify { executions =>
+      val newExecution = executions.get(executionId).fold {
+        ExecutionTimings(Map((scopeId, (start, end))))
+      } { case ExecutionTimings(timings) => ExecutionTimings(timings + ((scopeId, (start, end)))) }
+      val newExecutions = executions + ((executionId, newExecution))
+      val excessExecutions = java.lang.Math.max(newExecutions.size - recordedExecutions.value.toInt, 0)
+      newExecutions.drop(excessExecutions)
+    }.void
+  }
+}
+
+object TimingRepository {
+  def empty(recordedExecutions: Natural): Task[TimingRepository] = {
+    TaskRef(TreeMap.empty[ExecutionId, ExecutionTimings])
+      .map(TimingRepository(recordedExecutions, _))
+  }
+}
+
+object ScopeExecution {
+  def forTask[T](repo: TimingRepository, print: String => Task[Unit]): ScopeExecution[Task, T] =
+    new ScopeExecution[Task, T] {
+      def newExecution[A](executionId: ExecutionId, action: ScopeTiming[Task, T] => Task[A]): Task[A] = {
+        for {
+          a <- action(ScopeTiming.forTask(executionId, repo))
+          repository <- repo.repo.read
+          shownTimings <- repository.get(executionId).fold(().point[Task])(timings => print(s"${executionId.shows}\n${timings.shows}"))
+        } yield a
+      }
+    }
+
+  def forFreeTask[F[_], T](repo: TimingRepository, print: String => Free[F, Unit])
+                          (implicit task: Task :<: F): ScopeExecution[Free[F, ?], T] =
+    new ScopeExecution[Free[F, ?], T] {
+      def newExecution[A](executionId: ExecutionId, action: ScopeTiming[Free[F, ?], T] => Free[F, A]): Free[F, A] = {
+        for {
+          a <- action(ScopeTiming.forFreeTask(executionId, repo))
+          repository <- Free.liftF(task(repo.repo.read))
+          shownTimings <- repository.get(executionId).fold(().point[Free[F, ?]])(timings => print(s"${executionId.shows}\n${timings.shows}"))
+        } yield a
+      }
+    }
+}
+
+object ScopeTiming {
+  def forTask[T](executionId: ExecutionId, repo: TimingRepository): ScopeTiming[Task, T] =
+    new ScopeTiming[Task, T] {
+      def newScope[A](scopeId: String, f: => Task[A]): Task[A] = {
+        for {
+          start <- Task.delay(Instant.now())
+          result <- f
+          end <- Task.delay(Instant.now())
+          _ <- repo.addScope(executionId, scopeId, start, end)
+        } yield result
+      }
+    }
+
+  def forFreeTask[F[_], T](executionId: ExecutionId, repo: TimingRepository)
+                          (implicit task: Task :<: F): ScopeTiming[Free[F, ?], T] =
+  new ScopeTiming[Free[F, ?], T] {
+    def newScope[A](scopeId: String, f: => Free[F, A]): Free[F, A] = {
+      for {
+        start <- Free.liftF(task(Task.delay(Instant.now())))
+        result <- f
+        end <- Free.liftF(task(Task.delay(Instant.now())))
+        _ <- Free.liftF(task(repo.addScope(executionId, scopeId, start, end)))
+      } yield result
+    }
+  }
+}

--- a/interface/src/main/scala/quasar/main/Caching.scala
+++ b/interface/src/main/scala/quasar/main/Caching.scala
@@ -33,7 +33,7 @@ import scalaz.concurrent.{Strategy, Task}
 import scalaz.stream.{Process, time}
 
 object Caching {
-  type Eff[A] = (Task :\: ConnectionIO :/: CoreEff)#M[A]
+  type Eff[A] = Coproduct[Task, Coproduct[ConnectionIO, CoreEff, ?], A]
 
   val QT = QueryFile.Transforms[Free[Eff, ?]]
 

--- a/it/src/test/scala/quasar/server/ServiceSpec.scala
+++ b/it/src/test/scala/quasar/server/ServiceSpec.scala
@@ -37,6 +37,7 @@ import org.specs2.matcher.MatchResult
 import pathy.Path._
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
+import eu.timepit.refined.refineMV
 
 class ServiceSpec extends quasar.Qspec {
   val schema = Schema.schema
@@ -61,7 +62,7 @@ class ServiceSpec extends quasar.Qspec {
       _          <- metastoreInit.transact(transactor).liftM[MainErrT]
       metaRef    <- TaskRef(metastore).liftM[MainErrT]
       quasarFs   <- Quasar.initWithMeta(BackendConfig.Empty, metaRef, _ => ().point[MainTask])
-      shutdown   <- Server.startServer(quasarFs.interp, port, Nil, None, _ => ().point[MainTask]).liftM[MainErrT]
+      shutdown   <- Server.startServer(quasarFs.interp, port, Nil, None, _ => ().point[MainTask], refineMV(0L), false).liftM[MainErrT]
       r          <- f(uri).onFinish(κ(shutdown.onFinish(κ(quasarFs.shutdown)))).liftM[MainErrT]
     } yield r).run.unsafePerformSync
   }

--- a/repl/src/main/scala/quasar/repl/Command.scala
+++ b/repl/src/main/scala/quasar/repl/Command.scala
@@ -37,6 +37,7 @@ object Command {
   private val AppendPattern         = "(?i)append +([\\S]+) (.+)".r
   private val DeletePattern         = "(?i)rm +([\\S]+)".r
   private val SetPhaseFormatPattern = "(?i)(?:set +)?phaseFormat *= *(tree|code)".r
+  private val PrintTimingPattern    = "(?i)(?:set +)?printTiming *= *(0|1)".r
   private val DebugPattern          = "(?i)(?:set +)?debug *= *(0|1|2)".r
   private val SummaryCountPattern   = "(?i)(?:set +)?summaryCount *= *(\\d+)".r
   private val FormatPattern         = "(?i)(?:set +)?format *= *((?:table)|(?:precise)|(?:readable)|(?:csv))".r
@@ -60,6 +61,7 @@ object Command {
   final case class SummaryCount(rows: Int) extends Command
   final case class Format(format: OutputFormat) extends Command
   final case class SetPhaseFormat(format: PhaseFormat) extends Command
+  final case class PrintTiming(print: Boolean) extends Command
   final case class SetVar(name: String, value: String) extends Command
   final case class UnsetVar(name: String) extends Command
 
@@ -79,6 +81,7 @@ object Command {
       case DeletePattern(XFile(f))       => Delete(f)
       case DebugPattern(code)            => Debug(DebugLevel.int.unapply(code.toInt) | DebugLevel.Normal)
       case SetPhaseFormatPattern(format) => SetPhaseFormat(PhaseFormat.fromString(format) | PhaseFormat.Tree)
+      case PrintTimingPattern(format)    => PrintTiming(if (format == "1") true else false)
       case SummaryCountPattern(rows)     => SummaryCount(rows.toInt)
       case FormatPattern(format)         => Format(OutputFormat.fromString(format) | OutputFormat.Table)
       case HelpPattern()                 => Help

--- a/repl/src/main/scala/quasar/repl/Main.scala
+++ b/repl/src/main/scala/quasar/repl/Main.scala
@@ -113,16 +113,25 @@ object Main {
     S4: ManageFile :<: S,
     S5: FileSystemFailure :<: S
   ): Task[Command => Free[DriverEff, Unit]] = {
-    TaskRef(Repl.RunState(rootDir, DebugLevel.Normal, PhaseFormat.Tree, refineMV[Positive](10).some, OutputFormat.Table, Map())).map { ref =>
-      val i: ReplEff[S, ?] ~> DriverEffM =
-        injectFT[Task, DriverEff].compose(AtomicRef.fromTaskRef(ref)) :+:
+    for {
+      stateRef <- TaskRef(Repl.RunState(rootDir, DebugLevel.Normal, PhaseFormat.Tree, refineMV[Positive](10).some, OutputFormat.Table, Map(), false))
+      executionIdRef <- TaskRef(0L)
+      timingRepository <- TimingRepository.empty(refineMV(1))
+      i =
+        injectFT[Task, DriverEff].compose(AtomicRef.fromTaskRef(stateRef)) :+:
         injectFT[ConsoleIO, DriverEff]                                :+:
         injectFT[ReplFail, DriverEff]                                 :+:
         injectFT[Task, DriverEff].compose(Timing.toTask)              :+:
         injectFT[Task, DriverEff]                                     :+:
         fs
-
-      (cmd => Repl.command[ReplEff[S, ?]](cmd).foldMap(i))
+    } yield {
+      val timingPrint = (in: String) => for {
+        state <- Free.liftF(Inject[Task, ReplEff[S, ?]].inj(stateRef.read))
+        _ <- if (state.printTiming) Free.liftF(Inject[ConsoleIO, ReplEff[S, ?]].inj(ConsoleIO.PrintLn(in)))
+             else ().point[Free[ReplEff[S, ?], ?]]
+      } yield ()
+      implicit val SE = ScopeExecution.forFreeTask[ReplEff[S, ?], Nothing](timingRepository, timingPrint)
+      (cmd => Repl.command[ReplEff[S, ?], Nothing](cmd, executionIdRef).foldMap(i))
     }
   }
 

--- a/web/src/main/scala/quasar/server/Server.scala
+++ b/web/src/main/scala/quasar/server/Server.scala
@@ -25,9 +25,10 @@ import quasar.console.{logErrors, stdout}
 import quasar.contrib.scalaz._
 import quasar.contrib.scopt._
 import quasar.db.DbConnectionConfig
-import quasar.effect.{Read, Write}
+import quasar.effect.{Read, ScopeExecution, TimingRepository, Write}
 import quasar.fp._
 import quasar.fp.free._
+import quasar.fp.numeric.Natural
 import quasar.fs.mount.cache.VCache, VCache.{VCacheExpR, VCacheExpW}
 import quasar.main._
 import quasar.server.Http4sUtils.{openBrowser, waitForUserEnter}
@@ -48,7 +49,9 @@ object Server {
       port: Option[Int],
       configPath: Option[FsFile],
       loadConfig: BackendConfig,
-      openClient: Boolean) {
+      openClient: Boolean,
+      recordedExecutions: Natural,
+      printExecutions: Boolean) {
 
     def toCmdLineConfig: CmdLineConfig = CmdLineConfig(configPath, loadConfig, cmd)
   }
@@ -76,7 +79,7 @@ object Server {
             .map(some)) ⊛
         loadConfigM.liftM[MainErrT]) ((content, cfgPath, loadConfig) =>
         WebCmdLineConfig(
-          opts.cmd, content.toList, content.map(_.loc), opts.port, cfgPath, loadConfig, opts.openClient))
+          opts.cmd, content.toList, content.map(_.loc), opts.port, cfgPath, loadConfig, opts.openClient, opts.recordedExecutions, true))
     }
   }
 
@@ -103,8 +106,10 @@ object Server {
     staticContent: List[StaticContent],
     redirect: Option[String],
     eval: CoreEff ~> QErrs_CRW_TaskM,
-    persistPortChange: Int => MainTask[Unit]
-  ): PortChangingServer.ServiceStarter = {
+    persistPortChange: Int => MainTask[Unit],
+    recordedExecutions: Natural,
+    printExecutions: Boolean
+  ): Task[PortChangingServer.ServiceStarter] = {
     import RestApi._
 
     def interp: Task[CoreEffIORW ~> ResponseOr] =
@@ -120,15 +125,25 @@ object Server {
           injectFT[Task, QErrs_CRW_Task]       :+:
           eval))
 
-    (reload: Int => Task[String \/ Unit]) =>
-    finalizeServices(
-      toHttpServicesF[CoreEffIORW](
-        λ[Free[CoreEffIORW, ?] ~> ResponseOr] { fa =>
-          interp.liftM[ResponseT] >>= (fa foldMap _)
-        },
-        coreServices[CoreEffIORW]
-      ) ++ additionalServices
-    ) orElse nonApiService(defaultPort, Kleisli(persistPortChange andThen (a => a.run)) >> Kleisli(reload), staticContent, redirect)
+    val printAction = (s: String) =>
+      Free.liftF(Inject[Task, CoreEffIORW].inj(if (printExecutions) Task.delay(println(s)) else ().point[Task]))
+    for {
+      scopeExecution <- TimingRepository.empty(recordedExecutions).map(
+        ScopeExecution.forFreeTask[CoreEffIORW, Nothing](_, printAction)
+      )
+      executionIdRef <- TaskRef(0L)
+    } yield {
+      implicit val _ = scopeExecution
+      (reload: Int => Task[String \/ Unit]) =>
+        finalizeServices(
+          toHttpServicesF[CoreEffIORW](
+            λ[Free[CoreEffIORW, ?] ~> ResponseOr] { fa =>
+              interp.liftM[ResponseT] >>= (fa foldMap _)
+            },
+            coreServices[CoreEffIORW, Nothing](executionIdRef)
+          ) ++ additionalServices
+        ) orElse nonApiService(defaultPort, Kleisli(persistPortChange andThen (a => a.run)) >> Kleisli(reload), staticContent, redirect)
+    }
   }
 
   /**
@@ -140,11 +155,15 @@ object Server {
     port: Int,
     staticContent: List[StaticContent],
     redirect: Option[String],
-    persistPortChange: Int => MainTask[Unit]
+    persistPortChange: Int => MainTask[Unit],
+    recordedExecutions: Natural,
+    printExecutions: Boolean
   ): Task[Task[Unit]] =
-    PortChangingServer.start(
-      initialPort = port,
-      serviceStarter(defaultPort = port, staticContent, redirect, quasarInter, persistPortChange))
+    for {
+      starter <- serviceStarter(defaultPort = port, staticContent, redirect, quasarInter, persistPortChange, recordedExecutions, printExecutions)
+      shutdown <- PortChangingServer.start(initialPort = port, starter)
+    } yield shutdown
+
 
   def persistMetaStore(configPath: Option[FsFile]): DbConnectionConfig => MainTask[Unit] =
     persistWebConfig(configPath, conn => _.copy(metastore = MetaStoreConfig(conn).some))
@@ -178,7 +197,14 @@ object Server {
                val port = webCmdLineCfg.port | wCfg.server.port
                val persistPort = persistPortChange(webCmdLineCfg.configPath)
                (for {
-                 shutdown <- startServer(quasarInter, port, webCmdLineCfg.staticContent, webCmdLineCfg.redirect, persistPort)
+                 shutdown <- startServer(
+                  quasarInter,
+                  port,
+                  webCmdLineCfg.staticContent,
+                  webCmdLineCfg.redirect,
+                  persistPort,
+                  webCmdLineCfg.recordedExecutions,
+                  webCmdLineCfg.printExecutions)
                  _        <- openBrowser(port).whenM(webCmdLineCfg.openClient)
                  _        <- stdout("Press Enter to stop.")
                  // If user pressed enter (after this main thread has been blocked on it),

--- a/web/src/test/scala/quasar/api/services/VCacheFixture.scala
+++ b/web/src/test/scala/quasar/api/services/VCacheFixture.scala
@@ -48,16 +48,14 @@ trait VCacheFixture extends H2MetaStoreFixture {
   type Eff[A]  = Coproduct[Task, Eff0, A]
   type EffM[A] = Free[Eff, A]
 
-  type ViewEff[A] = (
-    PathMismatchFailure :\:
-    MountingFailure     :\:
-    Mounting            :\:
-    view.State          :\:
-    MonotonicSeq        :\:
-    VCacheExpR          :\:
-    VCacheExpW          :/:
-    Eff
-  )#M[A]
+  type ViewEff[A] =
+    Coproduct[PathMismatchFailure,
+      Coproduct[MountingFailure,
+        Coproduct[Mounting,
+          Coproduct[view.State,
+            Coproduct[MonotonicSeq,
+              Coproduct[VCacheExpR,
+                Coproduct[VCacheExpW, Eff, ?], ?], ?], ?], ?], ?], A]
 
   val vcacheInterp: Task[VCacheKVS ~> Task] = KeyValueStore.impl.default[AFile, ViewCache]
 

--- a/web/src/test/scala/quasar/api/services/query/ExecuteServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/query/ExecuteServiceSpec.scala
@@ -27,6 +27,7 @@ import quasar.common.{Map => _, _}
 import quasar.contrib.pathy._, PathArbitrary._
 import quasar.contrib.scalaz.catchable._
 import quasar.DateArbitrary._
+import quasar.effect.ScopeExecution
 import quasar.fp._
 import quasar.fp.free.{foldMapNT, injectNT, liftFT}
 import quasar.fp.ski._
@@ -71,6 +72,9 @@ class ExecuteServiceSpec extends quasar.Qspec with FileSystemFixture with Http4s
 
   val lpf = new LogicalPlanR[Fix[LogicalPlan]]
 
+  implicit val scopeExecutionViewEff: ScopeExecution[Free[ViewEff, ?], Nothing] =
+    ScopeExecution.ignore[Free[ViewEff, ?], Nothing]
+
   def executeServiceRef(
     mem: InMemState,
     f: QueryFile ~> Free[QueryFile, ?],
@@ -78,7 +82,7 @@ class ExecuteServiceSpec extends quasar.Qspec with FileSystemFixture with Http4s
   ): (Service[Request, Response], Task[InMemState]) = {
     val (inter, ref) = inMemFSWebInspect(mem, MountingsConfig(mounts)).unsafePerformSync
     val finalInter = free.transformIn(f andThen foldMapNT(injectNT[QueryFile, CoreEffIO] andThen inter), inter)
-    val svc = execute.service[CoreEffIO].toHttpService(finalInter).orNotFound
+    val svc = execute.service[CoreEffIO, Nothing](executionIdRef).toHttpService(finalInter).orNotFound
 
     (svc, ref.map{ case (mem, _) => mem })
   }
@@ -171,7 +175,7 @@ class ExecuteServiceSpec extends quasar.Qspec with FileSystemFixture with Http4s
           val (resp, vc) = evalViewTest(now, mounts, InMemState.empty) { (it, ir) =>
             (for {
               _ <- vcache.put(f, viewCache)
-              a <- VCacheMiddleware(execute.service[ViewEff]).apply(
+              a <- VCacheMiddleware(execute.service[ViewEff, Nothing](executionIdRef)).apply(
                      Request(uri = (pathUri(f) / "").copy(query =
                        http4s.Query.fromPairs(
                          "q" -> s"select * from `../${fileName(f).value}`"))))
@@ -202,7 +206,7 @@ class ExecuteServiceSpec extends quasar.Qspec with FileSystemFixture with Http4s
           val (resp, vc) = evalViewTest(now, mounts, InMemState.empty) { (it, ir) =>
             (for {
               _ <- vcache.put(f, viewCache)
-              a <- VCacheMiddleware(execute.service[ViewEff]).apply(
+              a <- VCacheMiddleware(execute.service[ViewEff, Nothing](executionIdRef)).apply(
                 Request(uri = (pathUri(f) / "").copy(query =
                   http4s.Query.fromPairs(
                     "q" -> s"select * from `../${fileName(f).value}`"))))


### PR DESCRIPTION
First pass on benchmarking infrastructure.

1. All queries have an associated "execution identifier", a pair of an integer which increments on every query and a start `Instant` (timestamp).
2. All queries have a set of "timing scopes" like "full query execution pipeline" and "parse SQL" which are pairs of start and end timestamps with identifiers attached. Adding a timing scope is as simple as a call into a type class wrapping some part of the query. There need to be a *lot* more of these; we haven't even separated query planning from query execution yet.
3. There's a "timing repository" containing a map from execution identifiers to maps containing all of the execution's timing scopes. It's size-limited, and drops the oldest executions when it goes over the size specified (with age measured by start-time). The goal here is to keep something like 200 timing scopes in memory at all times so that we can dump the info and understand why queries are slow, even after the fact (especially for customers).
4. When an execution finishes, there's an option to print out its timing info immediately. This option isn't currently exposed to the web server (and I'm not sure if it should), but it is to the REPL; use `set printTiming = 1`.

Potential issues:
- It may be best to order executions by *end time* instead, which would require not eagerly adding an execution's info to the timing repository.
- The integer part of the execution identifier may end up being redundant, the intention was to use it to keep them distinct and make it easier to index them mentally.
- The timing repository could use some tests to ensure it behaves as specified. Manual testing seemed to show it was fine, though.
- Code that populates timing scopes might need to be tested to ensure that it's doing it properly.

Some sample output from the REPL:
```
(v27.6.6) 💪 $ select substring(city, 0, 1), count(*) from zips
Query time: 0.3s
 0  | 1      |
----|--------|
 A  |  29353 |
 C  |  29353 |
 B  |  29353 |
 B  |  29353 |
 B  |  29353 |
 B  |  29353 |
 C  |  29353 |
 C  |  29353 |
 C  |  29353 |
 C  |  29353 |
Query execution 5 began at 2017-12-22T20:55:24.337Z
phase parse SQL: 6 ms
phase resolve imports: 1 ms
phase execute query: 363 ms
phase total query pipeline (REPL): 370 ms
(v27.6.6) 💪 $
```
#qz-3343 done