### PR TITLE
Update ExtractFreeMap and ReifyBuckets to use withName

### DIFF
--- a/connector/src/main/scala/quasar/qscript/qsu/ExpandShifts.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ExpandShifts.scala
@@ -56,6 +56,7 @@ final class ExpandShifts[T[_[_]]: BirecursiveT: EqualT: ShowT] extends QSUTTypes
   }
 
   val originalKey = "original"
+  val namePrefix = "expandshifts"
 
   def rotationsCompatible(rotation1: Rotation, rotation2: Rotation): Boolean = rotation1 match {
     case Rotation.FlattenArray | Rotation.ShiftArray =>
@@ -85,7 +86,7 @@ final class ExpandShifts[T[_[_]]: BirecursiveT: EqualT: ShowT] extends QSUTTypes
           val firstShiftPat: QScriptUniform[Symbol] =
             QSU.LeftShift[T, Symbol](source.root, struct, idStatus, firstRepair, rotation)
           for {
-            firstShift <- QSUGraph.withName[T, G](firstShiftPat)
+            firstShift <- QSUGraph.withName[T, G](namePrefix)(firstShiftPat)
             _ <- ApplyProvenance.computeProvenance[T, G](firstShift)
             shiftAndRotation <- ss.zipWithIndex.foldLeftM[G, (QSUGraph, Rotation)]((firstShift :++ mls, rotation)) {
               case ((shiftAbove, rotationAbove), ((newStruct, newIdStatus, newRotation), idx)) =>
@@ -97,7 +98,7 @@ final class ExpandShifts[T[_[_]]: BirecursiveT: EqualT: ShowT] extends QSUTTypes
                 val newShiftPat =
                   QSU.LeftShift[T, Symbol](shiftAbove.root, struct, newIdStatus, repair, newRotation)
                 for {
-                  newShift <- QSUGraph.withName[T, G](newShiftPat)
+                  newShift <- QSUGraph.withName[T, G](namePrefix)(newShiftPat)
                   _ <- ApplyProvenance.computeProvenance[T, G](newShift)
                   identityCondition =
                   if (rotationsCompatible(rotationAbove, newRotation))

--- a/connector/src/main/scala/quasar/qscript/qsu/ExpandShifts.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ExpandShifts.scala
@@ -56,7 +56,7 @@ final class ExpandShifts[T[_[_]]: BirecursiveT: EqualT: ShowT] extends QSUTTypes
   }
 
   val originalKey = "original"
-  val namePrefix = "expandshifts"
+  val namePrefix = "esh"
 
   def rotationsCompatible(rotation1: Rotation, rotation2: Rotation): Boolean = rotation1 match {
     case Rotation.FlattenArray | Rotation.ShiftArray =>

--- a/connector/src/main/scala/quasar/qscript/qsu/ExtractFreeMap.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ExtractFreeMap.scala
@@ -173,7 +173,7 @@ final class ExtractFreeMap[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T
     }
 
   private def withName[F[_]: Monad: NameGenerator: RevIdxM](node: QScriptUniform[Symbol]): F[QSUGraph] =
-    QSUGraph.withName[T, F]("extractfm")(node)
+    QSUGraph.withName[T, F]("efm")(node)
 }
 
 object ExtractFreeMap {

--- a/connector/src/main/scala/quasar/qscript/qsu/ExtractFreeMap.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ExtractFreeMap.scala
@@ -25,7 +25,7 @@ import quasar.qscript.{construction, JoinSide, LeftSide, RightSide}
 import quasar.sql.JoinDir
 
 import matryoshka.BirecursiveT
-import scalaz.{\/, -\/, \/-, Applicative, Functor, Monad, NonEmptyList => NEL, Scalaz}, Scalaz._
+import scalaz.{\/, -\/, \/-, Monad, NonEmptyList => NEL, Scalaz, StateT}, Scalaz._
 
 /** Extracts `MapFunc` expressions from operations by requiring an argument
   * to be a function of one or more sibling arguments and creating an
@@ -36,8 +36,10 @@ final class ExtractFreeMap[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T
   import QSUGraph.Extractors
 
   def apply[F[_]: Monad: NameGenerator: PlannerErrorME](graph: QSUGraph)
-      : F[QSUGraph] =
-    graph.rewriteM[F](extract[F])
+      : F[QSUGraph] = {
+    type G[A] = StateT[F, RevIdx, A]
+    graph.rewriteM[G](extract[G]).eval(graph.generateRevIndex)
+  }
 
   ////
 
@@ -45,7 +47,7 @@ final class ExtractFreeMap[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T
 
   private val func = construction.Func[T]
 
-  private def extract[F[_]: Monad: NameGenerator: PlannerErrorME]
+  private def extract[F[_]: Monad: NameGenerator: PlannerErrorME: RevIdxM]
       : PartialFunction[QSUGraph, F[QSUGraph]] = {
 
     // This will only work once #3170 is completed.
@@ -88,24 +90,27 @@ final class ExtractFreeMap[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T
         case ((\/-(sym), _)) => sym
       }
 
-      def autojoinVerts(head: Symbol, tail: List[Symbol]): F[(Symbol, QSUVerts[T])] = {
-        freshName[F].flatMap { joinRoot =>
-          val join: QSU[Symbol] = AutoJoin2(src.root, head,
-            func.StaticMapS("sort_source" -> func.LeftSide, head.name -> func.RightSide))
+      def autojoinAll(head: Symbol, tail: List[Symbol]): F[QSUGraph] =
+        for {
+          join <- withName[F](
+            AutoJoin2(src.root, head,
+              func.StaticMapS(
+                "sort_source" -> func.LeftSide,
+                head.name -> func.RightSide)))
 
-	      val updated: QSUVerts[T] = graph.vertices.updated(joinRoot, join)
+          updatedG = join :++ graph
 
-          tail.foldLeftM((joinRoot, updated)) {
-            case ((prev, verts), sym) =>
-              freshName[F].map { innerRoot =>
-                val join: QSU[Symbol] =
-	              AutoJoin2(prev, sym, func.ConcatMaps(func.LeftSide, func.MakeMapS(sym.name, func.RightSide)))
+          result <- tail.foldLeftM(updatedG) {
+            case (g, sym) =>
+              val join = withName[F](
+                AutoJoin2(g.root, sym,
+                  func.ConcatMaps(
+                    func.LeftSide,
+                    func.MakeMapS(sym.name, func.RightSide))))
 
-	            (innerRoot, verts.updated(innerRoot, join))
-              }
+              join map (_ :++ g)
           }
-        }
-      }
+        } yield result
 
       nonmappable match {
         case Nil =>
@@ -120,30 +125,23 @@ final class ExtractFreeMap[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T
 
         case head :: tail =>
           for {
-            interRoot <- freshName[F]
-            joined <- autojoinVerts(head, tail)
-          } yield {
-            val (joinRoot, verts) = joined
+            joined <- autojoinAll(head, tail)
 
-            val order: NEL[(FreeMap, SortDir)] =
-              access.map(_.leftMap {
-                case -\/(fm) => fm >> func.ProjectKeyS(func.Hole, "sort_source")
-                case \/-(sym) => func.ProjectKeyS(func.Hole, sym.name)
-              })
+            order = access.map(_.leftMap {
+              case -\/(fm) => fm >> func.ProjectKeyS(func.Hole, "sort_source")
+              case \/-(sym) => func.ProjectKeyS(func.Hole, sym.name)
+            })
 
-            val sort: QSU[Symbol] = QSSort(joinRoot, Nil, order)
-            val result: QSU[Symbol] = Map(interRoot, func.ProjectKeyS(func.Hole, "sort_source"))
+            sort <- withName[F](QSSort(joined.root, Nil, order))
 
-            val newVerts: QSUVerts[T] = verts
-              .updated(interRoot, sort)
-              .updated(graph.root, result)
+            result = graph.overwriteAtRoot(
+              Map(sort.root, func.ProjectKeyS(func.Hole, "sort_source")))
 
-            QSUGraph(graph.root, newVerts)
-          }
+          } yield result :++ sort :++ joined
       }
     }
 
-  private def autojoinFreeMap[F[_]: Applicative: NameGenerator: PlannerErrorME]
+  private def autojoinFreeMap[F[_]: Monad: NameGenerator: PlannerErrorME: RevIdxM]
     (graph: QSUGraph, src: Symbol, target: Symbol)
     (srcName: String, targetName: String)
     (makeQSU: (Symbol, FreeMap) => QSU[Symbol])
@@ -151,27 +149,20 @@ final class ExtractFreeMap[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T
     MappableRegion.unaryOf(src, graph refocus target)
       .map(makeQSU(src, _)) match {
 
-        case Some(qs) => graph.overwriteAtRoot(qs).point[F]
+        case Some(qs) =>
+          graph.overwriteAtRoot(qs).point[F]
 
-        case None => (freshName[F] |@| freshName[F]) {
-          case (joinRoot, interRoot) =>
-            val combine: JoinFunc = func.StaticMapS(
-              srcName -> func.LeftSide,
-              targetName -> func.RightSide)
+        case None =>
+          val combine: JoinFunc = func.StaticMapS(
+            srcName -> func.LeftSide,
+            targetName -> func.RightSide)
 
-            val join: QSU[Symbol] = AutoJoin2(src, target, combine)
-            val inter: QSU[Symbol] = makeQSU(joinRoot, func.ProjectKeyS(func.Hole, targetName))
-            val result: QSU[Symbol] = Map(interRoot, func.ProjectKeyS(func.Hole, srcName))
+          for {
+            join <- withName[F](AutoJoin2(src, target, combine))
+            inter <- withName[F](makeQSU(join.root, func.ProjectKeyS(func.Hole, targetName)))
+            result = graph.overwriteAtRoot(Map(inter.root, func.ProjectKeyS(func.Hole, srcName)))
 
-            val QSUGraph(origRoot, origVerts) = graph
-
-            val newVerts: QSUVerts[T] = origVerts
-              .updated(joinRoot, join)
-              .updated(interRoot, inter)
-              .updated(origRoot, result)
-
-            QSUGraph(origRoot, newVerts)
-        }
+          } yield result :++ inter :++ join
       }
 
   private def replaceRefs(g: QSUGraph, l: Symbol, r: Symbol)
@@ -181,8 +172,8 @@ final class ExtractFreeMap[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T
       case JoinSideRef(`r`) => RightSide
     }
 
-  private def freshName[F[_]: Functor: NameGenerator]: F[Symbol] =
-    freshSymbol("extract")
+  private def withName[F[_]: Monad: NameGenerator: RevIdxM](node: QScriptUniform[Symbol]): F[QSUGraph] =
+    QSUGraph.withName[T, F]("extractfm")(node)
 }
 
 object ExtractFreeMap {

--- a/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
@@ -317,7 +317,7 @@ object MinimizeAutoJoins {
       pat: QScriptUniform[T, Symbol]): G[QSUGraph[T]] = {
 
     for {
-      qgraph <- QSUGraph.withName[T, G]("expandajs")(pat)
+      qgraph <- QSUGraph.withName[T, G]("maj")(pat)
       _ <- updateProvenance[T, G](qgraph)
     } yield qgraph
   }

--- a/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/MinimizeAutoJoins.scala
@@ -96,7 +96,7 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT]
 
   // the Ints are indices into branches
   private def coalesceToMap[
-      G[_]: Monad: NameGenerator: RevIdxM[T, ?[_]]: MinStateM[T, ?[_]]: PlannerErrorME](
+      G[_]: Monad: NameGenerator: RevIdxM: MinStateM[T, ?[_]]: PlannerErrorME](
       qgraph: QSUGraph,
       branches: List[QSUGraph],
       combiner: FreeMapA[Int]): G[Option[QSUGraph]] = {
@@ -158,7 +158,7 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT]
   // the Int indexes into the final number of distinct roots
   @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
   private def coalesceRoots[
-      G[_]: Monad: NameGenerator: RevIdxM[T, ?[_]]: MinStateM[T, ?[_]]: PlannerErrorME](
+      G[_]: Monad: NameGenerator: RevIdxM: MinStateM[T, ?[_]]: PlannerErrorME](
       qgraph: QSUGraph,
       fm: => FreeMapA[Int],
       candidates: List[QSUGraph]): G[Option[QSUGraph]] = candidates match {
@@ -299,15 +299,10 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT]
 }
 
 object MinimizeAutoJoins {
-  import QSUGraph.RevIdx
-
   final case class MinimizationState[T[_[_]]](auth: QAuth[T], failed: Set[Symbol])
 
   type MinStateM[T[_[_]], F[_]] = MonadState_[F, MinimizationState[T]]
   def MinStateM[T[_[_]], F[_]](implicit ev: MinStateM[T, F]): MinStateM[T, F] = ev
-
-  type RevIdxM[T[_[_]], F[_]] = MonadState_[F, RevIdx[T]]
-  def RevIdxM[T[_[_]], F[_]](implicit ev: RevIdxM[T, F]): RevIdxM[T, F] = ev
 
   def apply[
       T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT,
@@ -322,7 +317,7 @@ object MinimizeAutoJoins {
       pat: QScriptUniform[T, Symbol]): G[QSUGraph[T]] = {
 
     for {
-      qgraph <- QSUGraph.withName[T, G](pat)
+      qgraph <- QSUGraph.withName[T, G]("expandajs")(pat)
       _ <- updateProvenance[T, G](qgraph)
     } yield qgraph
   }

--- a/connector/src/main/scala/quasar/qscript/qsu/QSUTTypes.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/QSUTTypes.scala
@@ -27,6 +27,7 @@ trait QSUTTypes[T[_[_]]] extends TTypes[T] {
   type FreeAccess[A] = quasar.qscript.qsu.FreeAccess[T, A]
   type QSUGraph = quasar.qscript.qsu.QSUGraph[T]
   type RevIdx = quasar.qscript.qsu.QSUGraph.RevIdx[T]
+  type RevIdxM[F[_]] = quasar.qscript.qsu.RevIdxM[T, F]
   type References = quasar.qscript.qsu.References[T, T[EJson]]
   type QScriptUniform[A] = quasar.qscript.qsu.QScriptUniform[T, A]
   type QScriptEducated[A] = quasar.qscript.QScriptEducated[T, A]

--- a/connector/src/main/scala/quasar/qscript/qsu/ReadLP.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ReadLP.scala
@@ -269,7 +269,7 @@ final class ReadLP[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T] {
     withName[G](constr(parent1.root, parent2.root, parent3.root)).map(_ :++ parent1 :++ parent2 :++ parent3)
 
   private def withName[G[_]: Monad: NameGenerator: RevIdxM](node: QScriptUniform[Symbol]): G[QSUGraph] =
-    QSUGraph.withName[T, G]("readlp")(node)
+    QSUGraph.withName[T, G]("rlp")(node)
 
   private def fromData(data: Data): Data \/ T[EJson] = {
     data.hyloM[Data \/ ?, CoEnv[Data, EJson, ?], T[EJson]](

--- a/connector/src/main/scala/quasar/qscript/qsu/ReadLP.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ReadLP.scala
@@ -268,9 +268,8 @@ final class ReadLP[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T] {
       constr: (Symbol, Symbol, Symbol) => QSU[Symbol]): G[QSUGraph] =
     withName[G](constr(parent1.root, parent2.root, parent3.root)).map(_ :++ parent1 :++ parent2 :++ parent3)
 
-  private def withName[G[_]: Monad: NameGenerator: MonadState_[?[_], RevIdx]](
-      node: QSU[Symbol]): G[QSUGraph] =
-    QSUGraph.withName[T, G](node)
+  private def withName[G[_]: Monad: NameGenerator: RevIdxM](node: QScriptUniform[Symbol]): G[QSUGraph] =
+    QSUGraph.withName[T, G]("readlp")(node)
 
   private def fromData(data: Data): Data \/ T[EJson] = {
     data.hyloM[Data \/ ?, CoEnv[Data, EJson, ?], T[EJson]](

--- a/connector/src/main/scala/quasar/qscript/qsu/ReifyBuckets.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ReifyBuckets.scala
@@ -67,7 +67,7 @@ final class ReifyBuckets[T[_[_]]: BirecursiveT: EqualT: ShowT] private () extend
                   })
 
                 for {
-                  autojoined <- QSUGraph.withName[T, G]("reifybuckets")(
+                  autojoined <- QSUGraph.withName[T, G]("rbu")(
                     qsu.autojoin2(sym, source.root, combine))
 
                   qauth0 <- MonadState_[G, QAuth].get

--- a/connector/src/main/scala/quasar/qscript/qsu/ReifyIdentities.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ReifyIdentities.scala
@@ -161,7 +161,7 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT: ShowT] private () extends QSU
       G.gets(_.status.lookup(g.root) getOrElse false)
 
     def freshName: F[Symbol] =
-      freshSymbol("reifyids")
+      freshSymbol("rid")
 
     def isReferenced(access: QAccess[Symbol]): G[Boolean] =
       G.gets(_.refs.accessed.member(access))

--- a/connector/src/main/scala/quasar/qscript/qsu/RewriteGroupByArrays.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/RewriteGroupByArrays.scala
@@ -25,12 +25,11 @@ import matryoshka.{BirecursiveT, ShowT}
 import scalaz.{Monad, Scalaz, StateT}, Scalaz._
 
 final class RewriteGroupByArrays[T[_[_]]: BirecursiveT: ShowT] private () extends QSUTTypes[T] {
-  import QSUGraph.withName
   import QSUGraph.Extractors._
 
   // recognize the pattern generated in LP of squishing groupbys together
   def apply[F[_]: Monad: NameGenerator](qgraph: QSUGraph): F[QSUGraph] = {
-    type G[A] = StateT[F, QSUGraph.RevIdx[T], A]
+    type G[A] = StateT[F, RevIdx, A]
 
     val back = qgraph rewriteM {
       case qgraph @ GroupBy(target, NAryArray(keys @ _*)) =>
@@ -39,7 +38,7 @@ final class RewriteGroupByArrays[T[_[_]]: BirecursiveT: ShowT] private () extend
           // this happens because inner and target don't necessarily exist in key's vertices
           for {
             key2 <- key.replaceWithRename[G](target.root, inner.root)
-            replaced <- withName[T, G](QSU.GroupBy[T, Symbol](inner.root, key2.root))
+            replaced <- QSUGraph.withName[T, G]("rewritegbarrays")(QSU.GroupBy[T, Symbol](inner.root, key2.root))
           } yield replaced :++ inner :++ key2
         }
 

--- a/connector/src/main/scala/quasar/qscript/qsu/RewriteGroupByArrays.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/RewriteGroupByArrays.scala
@@ -38,7 +38,7 @@ final class RewriteGroupByArrays[T[_[_]]: BirecursiveT: ShowT] private () extend
           // this happens because inner and target don't necessarily exist in key's vertices
           for {
             key2 <- key.replaceWithRename[G](target.root, inner.root)
-            replaced <- QSUGraph.withName[T, G]("rewritegbarrays")(QSU.GroupBy[T, Symbol](inner.root, key2.root))
+            replaced <- QSUGraph.withName[T, G]("rga")(QSU.GroupBy[T, Symbol](inner.root, key2.root))
           } yield replaced :++ inner :++ key2
         }
 

--- a/connector/src/main/scala/quasar/qscript/qsu/minimizers/CollapseShifts.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/minimizers/CollapseShifts.scala
@@ -71,7 +71,7 @@ final class CollapseShifts[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] pr
     candidates exists { case ConsecutiveUnbounded(_, _) => true; case _ => false }
 
   def extract[
-      G[_]: Monad: NameGenerator: PlannerErrorME: RevIdxM[T, ?[_]]: MinStateM[T, ?[_]]](
+      G[_]: Monad: NameGenerator: PlannerErrorME: RevIdxM: MinStateM[T, ?[_]]](
       qgraph: QSUGraph): Option[(QSUGraph, (QSUGraph, FreeMap) => G[QSUGraph])] = qgraph match {
 
     case ConsecutiveUnbounded(src, shifts) =>
@@ -177,7 +177,7 @@ final class CollapseShifts[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] pr
    */
   @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
   def apply[
-      G[_]: Monad: NameGenerator: PlannerErrorME: RevIdxM[T, ?[_]]: MinStateM[T, ?[_]]](
+      G[_]: Monad: NameGenerator: PlannerErrorME: RevIdxM: MinStateM[T, ?[_]]](
       qgraph: QSUGraph,
       src: QSUGraph,
       candidates: List[QSUGraph],

--- a/connector/src/main/scala/quasar/qscript/qsu/minimizers/MergeReductions.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/minimizers/MergeReductions.scala
@@ -49,7 +49,7 @@ final class MergeReductions[T[_[_]]: BirecursiveT: EqualT: ShowT] private () ext
   }
 
   def extract[
-      G[_]: Monad: NameGenerator: PlannerErrorME: RevIdxM[T, ?[_]]: MinStateM[T, ?[_]]](
+      G[_]: Monad: NameGenerator: PlannerErrorME: RevIdxM: MinStateM[T, ?[_]]](
       qgraph: QSUGraph): Option[(QSUGraph, (QSUGraph, FreeMap) => G[QSUGraph])] = qgraph match {
 
     case qgraph @ QSReduce(src, buckets, reducers, repair) =>
@@ -72,7 +72,7 @@ final class MergeReductions[T[_[_]]: BirecursiveT: EqualT: ShowT] private () ext
 
   @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
   def apply[
-      G[_]: Monad: NameGenerator: PlannerErrorME: RevIdxM[T, ?[_]]: MinStateM[T, ?[_]]](
+      G[_]: Monad: NameGenerator: PlannerErrorME: RevIdxM: MinStateM[T, ?[_]]](
       qgraph: QSUGraph,
       source: QSUGraph,
       candidates: List[QSUGraph],

--- a/connector/src/main/scala/quasar/qscript/qsu/minimizers/Minimizer.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/minimizers/Minimizer.scala
@@ -23,18 +23,18 @@ import slamdata.Predef._
 import scalaz.Monad
 
 trait Minimizer[T[_[_]]] extends QSUTTypes[T] {
-  import MinimizeAutoJoins.{MinStateM, RevIdxM}
+  import MinimizeAutoJoins.MinStateM
 
   def couldApplyTo(candidates: List[QSUGraph]): Boolean
 
   def extract[
-      G[_]: Monad: NameGenerator: PlannerErrorME: RevIdxM[T, ?[_]]: MinStateM[T, ?[_]]](
+      G[_]: Monad: NameGenerator: PlannerErrorME: RevIdxM: MinStateM[T, ?[_]]](
       qgraph: QSUGraph): Option[(QSUGraph, (QSUGraph, FreeMap) => G[QSUGraph])]
 
   // the first component of the tuple is the rewrite target on any provenance association
   // the second component is the root of the resulting graph
   def apply[
-      G[_]: Monad: NameGenerator: PlannerErrorME: RevIdxM[T, ?[_]]: MinStateM[T, ?[_]]](
+      G[_]: Monad: NameGenerator: PlannerErrorME: RevIdxM: MinStateM[T, ?[_]]](
       qgraph: QSUGraph,
       singleSource: QSUGraph,
       candidates: List[QSUGraph],

--- a/connector/src/main/scala/quasar/qscript/qsu/package.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/package.scala
@@ -19,6 +19,7 @@ package quasar.qscript
 import slamdata.Predef.{Map => SMap, _}
 import quasar.NameGenerator
 import quasar.Planner.{InternalError, PlannerErrorME}
+import quasar.contrib.scalaz.MonadState_
 import quasar.ejson.EJson
 import quasar.fp._
 import quasar.qscript.provenance.Dimensions
@@ -35,6 +36,9 @@ package object qsu {
   type FreeAccess[T[_[_]], A] = FreeMapA[T, QAccess[T, A]]
   type QDims[T[_[_]]] = Dimensions[QProv.P[T]]
   type QSUVerts[T[_[_]]] = SMap[Symbol, QScriptUniform[T, Symbol]]
+
+  type RevIdxM[T[_[_]], F[_]] = MonadState_[F, QSUGraph.RevIdx[T]]
+  def RevIdxM[T[_[_]], F[_]](implicit ev: RevIdxM[T, F]): RevIdxM[T, F] = ev
 
   def AccessValueF[T[_[_]], A](a: A): FreeAccess[T, A] =
     Free.pure[MapFunc[T, ?], QAccess[T, A]](Access.Value(a))

--- a/connector/src/test/scala/quasar/qscript/qsu/ExpandShiftsSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/ExpandShiftsSpec.scala
@@ -38,7 +38,7 @@ import quasar.qscript.qsu.{QScriptUniform => QSU}
 import QSU.Rotation
 import QSUGraph.Extractors._
 
-object ExpandShiftsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
+object eshSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
   type QSU[A] = QScriptUniform[A]
 
   val qsu = QScriptUniform.DslT[Fix]
@@ -114,8 +114,8 @@ object ExpandShiftsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
         outerRepair must beTreeEqual(
           func.Cond(
             func.Eq(
-              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('expandshifts0), _)),
-              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('expandshifts1), _))),
+              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('esh0), _)),
+              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('esh1), _))),
             func.StaticMapS(
                 "original" ->
                   func.ProjectKeyS(func.AccessLeftTarget(Access.valueHole(_)), "original"),
@@ -207,8 +207,8 @@ object ExpandShiftsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
         innerRepair must beTreeEqual(
           func.Cond(
             func.Eq(
-              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('expandshifts0), _)),
-              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('expandshifts1), _))),
+              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('esh0), _)),
+              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('esh1), _))),
             func.StaticMapS(
               "original" ->
                 func.ProjectKeyS(func.AccessLeftTarget(Access.valueHole(_)), "original"),
@@ -219,8 +219,8 @@ object ExpandShiftsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
         outerRepair must beTreeEqual(
           func.Cond(
             func.Eq(
-              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('expandshifts1), _)),
-              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('expandshifts2), _))),
+              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('esh1), _)),
+              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('esh2), _))),
             func.StaticMapS(
               "original" ->
                 func.ProjectKeyS(func.AccessLeftTarget(Access.valueHole(_)), "original"),

--- a/connector/src/test/scala/quasar/qscript/qsu/ExpandShiftsSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/ExpandShiftsSpec.scala
@@ -114,8 +114,8 @@ object ExpandShiftsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
         outerRepair must beTreeEqual(
           func.Cond(
             func.Eq(
-              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('qsu0), _)),
-              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('qsu1), _))),
+              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('expandshifts0), _)),
+              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('expandshifts1), _))),
             func.StaticMapS(
                 "original" ->
                   func.ProjectKeyS(func.AccessLeftTarget(Access.valueHole(_)), "original"),
@@ -207,8 +207,8 @@ object ExpandShiftsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
         innerRepair must beTreeEqual(
           func.Cond(
             func.Eq(
-              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('qsu0), _)),
-              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('qsu1), _))),
+              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('expandshifts0), _)),
+              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('expandshifts1), _))),
             func.StaticMapS(
               "original" ->
                 func.ProjectKeyS(func.AccessLeftTarget(Access.valueHole(_)), "original"),
@@ -219,8 +219,8 @@ object ExpandShiftsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
         outerRepair must beTreeEqual(
           func.Cond(
             func.Eq(
-              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('qsu1), _)),
-              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('qsu2), _))),
+              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('expandshifts1), _)),
+              func.AccessLeftTarget(Access.id(IdAccess.identity[Fix[EJson]]('expandshifts2), _))),
             func.StaticMapS(
               "original" ->
                 func.ProjectKeyS(func.AccessLeftTarget(Access.valueHole(_)), "original"),


### PR DESCRIPTION
Avoids direct manipulation of vertices and ensures identical structure will have identical names.