### PR TITLE
extend aggregate $out allowing to write to collections in other db's

### DIFF
--- a/mongodb/src/main/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutor.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutor.scala
@@ -25,7 +25,6 @@ import scalaz._
 import scalaz.std.list._
 import scalaz.std.vector._
 import scalaz.std.option._
-import scalaz.syntax.equal._
 import scalaz.syntax.foldable._
 import scalaz.syntax.functor._
 
@@ -46,15 +45,15 @@ private[mongodb] final class JavaScriptWorkflowExecutor
   private def foldExpr[F[_]: Foldable, A](fa: F[A])(f: (A, Expr) => Expr): ExprS[Unit] =
     fa.traverse_[ExprS](a => MonadState[ExprS, Expr].modify(f(a, _)))
 
-  protected def aggregate(src: Collection, pipeline: Pipeline, outColl: Option[Collection]) =
+  protected def aggregate(src: Collection, pipeline: Pipeline) =
     tell(Call(
-      Select(toJsRef0(src, outColl.map(_.database)), "aggregate"),
+      Select(toJsRef(src), "aggregate"),
       List(
         AnonElem(pipeline map (_.bson.toJs)),
         AnonObjDecl(List("allowDiskUse" -> Bool(true))))))
 
   protected def aggregateCursor(src: Collection, pipeline: Pipeline) =
-    aggregate(src, pipeline, None)
+    aggregate(src, pipeline)
 
   protected def count(src: Collection, cfg: Count) = {
     val count0 = List(
@@ -108,6 +107,16 @@ private[mongodb] final class JavaScriptWorkflowExecutor
     tell(Call(
       Select(toJsRef(src), "mapReduce"),
       List(mr.map, mr.reduce, mr.inlineBson.toJs)))
+
+  private def toNamespaceBsonText(c: Collection) =
+    Bson.Text(s"${c.database.value}.${c.collection.value}")
+
+  protected def renameCollection(src: Collection, dst: Collection) =
+    tell(Call(
+      Select(Ident("db"), "adminCommand"),
+      List(Bson.Doc(ListMap(
+        "renameCollection" -> toNamespaceBsonText(src),
+        "to" -> toNamespaceBsonText(dst))).toJs)))
 }
 
 private[mongodb] object JavaScriptWorkflowExecutor {
@@ -122,23 +131,5 @@ private[mongodb] object JavaScriptWorkflowExecutor {
 
     case name =>
       Call(Select(Ident("db"), "getCollection"), List(Str(name)))
-  }
-
-  def toJsRef0(col: Collection, outDb: Option[DatabaseName]) = {
-    outDb match {
-      // if out.db != col.db
-      // then execute from out.db and use getSiblingDb(col.db) to access `col`
-      case Some(out) if out ≠ col.database =>
-        val sibDb = Call(Select(Ident("db"), "getSiblingDB"), List(Str(col.database.value)))
-        val execDb = out.value
-        col.collection.value match {
-          case name @ SimpleCollectionNamePattern() =>
-            Select(sibDb, name)
-
-          case name =>
-            Call(Select(sibDb, "getCollection"), List(Str(name)))
-        }
-      case _ => toJsRef(col)
-    }
   }
 }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/MongoDbIOWorkflowExecutor.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/MongoDbIOWorkflowExecutor.scala
@@ -41,14 +41,8 @@ private[mongodb] final class MongoDbIOWorkflowExecutor
   private def foldS[F[_]: Foldable, S, A](fa: F[A])(f: (A, S) => S): State[S, Unit] =
     fa.traverseS_[S, Unit](a => MonadState[State[S,?], S].modify(f(a, _)))
 
-  protected def aggregate(src: Collection, pipeline: Pipeline, outColl: Option[Collection]) = {
-    MongoDbIO.aggregate(src, pipeline map (_.bson), true) *>
-      (outColl match {
-        case Some(out) if (src.database =/= out.database) =>
-          MongoDbIO.rename(src.copy(collection = out.collection), out, RenameSemantics.FailIfExists)
-        case _ => ().point[MongoDbIO]
-      })
-  }
+  protected def aggregate(src: Collection, pipeline: Pipeline) =
+    MongoDbIO.aggregate(src, pipeline map (_.bson), true)
 
   protected def aggregateCursor(src: Collection, pipeline: Pipeline) =
     toCursor(
@@ -122,6 +116,9 @@ private[mongodb] final class MongoDbIOWorkflowExecutor
     bcIO flatMap { bc =>
       MongoDbIO.async((bc: MongoIterable[_ <: BsonValue]).widen[BsonValue].batchCursor)
     }
+
+  protected def renameCollection(src: Collection, dst: Collection) =
+    MongoDbIO.rename(src, dst, RenameSemantics.FailIfExists)
 }
 
 private[mongodb] object MongoDbIOWorkflowExecutor {


### PR DESCRIPTION
Status:

- [x] for result file: extend `aggregate` `$out` to write to remote collection
- [ ] to implement: same for streaming 
- [x] basic testing done. E.g. ```(select p1.name as name from `/m32/test/cars` as p1) union (select p2.year, p2.name as name from `/m32/test2/cars2` as p2)``` works
- [ ] more extensive testing
- [ ] unit tests & integration test (latter may need to be postponed to another PR because there's no infrastructure yet to add cross-db queries)
- [ ] test non standard collection names https://github.com/quasar-analytics/quasar/blob/master/mongodb/src/main/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutor.scala#L123

#qz-3621 Done