### PR TITLE
Update incorrect comment on how Union should be implemented by connectors

### DIFF
--- a/connector/src/main/scala/quasar/qscript/QScriptCore.scala
+++ b/connector/src/main/scala/quasar/qscript/QScriptCore.scala
@@ -118,7 +118,7 @@ object ReduceIndex {
     extends QScriptCore[T, A]
 
 /** Creates a new dataset that contains the elements from the datasets created
-  * by each branch. Duplicate values should be eliminated.
+  * by each branch. Duplicate values should not be eliminated.
   */
 @Lenses final case class Union[T[_[_]], A](
   src: A,


### PR DESCRIPTION
#qz-3341 done

My mistake. Mongo's implementation for `Union` is correct. It's only the comment that's wrong.