### PR TITLE
Disable test for PostgreSQL

### DIFF
--- a/it/src/main/resources/tests/qa/s01_simple_selects/select_single_field.test
+++ b/it/src/main/resources/tests/qa/s01_simple_selects/select_single_field.test
@@ -3,6 +3,10 @@
 
   "data": "basic.data",
 
+  "backends": {
+    "postgres": "pending"
+  },
+
   "query": "select num from basic",
 
   "predicate": "exactly",


### PR DESCRIPTION
This is an unresolved issue on PostgreSQL. When we select a single field (without alias), it will be projected into a column anyway, because all results are represented as rows and columns. We need to figure out if we can detect such cases in the planner and use some magic json keys (apparently MongoDB planner went through similiar issue).