### PR TITLE
minor updates to union tests

### DIFF
--- a/it/src/main/resources/tests/qa/s06_union/columns_self_union.test
+++ b/it/src/main/resources/tests/qa/s06_union/columns_self_union.test
@@ -2,15 +2,11 @@
   "name": "[qa_s06] select columns self union",
 
   "backends": {
-    "mimir": "ignoreResultOrder",
-    "mongodb_3_2": "ignoreResultOrder",
-    "mongodb_3_4": "ignoreResultOrder",
-    "mongodb_read_only": "ignoreResultOrder"
   },
 
   "data": "simple_union.data",
 
-  "query": "select a as a from simple_union union select to_string(b) as a from simple_union",
+  "query": "select * from (select a as a from simple_union union select to_string(b) as a from simple_union) order by a desc",
 
   "predicate": "exactly",
 

--- a/it/src/main/resources/tests/qa/s06_union/self_union.test
+++ b/it/src/main/resources/tests/qa/s06_union/self_union.test
@@ -2,14 +2,11 @@
   "name": "[qa_s06] select all self union",
 
   "backends": {
-    "mimir": "ignoreResultOrder",
-    "marklogic_json": "ignoreResultOrder",
-    "marklogic_xml": "ignoreResultOrder"
   },
 
   "data": "simple_union.data",
 
-  "query": "select * from simple_union union select * from simple_union",
+  "query": "select * from (select * from simple_union union select * from simple_union) order by a",
 
   "predicate": "exactly",
 

--- a/it/src/main/resources/tests/qa/s06_union/simple_union.test
+++ b/it/src/main/resources/tests/qa/s06_union/simple_union.test
@@ -2,13 +2,11 @@
   "name": "[qa_s06] simple union",
 
   "backends": {
-    "marklogic_json": "ignoreResultOrder",
-    "marklogic_xml": "ignoreResultOrder"
   },
 
   "data": ["simple_union.data", "simple_union2.data"],
 
-  "query": "select * from simple_union union select * from simple_union2",
+  "query": "select * from (select * from simple_union union select * from simple_union2) order by b",
 
   "predicate": "exactly",
 

--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/postgres/planner/PostgresRenderQuery.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/postgres/planner/PostgresRenderQuery.scala
@@ -110,7 +110,7 @@ object PostgresRenderQuery extends RenderQuery {
             s"->${midTail.map(e => s"$e").intercalate("->")}"
           else
             ""
-          s"""$key."$firstValStripped"$midStr->$last""".right
+          s"""$key."$firstValStripped from"$midStr->$last""".right
         case _ => InternalError.fromMsg(s"Cannot process Refs($srcs)").left
       }
     case Obj(m) =>
@@ -177,7 +177,7 @@ object PostgresRenderQuery extends RenderQuery {
 
       val fromExpr = s" from ${from.v._2} ${from.alias.v}"
       s"(select ${selection.v._2}$fromExpr$filter$orderByStr)".right
-    case Union((_, left), (_, right)) => s"($left) UNION ($right)".right
+    case Union((_, left), (_, right)) => s"($left UNION $right)".right
     case Constant(Data.Str(v)) =>
       val text = v.flatMap { case ''' => "''"; case iv => iv.toString }.self
       s"'$text'".right


### PR DESCRIPTION
Avoid the `ignoreResultOrder` flag by using explicit ordering.