### PR TITLE
RDBMS: Optimize Search for const conditions

### DIFF
--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/postgres/planner/PostgresRenderQuery.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/postgres/planner/PostgresRenderQuery.scala
@@ -117,8 +117,9 @@ object PostgresRenderQuery extends RenderQuery {
       buildJson(m.map {
         case ((_, k), (_, v)) => s"'$k', $v"
       }.mkString(",")).right
-    case RegexMatches(TextExpr(e), (_, pattern)) =>
-      s"($e ~ '$pattern')".right
+    case RegexMatches(TextExpr(e), TextExpr(pattern), caseInsensitive: Boolean) =>
+      val op = if (caseInsensitive) "~*" else "~"
+      s"($e $op $pattern)".right
     case IsNotNull((_, expr)) =>
       s"($expr notnull)".right
     case IfNull(exprs) =>

--- a/rdbms/src/main/scala/quasar/physical/rdbms/planner/sql/SqlExpr.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/planner/sql/SqlExpr.scala
@@ -81,7 +81,7 @@ object SqlExpr extends SqlExprInstances {
   final case class BinaryFunction[T](t: BinaryFunctionType, a1: T, a2: T) extends SqlExpr[T]
   final case class TernaryFunction[T](t: TernaryFunctionType, a1: T, a2: T, a3: T) extends SqlExpr[T]
 
-  final case class RegexMatches[T](a1: T, a2: T) extends SqlExpr[T]
+  final case class RegexMatches[T](a1: T, a2: T, caseInsensitive: Boolean) extends SqlExpr[T]
 
   final case class Limit[T](from: T, count: T) extends SqlExpr[T]
   final case class Offset[T](from: T, count: T) extends SqlExpr[T]

--- a/rdbms/src/main/scala/quasar/physical/rdbms/planner/sql/SqlExprInstance.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/planner/sql/SqlExprInstance.scala
@@ -36,7 +36,7 @@ trait SqlExprTraverse {
       case Obj(m)              => m.traverse(_.bitraverse(f, f)) ∘ (l => Obj(l))
       case Constant(d)         => G.point(Constant(d))
       case Id(str)             => G.point(Id(str))
-      case RegexMatches(a1, a2) => (f(a1) ⊛ f(a2))(RegexMatches(_, _))
+      case RegexMatches(a1, a2, i) => (f(a1) ⊛ f(a2))(RegexMatches(_, _, i))
       case ExprWithAlias(e, a) => (f(e) ⊛ G.point(a))(ExprWithAlias.apply)
       case ExprPair(e1, e2)    => (f(e1) ⊛ f(e2))(ExprPair.apply)
       case ConcatStr(a1, a2)   => (f(a1) ⊛ f(a2))(ConcatStr(_, _))

--- a/rdbms/src/main/scala/quasar/physical/rdbms/planner/sql/SqlExprRenderTree.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/planner/sql/SqlExprRenderTree.scala
@@ -54,8 +54,8 @@ trait SqlExprRenderTree {
             nonTerminal("NotNull", a1)
           case IfNull(a) =>
             nonTerminal("IfNull", a.toList: _*)
-          case RegexMatches(a1, a2) =>
-            nonTerminal("RegexMatches", a1, a2)
+          case RegexMatches(a1, a2, caseInsensitive) =>
+            nonTerminal(s"RegexMatches (insensitive = $caseInsensitive)", a1, a2)
           case ExprWithAlias(e, a) =>
             nonTerminal(s"ExprWithAlias($a)", e)
           case ExprPair(expr1, expr2) =>


### PR DESCRIPTION
All `like` expressions were translated to `when (true) ... else .... end`. To avoid `when (true)` and `when (false)`, such cases are now handled independently in the planner proper.

This optimization is not intended to increase performance, just readability of initial DB queries when debugging.