### PR TITLE
Automation friendliness

### DIFF
--- a/effect/src/main/scala/quasar/effect/ScopeExecution.scala
+++ b/effect/src/main/scala/quasar/effect/ScopeExecution.scala
@@ -23,6 +23,9 @@ import scala.collection.immutable.TreeMap
 import quasar.RenderedTree
 import quasar.fp._
 import quasar.fp.numeric.Natural
+import matryoshka._
+import matryoshka.patterns.EnvT
+import matryoshka.data.cofree._
 
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
@@ -30,28 +33,45 @@ import scalaz.concurrent.Task
 /** Represents the ability to create an execution scope, within which timing scopes can be created.
   */
 trait ScopeExecution[F[_], T] {
-  def newExecution[A](executionId: ExecutionId, action: ScopeTiming[F, T] => F[A]): F[A]
+  def newExecution[A](index: Long, action: ScopeTiming[F, T] => F[A]): F[A]
 }
 
 object ScopeExecution {
   def ignore[F[_], T]: ScopeExecution[F, T] = new ScopeExecution[F, T] {
-    def newExecution[A](executionId: ExecutionId, action: ScopeTiming[F, T] => F[A]): F[A] =
+    def newExecution[A](index: Long, action: ScopeTiming[F, T] => F[A]): F[A] =
       action(ScopeTiming.ignore[F, T])
   }
-  def forTask[T](repo: TimingRepository, print: (ExecutionId, ExecutionTimings) => Task[Unit]): ScopeExecution[Task, T] =
+  def forTask[T](repo: TimingRepository,
+                 print: (ExecutionId, ExecutionTimings) => Task[Unit]): ScopeExecution[Task, T] =
     new ScopeExecution[Task, T] {
-      def newExecution[A](executionId: ExecutionId, action: ScopeTiming[Task, T] => Task[A]): Task[A] = {
-        action(ScopeTiming.forTask(executionId, repo)) <* 
-          (repo.repo.read >>= (_.get(executionId).fold(().point[Task])(print(executionId, _))))
+      def newExecution[A](index: Long, action: ScopeTiming[Task, T] => Task[A]): Task[A] = {
+        for {
+          newExecutionRef <- SingleExecutionRef.empty
+          start <- Task.delay(Instant.now())
+          result <- action(ScopeTiming.forTask(newExecutionRef))
+          end <- Task.delay(Instant.now())
+          executionId = ExecutionId(index, start, end)
+          newScope <- newExecutionRef.under.read
+          _ <- repo.addExecution(executionId, newScope)
+          _ <- print(executionId, newScope)
+        } yield result
       }
     }
 
   def forFreeTask[F[_], T](repo: TimingRepository, print: (ExecutionId, ExecutionTimings) => Free[F, Unit])
                           (implicit task: Task :<: F): ScopeExecution[Free[F, ?], T] =
     new ScopeExecution[Free[F, ?], T] {
-      def newExecution[A](executionId: ExecutionId, action: ScopeTiming[Free[F, ?], T] => Free[F, A]): Free[F, A] = {
-        action(ScopeTiming.forFreeTask(executionId, repo)) <*
-          (Free.liftF(task(repo.repo.read)) >>= (_.get(executionId).fold(().point[Free[F, ?]])(print(executionId, _))))
+      def newExecution[A](index: Long, action: ScopeTiming[Free[F, ?], T] => Free[F, A]): Free[F, A] = {
+        for {
+          newExecutionRef <- Free.liftF(task(SingleExecutionRef.empty))
+          start <- Free.liftF(task(Task.delay(Instant.now())))
+          result <- action(ScopeTiming.forFreeTask(newExecutionRef))
+          end <- Free.liftF(task(Task.delay(Instant.now())))
+          executionId = ExecutionId(index, start, end)
+          newScope <- Free.liftF(task(newExecutionRef.under.read))
+          _ <- Free.liftF(task(repo.addExecution(executionId, newScope)))
+          _ <- print(executionId, newScope)
+        } yield result
       }
     }
 }
@@ -66,19 +86,19 @@ object ScopeTiming {
   def ignore[F[_], T]: ScopeTiming[F, T] = new ScopeTiming[F, T] {
     def newScope[A](scopeId: String, fa: => F[A]): F[A] = fa
   }
-  def forTask[T](executionId: ExecutionId, repo: TimingRepository): ScopeTiming[Task, T] =
+  def forTask[T](ref: SingleExecutionRef): ScopeTiming[Task, T] =
     new ScopeTiming[Task, T] {
       def newScope[A](scopeId: String, f: => Task[A]): Task[A] = {
         for {
           start <- Task.delay(Instant.now())
           result <- f
           end <- Task.delay(Instant.now())
-          _ <- repo.addScope(executionId, scopeId, start, end)
+          _ <- ref.addScope(scopeId, start, end)
         } yield result
       }
     }
 
-  def forFreeTask[F[_], T](executionId: ExecutionId, repo: TimingRepository)
+  def forFreeTask[F[_], T](ref: SingleExecutionRef)
                           (implicit task: Task :<: F): ScopeTiming[Free[F, ?], T] =
   new ScopeTiming[Free[F, ?], T] {
     def newScope[A](scopeId: String, f: => Free[F, A]): Free[F, A] = {
@@ -86,35 +106,32 @@ object ScopeTiming {
         start <- Free.liftF(task(Task.delay(Instant.now())))
         result <- f
         end <- Free.liftF(task(Task.delay(Instant.now())))
-        _ <- Free.liftF(task(repo.addScope(executionId, scopeId, start, end)))
+        _ <- Free.liftF(task(ref.addScope(scopeId, start, end)))
       } yield result
     }
   }
 }
 
-final case class ExecutionId(index: Long, start: Instant)
+final case class ExecutionId(index: Long, start: Instant, end: Instant)
 object ExecutionId {
   import scala.Ordering
-  implicit val executionIdOrdering: Ordering[ExecutionId] = Ordering.ordered[Instant](x => x).on(_.start)
+  implicit val executionIdOrdering: Ordering[ExecutionId] = Ordering.ordered[Instant](x => x).on(_.end)
   implicit val executionIdShow: Show[ExecutionId] = Show.shows {
-    case ExecutionId(index, start) => s"Query execution $index began at $start"
+    case ExecutionId(index, start, end) => s"Query execution $index began at $start and ended at $end"
   }
-  def ofRef(ref: TaskRef[Long]): Task[ExecutionId] =
-    for {
-      i <- ref.modify(_ + 1)
-      now <- Task.delay(Instant.now())
-    } yield ExecutionId(i, now)
 }
 
-final case class ExecutionTimings(timings: Map[String, (Instant, Instant)])
 final case class LabelledInterval(label: String, start: Long, size: Long) {
   def contains(other: LabelledInterval) = start < other.start && (start + size) > (other.start + size)
 }
+
+final case class ExecutionTimings(timings: Map[String, (Instant, Instant)])
+
 object ExecutionTimings {
   // Flame graph tree
   type LabelledIntervalTree = Cofree[List, LabelledInterval]
   def LabelledIntervalTree[A](head: LabelledInterval, tail: List[LabelledIntervalTree]): LabelledIntervalTree = Cofree(head, tail)
-  def toLabelledIntervalTree(executionId: ExecutionId, timings: ExecutionTimings): Option[LabelledIntervalTree] = {
+  def toLabelledIntervalTree(executionId: ExecutionId, timings: ExecutionTimings): LabelledIntervalTree = {
     def constructIntervalTree(newLabelledInterval: LabelledInterval, tree: LabelledIntervalTree): LabelledIntervalTree = {
       if (newLabelledInterval.contains(tree.head)) {
         LabelledIntervalTree(newLabelledInterval, List(tree))
@@ -141,12 +158,9 @@ object ExecutionTimings {
     }.toList
     val sortedBySize =
       asIntervalsFromStart.sortBy(-_.size)
-    sortedBySize.toNel.map {
-      case NonEmptyList(head, tail) =>
-        val initTree = LabelledIntervalTree(head, Nil)
-        val intervalTree = tail.foldRight(initTree)(constructIntervalTree)
-        intervalTree
-    }
+    val totalInterval = LabelledInterval("total", 0L, executionId.start.until(executionId.end, ChronoUnit.MILLIS))
+    val initTree = LabelledIntervalTree(totalInterval, Nil)
+    sortedBySize.foldRight(initTree)(constructIntervalTree)
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
@@ -158,29 +172,42 @@ object ExecutionTimings {
   import argonaut.Json
   def asJson(executionId: ExecutionId, tree: LabelledIntervalTree): Json = {
     @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
-    def treeToJson(in: LabelledIntervalTree): Json =
+    type PF[A] = EnvT[LabelledInterval, List, A]
+    def treeToJson(in: PF[(String, Json)]): Json =
       Json.jObjectFields(
-        "id" -> Json.jString(in.head.label),
-        "start" -> Json.jNumber(in.head.start),
-        "size" -> Json.jNumber(in.head.size),
-        "children" -> Json.jArray(in.tail.map(treeToJson))
+        "start" -> Json.jNumber(in.ask.start),
+        "size" -> Json.jNumber(in.ask.size),
+        "children" -> Json.jObjectFields(in.lower: _*)
       )
+    val subtrees =
+      Recursive[LabelledIntervalTree, PF].zygo[Json, String](tree)(_.ask.label, treeToJson)
     Json.jObjectFields(
       "id" -> Json.jObjectFields(
         "index" -> Json.jNumber(executionId.index),
         "start" -> Json.jString(executionId.start.toString)),
-      "timings" -> treeToJson(tree)
+      "timings" -> subtrees
     )
   }
 }
 
-final case class TimingRepository(recordedExecutions: Natural, repo: TaskRef[TreeMap[ExecutionId, ExecutionTimings]]) {
-  def addScope(executionId: ExecutionId, scopeId: String, start: Instant, end: Instant): Task[Unit] = {
-    repo.modify { executions =>
-      val newExecution = executions.get(executionId).fold {
-        ExecutionTimings(Map((scopeId, (start, end))))
-      } { case ExecutionTimings(timings) => ExecutionTimings(timings + ((scopeId, (start, end)))) }
-      val newExecutions = executions + ((executionId, newExecution))
+final case class SingleExecutionRef(under: TaskRef[ExecutionTimings]) {
+  def addScope(scopeId: String, start: Instant, end: Instant): Task[Unit] = {
+    under.modify {
+      case ExecutionTimings(scopes) =>
+        ExecutionTimings(scopes + ((scopeId, (start, end))))
+    }.void
+  }
+}
+
+object SingleExecutionRef {
+  def empty: Task[SingleExecutionRef] =
+   TaskRef(ExecutionTimings(Map.empty)).map(SingleExecutionRef(_))
+}
+
+final case class TimingRepository(recordedExecutions: Natural, under: TaskRef[TreeMap[ExecutionId, ExecutionTimings]]) {
+  def addExecution(executionId: ExecutionId, timings: ExecutionTimings): Task[Unit] = {
+    under.modify { executions =>
+      val newExecutions = executions + ((executionId, timings))
       val excessExecutions = java.lang.Math.max(newExecutions.size - recordedExecutions.value.toInt, 0)
       newExecutions.drop(excessExecutions)
     }.void

--- a/effect/src/main/scala/quasar/effect/ScopeExecution.scala
+++ b/effect/src/main/scala/quasar/effect/ScopeExecution.scala
@@ -143,7 +143,7 @@ object ExecutionTimings {
       asIntervalsFromStart.sortBy(-_.size)
     sortedBySize.toNel.map {
       case NonEmptyList(head, tail) =>
-        val initTree = Cofree[List, LabelledInterval](head, Nil)
+        val initTree = LabelledIntervalTree(head, Nil)
         val intervalTree = tail.foldRight(initTree)(constructIntervalTree)
         intervalTree
     }

--- a/effect/src/main/scala/quasar/effect/TimingScope.scala
+++ b/effect/src/main/scala/quasar/effect/TimingScope.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.effect
+
+import slamdata.Predef._
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import scala.collection.immutable.TreeMap
+import quasar.fp._
+import quasar.fp.numeric.Natural
+
+import scalaz._, Scalaz._
+import scalaz.concurrent.Task
+
+/** Represents the ability to create an execution scope, within which timing scopes can be created.
+  */
+trait ScopeExecution[F[_], T] {
+  def newExecution[A](executionId: ExecutionId, action: ScopeTiming[F, T] => F[A]): F[A]
+}
+
+/** Represents the ability to create a timing scope.
+  */
+trait ScopeTiming[F[_], T] {
+  def newScope[A](scopeId: String, fa: => F[A]): F[A]
+}
+
+final case class ExecutionId(index: Long, startTime: Instant)
+object ExecutionId {
+  import scala.Ordering
+  implicit val executionIdOrdering: Ordering[ExecutionId] = Ordering.ordered[Instant](x => x).on(_.startTime)
+  implicit val executionIdShow: Show[ExecutionId] = Show.shows {
+    case ExecutionId(index, start) => s"Query execution $index began at $start"
+  }
+  def ofRef(ref: TaskRef[Long]): Task[ExecutionId] =
+    for {
+      i <- ref.modify(_ + 1)
+      now <- Task.delay(Instant.now())
+    } yield ExecutionId(i, now)
+}
+
+final case class ExecutionTimings(timings: Map[String, (Instant, Instant)])
+object ExecutionTimings {
+  implicit val executionTimingsShow: Show[ExecutionTimings] = Show.show {
+    executionTimings =>
+      executionTimings.timings.map {
+        case (identifier, (start, end)) =>
+          val millisBetween = start.until(end, ChronoUnit.MILLIS)
+          Cord("phase ") ++
+          Cord(identifier) ++
+          Cord(": ") ++
+          millisBetween.show ++
+          Cord(" ms")
+      }.mkString("\n")
+  }
+}
+final case class TimingRepository(recordedExecutions: Natural, repo: TaskRef[TreeMap[ExecutionId, ExecutionTimings]]) {
+  def addScope(executionId: ExecutionId, scopeId: String, start: Instant, end: Instant): Task[Unit] = {
+    repo.modify { executions =>
+      val newExecution = executions.get(executionId).fold {
+        ExecutionTimings(Map((scopeId, (start, end))))
+      } { case ExecutionTimings(timings) => ExecutionTimings(timings + ((scopeId, (start, end)))) }
+      val newExecutions = executions + ((executionId, newExecution))
+      val excessExecutions = java.lang.Math.max(newExecutions.size - recordedExecutions.value.toInt, 0)
+      newExecutions.drop(excessExecutions)
+    }.void
+  }
+}
+
+object TimingRepository {
+  def empty(recordedExecutions: Natural): Task[TimingRepository] = {
+    TaskRef(TreeMap.empty[ExecutionId, ExecutionTimings])
+      .map(TimingRepository(recordedExecutions, _))
+  }
+}
+
+object ScopeExecution {
+  def forTask[T](repo: TimingRepository, print: String => Task[Unit]): ScopeExecution[Task, T] =
+    new ScopeExecution[Task, T] {
+      def newExecution[A](executionId: ExecutionId, action: ScopeTiming[Task, T] => Task[A]): Task[A] = {
+        for {
+          a <- action(ScopeTiming.forTask(executionId, repo))
+          repository <- repo.repo.read
+          shownTimings <- repository.get(executionId).fold(().point[Task])(timings => print(s"${executionId.shows}\n${timings.shows}"))
+        } yield a
+      }
+    }
+
+  def forFreeTask[F[_], T](repo: TimingRepository, print: String => Free[F, Unit])
+                          (implicit task: Task :<: F): ScopeExecution[Free[F, ?], T] =
+    new ScopeExecution[Free[F, ?], T] {
+      def newExecution[A](executionId: ExecutionId, action: ScopeTiming[Free[F, ?], T] => Free[F, A]): Free[F, A] = {
+        for {
+          a <- action(ScopeTiming.forFreeTask(executionId, repo))
+          repository <- Free.liftF(task(repo.repo.read))
+          shownTimings <- repository.get(executionId).fold(().point[Free[F, ?]])(timings => print(s"${executionId.shows}\n${timings.shows}"))
+        } yield a
+      }
+    }
+}
+
+object ScopeTiming {
+  def forTask[T](executionId: ExecutionId, repo: TimingRepository): ScopeTiming[Task, T] =
+    new ScopeTiming[Task, T] {
+      def newScope[A](scopeId: String, f: => Task[A]): Task[A] = {
+        for {
+          start <- Task.delay(Instant.now())
+          result <- f
+          end <- Task.delay(Instant.now())
+          _ <- repo.addScope(executionId, scopeId, start, end)
+        } yield result
+      }
+    }
+
+  def forFreeTask[F[_], T](executionId: ExecutionId, repo: TimingRepository)
+                          (implicit task: Task :<: F): ScopeTiming[Free[F, ?], T] =
+  new ScopeTiming[Free[F, ?], T] {
+    def newScope[A](scopeId: String, f: => Free[F, A]): Free[F, A] = {
+      for {
+        start <- Free.liftF(task(Task.delay(Instant.now())))
+        result <- f
+        end <- Free.liftF(task(Task.delay(Instant.now())))
+        _ <- Free.liftF(task(repo.addScope(executionId, scopeId, start, end)))
+      } yield result
+    }
+  }
+}

--- a/interface/src/main/scala/quasar/main/Caching.scala
+++ b/interface/src/main/scala/quasar/main/Caching.scala
@@ -33,7 +33,7 @@ import scalaz.concurrent.{Strategy, Task}
 import scalaz.stream.{Process, time}
 
 object Caching {
-  type Eff[A] = (Task :\: ConnectionIO :/: CoreEff)#M[A]
+  type Eff[A] = Coproduct[Task, Coproduct[ConnectionIO, CoreEff, ?], A]
 
   val QT = QueryFile.Transforms[Free[Eff, ?]]
 

--- a/it/src/test/scala/quasar/server/ServiceSpec.scala
+++ b/it/src/test/scala/quasar/server/ServiceSpec.scala
@@ -37,6 +37,7 @@ import org.specs2.matcher.MatchResult
 import pathy.Path._
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
+import eu.timepit.refined.refineMV
 
 class ServiceSpec extends quasar.Qspec {
   val schema = Schema.schema
@@ -61,7 +62,7 @@ class ServiceSpec extends quasar.Qspec {
       _          <- metastoreInit.transact(transactor).liftM[MainErrT]
       metaRef    <- TaskRef(metastore).liftM[MainErrT]
       quasarFs   <- Quasar.initWithMeta(BackendConfig.Empty, metaRef, _ => ().point[MainTask])
-      shutdown   <- Server.startServer(quasarFs.interp, port, Nil, None, _ => ().point[MainTask]).liftM[MainErrT]
+      shutdown   <- Server.startServer(quasarFs.interp, port, Nil, None, _ => ().point[MainTask], refineMV(0L), false).liftM[MainErrT]
       r          <- f(uri).onFinish(κ(shutdown.onFinish(κ(quasarFs.shutdown)))).liftM[MainErrT]
     } yield r).run.unsafePerformSync
   }

--- a/repl/src/main/scala/quasar/repl/Command.scala
+++ b/repl/src/main/scala/quasar/repl/Command.scala
@@ -25,25 +25,25 @@ import scalaz._, Scalaz._
 
 sealed abstract class Command
 object Command {
-  private val ExitPattern           = "(?i)(?:exit)|(?:quit)".r
-  private val HelpPattern           = "(?i)(?:help)|(?:commands)|\\?".r
-  private val CdPattern             = "(?i)cd(?: +(.+))?".r
-  private val NamedExprPattern      = "(?i)([^ :]+) *<- *(.+)".r
-  private val ExplainPattern        = "(?i)explain +(.+)".r
-  private val CompilePattern        = "(?i)compile +(.+)".r
-  private val SchemaPattern         = "(?i)schema +(.+)".r
-  private val LsPattern             = "(?i)ls(?: +(.+))?".r
-  private val SavePattern           = "(?i)save +([\\S]+) (.+)".r
-  private val AppendPattern         = "(?i)append +([\\S]+) (.+)".r
-  private val DeletePattern         = "(?i)rm +([\\S]+)".r
-  private val SetPhaseFormatPattern = "(?i)(?:set +)?phaseFormat *= *(tree|code)".r
-  private val PrintTimingPattern    = "(?i)(?:set +)?printTiming *= *(0|1)".r
-  private val DebugPattern          = "(?i)(?:set +)?debug *= *(0|1|2)".r
-  private val SummaryCountPattern   = "(?i)(?:set +)?summaryCount *= *(\\d+)".r
-  private val FormatPattern         = "(?i)(?:set +)?format *= *((?:table)|(?:precise)|(?:readable)|(?:csv))".r
-  private val SetVarPattern         = "(?i)(?:set +)?(\\w+) *= *(.*\\S)".r
-  private val UnsetVarPattern       = "(?i)unset +(\\w+)".r
-  private val ListVarPattern        = "(?i)env".r
+  private val ExitPattern            = "(?i)(?:exit)|(?:quit)".r
+  private val HelpPattern            = "(?i)(?:help)|(?:commands)|\\?".r
+  private val CdPattern              = "(?i)cd(?: +(.+))?".r
+  private val NamedExprPattern       = "(?i)([^ :]+) *<- *(.+)".r
+  private val ExplainPattern         = "(?i)explain +(.+)".r
+  private val CompilePattern         = "(?i)compile +(.+)".r
+  private val SchemaPattern          = "(?i)schema +(.+)".r
+  private val LsPattern              = "(?i)ls(?: +(.+))?".r
+  private val SavePattern            = "(?i)save +([\\S]+) (.+)".r
+  private val AppendPattern          = "(?i)append +([\\S]+) (.+)".r
+  private val DeletePattern          = "(?i)rm +([\\S]+)".r
+  private val SetPhaseFormatPattern  = "(?i)(?:set +)?phaseFormat *= *(tree|code)".r
+  private val SetTimingFormatPattern = "(?i)(?:set +)?timingFormat *= *(readable|total|json|nothing)".r
+  private val DebugPattern           = "(?i)(?:set +)?debug *= *(0|1|2)".r
+  private val SummaryCountPattern    = "(?i)(?:set +)?summaryCount *= *(\\d+)".r
+  private val FormatPattern          = "(?i)(?:set +)?format *= *((?:table)|(?:precise)|(?:readable)|(?:csv)|(?:nothing))".r
+  private val SetVarPattern          = "(?i)(?:set +)?(\\w+) *= *(.*\\S)".r
+  private val UnsetVarPattern        = "(?i)unset +(\\w+)".r
+  private val ListVarPattern         = "(?i)env".r
 
   final case object Exit extends Command
   final case object Help extends Command
@@ -61,34 +61,34 @@ object Command {
   final case class SummaryCount(rows: Int) extends Command
   final case class Format(format: OutputFormat) extends Command
   final case class SetPhaseFormat(format: PhaseFormat) extends Command
-  final case class PrintTiming(print: Boolean) extends Command
+  final case class SetTimingFormat(format: TimingFormat) extends Command
   final case class SetVar(name: String, value: String) extends Command
   final case class UnsetVar(name: String) extends Command
 
   def parse(input: String): Command =
     input match {
-      case ExitPattern()                 => Exit
-      case CdPattern(XDir(d))            => Cd(d)
-      case CdPattern(_)                  => Cd(rootDir.right)
-      case NamedExprPattern(name, query) => Select(Some(name), Query(query))
-      case ExplainPattern(query)         => Explain(Query(query))
-      case CompilePattern(query)         => Compile(Query(query))
-      case SchemaPattern(query)          => Schema(Query(query))
-      case LsPattern(XDir(d))            => Ls(d.some)
-      case LsPattern(_)                  => Ls(none)
-      case SavePattern(XFile(f), value)  => Save(f, value)
+      case ExitPattern()                  => Exit
+      case CdPattern(XDir(d))             => Cd(d)
+      case CdPattern(_)                   => Cd(rootDir.right)
+      case NamedExprPattern(name, query)  => Select(Some(name), Query(query))
+      case ExplainPattern(query)          => Explain(Query(query))
+      case CompilePattern(query)          => Compile(Query(query))
+      case SchemaPattern(query)           => Schema(Query(query))
+      case LsPattern(XDir(d))             => Ls(d.some)
+      case LsPattern(_)                   => Ls(none)
+      case SavePattern(XFile(f), value)   => Save(f, value)
       case AppendPattern(XFile(f), value) => Append(f, value)
-      case DeletePattern(XFile(f))       => Delete(f)
-      case DebugPattern(code)            => Debug(DebugLevel.int.unapply(code.toInt) | DebugLevel.Normal)
-      case SetPhaseFormatPattern(format) => SetPhaseFormat(PhaseFormat.fromString(format) | PhaseFormat.Tree)
-      case PrintTimingPattern(format)    => PrintTiming(if (format == "1") true else false)
-      case SummaryCountPattern(rows)     => SummaryCount(rows.toInt)
-      case FormatPattern(format)         => Format(OutputFormat.fromString(format) | OutputFormat.Table)
-      case HelpPattern()                 => Help
-      case SetVarPattern(name, value)    => SetVar(name, value)
-      case UnsetVarPattern(name)         => UnsetVar(name)
-      case ListVarPattern()              => ListVars
-      case _                             => Select(None, Query(input))
+      case DeletePattern(XFile(f))        => Delete(f)
+      case DebugPattern(code)             => Debug(DebugLevel.int.unapply(code.toInt) | DebugLevel.Normal)
+      case SetPhaseFormatPattern(format)  => SetPhaseFormat(PhaseFormat.fromString(format) | PhaseFormat.Tree)
+      case SetTimingFormatPattern(format) => SetTimingFormat(TimingFormat.fromString(format) | TimingFormat.Total)
+      case SummaryCountPattern(rows)      => SummaryCount(rows.toInt)
+      case FormatPattern(format)          => Format(OutputFormat.fromString(format) | OutputFormat.Table)
+      case HelpPattern()                  => Help
+      case SetVarPattern(name, value)     => SetVar(name, value)
+      case UnsetVarPattern(name)          => UnsetVar(name)
+      case ListVarPattern()               => ListVars
+      case _                              => Select(None, Query(input))
     }
 
   type XDir = RelDir[Unsandboxed] \/ ADir

--- a/repl/src/main/scala/quasar/repl/Command.scala
+++ b/repl/src/main/scala/quasar/repl/Command.scala
@@ -37,6 +37,7 @@ object Command {
   private val AppendPattern         = "(?i)append +([\\S]+) (.+)".r
   private val DeletePattern         = "(?i)rm +([\\S]+)".r
   private val SetPhaseFormatPattern = "(?i)(?:set +)?phaseFormat *= *(tree|code)".r
+  private val PrintTimingPattern    = "(?i)(?:set +)?printTiming *= *(0|1)".r
   private val DebugPattern          = "(?i)(?:set +)?debug *= *(0|1|2)".r
   private val SummaryCountPattern   = "(?i)(?:set +)?summaryCount *= *(\\d+)".r
   private val FormatPattern         = "(?i)(?:set +)?format *= *((?:table)|(?:precise)|(?:readable)|(?:csv))".r
@@ -60,6 +61,7 @@ object Command {
   final case class SummaryCount(rows: Int) extends Command
   final case class Format(format: OutputFormat) extends Command
   final case class SetPhaseFormat(format: PhaseFormat) extends Command
+  final case class PrintTiming(print: Boolean) extends Command
   final case class SetVar(name: String, value: String) extends Command
   final case class UnsetVar(name: String) extends Command
 
@@ -79,6 +81,7 @@ object Command {
       case DeletePattern(XFile(f))       => Delete(f)
       case DebugPattern(code)            => Debug(DebugLevel.int.unapply(code.toInt) | DebugLevel.Normal)
       case SetPhaseFormatPattern(format) => SetPhaseFormat(PhaseFormat.fromString(format) | PhaseFormat.Tree)
+      case PrintTimingPattern(format)    => PrintTiming(if (format == "1") true else false)
       case SummaryCountPattern(rows)     => SummaryCount(rows.toInt)
       case FormatPattern(format)         => Format(OutputFormat.fromString(format) | OutputFormat.Table)
       case HelpPattern()                 => Help

--- a/repl/src/main/scala/quasar/repl/Command.scala
+++ b/repl/src/main/scala/quasar/repl/Command.scala
@@ -37,7 +37,7 @@ object Command {
   private val AppendPattern          = "(?i)append +([\\S]+) (.+)".r
   private val DeletePattern          = "(?i)rm +([\\S]+)".r
   private val SetPhaseFormatPattern  = "(?i)(?:set +)?phaseFormat *= *(tree|code)".r
-  private val SetTimingFormatPattern = "(?i)(?:set +)?timingFormat *= *(readable|total|json|nothing)".r
+  private val SetTimingFormatPattern = "(?i)(?:set +)?timingFormat *= *(tree|onlytotal|json|nothing)".r
   private val DebugPattern           = "(?i)(?:set +)?debug *= *(0|1|2)".r
   private val SummaryCountPattern    = "(?i)(?:set +)?summaryCount *= *(\\d+)".r
   private val FormatPattern          = "(?i)(?:set +)?format *= *((?:table)|(?:precise)|(?:readable)|(?:csv)|(?:nothing))".r
@@ -81,7 +81,7 @@ object Command {
       case DeletePattern(XFile(f))        => Delete(f)
       case DebugPattern(code)             => Debug(DebugLevel.int.unapply(code.toInt) | DebugLevel.Normal)
       case SetPhaseFormatPattern(format)  => SetPhaseFormat(PhaseFormat.fromString(format) | PhaseFormat.Tree)
-      case SetTimingFormatPattern(format) => SetTimingFormat(TimingFormat.fromString(format) | TimingFormat.Total)
+      case SetTimingFormatPattern(format) => SetTimingFormat(TimingFormat.fromString(format) | TimingFormat.OnlyTotal)
       case SummaryCountPattern(rows)      => SummaryCount(rows.toInt)
       case FormatPattern(format)          => Format(OutputFormat.fromString(format) | OutputFormat.Table)
       case HelpPattern()                  => Help

--- a/repl/src/main/scala/quasar/repl/Main.scala
+++ b/repl/src/main/scala/quasar/repl/Main.scala
@@ -114,7 +114,7 @@ object Main {
     S5: FileSystemFailure :<: S
   ): Task[Command => Free[DriverEff, Unit]] = {
     for {
-      stateRef <- TaskRef(Repl.RunState(rootDir, DebugLevel.Normal, PhaseFormat.Tree, refineMV[Positive](10).some, OutputFormat.Table, Map(), TimingFormat.Total))
+      stateRef <- TaskRef(Repl.RunState(rootDir, DebugLevel.Normal, PhaseFormat.Tree, refineMV[Positive](10).some, OutputFormat.Table, Map(), TimingFormat.OnlyTotal))
       executionIdRef <- TaskRef(0L)
       timingRepository <- TimingRepository.empty(refineMV(1))
       i =
@@ -128,9 +128,9 @@ object Main {
       val timingPrint = (id: ExecutionId, timings: ExecutionTimings) => for {
         state <- Free.liftF(Inject[Task, ReplEff[S, ?]].inj(stateRef.read))
         _ <- state.timingFormat match {
-          case TimingFormat.Nothing | TimingFormat.Total =>
+          case TimingFormat.Nothing | TimingFormat.OnlyTotal =>
             ().point[Free[ReplEff[S, ?], ?]]
-          case TimingFormat.Readable =>
+          case TimingFormat.Tree =>
             val timingTree =
               ExecutionTimings.render(ExecutionTimings.toLabelledIntervalTree(id, timings)).shows
             Free.liftF(Inject[ConsoleIO, ReplEff[S, ?]].inj(ConsoleIO.PrintLn(timingTree)))

--- a/repl/src/main/scala/quasar/repl/Main.scala
+++ b/repl/src/main/scala/quasar/repl/Main.scala
@@ -113,16 +113,25 @@ object Main {
     S4: ManageFile :<: S,
     S5: FileSystemFailure :<: S
   ): Task[Command => Free[DriverEff, Unit]] = {
-    TaskRef(Repl.RunState(rootDir, DebugLevel.Normal, PhaseFormat.Tree, refineMV[Positive](10).some, OutputFormat.Table, Map())).map { ref =>
-      val i: ReplEff[S, ?] ~> DriverEffM =
-        injectFT[Task, DriverEff].compose(AtomicRef.fromTaskRef(ref)) :+:
+    for {
+      stateRef <- TaskRef(Repl.RunState(rootDir, DebugLevel.Normal, PhaseFormat.Tree, refineMV[Positive](10).some, OutputFormat.Table, Map(), false))
+      executionIdRef <- TaskRef(0L)
+      timingRepository <- TimingRepository.empty(refineMV(1))
+      i =
+        injectFT[Task, DriverEff].compose(AtomicRef.fromTaskRef(stateRef)) :+:
         injectFT[ConsoleIO, DriverEff]                                :+:
         injectFT[ReplFail, DriverEff]                                 :+:
         injectFT[Task, DriverEff].compose(Timing.toTask)              :+:
         injectFT[Task, DriverEff]                                     :+:
         fs
-
-      (cmd => Repl.command[ReplEff[S, ?]](cmd).foldMap(i))
+    } yield {
+      val timingPrint = (in: String) => for {
+        state <- Free.liftF(Inject[Task, ReplEff[S, ?]].inj(stateRef.read))
+        _ <- if (state.printTiming) Free.liftF(Inject[ConsoleIO, ReplEff[S, ?]].inj(ConsoleIO.PrintLn(in)))
+             else ().point[Free[ReplEff[S, ?], ?]]
+      } yield ()
+      implicit val SE = ScopeExecution.forFreeTask[ReplEff[S, ?], Nothing](timingRepository, timingPrint)
+      (cmd => Repl.command[ReplEff[S, ?], Nothing](cmd, executionIdRef).foldMap(i))
     }
   }
 

--- a/repl/src/main/scala/quasar/repl/Main.scala
+++ b/repl/src/main/scala/quasar/repl/Main.scala
@@ -114,7 +114,7 @@ object Main {
     S5: FileSystemFailure :<: S
   ): Task[Command => Free[DriverEff, Unit]] = {
     for {
-      stateRef <- TaskRef(Repl.RunState(rootDir, DebugLevel.Normal, PhaseFormat.Tree, refineMV[Positive](10).some, OutputFormat.Table, Map(), false))
+      stateRef <- TaskRef(Repl.RunState(rootDir, DebugLevel.Normal, PhaseFormat.Tree, refineMV[Positive](10).some, OutputFormat.Table, Map(), TimingFormat.Total))
       executionIdRef <- TaskRef(0L)
       timingRepository <- TimingRepository.empty(refineMV(1))
       i =
@@ -125,10 +125,22 @@ object Main {
         injectFT[Task, DriverEff]                                     :+:
         fs
     } yield {
-      val timingPrint = (in: String) => for {
+      val timingPrint = (id: ExecutionId, timings: ExecutionTimings) => for {
         state <- Free.liftF(Inject[Task, ReplEff[S, ?]].inj(stateRef.read))
-        _ <- if (state.printTiming) Free.liftF(Inject[ConsoleIO, ReplEff[S, ?]].inj(ConsoleIO.PrintLn(in)))
-             else ().point[Free[ReplEff[S, ?], ?]]
+        _ <- state.timingFormat match {
+          case TimingFormat.Nothing | TimingFormat.Total =>
+            ().point[Free[ReplEff[S, ?], ?]]
+          case TimingFormat.Readable =>
+            val flameGraph =
+              ExecutionTimings.toLabelledIntervalTree(id, timings)
+                .cata(ExecutionTimings.render(_).shows, "timing information not available")
+            Free.liftF(Inject[ConsoleIO, ReplEff[S, ?]].inj(ConsoleIO.PrintLn(flameGraph)))
+          case TimingFormat.Json =>
+            val renderedJson =
+              ExecutionTimings.toLabelledIntervalTree(id, timings)
+                .cata(ExecutionTimings.asJson(id, _).nospaces, "timing information not available")
+            Free.liftF(Inject[ConsoleIO, ReplEff[S, ?]].inj(ConsoleIO.PrintLn(renderedJson)))
+        }
       } yield ()
       implicit val SE = ScopeExecution.forFreeTask[ReplEff[S, ?], Nothing](timingRepository, timingPrint)
       (cmd => Repl.command[ReplEff[S, ?], Nothing](cmd, executionIdRef).foldMap(i))

--- a/repl/src/main/scala/quasar/repl/Main.scala
+++ b/repl/src/main/scala/quasar/repl/Main.scala
@@ -131,14 +131,12 @@ object Main {
           case TimingFormat.Nothing | TimingFormat.Total =>
             ().point[Free[ReplEff[S, ?], ?]]
           case TimingFormat.Readable =>
-            val flameGraph =
-              ExecutionTimings.toLabelledIntervalTree(id, timings)
-                .cata(ExecutionTimings.render(_).shows, "timing information not available")
-            Free.liftF(Inject[ConsoleIO, ReplEff[S, ?]].inj(ConsoleIO.PrintLn(flameGraph)))
+            val timingTree =
+              ExecutionTimings.render(ExecutionTimings.toLabelledIntervalTree(id, timings)).shows
+            Free.liftF(Inject[ConsoleIO, ReplEff[S, ?]].inj(ConsoleIO.PrintLn(timingTree)))
           case TimingFormat.Json =>
             val renderedJson =
-              ExecutionTimings.toLabelledIntervalTree(id, timings)
-                .cata(ExecutionTimings.asJson(id, _).nospaces, "timing information not available")
+              ExecutionTimings.asJson(id, ExecutionTimings.toLabelledIntervalTree(id, timings)).nospaces
             Free.liftF(Inject[ConsoleIO, ReplEff[S, ?]].inj(ConsoleIO.PrintLn(renderedJson)))
         }
       } yield ()

--- a/repl/src/main/scala/quasar/repl/Repl.scala
+++ b/repl/src/main/scala/quasar/repl/Repl.scala
@@ -74,7 +74,7 @@ object Repl {
       |  rm [path]
       |  set debug = 0 | 1 | 2
       |  set phaseFormat = tree | code
-      |  set timingFormat = json | readable | total | nothing
+      |  set timingFormat = json | tree | onlytotal | nothing
       |  set summaryCount = [rows]
       |  set format = table | precise | readable | csv | nothing
       |  set [var] = [value]
@@ -155,7 +155,7 @@ object Repl {
           case  \/-(-\/ (fsErr)) => DF.fail(fsErr.shows)
           case  \/-( \/-(a))     =>
             (state.timingFormat match {
-              case TimingFormat.Total => P.println(f"Query time: ${elapsed.toMillis/1000.0}%.1fs")
+              case TimingFormat.OnlyTotal => P.println(f"Query time: ${elapsed.toMillis/1000.0}%.1fs")
               case _ => ().point[Free[S, ?]]
             }) *> f(a)
         }

--- a/repl/src/main/scala/quasar/repl/Repl.scala
+++ b/repl/src/main/scala/quasar/repl/Repl.scala
@@ -74,9 +74,9 @@ object Repl {
       |  rm [path]
       |  set debug = 0 | 1 | 2
       |  set phaseFormat = tree | code
-      |  set printTiming = true | false
+      |  set timingFormat = json | readable | total | nothing
       |  set summaryCount = [rows]
-      |  set format = table | precise | readable | csv
+      |  set format = table | precise | readable | csv | nothing
       |  set [var] = [value]
       |  env""".stripMargin
 
@@ -88,7 +88,7 @@ object Repl {
     summaryCount: Option[Int Refined Positive],
     format:       OutputFormat,
     variables:    Map[String, String],
-    printTiming:  Boolean) {
+    timingFormat: TimingFormat) {
 
   def targetDir(path: Option[XDir]): ADir =
     path match {
@@ -154,8 +154,10 @@ object Repl {
           case -\/ (semErr)      => DF.fail(semErr.list.map(_.shows).toList.mkString("; "))
           case  \/-(-\/ (fsErr)) => DF.fail(fsErr.shows)
           case  \/-( \/-(a))     =>
-            P.println(f"Query time: ${elapsed.toMillis/1000.0}%.1fs") *>
-              f(a)
+            (state.timingFormat match {
+              case TimingFormat.Total => P.println(f"Query time: ${elapsed.toMillis/1000.0}%.1fs")
+              case _ => ().point[Free[S, ?]]
+            }) *> f(a)
         }
       } yield ()
 
@@ -202,9 +204,9 @@ object Repl {
         RS.modify(_.copy(phaseFormat = fmt)) *>
           P.println(s"Set phase format: $fmt")
 
-      case PrintTiming(print) =>
-        RS.modify(_.copy(printTiming = print)) *>
-          P.println(s"Set print timing: $print")
+      case SetTimingFormat(fmt) =>
+        RS.modify(_.copy(timingFormat = fmt)) *>
+          P.println(s"Set timing format: $fmt")
 
       case SetVar(n, v) =>
         RS.modify(state => state.copy(variables = state.variables + (n -> v))).void
@@ -242,7 +244,7 @@ object Repl {
       case Select(n, q) =>
         Free.liftF(S3(ExecutionId.ofRef(executionIdRef))).flatMap(id => SE.newExecution[Unit](id, { ST =>
           ST.newScope(
-            "total query pipeline (REPL)",
+            "total (REPL)",
             for {
               state <- RS.get
               expr  <- ST.newScope("parse SQL", DF.unattempt_(sql.fixParser.parse(q.value).leftMap(_.message)))
@@ -252,18 +254,18 @@ object Repl {
                          {
                            val out = state.cwd </> file(name)
                            for {
-                             query <- ST.newScope("plan query",
+                             query <- ST.newScope("plan",
                                fsQ.executeQuery(block, Variables.fromMap(state.variables), state.cwd, out).pure[Free[S, ?]])
-                             results <- ST.newScope("evaluate query",
+                             results <- ST.newScope("evaluate",
                               runQuery(state, query)(κ(P.println("Wrote file: " + posixCodec.printPath(out)))))
                            } yield results
                          },
                          {
                            for {
-                             query <- ST.newScope("plan query",
+                             query <- ST.newScope("plan",
                                fsQ.queryResults(block, vars, state.cwd, 0L, state.summaryCount.map(widenPositive[Refined, _0]))
                                  .map(_.toVector).pure[Free[S, ?]])
-                             results <- ST.newScope("evaluate query",
+                             results <- ST.newScope("evaluate",
                               runQuery(state, query)(ds => summarize[S](state.summaryCount.map(_.value), state.format)(ds)))
                            } yield results
                          })
@@ -381,6 +383,8 @@ object Repl {
           prefix.map(formatJson(DataCodec.Readable)).unite
         case OutputFormat.Csv =>
           Prettify.renderValues(prefix).map(CsvWriter(none)(_).trim)
+        case OutputFormat.Nothing =>
+          Nil
       }).foldMap(P.println) *>
         (if (max.fold(false)(rows.lengthCompare(_) > 0)) P.println("...")
         else ().point[Free[S, ?]])

--- a/repl/src/main/scala/quasar/repl/TimingFormat.scala
+++ b/repl/src/main/scala/quasar/repl/TimingFormat.scala
@@ -20,19 +20,17 @@ import slamdata.Predef._
 
 import scalaz._, Scalaz._
 
-sealed abstract class OutputFormat
-object OutputFormat {
-  case object Table extends OutputFormat
-  case object Precise extends OutputFormat
-  case object Readable extends OutputFormat
-  case object Csv extends OutputFormat
-  case object Nothing extends OutputFormat
+sealed abstract class TimingFormat
+object TimingFormat {
+  case object Json extends TimingFormat
+  case object Readable extends TimingFormat
+  case object Total extends TimingFormat
+  case object Nothing extends TimingFormat
 
-  def fromString(str: String): Option[OutputFormat] = str.toLowerCase match {
-    case "table"    => Table.some
-    case "precise"  => Precise.some
+  def fromString(str: String): Option[TimingFormat] = str.toLowerCase match {
+    case "json"     => Json.some
     case "readable" => Readable.some
-    case "csv"      => Csv.some
+    case "total"    => Total.some
     case "nothing"  => Nothing.some
     case _          => none
   }

--- a/repl/src/main/scala/quasar/repl/TimingFormat.scala
+++ b/repl/src/main/scala/quasar/repl/TimingFormat.scala
@@ -22,9 +22,13 @@ import scalaz._, Scalaz._
 
 sealed abstract class TimingFormat
 object TimingFormat {
+  // Print timing data as JSON
   case object Json extends TimingFormat
+  // Print timing data as a RenderedTree
   case object Tree extends TimingFormat
+  // Only include the total time
   case object OnlyTotal extends TimingFormat
+  // Print no timing data
   case object Nothing extends TimingFormat
 
   def fromString(str: String): Option[TimingFormat] = str.toLowerCase match {

--- a/repl/src/main/scala/quasar/repl/TimingFormat.scala
+++ b/repl/src/main/scala/quasar/repl/TimingFormat.scala
@@ -23,15 +23,15 @@ import scalaz._, Scalaz._
 sealed abstract class TimingFormat
 object TimingFormat {
   case object Json extends TimingFormat
-  case object Readable extends TimingFormat
-  case object Total extends TimingFormat
+  case object Tree extends TimingFormat
+  case object OnlyTotal extends TimingFormat
   case object Nothing extends TimingFormat
 
   def fromString(str: String): Option[TimingFormat] = str.toLowerCase match {
-    case "json"     => Json.some
-    case "readable" => Readable.some
-    case "total"    => Total.some
-    case "nothing"  => Nothing.some
-    case _          => none
+    case "json"      => Json.some
+    case "tree"      => Tree.some
+    case "onlytotal" => OnlyTotal.some
+    case "nothing"   => Nothing.some
+    case _           => none
   }
 }

--- a/web/src/main/scala/quasar/server/CliOptions.scala
+++ b/web/src/main/scala/quasar/server/CliOptions.scala
@@ -118,7 +118,7 @@ object CliOptions {
     } text("the port to run Quasar on")
 
     opt[Int]('x', "recorded-executions") validate { x =>
-      if (x < 0) Left(s"Recorded executions must be negative, but are set to $x")
+      if (x < 0) Left(s"Recorded executions must not be negative, but is set to $x")
       else Right(())
     } action { (x, c) =>
       (l composeLens recordedExecutions).set(RefType[Refined].unsafeWrap(x.toLong))(c)

--- a/web/src/main/scala/quasar/server/Server.scala
+++ b/web/src/main/scala/quasar/server/Server.scala
@@ -128,8 +128,7 @@ object Server {
     val printAction = { (id: ExecutionId, timings: ExecutionTimings) =>
       if (printExecutions) {
         Free.liftF(Inject[Task, CoreEffIORW].inj(Task.delay(println(
-          ExecutionTimings.toLabelledIntervalTree(id, timings)
-            .cata(ExecutionTimings.render(_).shows, "timing information not available")
+          ExecutionTimings.render(ExecutionTimings.toLabelledIntervalTree(id, timings)).shows
         ))))
       } else {
         ().point[Free[CoreEffIORW, ?]]

--- a/web/src/main/scala/quasar/server/Server.scala
+++ b/web/src/main/scala/quasar/server/Server.scala
@@ -25,9 +25,10 @@ import quasar.console.{logErrors, stdout}
 import quasar.contrib.scalaz._
 import quasar.contrib.scopt._
 import quasar.db.DbConnectionConfig
-import quasar.effect.{Read, Write}
+import quasar.effect.{Read, ScopeExecution, TimingRepository, Write}
 import quasar.fp._
 import quasar.fp.free._
+import quasar.fp.numeric.Natural
 import quasar.fs.mount.cache.VCache, VCache.{VCacheExpR, VCacheExpW}
 import quasar.main._
 import quasar.server.Http4sUtils.{openBrowser, waitForUserEnter}
@@ -48,7 +49,9 @@ object Server {
       port: Option[Int],
       configPath: Option[FsFile],
       loadConfig: BackendConfig,
-      openClient: Boolean) {
+      openClient: Boolean,
+      recordedExecutions: Natural,
+      printExecutions: Boolean) {
 
     def toCmdLineConfig: CmdLineConfig = CmdLineConfig(configPath, loadConfig, cmd)
   }
@@ -76,7 +79,7 @@ object Server {
             .map(some)) ⊛
         loadConfigM.liftM[MainErrT]) ((content, cfgPath, loadConfig) =>
         WebCmdLineConfig(
-          opts.cmd, content.toList, content.map(_.loc), opts.port, cfgPath, loadConfig, opts.openClient))
+          opts.cmd, content.toList, content.map(_.loc), opts.port, cfgPath, loadConfig, opts.openClient, opts.recordedExecutions, true))
     }
   }
 
@@ -103,8 +106,10 @@ object Server {
     staticContent: List[StaticContent],
     redirect: Option[String],
     eval: CoreEff ~> QErrs_CRW_TaskM,
-    persistPortChange: Int => MainTask[Unit]
-  ): PortChangingServer.ServiceStarter = {
+    persistPortChange: Int => MainTask[Unit],
+    recordedExecutions: Natural,
+    printExecutions: Boolean
+  ): Task[PortChangingServer.ServiceStarter] = {
     import RestApi._
 
     def interp: Task[CoreEffIORW ~> ResponseOr] =
@@ -120,15 +125,25 @@ object Server {
           injectFT[Task, QErrs_CRW_Task]       :+:
           eval))
 
-    (reload: Int => Task[String \/ Unit]) =>
-    finalizeServices(
-      toHttpServicesF[CoreEffIORW](
-        λ[Free[CoreEffIORW, ?] ~> ResponseOr] { fa =>
-          interp.liftM[ResponseT] >>= (fa foldMap _)
-        },
-        coreServices[CoreEffIORW]
-      ) ++ additionalServices
-    ) orElse nonApiService(defaultPort, Kleisli(persistPortChange andThen (a => a.run)) >> Kleisli(reload), staticContent, redirect)
+    val printAction = (s: String) =>
+      Free.liftF(Inject[Task, CoreEffIORW].inj(if (printExecutions) Task.delay(println(s)) else ().point[Task]))
+    for {
+      scopeExecution <- TimingRepository.empty(recordedExecutions).map(
+        ScopeExecution.forFreeTask[CoreEffIORW, Nothing](_, printAction)
+      )
+      executionIdRef <- TaskRef(0L)
+    } yield {
+      implicit val _ = scopeExecution
+      (reload: Int => Task[String \/ Unit]) =>
+        finalizeServices(
+          toHttpServicesF[CoreEffIORW](
+            λ[Free[CoreEffIORW, ?] ~> ResponseOr] { fa =>
+              interp.liftM[ResponseT] >>= (fa foldMap _)
+            },
+            coreServices[CoreEffIORW, Nothing](executionIdRef)
+          ) ++ additionalServices
+        ) orElse nonApiService(defaultPort, Kleisli(persistPortChange andThen (a => a.run)) >> Kleisli(reload), staticContent, redirect)
+    }
   }
 
   /**
@@ -140,11 +155,15 @@ object Server {
     port: Int,
     staticContent: List[StaticContent],
     redirect: Option[String],
-    persistPortChange: Int => MainTask[Unit]
+    persistPortChange: Int => MainTask[Unit],
+    recordedExecutions: Natural,
+    printExecutions: Boolean
   ): Task[Task[Unit]] =
-    PortChangingServer.start(
-      initialPort = port,
-      serviceStarter(defaultPort = port, staticContent, redirect, quasarInter, persistPortChange))
+    for {
+      starter <- serviceStarter(defaultPort = port, staticContent, redirect, quasarInter, persistPortChange, recordedExecutions, printExecutions)
+      shutdown <- PortChangingServer.start(initialPort = port, starter)
+    } yield shutdown
+
 
   def persistMetaStore(configPath: Option[FsFile]): DbConnectionConfig => MainTask[Unit] =
     persistWebConfig(configPath, conn => _.copy(metastore = MetaStoreConfig(conn).some))
@@ -178,7 +197,14 @@ object Server {
                val port = webCmdLineCfg.port | wCfg.server.port
                val persistPort = persistPortChange(webCmdLineCfg.configPath)
                (for {
-                 shutdown <- startServer(quasarInter, port, webCmdLineCfg.staticContent, webCmdLineCfg.redirect, persistPort)
+                 shutdown <- startServer(
+                  quasarInter,
+                  port,
+                  webCmdLineCfg.staticContent,
+                  webCmdLineCfg.redirect,
+                  persistPort,
+                  webCmdLineCfg.recordedExecutions,
+                  webCmdLineCfg.printExecutions)
                  _        <- openBrowser(port).whenM(webCmdLineCfg.openClient)
                  _        <- stdout("Press Enter to stop.")
                  // If user pressed enter (after this main thread has been blocked on it),

--- a/web/src/test/scala/quasar/api/services/VCacheFixture.scala
+++ b/web/src/test/scala/quasar/api/services/VCacheFixture.scala
@@ -48,16 +48,14 @@ trait VCacheFixture extends H2MetaStoreFixture {
   type Eff[A]  = Coproduct[Task, Eff0, A]
   type EffM[A] = Free[Eff, A]
 
-  type ViewEff[A] = (
-    PathMismatchFailure :\:
-    MountingFailure     :\:
-    Mounting            :\:
-    view.State          :\:
-    MonotonicSeq        :\:
-    VCacheExpR          :\:
-    VCacheExpW          :/:
-    Eff
-  )#M[A]
+  type ViewEff[A] =
+    Coproduct[PathMismatchFailure,
+      Coproduct[MountingFailure,
+        Coproduct[Mounting,
+          Coproduct[view.State,
+            Coproduct[MonotonicSeq,
+              Coproduct[VCacheExpR,
+                Coproduct[VCacheExpW, Eff, ?], ?], ?], ?], ?], ?], A]
 
   val vcacheInterp: Task[VCacheKVS ~> Task] = KeyValueStore.impl.default[AFile, ViewCache]
 

--- a/web/src/test/scala/quasar/api/services/query/ExecuteServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/query/ExecuteServiceSpec.scala
@@ -27,6 +27,7 @@ import quasar.common.{Map => _, _}
 import quasar.contrib.pathy._, PathArbitrary._
 import quasar.contrib.scalaz.catchable._
 import quasar.DateArbitrary._
+import quasar.effect.ScopeExecution
 import quasar.fp._
 import quasar.fp.free.{foldMapNT, injectNT, liftFT}
 import quasar.fp.ski._
@@ -71,6 +72,9 @@ class ExecuteServiceSpec extends quasar.Qspec with FileSystemFixture with Http4s
 
   val lpf = new LogicalPlanR[Fix[LogicalPlan]]
 
+  implicit val scopeExecutionViewEff: ScopeExecution[Free[ViewEff, ?], Nothing] =
+    ScopeExecution.ignore[Free[ViewEff, ?], Nothing]
+
   def executeServiceRef(
     mem: InMemState,
     f: QueryFile ~> Free[QueryFile, ?],
@@ -78,7 +82,7 @@ class ExecuteServiceSpec extends quasar.Qspec with FileSystemFixture with Http4s
   ): (Service[Request, Response], Task[InMemState]) = {
     val (inter, ref) = inMemFSWebInspect(mem, MountingsConfig(mounts)).unsafePerformSync
     val finalInter = free.transformIn(f andThen foldMapNT(injectNT[QueryFile, CoreEffIO] andThen inter), inter)
-    val svc = execute.service[CoreEffIO].toHttpService(finalInter).orNotFound
+    val svc = execute.service[CoreEffIO, Nothing](executionIdRef).toHttpService(finalInter).orNotFound
 
     (svc, ref.map{ case (mem, _) => mem })
   }
@@ -171,7 +175,7 @@ class ExecuteServiceSpec extends quasar.Qspec with FileSystemFixture with Http4s
           val (resp, vc) = evalViewTest(now, mounts, InMemState.empty) { (it, ir) =>
             (for {
               _ <- vcache.put(f, viewCache)
-              a <- VCacheMiddleware(execute.service[ViewEff]).apply(
+              a <- VCacheMiddleware(execute.service[ViewEff, Nothing](executionIdRef)).apply(
                      Request(uri = (pathUri(f) / "").copy(query =
                        http4s.Query.fromPairs(
                          "q" -> s"select * from `../${fileName(f).value}`"))))
@@ -202,7 +206,7 @@ class ExecuteServiceSpec extends quasar.Qspec with FileSystemFixture with Http4s
           val (resp, vc) = evalViewTest(now, mounts, InMemState.empty) { (it, ir) =>
             (for {
               _ <- vcache.put(f, viewCache)
-              a <- VCacheMiddleware(execute.service[ViewEff]).apply(
+              a <- VCacheMiddleware(execute.service[ViewEff, Nothing](executionIdRef)).apply(
                 Request(uri = (pathUri(f) / "").copy(query =
                   http4s.Query.fromPairs(
                     "q" -> s"select * from `../${fileName(f).value}`"))))


### PR DESCRIPTION
Makes the REPL friendly to automation by allowing us to turn off the default timing information and not print results, so we don't have to filter it out in a script running the REPL. Also makes the "readable" timing info more readable.

Depends on #3348.