### PR TITLE
Apparently it's important to USE values you create...

### DIFF
--- a/connector/src/main/scala/quasar/qscript/qsu/minimizers/CollapseShifts.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/minimizers/CollapseShifts.scala
@@ -286,7 +286,7 @@ final class CollapseShifts[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] pr
                 func.ProjectKeyS(accessHoleLeftF, OriginalField)),
               func.MakeMapS(ResultsField, repair2))
 
-            updateGraph[T, G](QSU.MultiLeftShift[T, Symbol](src.root, shifts2, repair2)) map { rewritten =>
+            updateGraph[T, G](QSU.MultiLeftShift[T, Symbol](src.root, shifts2, repair3)) map { rewritten =>
               rewritten :++ src
             }
         }


### PR DESCRIPTION
We were not creating the expected structure in a particular (not-uncommon) `LeftShift` collapse case, just because we weren't actually using a variable where the structure existed.