### PR TITLE
Prevent Search from erroring in simplifier with invalid regex

### DIFF
--- a/frontend/src/main/scala/quasar/std/library.scala
+++ b/frontend/src/main/scala/quasar/std/library.scala
@@ -39,7 +39,7 @@ trait Library {
   protected def constTyper[N <: Nat](codomain: Codomain): Typer[N] =
     _ => Some(success(codomain))
 
-  private def partialTyperOV[N <: Nat](f: Domain[N] => Option[VCodomain]): Typer[N] = f
+  def partialTyperOV[N <: Nat](f: Domain[N] => Option[VCodomain]): Typer[N] = f
 
   def partialTyperV[N <: Nat](f: PartialFunction[Domain[N], VCodomain]): Typer[N] =
     partialTyperOV[N](f.lift)


### PR DESCRIPTION
I tried to use matchers in `StdLibTypeCoherenceSpec`, but it looks like matchers cannot use scalacheck and the fragments need to be explicit and that means it would take at least five (maybe six) times as many LOC as it does now. We'll have to do with the test names.

Did manage to avoid compiling the regex twice in the success case, though.