### PR TITLE
Extract "filtering" Cond expressions in addition to Guards

### DIFF
--- a/connector/src/main/scala/quasar/qscript/MapFuncCore.scala
+++ b/connector/src/main/scala/quasar/qscript/MapFuncCore.scala
@@ -342,6 +342,14 @@ object MapFuncCore {
           if index.isValidInt =>
         as.lift(index.intValue).map(_.project)
 
+      case ProjectIndex(
+        ExtractFunc(Cond(cond, Embed(StaticArrayPrefix(consArr)), Embed(StaticArrayPrefix(altArr)))),
+        ExtractFunc(Constant(Embed(EX(ejson.Int(index))))))
+          if index.isValidInt =>
+        (consArr.lift(index.intValue) |@| altArr.lift(index.intValue)) {
+          case (cons, alt) => rollMF[T, A](MFC(Cond(cond, cons, alt)))
+        }
+
       case ProjectKey(
         Embed(StaticMap(map)),
         ExtractFunc(Constant(key))) =>

--- a/connector/src/main/scala/quasar/qscript/MapFuncCore.scala
+++ b/connector/src/main/scala/quasar/qscript/MapFuncCore.scala
@@ -331,7 +331,7 @@ object MapFuncCore {
 
       // TODO: Generalize this to `StaticMapSuffix`.
       case DeleteKey(
-        Embed(CoEnv(\/-(MFC(ConcatMaps(m, Embed(CoEnv(\/-(MFC(MakeMap(k, _)))))))))),
+        ExtractFunc(ConcatMaps(m, ExtractFunc(MakeMap(k, _)))),
         f)
           if k ≟ f =>
         rollMF[T, A](MFC(DeleteKey(m, f))).some
@@ -348,28 +348,18 @@ object MapFuncCore {
         map.reverse.find(_._1 ≟ key) ∘ (_._2.project)
 
       case ProjectKey(
-        Embed(CoEnv(\/-(MFC(Cond(cond, Embed(StaticMap(consMap)), Embed(StaticMap(altMap))))))),
+        ExtractFunc(Cond(cond, Embed(StaticMap(consMap)), Embed(StaticMap(altMap)))),
         ExtractFunc(Constant(key))) =>
-        (consMap.reverse.find(_._1 ≟ key) ∘ (_._2) |@| altMap.reverse.find(_._1 ≟ key) ∘ (_._2)) {
-          case (cons, alt) => rollMF[T, A](MFC(Cond(cond, cons, alt)))
+        (consMap.reverse.find(_._1 ≟ key) |@| altMap.reverse.find(_._1 ≟ key)) {
+          case ((_, cons), (_, alt)) => rollMF[T, A](MFC(Cond(cond, cons, alt)))
         }
 
-      case ProjectKey(
-        Embed(CoEnv(\/-(MFC(Cond(cond, Embed(StaticMap(map)), alt))))),
-        ExtractFunc(Constant(key))) =>
-        map.reverse.find(_._1 ≟ key) ∘ (_._2) ∘ (v => rollMF[T, A](MFC(Cond(cond, v, alt))))
-
-      case ProjectKey(
-        Embed(CoEnv(\/-(MFC(Cond(cond, cons, Embed(StaticMap(map))))))),
-        ExtractFunc(Constant(key))) =>
-        map.reverse.find(_._1 ≟ key) ∘ (_._2) ∘ (v => rollMF[T, A](MFC(Cond(cond, cons, v))))
-
       // TODO: Generalize these to `StaticMapSuffix`
-      case ProjectKey(Embed(CoEnv(\/-(MFC(MakeMap(k, Embed(v)))))), f) if k ≟ f =>
+      case ProjectKey(ExtractFunc(MakeMap(k, Embed(v))), f) if k ≟ f =>
         v.some
 
       case ProjectKey(
-        Embed(CoEnv(\/-(MFC(ConcatMaps(_, Embed(CoEnv(\/-(MFC(MakeMap(k, Embed(v))))))))))),
+        ExtractFunc(ConcatMaps(_, ExtractFunc(MakeMap(k, Embed(v))))),
         f)
           if k ≟ f =>
         v.some

--- a/connector/src/main/scala/quasar/qscript/package.scala
+++ b/connector/src/main/scala/quasar/qscript/package.scala
@@ -151,8 +151,8 @@ package object qscript {
   type CoEnvMap[T[_[_]], A]     = CoEnvMapA[T, Hole, A]
 
   object ExtractFunc {
-    def unapply[T[_[_]], A](fma: FreeMapA[T, A]): Option[MapFuncCore[T, _]] = fma match {
-      case Embed(CoEnv(\/-(MFC(func: MapFuncCore[T, _])))) => Some(func)
+    def unapply[T[_[_]], A](fma: FreeMapA[T, A]): Option[MapFuncCore[T, FreeMapA[T, A]]] = fma match {
+      case Embed(CoEnv(\/-(MFC(func)))) => Some(func)
       case _ => None
     }
   }

--- a/connector/src/main/scala/quasar/qscript/rewrites/ExtractFiltering.scala
+++ b/connector/src/main/scala/quasar/qscript/rewrites/ExtractFiltering.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.rewrites
+
+import slamdata.Predef.Option
+import quasar.Type
+import quasar.ejson.implicits._
+import quasar.fp.coproductEqual
+import quasar.qscript.{
+  construction,
+  ExtractFunc,
+  MFC,
+  MapFuncCore,
+  MapFuncsCore,
+  TTypes
+}
+import MapFuncCore.{rollMF, CoMapFuncR}
+
+import matryoshka._
+import matryoshka.data.free._
+import scalaz.{\/, Equal, Free, IList, Validation, Writer}
+import scalaz.std.option._
+import scalaz.std.tuple._
+import scalaz.syntax.bind._
+import scalaz.syntax.either._
+import scalaz.syntax.traverse._
+import scalaz.syntax.validation._
+
+final class ExtractFiltering[T[_[_]]: BirecursiveT: EqualT] private () extends TTypes[T] {
+  import MapFuncsCore._
+
+  val func = construction.Func[T]
+
+  case class Filtering[A](p: (FreeMapA[A], Type) \/ FreeMapA[A]) {
+    def build(res: Validation[FreeMapA[A], FreeMapA[A]]): MapFunc[FreeMapA[A]] = {
+      val (s, f) = res.fold((func.Undefined[A], _), (_, func.Undefined[A]))
+
+      MFC(p.fold({ case (e, t) => Guard(e, t, s, f) }, Cond(_, s, f)))
+    }
+  }
+
+  object Filtering {
+    implicit def equal[A: Equal]: Equal[Filtering[A]] =
+      Equal.equalBy(_.p)
+  }
+
+  def apply[A: Equal](mf: CoMapFuncR[T, A]): Option[CoMapFuncR[T, A]] =
+    mf.run.toOption >>= (MFC.unapply) >>= {
+      // NB: The last case pulls conditionals into a wider scope, and we
+      //     want to avoid doing that for certain MapFuncs, so we skip them
+      //     here.
+      case Guard(_, _, _, _)
+         | Cond(_, _, _)
+         | IfUndefined(_, _)
+         | MakeArray(_)
+         | MakeMap(_, _)
+         | Or(_, _) => none
+
+      case func =>
+        val extracted =
+          func.traverse[Writer[IList[Validation[Filtering[A], Filtering[A]]], ?], FreeMapA[A]] {
+            case ExtractFunc(Guard(e, t, s, ExtractFunc(Undefined()))) =>
+              Writer(IList(Filtering((e, t).left).success), s)
+
+            case ExtractFunc(Guard(e, t, ExtractFunc(Undefined()), f)) =>
+              Writer(IList(Filtering((e, t).left).failure), f)
+
+            case ExtractFunc(Cond(p, s, ExtractFunc(Undefined()))) =>
+              Writer(IList(Filtering(p.right).success), s)
+
+            case ExtractFunc(Cond(p, ExtractFunc(Undefined()), f)) =>
+              Writer(IList(Filtering(p.right).failure), f)
+
+            case arg => Writer(IList(), arg)
+          }
+
+        extracted.written.toNel map { filters =>
+          rollMF[T, A](filters.distinctE.foldRight(MFC(extracted.value)) {
+            case (filter, v) =>
+              val fm = Free.roll(v)
+              filter.fold(_.build(fm.failure), _.build(fm.success))
+          })
+        }
+    }
+}
+
+object ExtractFiltering {
+  /** Pulls "filtering" conditionals (Cond or Guard where one branch is
+    * `Undefined`) as far towards the root of the expression as possible.
+    */
+  def apply[T[_[_]]: BirecursiveT: EqualT, A: Equal]
+      : CoMapFuncR[T, A] => Option[CoMapFuncR[T, A]] =
+    new ExtractFiltering[T].apply[A](_)
+}

--- a/connector/src/main/scala/quasar/qscript/rewrites/Normalizable.scala
+++ b/connector/src/main/scala/quasar/qscript/rewrites/Normalizable.scala
@@ -91,7 +91,7 @@ class NormalizableT[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends T
 
   def freeMF[A: Equal: Show](fm: Free[MapFunc, A]): Free[MapFunc, A] =
     fm.transCata[Free[MapFunc, A]](MapFuncCore.normalize[T, A])
-      .transCata[Free[MapFunc, A]](repeatedly(MapFuncCore.extractGuards[T, A]))
+      .transCata[Free[MapFunc, A]](repeatedly(ExtractFiltering[T, A]))
 
   def makeNorm[A, B, C](
     lOrig: A, rOrig: B)(

--- a/connector/src/test/scala/quasar/qscript/rewrites/ExtractFilteringSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/rewrites/ExtractFilteringSpec.scala
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.rewrites
+
+import quasar.{Qspec, TreeMatchers, Type}
+import quasar.ejson.{EJson, Fixed}
+import quasar.ejson.implicits._
+import quasar.fp.coproductEqual
+import quasar.qscript.{construction, Hole, TTypes}
+
+import matryoshka._
+import matryoshka.data.Fix
+import matryoshka.implicits._
+
+final class ExtractFilteringSpec extends Qspec with TTypes[Fix] with TreeMatchers {
+
+  val func = construction.Func[Fix]
+  val ejs = Fixed[Fix[EJson]]
+
+  val extractFiltering =
+    (_: FreeMap).transCata[FreeMap](repeatedly(ExtractFiltering[Fix, Hole]))
+
+  "extracting filtering conditionals" should {
+
+    "extract filtering success Guard" >> {
+      val expr =
+        func.ProjectKeyS(
+          func.Guard(
+            func.ProjectIndexI(func.Hole, 1),
+            Type.AnyObject,
+            func.ProjectIndexI(func.Hole, 1),
+            func.Undefined),
+          "foo")
+
+      val expected =
+          func.Guard(
+            func.ProjectIndexI(func.Hole, 1),
+            Type.AnyObject,
+            func.ProjectKeyS(func.ProjectIndexI(func.Hole, 1), "foo"),
+            func.Undefined)
+
+      extractFiltering(expr) must beTreeEqual(expected)
+    }
+
+    "extract filtering failure Guard" >> {
+      val expr =
+        func.ProjectKeyS(
+          func.Guard(
+            func.ProjectIndexI(func.Hole, 1),
+            Type.AnyObject,
+            func.Undefined,
+            func.ProjectIndexI(func.Hole, 1)),
+          "foo")
+
+      val expected =
+          func.Guard(
+            func.ProjectIndexI(func.Hole, 1),
+            Type.AnyObject,
+            func.Undefined,
+            func.ProjectKeyS(func.ProjectIndexI(func.Hole, 1), "foo"))
+
+      extractFiltering(expr) must beTreeEqual(expected)
+    }
+
+    "extract multiple Guards" >> {
+      val expr =
+        func.ProjectKey(
+          func.Guard(
+            func.ProjectKeyS(func.Hole, "foo"),
+            Type.AnyObject,
+            func.ProjectKeyS(func.Hole, "foo"),
+            func.Undefined),
+          func.Guard(
+            func.ProjectKeyS(func.Hole, "bar"),
+            Type.Str,
+            func.ProjectKeyS(func.Hole, "bar"),
+            func.Undefined))
+
+      val expected =
+          func.Guard(
+            func.ProjectKeyS(func.Hole, "foo"),
+            Type.AnyObject,
+            func.Guard(
+              func.ProjectKeyS(func.Hole, "bar"),
+              Type.Str,
+              func.ProjectKey(
+                func.ProjectKeyS(func.Hole, "foo"),
+                func.ProjectKeyS(func.Hole, "bar")),
+              func.Undefined),
+            func.Undefined)
+
+      extractFiltering(expr) must beTreeEqual(expected)
+    }
+
+    "extract filtering true Cond" >> {
+      val expr =
+        func.ProjectKeyS(
+          func.Cond(
+            func.Eq(func.Hole, func.Constant(ejs.int(42))),
+            func.ProjectIndexI(func.Hole, 1),
+            func.Undefined),
+          "foo")
+
+      val expected =
+        func.Cond(
+          func.Eq(func.Hole, func.Constant(ejs.int(42))),
+          func.ProjectKeyS(func.ProjectIndexI(func.Hole, 1), "foo"),
+          func.Undefined)
+
+      extractFiltering(expr) must beTreeEqual(expected)
+    }
+
+    "extract filtering false Cond" >> {
+      val expr =
+        func.ProjectKeyS(
+          func.Cond(
+            func.Eq(func.Hole, func.Constant(ejs.int(42))),
+            func.Undefined,
+            func.ProjectIndexI(func.Hole, 1)),
+          "foo")
+
+      val expected =
+        func.Cond(
+          func.Eq(func.Hole, func.Constant(ejs.int(42))),
+          func.Undefined,
+          func.ProjectKeyS(func.ProjectIndexI(func.Hole, 1), "foo"))
+
+      extractFiltering(expr) must beTreeEqual(expected)
+    }
+
+    "extract multiple Conds" >> {
+      val expr =
+        func.Add(
+          func.Cond(
+            func.Eq(
+              func.ProjectKeyS(func.Hole, "bar"),
+              func.Constant(ejs.str("foo"))),
+            func.Undefined,
+            func.ProjectKeyS(func.Hole, "price")),
+          func.Cond(
+            func.Gt(
+              func.ProjectKeyS(func.Hole, "rate"),
+              func.Constant(ejs.dec(3.42))),
+            func.ProjectKeyS(func.Hole, "rate"),
+            func.Undefined))
+
+      val expected =
+          func.Cond(
+            func.Eq(
+              func.ProjectKeyS(func.Hole, "bar"),
+              func.Constant(ejs.str("foo"))),
+            func.Undefined,
+            func.Cond(
+              func.Gt(
+                func.ProjectKeyS(func.Hole, "rate"),
+                func.Constant(ejs.dec(3.42))),
+              func.Add(
+                func.ProjectKeyS(func.Hole, "price"),
+                func.ProjectKeyS(func.Hole, "rate")),
+              func.Undefined))
+
+      extractFiltering(expr) must beTreeEqual(expected)
+    }
+
+    "extract a mixture of Cond and Guard" >> {
+      val expr =
+        func.Add(
+          func.Cond(
+            func.Eq(
+              func.ProjectKeyS(func.Hole, "bar"),
+              func.Constant(ejs.str("foo"))),
+            func.Undefined,
+            func.ProjectKeyS(func.Hole, "price")),
+          func.Guard(
+            func.ProjectKeyS(func.Hole, "rate"),
+            Type.Numeric,
+            func.ProjectKeyS(func.Hole, "rate"),
+            func.Undefined))
+
+      val expected =
+        func.Cond(
+          func.Eq(
+            func.ProjectKeyS(func.Hole, "bar"),
+            func.Constant(ejs.str("foo"))),
+          func.Undefined,
+          func.Guard(
+            func.ProjectKeyS(func.Hole, "rate"),
+            Type.Numeric,
+            func.Add(
+              func.ProjectKeyS(func.Hole, "price"),
+              func.ProjectKeyS(func.Hole, "rate")),
+            func.Undefined))
+
+      extractFiltering(expr) must beTreeEqual(expected)
+    }
+  }
+}

--- a/it/src/main/resources/tests/filteredFlatten.test
+++ b/it/src/main/resources/tests/filteredFlatten.test
@@ -2,8 +2,6 @@
     "name": "filter flattened field",
 
     "backends": {
-      "marklogic_json": "pending",
-      "marklogic_xml": "pending"
     },
 
     "data": "demo/patients.data",


### PR DESCRIPTION
Extends the extracting of "filtering" conditional expressions (where one branch is `Undefined`) to `Cond` in addition to `Guard`.