### PR TITLE
Improve warning message when failing to load filesystem mount

### DIFF
--- a/connector/src/main/scala/quasar/fs/mount/BackendDef.scala
+++ b/connector/src/main/scala/quasar/fs/mount/BackendDef.scala
@@ -32,7 +32,7 @@ import BackendDef._
 final case class BackendDef[F[_]](run: FsCfg => Option[DefErrT[F, DefinitionResult[F]]]) {
   def apply(typ: FileSystemType, uri: ConnectionUri)(implicit F: Monad[F]): DefErrT[F, DefinitionResult[F]] =
     run((typ, uri)).getOrElse(NonEmptyList(
-      s"Unsupported filesystem type: ${typ.value}"
+      s"Unsupported filesystem type: ${typ.value}, are you sure you enabled the appropriate plugin?"
     ).left[EnvironmentError].raiseError[DefErrT[F, ?], DefinitionResult[F]])
 
   def orElse(other: => BackendDef[F]): BackendDef[F] =


### PR DESCRIPTION
Provide suggestion that perhaps a required plugin is not enabled. This is after both Doug and Nic (which are both "power-users" were initially confused at what could be the problem)