### PR TITLE
Display incremental regression test results in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ script:
   - |-
     ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION \
       it/sideEffectTestFSConfig \
-      "it/testOnly -- xonly failtrace" \
+      "it/testOnly" \
       "$SPECIFIC_DELEGATE"
 
   - set +e

--- a/it/src/main/resources/tests/groupByFlatten.test
+++ b/it/src/main/resources/tests/groupByFlatten.test
@@ -2,7 +2,9 @@
     "name": "group by flattened field",
     "backends": {
         "couchbase":         "pending",
+        "marklogic_xml":     "pending",
         "marklogic_json":    "pendingIgnoreFieldOrder",
+        "mimir":             "pendingIgnoreFieldOrder",
         "mongodb_3_2":       "pending",
         "mongodb_3_4":       "pending",
         "mongodb_read_only": "pending",


### PR DESCRIPTION
We were previously only displaying errors, but now that we're using the incremental specs2 output as a quasi-heartbeat, we need to see all the output to avoid travis killing the job due to inactivity.