### PR TITLE
Redefine RDBMS error handling

### DIFF
--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsQueryFile.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsQueryFile.scala
@@ -39,7 +39,6 @@ import matryoshka.data.Fix
 import pathy.Path
 import scalaz._
 import Scalaz._
-import scalaz.stream.Process._
 
 trait RdbmsQueryFile extends ManagedQueryFile[DbDataStream] {
   self: Rdbms =>
@@ -90,8 +89,7 @@ trait RdbmsQueryFile extends ManagedQueryFile[DbDataStream] {
               .query[Data]
               .process
               .chunk(chunkSize)
-              .attempt(ex =>
-                emit(readFailed(qStr, ex.getLocalizedMessage)))
+              .map(_.right[quasar.fs.FileSystemError])
               .transact(xa))
           }.liftB
      })

--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsReadFile.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsReadFile.scala
@@ -24,7 +24,6 @@ import quasar.effect.Kvs
 import quasar.effect.Kvs._
 import quasar.fp.numeric.{Natural, Positive}
 import quasar.fs._
-import quasar.fs.FileSystemError._
 import quasar.physical.rdbms.Rdbms
 import quasar.physical.rdbms.common.TablePath
 import quasar.connector.ManagedReadFile
@@ -36,7 +35,6 @@ import doobie.util.meta.Meta
 import doobie.syntax.process._
 import scalaz._
 import Scalaz._
-import scalaz.stream.Process._
 import scalaz.concurrent.Task
 
 trait RdbmsReadFile
@@ -76,8 +74,7 @@ trait RdbmsReadFile
             .query[Data]
             .process
             .chunk(chunkSize)
-            .attempt(ex =>
-              emit(readFailed(dbPath.shows, ex.getLocalizedMessage)))
+            .map(_.right[quasar.fs.FileSystemError])
             .transact(xa))
       }.liftB
     }


### PR DESCRIPTION
When using `.attempt(ex => emit(readFailed(...))`, our stream emits a `Left[FileSystemError]`, but this causes problems with database connections. Apparently this swallows the exception, which doesn't go through standard handling, which leaves a leaking connection and freezes integration tests after saturating the connection pool.
Letting the stream crash in a standard way fixes the problem with leaking connections, but I suppose it's not the right way to fail here, because we would prefer to get the `FileSystemError` wrapped in `Backend`?
Could someone confirm this and eventually offer a solution for correct handling?