### PR TITLE
Add 'onUndefined' property to LeftShift

### DIFF
--- a/connector/src/main/scala/quasar/qscript/ExtractPath.scala
+++ b/connector/src/main/scala/quasar/qscript/ExtractPath.scala
@@ -77,14 +77,14 @@ sealed abstract class ExtractPathInstances extends ExtractPathInstances0 {
   ): ExtractPath[QScriptCore[T, ?], P] =
     new ExtractPath[QScriptCore[T, ?], P] {
       def extractPath[G[_]: ApplicativePlus] = {
-        case Filter(paths, _)             => paths
-        case LeftShift(paths, _, _, _, _) => paths
-        case Map(paths, _)                => paths
-        case Reduce(paths, _, _, _)       => paths
-        case Sort(paths, _, _)            => paths
-        case Subset(paths, fm, _, ct)     => extractBranch[T, G, P](fm) <+> extractBranch[T, G, P](ct) <+> paths
-        case Union(paths, l, r)           => extractBranch[T, G, P](l)  <+> extractBranch[T, G, P](r)  <+> paths
-        case Unreferenced()               => mempty[G, P]
+        case Filter(paths, _)                => paths
+        case LeftShift(paths, _, _, _, _, _) => paths
+        case Map(paths, _)                   => paths
+        case Reduce(paths, _, _, _)          => paths
+        case Sort(paths, _, _)               => paths
+        case Subset(paths, fm, _, ct)        => extractBranch[T, G, P](fm) <+> extractBranch[T, G, P](ct) <+> paths
+        case Union(paths, l, r)              => extractBranch[T, G, P](l)  <+> extractBranch[T, G, P](r)  <+> paths
+        case Unreferenced()                  => mempty[G, P]
       }
     }
 

--- a/connector/src/main/scala/quasar/qscript/OnUndefined.scala
+++ b/connector/src/main/scala/quasar/qscript/OnUndefined.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript
+
+import slamdata.Predef.{Boolean, Option, Some}
+import quasar.RenderTree
+
+import scalaz.{Enum, Show}
+import scalaz.std.anyVal._
+import scalaz.syntax.order._
+
+sealed abstract class OnUndefined {
+  def fold[A](emit: => A, omit: => A): A =
+    this match {
+      case OnUndefined.Emit => emit
+      case OnUndefined.Omit => omit
+    }
+}
+
+object OnUndefined {
+  case object Emit extends OnUndefined
+  case object Omit extends OnUndefined
+
+  val emit: OnUndefined = Emit
+  val omit: OnUndefined = Omit
+
+  implicit val enum: Enum[OnUndefined] =
+    new Enum[OnUndefined] {
+      def order(x: OnUndefined, y: OnUndefined) =
+        asBool(x) ?|? asBool(y)
+
+      def pred(x: OnUndefined): OnUndefined =
+        x.fold(omit, emit)
+
+      def succ(x: OnUndefined): OnUndefined =
+        x.fold(omit, emit)
+
+      override val min: Option[OnUndefined] =
+        Some(Emit)
+
+      override val max: Option[OnUndefined] =
+        Some(Omit)
+
+      private val asBool: OnUndefined => Boolean =
+        _.fold(false, true)
+    }
+
+  implicit def renderTree: RenderTree[OnUndefined] =
+    RenderTree.fromShow("OnUndefined")
+
+  implicit def show: Show[OnUndefined] =
+    Show.showFromToString
+}

--- a/connector/src/main/scala/quasar/qscript/RenderQScriptDSL.scala
+++ b/connector/src/main/scala/quasar/qscript/RenderQScriptDSL.scala
@@ -311,12 +311,13 @@ object RenderQScriptDSL {
           case Map(src, f) =>
             DSLTree(base, "Map", (A(base, src).right :: freeMap(base, f).right :: Nil).some)
 
-          case LeftShift(src, struct, idStatus, shiftType, repair) =>
+          case LeftShift(src, struct, idStatus, shiftType, undef, repair) =>
             DSLTree(base, "LeftShift",
               (A(base, src).right ::
                 freeMap(base, struct).right ::
                 idStatus.shows.left ::
                 ("ShiftType." + shiftType.shows).left ::
+                ("OnUndefined." + undef.shows).left ::
                 joinFunc(base, repair).right ::
                 Nil).some)
 

--- a/connector/src/main/scala/quasar/qscript/UnaryFunctions.scala
+++ b/connector/src/main/scala/quasar/qscript/UnaryFunctions.scala
@@ -62,8 +62,8 @@ object UnaryFunctions {
             s match {
               case Map(src, fm) =>
                 (f(fm)).map(Map(src, _))
-              case LeftShift(src, struct, id, stpe, repair) =>
-                (f(struct)).map(LeftShift(src, _, id, stpe, repair))
+              case LeftShift(src, struct, id, stpe, undef, repair) =>
+                (f(struct)).map(LeftShift(src, _, id, stpe, undef, repair))
               case Reduce(src, bucket, red, repair) =>
                 (bucket.traverse(f) |@| red.traverse(_.traverse(f)))(Reduce(src, _, _, repair))
               case Sort(src, bucket, order) =>

--- a/connector/src/main/scala/quasar/qscript/analysis/Cardinality.scala
+++ b/connector/src/main/scala/quasar/qscript/analysis/Cardinality.scala
@@ -73,7 +73,7 @@ object Cardinality {
             case _ => c
           }
         }.point[M]
-        case LeftShift(card, struct, id, stpe, repair) => (card * 10).point[M]
+        case LeftShift(card, _, _, _, _, _) => (card * 10).point[M]
         case Union(card, lBranch, rBranch) => {
           val compile = Cardinality[QScriptTotal[T, ?]].calculate(pathCard)
           (lBranch.cataM(interpretM(κ(card.point[M]), compile)) |@| rBranch.cataM(interpretM(κ(card.point[M]), compile))) { _ + _}

--- a/connector/src/main/scala/quasar/qscript/analysis/Cost.scala
+++ b/connector/src/main/scala/quasar/qscript/analysis/Cost.scala
@@ -65,7 +65,7 @@ object Cost {
         case Sort((card, cost), bucket, orders) => (card + cost).point[M]
         case Filter((card, cost), f) => (card + cost).point[M]
         case Subset((card, cost), from, sel, count) => (card + cost).point[M]
-        case LeftShift((card, cost), struct, id, stpe, repair) => (card + cost).point[M]
+        case LeftShift((card, cost), _, _, _, _, _) => (card + cost).point[M]
         case Union((card, cost), lBranch, rBranch) => {
           val compileCardinality = Cardinality[QScriptTotal[T, ?]].calculate(pathCard)
           val compileCost = Cost[QScriptTotal[T, ?]].evaluate(pathCard)

--- a/connector/src/main/scala/quasar/qscript/analysis/DeepShape.scala
+++ b/connector/src/main/scala/quasar/qscript/analysis/DeepShape.scala
@@ -148,11 +148,11 @@ sealed abstract class DeepShapeInstances {
 
         case Map(shape, fm) => fm >> shape
 
-        case LeftShift(shape, struct, id, stpe, repair) =>
+        case LeftShift(shape, struct, id, _, _, repair) =>
           repair >>= {
             case LeftSide => shape
             case RightSide => freeShape[T](Shifting[T](id, struct >> shape))
-	  }
+          }
 
         case Reduce(shape, bucket, reducers, repair) =>
           repair >>= {

--- a/connector/src/main/scala/quasar/qscript/analysis/Outline.scala
+++ b/connector/src/main/scala/quasar/qscript/analysis/Outline.scala
@@ -229,7 +229,7 @@ sealed abstract class OutlineInstances {
         case Map(inShape, fm) =>
           outlineF(fm)(κ(inShape))
 
-        case LeftShift(inShape, _, idStatus, shiftType, repair) =>
+        case LeftShift(inShape, _, idStatus, _, _, repair) =>
           outlineF(repair) {
             case LeftSide => inShape
             case RightSide => idStatus match {

--- a/connector/src/main/scala/quasar/qscript/analysis/ShapePreserving.scala
+++ b/connector/src/main/scala/quasar/qscript/analysis/ShapePreserving.scala
@@ -94,7 +94,7 @@ object ShapePreserving {
     new ShapePreserving[QScriptCore[T, ?]] {
       def shapePreservingƒ: Algebra[QScriptCore[T, ?], Option[IdStatus]] = {
         case Map(_, _) => none
-        case LeftShift(_, _, _, _, _) => none
+        case LeftShift(_, _, _, _, _, _) => none
         case Reduce(_, _, _, _) => none
         case Sort(src, _, _) => src
         case Union(src, l, r) =>

--- a/connector/src/main/scala/quasar/qscript/construction.scala
+++ b/connector/src/main/scala/quasar/qscript/construction.scala
@@ -251,8 +251,9 @@ object construction {
                   struct: FreeMap[T],
                   idStatus: IdStatus,
                   shiftType: ShiftType,
+                  onUndefined: OnUndefined,
                   repair: JoinFunc[T]): R =
-      core(qscript.LeftShift(src, struct, idStatus, shiftType, repair))
+      core(qscript.LeftShift(src, struct, idStatus, shiftType, onUndefined, repair))
     def Reduce(src: R,
                bucket: List[FreeMap[T]],
                reducers: List[ReduceFunc[FreeMap[T]]],

--- a/connector/src/main/scala/quasar/qscript/qsu/Graduate.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/Graduate.scala
@@ -36,6 +36,7 @@ import quasar.qscript.{
   LeftSide,
   RightSide,
   LeftShift,
+  OnUndefined,
   JoinSide,
   Map,
   QCE,
@@ -206,7 +207,7 @@ final class Graduate[T[_[_]]: BirecursiveT: ShowT] private () extends QSUTTypes[
               case QSU.Rotation.FlattenMap | QSU.Rotation.ShiftMap =>
                 ShiftType.Map
             }
-          } yield QCE(LeftShift[T, QSUGraph](source, struct, idStatus, shiftType, resolvedRepair))
+          } yield QCE(LeftShift[T, QSUGraph](source, struct, idStatus, shiftType, OnUndefined.omit, resolvedRepair))
 
         case QSU.QSSort(source, buckets, order) =>
           buckets traverse (resolveAccess(_)(_.left)(holeAs(source.root))) map { bs =>

--- a/connector/src/main/scala/quasar/qscript/rewrites/Normalizable.scala
+++ b/connector/src/main/scala/quasar/qscript/rewrites/Normalizable.scala
@@ -228,12 +228,12 @@ class NormalizableT[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends T
 
         makeNorm(bucket, order)(rebucket, _ => orderNormOpt)(Sort(src, _, _))
 
-      case Map(src, f)                => freeMFEq(f).map(Map(src, _))
-      case LeftShift(src, s, i, t, r) => makeNorm(s, r)(freeMFEq(_), freeMFEq(_))(LeftShift(src, _, i, t, _))
-      case Union(src, l, r)           => makeNorm(l, r)(freeTCEq(_), freeTCEq(_))(Union(src, _, _))
-      case Filter(src, f)             => freeMFEq(f).map(Filter(src, _))
+      case Map(src, f)                   => freeMFEq(f).map(Map(src, _))
+      case LeftShift(src, s, i, t, u, r) => makeNorm(s, r)(freeMFEq(_), freeMFEq(_))(LeftShift(src, _, i, t, u, _))
+      case Union(src, l, r)              => makeNorm(l, r)(freeTCEq(_), freeTCEq(_))(Union(src, _, _))
+      case Filter(src, f)                => freeMFEq(f).map(Filter(src, _))
       case Subset(src, from, sel, count) => makeNorm(from, count)(freeTCEq(_), freeTCEq(_))(Subset(src, _, sel, _))
-      case Unreferenced()          => None
+      case Unreferenced()                => None
     })
   }
 

--- a/connector/src/main/scala/quasar/qscript/rewrites/PreferProjection.scala
+++ b/connector/src/main/scala/quasar/qscript/rewrites/PreferProjection.scala
@@ -157,16 +157,16 @@ sealed abstract class PreferProjectionInstances {
         case Map((srcShape, u), f) =>
           BtoF(Map(u, prjFreeMap(srcShape, f)))
 
-        case LeftShift((srcShape, u), struct, idStatus, shiftType, repair) =>
+        case LeftShift((srcShape, u), struct, idStatus, shiftType, undef, repair) =>
           // NB: This is necessary as srcShape gives us the input shape to the
           //     LeftShift, which is what we need to rewrite `struct`, however
           //     to rewrite `repair` we need any modifications that `LeftShift`
           //     makes to the shape, excluding `repair`'s own modifications.
           val prjRepair = projectComplement(repair) { joinSide =>
-            O.outlineƒ(LeftShift(srcShape, struct, idStatus, shiftType, Free.point(joinSide)))
+            O.outlineƒ(LeftShift(srcShape, struct, idStatus, shiftType, undef, Free.point(joinSide)))
           }
 
-          BtoF(LeftShift(u, prjFreeMap(srcShape, struct), idStatus, shiftType, prjRepair))
+          BtoF(LeftShift(u, prjFreeMap(srcShape, struct), idStatus, shiftType, undef, prjRepair))
 
         case Reduce((srcShape, u), buckets, reducers, repair) =>
           val prjBuckets = buckets map (prjFreeMap(srcShape, _))

--- a/connector/src/test/scala/quasar/qscript/RenderQScriptDSLSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/RenderQScriptDSLSpec.scala
@@ -178,7 +178,7 @@ class RenderQScriptDSLSpec extends quasar.Qspec with QScriptHelpers {
     List[FreeQS](
       free.Hole,
       free.Map(h, func.Undefined),
-      free.LeftShift(h, func.Undefined, ExcludeId, ShiftType.Array, func.LeftSide),
+      free.LeftShift(h, func.Undefined, ExcludeId, ShiftType.Array, OnUndefined.Omit, func.LeftSide),
       free.Reduce(h, Nil, Nil, func.ReduceIndex(1.right)),
       free.Sort(h, Nil, NonEmptyList((func.Hole, SortDir.Ascending))),
       free.Union(h, h, h),
@@ -204,7 +204,7 @@ class RenderQScriptDSLSpec extends quasar.Qspec with QScriptHelpers {
     val h = free.Hole
     List[Fix[QST]](
       fix.Map(u, func.Undefined),
-      fix.LeftShift(u, func.Undefined, ExcludeId, ShiftType.Array, func.LeftSide),
+      fix.LeftShift(u, func.Undefined, ExcludeId, ShiftType.Array, OnUndefined.Omit, func.LeftSide),
       fix.Reduce(u, Nil, Nil, func.ReduceIndex(1.right)),
       fix.Sort(u, Nil, NonEmptyList((func.Hole, SortDir.Ascending), (func.Hole, SortDir.Descending))),
       fix.Union(u, free.Hole, free.Hole),

--- a/connector/src/test/scala/quasar/qscript/analysis/CardinalitySpec.scala
+++ b/connector/src/test/scala/quasar/qscript/analysis/CardinalitySpec.scala
@@ -178,7 +178,7 @@ class CardinalitySpec extends quasar.Qspec with QScriptHelpers with DisjunctionM
           val fun: FreeMap =
             func.Eq(func.ProjectKeyS(func.Hole, "key"), func.Constant(json.str("value")))
           val joinFunc: JoinFunc = func.LeftSide
-          val leftShift = LeftShift(cardinality, fun, IdOnly, ShiftType.Array, joinFunc)
+          val leftShift = LeftShift(cardinality, fun, IdOnly, ShiftType.Array, OnUndefined.Omit, joinFunc)
           compile(leftShift) must_== cardinality * 10
         }
       }

--- a/connector/src/test/scala/quasar/qscript/analysis/DeepShapeSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/analysis/DeepShapeSpec.scala
@@ -60,7 +60,7 @@ final class DeepShapeSpec extends quasar.Qspec with QScriptHelpers with TTypes[F
             func.MakeArray(func.Add(func.LeftSide, IntLit(9))),
             func.MakeArray(func.Subtract(func.RightSide, IntLit(10))))
 
-        val qs = LeftShift(shape, struct, IdOnly, ShiftType.Array, repair)
+        val qs = LeftShift(shape, struct, IdOnly, ShiftType.Array, OnUndefined.Omit, repair)
 
         val expected: FreeShape[Fix] =
           func.ConcatArrays(
@@ -206,6 +206,7 @@ final class DeepShapeSpec extends quasar.Qspec with QScriptHelpers with TTypes[F
           func.Hole,
           IncludeId,
           ShiftType.Array,
+          OnUndefined.Omit,
           func.RightSide)
 
       val rBranch: FreeQS =
@@ -216,6 +217,7 @@ final class DeepShapeSpec extends quasar.Qspec with QScriptHelpers with TTypes[F
           func.Hole,
           IncludeId,
           ShiftType.Array,
+          OnUndefined.Omit,
           func.LeftSide)
 
       val combine: JoinFunc =

--- a/connector/src/test/scala/quasar/qscript/analysis/OutlineSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/analysis/OutlineSpec.scala
@@ -228,11 +228,11 @@ final class OutlineSpec extends quasar.Qspec with QScriptHelpers {
 
     "LeftShift(IncludeId) results in shape of repair applied to static array" >> prop { srcShape: Shape =>
       val r = rollS(CommonEJson(ejson.Arr(List(unknownF, unknownF))))
-      outlineQC(LeftShift(srcShape, func.Hole, IncludeId, ShiftType.Array, joinFunc)) must_= modSides(srcShape, r)
+      outlineQC(LeftShift(srcShape, func.Hole, IncludeId, ShiftType.Array, OnUndefined.Omit, joinFunc)) must_= modSides(srcShape, r)
     }
 
     "RightSide of repair is unknown when not IncludeId" >> prop { srcShape: Shape =>
-      outlineQC(LeftShift(srcShape, func.Hole, ExcludeId, ShiftType.Array, joinFunc)) must_= modSides(srcShape, unknownF)
+      outlineQC(LeftShift(srcShape, func.Hole, ExcludeId, ShiftType.Array, OnUndefined.Omit, joinFunc)) must_= modSides(srcShape, unknownF)
     }
 
     "Reduce tracks static input shape through buckets" >> prop { srcShape: Shape =>

--- a/connector/src/test/scala/quasar/qscript/qsu/GraduateSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/GraduateSpec.scala
@@ -29,6 +29,7 @@ import quasar.qscript.{
   HoleF,
   IncludeId,
   JoinSide,
+  OnUndefined,
   ReduceFunc,
   ReduceFuncs,
   ReduceIndex,
@@ -124,7 +125,7 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
             func.MakeArray(func.RightSide)))
 
         val qgraph: Fix[QSU] = qsu.leftShift(qsu.read(afile), struct, IncludeId, arepair, Rotation.ShiftArray)
-        val qscript: Fix[QSE] = qse.LeftShift(qse.Read[AFile](afile), struct, IncludeId, ShiftType.Array, repair)
+        val qscript: Fix[QSE] = qse.LeftShift(qse.Read[AFile](afile), struct, IncludeId, ShiftType.Array, OnUndefined.Omit, repair)
 
         qgraph must graduateAs(qscript)
       }
@@ -203,6 +204,7 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
           HoleF[Fix],
           IncludeId,
           ShiftType.Array,
+          OnUndefined.Omit,
           concatArr)
 
       val rhs: Free[QSE, Hole] =

--- a/connector/src/test/scala/quasar/qscript/qsu/LPtoQSSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/LPtoQSSpec.scala
@@ -24,7 +24,7 @@ import quasar.ejson.{EJson, Fixed}
 import quasar.fp._
 import quasar.frontend.logicalplan.LogicalPlan
 import quasar.qscript.construction
-import quasar.qscript.{ExcludeId, HoleF, ReduceFuncs, ReduceIndex, RightSideF, ShiftType}
+import quasar.qscript.{ExcludeId, HoleF, OnUndefined, ReduceFuncs, ReduceIndex, RightSideF, ShiftType}
 import quasar.sql.CompilerHelpers
 import quasar.std.{AggLib, IdentityLib}
 import slamdata.Predef._
@@ -71,6 +71,7 @@ object LPtoQSSpec extends Qspec with CompilerHelpers with QSUTTypes[Fix] {
         HoleF[Fix],
         ExcludeId,
         ShiftType.Map,
+        OnUndefined.Omit,
         RightSideF[Fix])
 
       lp must compileTo(expected)
@@ -89,6 +90,7 @@ object LPtoQSSpec extends Qspec with CompilerHelpers with QSUTTypes[Fix] {
           HoleF[Fix],
           ExcludeId,
           ShiftType.Map,
+          OnUndefined.Omit,
           RightSideF[Fix]),
         Nil,
         List(ReduceFuncs.Count(HoleF[Fix])),

--- a/connector/src/test/scala/quasar/qscript/rewrites/PreferProjectionSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/rewrites/PreferProjectionSpec.scala
@@ -106,6 +106,7 @@ final class PreferProjectionSpec extends quasar.Qspec with QScriptHelpers {
         func.Hole,
         ExcludeId,
         ShiftType.Array,
+        OnUndefined.Omit,
         MapFuncCore.StaticMap(List(
           json.str("a") -> func.ProjectIndex(func.RightSide, func.Constant(json.int(0))),
           json.str("b") -> func.ProjectIndex(func.RightSide, func.Constant(json.int(2))),
@@ -137,6 +138,7 @@ final class PreferProjectionSpec extends quasar.Qspec with QScriptHelpers {
           func.DeleteKeyS(func.Hole, "c"),
           IncludeId,
           ShiftType.Array,
+          OnUndefined.Omit,
           MapFuncCore.StaticArray(List(
             func.DeleteKeyS(func.DeleteKeyS(func.LeftSide, "a"), "b"),
             func.RightSide)))
@@ -147,6 +149,7 @@ final class PreferProjectionSpec extends quasar.Qspec with QScriptHelpers {
           prjFrom(func.Hole, "a", "b"),
           IncludeId,
           ShiftType.Array,
+          OnUndefined.Omit,
           MapFuncCore.StaticArray(List(
             prjFrom(func.LeftSide, "c"),
             func.RightSide)))

--- a/connector/src/test/scala/quasar/qscript/rewrites/RewriteSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/rewrites/RewriteSpec.scala
@@ -104,6 +104,7 @@ class RewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           func.Hole,
           ExcludeId,
           ShiftType.Array,
+          OnUndefined.Omit,
           func.RightSide).unFix
 
       Coalesce[Fix, QScriptCore, QScriptCore].coalesceQC(idPrism).apply(exp) must
@@ -113,6 +114,7 @@ class RewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           func.Constant(json.bool(true)),
           ExcludeId,
           ShiftType.Array,
+          OnUndefined.Omit,
           func.RightSide).unFix.some)
     }
 
@@ -203,6 +205,7 @@ class RewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
             func.Hole,
             IncludeId,
             ShiftType.Array,
+            OnUndefined.Omit,
             func.ConcatArrays(
               func.MakeArray(func.LeftSide),
               func.MakeArray(func.RightSide))),
@@ -225,6 +228,7 @@ class RewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
             func.ProjectKeyS(func.Hole, "city"),
             ExcludeId,
             ShiftType.Array,
+            OnUndefined.Omit,
             func.ProjectKeyS(func.RightSide, "name"))))
     }
 
@@ -261,6 +265,7 @@ class RewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
               func.Hole,
               IncludeId,
               ShiftType.Array,
+              OnUndefined.Omit,
               func.ConcatArrays(
                 func.MakeArray(func.LeftSide),
                 func.MakeArray(func.RightSide))),
@@ -286,6 +291,7 @@ class RewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
             func.Hole,
             IncludeId,
             ShiftType.Array,
+            OnUndefined.Omit,
             func.ConcatArrays(
               func.Constant(json.arr(List(json.str("name")))),
               func.MakeArray(
@@ -409,6 +415,7 @@ class RewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           func.ProjectKeyS(func.ProjectIndexI(func.Hole, 1), "foo"),
           ExcludeId,
           ShiftType.Map,
+          OnUndefined.Omit,
           func.StaticMapS(
             "a" -> func.ProjectKeyS(func.ProjectIndexI(func.LeftSide, 1), "quux"),
             "b" -> func.RightSide))
@@ -419,6 +426,7 @@ class RewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           func.ProjectKeyS(func.Hole, "foo"),
           ExcludeId,
           ShiftType.Map,
+          OnUndefined.Omit,
           func.StaticMapS(
             "a" -> func.ProjectKeyS(func.LeftSide, "quux"),
             "b" -> func.RightSide))
@@ -436,6 +444,7 @@ class RewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           func.Hole,
           ExcludeId,
           ShiftType.Array,
+          OnUndefined.Emit,
           func.StaticMapS(
             "right" -> func.RightSide,
             "left" -> func.LeftSide))
@@ -460,6 +469,7 @@ class RewriteSpec extends quasar.Qspec with CompilerHelpers with QScriptHelpers 
           func.MakeArray(func.Subtract(func.Hole, func.Constant(json.int(5)))),
           ExcludeId,
           ShiftType.Array,
+          OnUndefined.Emit,
           func.StaticMapS(
             "right" -> func.RightSide,
             "left" -> func.LeftSide))

--- a/connector/src/test/scala/quasar/qscript/rewrites/ShiftReadSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/rewrites/ShiftReadSpec.scala
@@ -39,7 +39,7 @@ class ShiftReadSpec extends quasar.Qspec with QScriptHelpers with TreeMatchers {
       val qScript: Fix[QS] =
         chainQS(
           qsdsl.fix.Read[AFile](sampleFile),
-          qsdsl.fix.LeftShift(_, qsdsl.func.Hole, ExcludeId, ShiftType.Array, qsdsl.func.RightSide))
+          qsdsl.fix.LeftShift(_, qsdsl.func.Hole, ExcludeId, ShiftType.Array, OnUndefined.Omit, qsdsl.func.RightSide))
 
       val newQScript: Fix[QST] =
         qScript.codyna(
@@ -60,6 +60,7 @@ class ShiftReadSpec extends quasar.Qspec with QScriptHelpers with TreeMatchers {
           qsdsl.func.Hole,
           ExcludeId,
           ShiftType.Array,
+          OnUndefined.Omit,
           qsdsl.func.RightSide),
         Nil,
         List(ReduceFuncs.Count(qsdsl.func.Hole)),

--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/QScriptCorePlanner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/QScriptCorePlanner.scala
@@ -79,7 +79,8 @@ final class QScriptCorePlanner[
         groupBy = none,
         orderBy = nil).embed
 
-    case LeftShift(src, struct, id, _, repair) =>
+    // FIXME: Handle `onUndef`
+    case LeftShift(src, struct, id, _, onUndef, repair) =>
       for {
         id1 <- genId[T[N1QL], F]
         id2 <- genId[T[N1QL], F]

--- a/it/src/main/resources/tests/qa/s07_join/changedTestStatusInterim.test
+++ b/it/src/main/resources/tests/qa/s07_join/changedTestStatusInterim.test
@@ -2,11 +2,12 @@
     "name": "[qa_s07] select tests that have changed status (interim)",
     "NB": "This is a workaround for a QScript issue in changedTestStatus.test
            and shoud be removed when some connectors start passing that test.",
+    "NB": "Skipped on mimir due to timeout.",
     "backends": {
         "couchbase":         "pending",
         "marklogic_json":    "pending",
         "marklogic_xml":     "pending",
-        "mimir":             "pendingIgnoreFieldOrder",
+        "mimir":             "skip",
         "mongodb_3_2":       "pendingIgnoreFieldOrder",
         "mongodb_3_4":       "pendingIgnoreFieldOrder",
         "mongodb_read_only": "pendingIgnoreFieldOrder",

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -105,23 +105,13 @@ abstract class QueryRegressionTest[S[_]](
 
   lazy val tests = regressionTests(TestDataRoot, TestsRoot, knownFileSystems).unsafePerformSync
 
-  // NB: The printing is just to indicate progress (especially for travis-ci) as
-  //     these tests have the potential to be slow for a backend.
-  //
-  //     Ideally, we'd have specs2 log each example in the suite as it finishes, but
-  //     all attempts at doing this have been unsuccessful, if we succeed eventually
-  //     this printing can be removed.
   fileSystemShould { (fs, fsNonChrooted) =>
     suiteName should {
-      step(print(s"Running $suiteName ["))
-
       tests.toList foreach { case (f, t) =>
         val fsʹ = t.data.nonEmpty.fold(fs, fsNonChrooted)
         regressionExample(f, t, fsʹ.ref.name, fsʹ.setupInterpM, fsʹ.testInterpM)
-        step(print("."))
       }
 
-      step(println("]"))
       step(runT(fs.setupInterpM)(manage.delete(DataDir)).runVoid)
     }
   }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/QScriptCorePlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/QScriptCorePlanner.scala
@@ -64,9 +64,9 @@ private[qscript] final class QScriptCorePlanner[
           for_(x in src) return_ g
       }).right
 
-    // TODO: Use type information from `Guard` when available to determine
-    //       if `ext` is being treated as an array or an object.
-    case LeftShift(src0, struct, id, _, repair) =>
+    // FIXME: Handle `onUndef`
+    // TODO: Leverage `ShiftType`
+    case LeftShift(src0, struct, id, _, onUndef, repair) =>
       for {
         l       <- freshName[F]
         ext     <- freshName[F]

--- a/mimir/src/main/scala/quasar/mimir/Mimir.scala
+++ b/mimir/src/main/scala/quasar/mimir/Mimir.scala
@@ -453,7 +453,8 @@ object Mimir extends BackendModule with Logging with DefaultAnalyzeModule {
           }
         } yield Repr(src.P)(table)
 
-      case qscript.LeftShift(src, struct, idStatus, _, repair) =>
+      // FIXME: Handle `onUndef`
+      case qscript.LeftShift(src, struct, idStatus, _, onUndef, repair) =>
         import src.P.trans._
 
         for {

--- a/mongodb/src/main/scala/quasar/physical/mongodb/MongoDbPlanner.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/MongoDbPlanner.scala
@@ -900,7 +900,9 @@ object MongoDbPlanner {
             ev3: EX :<: ExprOp) = {
           case qscript.Map(src, f) =>
             getExprBuilder[T, M, WF, EX](cfg.funcHandler, cfg.staticHandler)(src, f)
-          case LeftShift(src, struct, id, shiftType, repair) => {
+
+          // FIXME: Handle `onUndef`
+          case LeftShift(src, struct, id, shiftType, onUndef, repair) => {
             def rewriteUndefined[A]: CoMapFuncR[T, A] => Option[CoMapFuncR[T, A]] = {
               case CoEnv(\/-(MFC(Guard(exp, tpe @ Type.FlexArr(_, _, _), exp0, Embed(CoEnv(\/-(MFC(Undefined())))))))) =>
                 rollMF[T, A](MFC(Guard(exp, tpe, exp0, Free.roll(MFC(MakeArray(Free.roll(MFC(Undefined())))))))).some

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/assumeReadType.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/assumeReadType.scala
@@ -138,10 +138,10 @@ def apply[T[_[_]]: BirecursiveT: EqualT, F[_]: Functor, M[_]: Monad: MonadFsErr]
                 case h :: t => GtoF.reverseGet(
                   QC(Filter(src, t.foldLeft[FreeMap[T]](h)((acc, e) => Free.roll(MFC(MapFuncsCore.And(acc, e)))))))
               })
-        case QC(LeftShift(src, struct, id, stpe, repair))
+        case QC(LeftShift(src, struct, id, stpe, onUndef, repair))
           if (isRewrite[T, F, G, A](GtoF, src.project)) =>
             (elide(struct) ⊛
-              elideJoinFunc(true, LeftSide, repair))((s, r) => GtoF.reverseGet(QC(LeftShift(src, s, id, stpe, r))))
+              elideJoinFunc(true, LeftSide, repair))((s, r) => GtoF.reverseGet(QC(LeftShift(src, s, id, stpe, onUndef, r))))
         case QC(qscript.Map(src, mf))
           if (isRewrite[T, F, G, A](GtoF, src.project)) =>
             elide(mf) ∘

--- a/mongodb/src/test/scala/quasar/physical/mongodb/PlannerQScriptSpec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/PlannerQScriptSpec.scala
@@ -25,7 +25,7 @@ import quasar.javascript._
 import quasar.physical.mongodb.expression._
 import quasar.physical.mongodb.planner._
 import quasar.physical.mongodb.workflow._
-import quasar.qscript.ShiftType
+import quasar.qscript.{OnUndefined, ShiftType}
 import quasar.sql.JoinDir
 import slamdata.Predef._
 
@@ -271,6 +271,7 @@ class PlannerQScriptSpec extends
             func.Undefined),
           qscript.ExcludeId,
           ShiftType.Array,
+          OnUndefined.Omit,
           func.StaticMapS(
             "codes" ->
               func.RightSide,
@@ -310,6 +311,7 @@ class PlannerQScriptSpec extends
               func.Undefined),
             qscript.ExcludeId,
             qscript.ShiftType.Array,
+            OnUndefined.Omit,
             func.StaticMapS(
               "city" ->
                 func.ProjectKeyS(func.LeftSide, "city"),
@@ -345,6 +347,7 @@ class PlannerQScriptSpec extends
               func.Undefined),
             qscript.ExcludeId,
             qscript.ShiftType.Array,
+            OnUndefined.Omit,
             func.RightSide),
           func.Lt(func.Hole, func.Constant(json.int(-165))))) must beWorkflow0(
         chain[Workflow](
@@ -375,6 +378,7 @@ class PlannerQScriptSpec extends
               func.Undefined),
             qscript.ExcludeId,
             qscript.ShiftType.Array,
+            OnUndefined.Omit,
             func.StaticMapS(
               "results" ->
                 func.Guard(
@@ -387,6 +391,7 @@ class PlannerQScriptSpec extends
           func.ProjectKeyS(func.Hole, "results"),
           qscript.ExcludeId,
           qscript.ShiftType.Array,
+          OnUndefined.Omit,
           func.StaticMapS(
             "0" ->
               func.ProjectKeyS(
@@ -435,6 +440,7 @@ class PlannerQScriptSpec extends
               func.Undefined),
             qscript.ExcludeId,
             qscript.ShiftType.Array,
+            OnUndefined.Omit,
             func.Guard(func.RightSide,
               Type.FlexArr(0, None, Type.Top),
               func.RightSide,
@@ -442,6 +448,7 @@ class PlannerQScriptSpec extends
           func.Hole,
           qscript.ExcludeId,
           qscript.ShiftType.Array,
+          OnUndefined.Omit,
           func.RightSide)) must beWorkflow0(
         chain[Workflow](
           $read(collection("db", "zips")),
@@ -478,6 +485,7 @@ class PlannerQScriptSpec extends
             func.Undefined),
           qscript.ExcludeId,
           qscript.ShiftType.Array,
+          OnUndefined.Omit,
           func.StaticMapS(
             "city" ->
               func.ProjectKeyS(func.LeftSide, "city"),
@@ -530,6 +538,7 @@ class PlannerQScriptSpec extends
             func.Undefined),
           qscript.ExcludeId,
           ShiftType.Array,
+          OnUndefined.Omit,
           func.StaticMapS(
             "codes" ->
               func.RightSide,

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/QScriptCorePlanner.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/QScriptCorePlanner.scala
@@ -256,7 +256,8 @@ class QScriptCorePlanner[T[_[_]]: BirecursiveT: ShowT, S[_]]
           case Sample => (i: Index, c: Count) => i < c
         })
 
-    case LeftShift(src, struct, id, _, repair) =>
+    // FIXME: Handle `onUndef`
+    case LeftShift(src, struct, id, _, onUndef, repair) =>
 
       val structFunc: PlannerError \/ (Data => Data) =
         CoreMap.changeFreeMap(struct)

--- a/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/PlannerSpec.scala
+++ b/sparkcore/src/test/scala/quasar/physical/sparkcore/fs/PlannerSpec.scala
@@ -439,7 +439,7 @@ class PlannerSpec
           def struct: FreeMap = func.ProjectKeyS(func.Hole, "countries")
           def repair: JoinFunc = func.RightSide
 
-          val leftShift = quasar.qscript.LeftShift(src, struct, ExcludeId, ShiftType.Array, repair)
+          val leftShift = quasar.qscript.LeftShift(src, struct, ExcludeId, ShiftType.Array, OnUndefined.Omit, repair)
 
           val program: SparkState[Task, RDD[Data]] = compile(leftShift)
           program.eval(sc).run.map(result => result must beRightDisjunction.like{


### PR DESCRIPTION
Adds an `onUndefined` property to `LeftShift` that indicates how to handle `Undefined` values produced by the `struct` expression from a `LeftShift`.

Updating individual connectors and properly emitting this value from `QSU` will come along shortly.

Part of #qz-3583.