### PR TITLE
Enable flattenGroupedObject.test for marklogic_xml

### DIFF
--- a/it/src/main/resources/tests/flattenGroupedObject.test
+++ b/it/src/main/resources/tests/flattenGroupedObject.test
@@ -2,8 +2,7 @@
     "name": "flatten a grouped object with filter",
     "backends": {
         "couchbase":         "pending",
-        "marklogic_json":    "skip",
-        "marklogic_xml":     "skip",
+        "marklogic_json":    "pendingIgnoreFieldOrder",
         "mimir":             "ignoreFieldOrder",
         "mongodb_3_2":       "pending",
         "mongodb_3_4":       "pending",


### PR DESCRIPTION
Happened to notice this was `skip`ped for ML and it happens to be passing for `marklogic_xml`.