### PR TITLE
Greedily extract mappable regions prior to autojoining

### DIFF
--- a/connector/src/main/scala/quasar/qscript/MapFuncCore.scala
+++ b/connector/src/main/scala/quasar/qscript/MapFuncCore.scala
@@ -353,13 +353,26 @@ object MapFuncCore {
   private def rewrite[T[_[_]]: BirecursiveT: EqualT, A: Equal]:
       CoMapFuncR[T, A] => Option[CoMapFuncR[T, A]] =
     _.run.toOption >>= (MFC.unapply _) >>= {
-      case Eq(v1, v2) if v1 ≟ v2 =>
-        rollMF[T, A](
-          MFC(Constant(EJson.fromCommon(ejson.Bool[T[EJson]](true))))).some
+      case And(BoolLit(true), b) => some(b.project)
+
+      case And(a, BoolLit(true)) => some(a.project)
+
+      case And(BoolLit(false), _) => some(BoolLit[T, A](false).project)
+
+      case And(_, BoolLit(false)) => some(BoolLit[T, A](false).project)
+
+      case Or(a, BoolLit(false)) => some(a.project)
+
+      case Or(BoolLit(false), b) => some(b.project)
+
+      case Or(_, BoolLit(true)) => some(BoolLit[T, A](true).project)
+
+      case Or(BoolLit(true), _) => some(BoolLit[T, A](true).project)
+
+      case Eq(v1, v2) if v1 ≟ v2 => some(BoolLit[T, A](true).project)
 
       case Eq(ExtractFunc(Constant(v1)), ExtractFunc(Constant(v2))) =>
-        rollMF[T, A](
-          MFC(Constant(EJson.fromCommon(ejson.Bool[T[EJson]](v1 ≟ v2))))).some
+        some(BoolLit[T, A](v1 ≟ v2).project)
 
       case DeleteKey(
         Embed(StaticMap(map)),

--- a/connector/src/main/scala/quasar/qscript/qsu/ExtractFreeMap.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ExtractFreeMap.scala
@@ -20,12 +20,12 @@ import slamdata.Predef._
 
 import quasar.NameGenerator
 import quasar.Planner.{InternalError, PlannerErrorME}
-import quasar.common.SortDir
+import quasar.fp.symbolOrder
 import quasar.qscript.{construction, JoinSide, LeftSide, RightSide}
 import quasar.sql.JoinDir
 
 import matryoshka.BirecursiveT
-import scalaz.{\/, -\/, \/-, Monad, NonEmptyList => NEL, Scalaz, StateT}, Scalaz._
+import scalaz.{Monad, NonEmptyList, Scalaz, StateT}, Scalaz._
 
 /** Extracts `MapFunc` expressions from operations by requiring an argument
   * to be a function of one or more sibling arguments and creating an
@@ -50,16 +50,14 @@ final class ExtractFreeMap[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T
   private def extract[F[_]: Monad: NameGenerator: PlannerErrorME: RevIdxM]
       : PartialFunction[QSUGraph, F[QSUGraph]] = {
 
-    // This will only work once #3170 is completed.
-    // We need access to the group key through the `Map`.
     case graph @ Extractors.GroupBy(src, key) =>
-      autojoinFreeMap[F](graph, src.root, key.root)("group_source", "group_key") {
-        case (sym, fm) => DimEdit(sym, DTrans.Group(fm))
+      unifyShapePreserving[F](graph, src.root, NonEmptyList(key.root))("group_source", "group_key") {
+        case (sym, fms) => DimEdit(sym, DTrans.Group(fms.head))
       }
 
     case graph @ Extractors.LPFilter(src, predicate) =>
-      autojoinFreeMap[F](graph, src.root, predicate.root)("filter_source", "filter_predicate") {
-        case (sym, fm) => QSFilter(sym, fm)
+      unifyShapePreserving[F](graph, src.root, NonEmptyList(predicate.root))("filter_source", "filter_predicate") {
+        case (sym, fms) => QSFilter(sym, fms.head)
       }
 
     case graph @ Extractors.LPJoin(left, right, cond, jtype, lref, rref) =>
@@ -78,98 +76,35 @@ final class ExtractFreeMap[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T
         }
 
     case graph @ Extractors.LPSort(src, keys) =>
-      val access: NEL[(FreeMap \/ Symbol, SortDir)] =
-        keys.map(_.leftMap { key =>
-          MappableRegion.unaryOf(src.root, graph refocus key.root) match {
-            case Some(fm) => fm.left[Symbol]
-            case None => key.root.right[FreeMap]
-          }
-        })
-
-      val nonmappable: List[Symbol] = access.toList collect {
-        case ((\/-(sym), _)) => sym
+      unifyShapePreserving[F](graph, src.root, keys map (_._1.root))("sort_source", "sort_key") {
+        case (sym, fms) => QSSort(sym, Nil, fms fzip keys.seconds)
       }
-
-      def autojoinAll(head: Symbol, tail: List[Symbol]): F[QSUGraph] =
-        for {
-          join <- withName[F](
-            AutoJoin2(src.root, head,
-              func.StaticMapS(
-                "sort_source" -> func.LeftSide,
-                head.name -> func.RightSide)))
-
-          updatedG = join :++ graph
-
-          result <- tail.foldLeftM(updatedG) {
-            case (g, sym) =>
-              val join = withName[F](
-                AutoJoin2(g.root, sym,
-                  func.ConcatMaps(
-                    func.LeftSide,
-                    func.MakeMapS(sym.name, func.RightSide))))
-
-              join map (_ :++ g)
-          }
-        } yield result
-
-      nonmappable match {
-        case Nil =>
-          access.toList collect {
-            case ((-\/(fm), dir)) => (fm, dir)
-          } match {
-            case Nil =>
-              PlannerErrorME[F].raiseError[QSUGraph](InternalError(s"No sort keys found.", None))
-            case head :: tail =>
-              graph.overwriteAtRoot(QSSort(src.root, Nil, NEL(head, tail: _*))).point[F]
-          }
-
-        case head :: tail =>
-          for {
-            joined <- autojoinAll(head, tail)
-
-            order = access.map(_.leftMap {
-              case -\/(fm) => fm >> func.ProjectKeyS(func.Hole, "sort_source")
-              case \/-(sym) => func.ProjectKeyS(func.Hole, sym.name)
-            })
-
-            sort <- withName[F](QSSort(joined.root, Nil, order))
-
-            result = graph.overwriteAtRoot(
-              Map(sort.root, func.ProjectKeyS(func.Hole, "sort_source")))
-
-          } yield result :++ sort :++ joined
-      }
-    }
-
-  private def autojoinFreeMap[F[_]: Monad: NameGenerator: PlannerErrorME: RevIdxM]
-    (graph: QSUGraph, src: Symbol, target: Symbol)
-    (srcName: String, targetName: String)
-    (makeQSU: (Symbol, FreeMap) => QSU[Symbol])
-      : F[QSUGraph] =
-    MappableRegion.unaryOf(src, graph refocus target)
-      .map(makeQSU(src, _)) match {
-
-        case Some(qs) =>
-          graph.overwriteAtRoot(qs).point[F]
-
-        case None =>
-          val combine: JoinFunc = func.StaticMapS(
-            srcName -> func.LeftSide,
-            targetName -> func.RightSide)
-
-          for {
-            join <- withName[F](AutoJoin2(src, target, combine))
-            inter <- withName[F](makeQSU(join.root, func.ProjectKeyS(func.Hole, targetName)))
-            result = graph.overwriteAtRoot(Map(inter.root, func.ProjectKeyS(func.Hole, srcName)))
-
-          } yield result :++ inter :++ join
-      }
+  }
 
   private def replaceRefs(g: QSUGraph, l: Symbol, r: Symbol)
       : Symbol => Option[JoinSide] =
     s => g.vertices.get(s) collect {
       case JoinSideRef(`l`) => LeftSide
       case JoinSideRef(`r`) => RightSide
+    }
+
+  private def unifyShapePreserving[F[_]: Monad: NameGenerator: RevIdxM](
+      graph: QSUGraph,
+      source: Symbol,
+      targets: NonEmptyList[Symbol])(
+      sourceName: String,
+      targetPrefix: String)(
+      buildNode: (Symbol, NonEmptyList[FreeMap]) => QScriptUniform[Symbol]): F[QSUGraph] =
+    UnifyTargets[T, F](withName[F](_))(graph, source, targets)(sourceName, targetPrefix) flatMap {
+      case (newSrc, original, targetExprs) =>
+        val node = buildNode(newSrc.root, targetExprs)
+
+        if (newSrc.root === source)
+          graph.overwriteAtRoot(node).point[F]
+        else
+          withName[F](node) map { inter =>
+            graph.overwriteAtRoot(Map(inter.root, original)) :++ inter :++ newSrc
+          }
     }
 
   private def withName[F[_]: Monad: NameGenerator: RevIdxM](node: QScriptUniform[Symbol]): F[QSUGraph] =

--- a/connector/src/main/scala/quasar/qscript/qsu/ReifyBuckets.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ReifyBuckets.scala
@@ -27,7 +27,7 @@ import quasar.qscript.{construction, Hole, HoleF, ReduceFunc, ReduceIndexF, SrcH
 import ApplyProvenance.AuthenticatedQSU
 
 import matryoshka._
-import scalaz.{ISet, Monad, Scalaz, StateT}, Scalaz._
+import scalaz.{ISet, Monad, NonEmptyList, Scalaz, StateT}, Scalaz._
 
 final class ReifyBuckets[T[_[_]]: BirecursiveT: EqualT: ShowT] private () extends QSUTTypes[T] {
   import QSUGraph.Extractors._
@@ -49,44 +49,23 @@ final class ReifyBuckets[T[_[_]]: BirecursiveT: EqualT: ShowT] private () extend
           (srcs, buckets0) = res
 
           reifiedG <- srcs.findMin match {
-
             case Some(sym) =>
-              MappableRegion.unaryOf(sym, source) map { fm =>
-                g.overwriteAtRoot(mkReduce(sym, buckets0, reduce as fm))
-              } getOrElseF {
-                val combine = func.ConcatMaps(
-                  func.MakeMapS(GroupedKey, func.LeftSide),
-                  func.MakeMapS(ReduceExprKey, func.RightSide))
+              UnifyTargets[T, G](buildGraph[G](_))(g, sym, NonEmptyList(source.root))(GroupedKey, ReduceExprKey) map {
+                case (newSrc, original, reduceExpr) =>
+                  val buckets =
+                    buckets0.map(_ flatMap { access =>
+                      if (Access.valueHole.isEmpty(access))
+                        func.Hole as access
+                      else
+                        original as access
+                    })
 
-                val buckets =
-                  buckets0.map(_ flatMap { access =>
-                    if (Access.valueHole.isEmpty(access))
-                      func.Hole as access
-                    else
-                      func.ProjectKeyS(func.Hole, GroupedKey) as access
-                  })
-
-                for {
-                  autojoined <- QSUGraph.withName[T, G]("rbu")(
-                    qsu.autojoin2(sym, source.root, combine))
-
-                  qauth0 <- MonadState_[G, QAuth].get
-                  qauth1 <- ApplyProvenance.computeProvenance[T, G](autojoined)
-                               .exec(qauth0).liftM[StateT[?[_], QAuth, ?]]
-
-                  reduceExpr = func.ProjectKeyS(func.Hole, ReduceExprKey)
-                  reduced = g.overwriteAtRoot(mkReduce(autojoined.root, buckets, reduce as reduceExpr))
-
-                  qauth2 <- ApplyProvenance.computeProvenance[T, G](reduced)
-                               .exec(qauth1).liftM[StateT[?[_], QAuth, ?]]
-                  _ <- MonadState_[G, QAuth].put(qauth2)
-                } yield reduced :++ autojoined
+                  g.overwriteAtRoot(mkReduce(newSrc.root, buckets, reduce as reduceExpr.head)) :++ newSrc
               }
 
             case None =>
               g.overwriteAtRoot(mkReduce(source.root, buckets0, reduce as HoleF)).point[G]
           }
-
         } yield reifiedG
 
       case g @ QSSort(source, Nil, keys) =>
@@ -126,6 +105,14 @@ final class ReifyBuckets[T[_[_]]: BirecursiveT: EqualT: ShowT] private () extend
           (ISet.empty[Symbol], HoleF[T] as Access.id[prov.D, Hole](other, SrcHole)).point[F]
       }
     } yield res.unfzip leftMap (_.foldMap(ι))
+
+  private def buildGraph[F[_]: Monad: NameGenerator: PlannerErrorME: RevIdxM: MonadState_[?[_], QAuth]](
+      node: QScriptUniform[Symbol])
+      : F[QSUGraph] =
+    for {
+      newGraph <- QSUGraph.withName[T, F]("rbu")(node)
+      _        <- ApplyProvenance.computeProvenance[T, F](newGraph)
+    } yield newGraph
 
   private def mkReduce[A](
       src: A,

--- a/connector/src/main/scala/quasar/qscript/qsu/UnifyTargets.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/UnifyTargets.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.qsu
+
+import slamdata.Predef.{Map => SMap, _}
+
+import quasar.fp.symbolOrder
+import quasar.qscript.{construction, FreeMap => FM}
+
+import matryoshka.BirecursiveT
+import scalaz.{ICons, IList, INil, Monad, NonEmptyList, Scalaz, WriterT}, Scalaz._
+
+/** Given a graph, source and targets vertices, unifies access to the target
+  * values via `FreeMap`s over a common source.
+  *
+  * Returns the new source graph, a unary function to access the original source
+  * value and a list of unary functions to access the values of each of the
+  * provided targets.
+  */
+final class UnifyTargets[T[_[_]]: BirecursiveT, F[_]: Monad] private (
+    sourceName: String,
+    targetPrefix: String,
+    buildGraph: QScriptUniform[T, Symbol] => F[QSUGraph[T]],
+  ) extends QSUTTypes[T] {
+
+  import QScriptUniform.AutoJoin2
+
+  def apply(graph: QSUGraph, source: Symbol, targets: NonEmptyList[Symbol])
+      : F[(QSUGraph, FreeMap, NonEmptyList[FreeMap])] = {
+
+    val (roots, targetExprs) =
+      targets.traverse(t =>
+        MappableRegion(_ === source, graph refocus t) traverse { g =>
+          if (g.root === source)
+            WriterT.writer((IList[Symbol](), source))
+          else
+            WriterT.writer((IList(g.root), g.root))
+        }).run
+
+    roots.distinct.zipWithIndex match {
+      case INil() =>
+        (graph refocus source, func.Hole, targetExprs map (_ >> func.Hole)).point[F]
+
+      case ICons(h @ (head, _), tail) =>
+        val targetAccesses = (h :: tail) map (_ map targetAccess)
+        val accessIndex = SMap((source, sourceAccess) :: targetAccesses.toList : _*)
+
+        val srcCombine =
+          func.StaticMapS(
+            sourceName -> func.LeftSide,
+            targetName(0) -> func.RightSide)
+
+        val autojoinedM =
+          buildGraph(AutoJoin2(source, head, srcCombine)) flatMap { srcJoin =>
+            tail.foldLeftM(srcJoin) { case (joins, (tgt, i)) =>
+              val tgtCombine =
+                func.ConcatMaps(
+                  func.LeftSide,
+                  func.MakeMapS(targetName(i), func.RightSide))
+
+              buildGraph(AutoJoin2(joins.root, tgt, tgtCombine)) map (_ :++ joins)
+            }
+          }
+
+        autojoinedM map (g => (g :++ graph, sourceAccess, targetExprs map (_ >>= accessIndex)))
+    }
+  }
+
+  ////
+
+  private val func = construction.Func[T]
+
+  private val sourceAccess =
+    func.ProjectKeyS(func.Hole, sourceName)
+
+  private def targetAccess(idx: Int): FreeMap =
+    func.ProjectKeyS(func.Hole, targetName(idx))
+
+  private def targetName(idx: Int): String =
+    s"${targetPrefix}_${idx}"
+}
+
+object UnifyTargets {
+  def apply[T[_[_]]: BirecursiveT, F[_]: Monad](
+      buildGraph: QScriptUniform[T, Symbol] => F[QSUGraph[T]])(
+      graph: QSUGraph[T],
+      source: Symbol,
+      targets: NonEmptyList[Symbol])(
+      sourceName: String,
+      targetPrefix: String)
+      : F[(QSUGraph[T], FM[T], NonEmptyList[FM[T]])] =
+    new UnifyTargets[T, F](sourceName, targetPrefix, buildGraph).apply(graph, source, targets)
+}

--- a/connector/src/test/scala/quasar/qscript/qsu/ExtractFreeMapSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/ExtractFreeMapSpec.scala
@@ -17,7 +17,7 @@
 package quasar.qscript.qsu
 
 import slamdata.Predef._
-import quasar.Qspec
+import quasar.{Qspec, TreeMatchers}
 import quasar.Planner.PlannerError
 import quasar.common.SortDir
 import quasar.contrib.matryoshka._
@@ -26,16 +26,16 @@ import quasar.ejson.{EJson, Fixed}
 import quasar.ejson.implicits._
 import quasar.fp._
 import quasar.qscript.construction
-import quasar.qscript.{MapFuncsCore, MFC}
+import quasar.qscript.MapFuncsCore
 
 import matryoshka._
 import matryoshka.data._
 import matryoshka.data.free._
 import pathy.Path
-import scalaz.{\/, -\/, \/-, EitherT, ICons, INil, Need, NonEmptyList => NEL, StateT}
+import scalaz.{\/, \/-, EitherT, ICons, INil, Need, NonEmptyList => NEL, StateT}
 import scalaz.Scalaz._
 
-object ExtractFreeMapSpec extends Qspec with QSUTTypes[Fix] {
+object ExtractFreeMapSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
   import QScriptUniform.{DTrans, Retain, Rotation}
   import QSUGraph.Extractors._
 
@@ -89,10 +89,48 @@ object ExtractFreeMapSpec extends Qspec with QSUTTypes[Fix] {
                 autojoinCondition),
               filterPredicate),
             valueAccess)) =>
-          fm must_= predicate
-          filterPredicate must_= projectStrKey("filter_predicate")
-          valueAccess must_= projectStrKey("filter_source")
-          autojoinCondition must_= makeMap("filter_source", "filter_predicate")
+
+          fm must beTreeEqual(predicate)
+
+          filterPredicate must beTreeEqual(projectStrKey("filter_predicate_0"))
+
+          valueAccess must beTreeEqual(projectStrKey("filter_source"))
+
+          autojoinCondition must beTreeEqual(makeMap("filter_source", "filter_predicate_0"))
+      }
+    }
+
+    "greedily convert mappable function applied to transposed filter predicate" >> {
+      val field = projectStrKey("foo")
+
+      val predicate =
+        func.Gt(func.Hole, func.Constant(ejs.int(42)))
+
+      val graph = QSUGraph.fromTree[Fix](
+        qsu.lpFilter(
+          qsu.read(orders),
+          qsu.autojoin2((
+            qsu.transpose(qsu.map(qsu.read(orders), field), Retain.Values, Rotation.ShiftMap),
+            qsu.cint(42),
+            _(MapFuncsCore.Gt(_, _))))))
+
+      evaluate(extractFM(graph)) must beLike {
+        case \/-(Map(
+            QSFilter(
+              AutoJoin2(
+                Read(`orders`),
+                Transpose(Map(Read(`orders`), fm), Retain.Values, Rotation.ShiftMap),
+                autojoinCondition),
+              filterPredicate),
+            valueAccess)) =>
+
+          fm must beTreeEqual(field)
+
+          filterPredicate must beTreeEqual(predicate >> projectStrKey("filter_predicate_0"))
+
+          valueAccess must beTreeEqual(projectStrKey("filter_source"))
+
+          autojoinCondition must beTreeEqual(makeMap("filter_source", "filter_predicate_0"))
       }
     }
 
@@ -126,10 +164,47 @@ object ExtractFreeMapSpec extends Qspec with QSUTTypes[Fix] {
                 autojoinCondition),
               DTrans.Group(groupKey)),
             valueAccess)) =>
-          fm must_= key
-          groupKey must_= projectStrKey("group_key")
-          valueAccess must_= projectStrKey("group_source")
-          autojoinCondition must_= makeMap("group_source", "group_key")
+
+          fm must beTreeEqual(key)
+
+          groupKey must beTreeEqual(projectStrKey("group_key_0"))
+
+          valueAccess must beTreeEqual(projectStrKey("group_source"))
+
+          autojoinCondition must beTreeEqual(makeMap("group_source", "group_key_0"))
+      }
+    }
+
+    "greedily convert mappable function applied to transposed group key" >> {
+      val key = projectStrKey("foo")
+
+      val f =
+        func.Add(func.Modulo(func.Hole, func.Constant(ejs.int(13))), func.Constant(ejs.int(1)))
+
+      val graph = QSUGraph.fromTree[Fix](
+        qsu.groupBy(
+          qsu.read(orders),
+          qsu.map(
+            qsu.transpose(qsu.map(qsu.read(orders), key), Retain.Values, Rotation.ShiftMap),
+            f)))
+
+      evaluate(extractFM(graph)) must beLike {
+        case \/-(Map(
+            DimEdit(
+              AutoJoin2(
+                Read(`orders`),
+                Transpose(Map(Read(`orders`), fm), Retain.Values, Rotation.ShiftMap),
+                autojoinCondition),
+              DTrans.Group(groupKey)),
+            valueAccess)) =>
+
+          fm must beTreeEqual(key)
+
+          groupKey must beTreeEqual(f >> projectStrKey("group_key_0"))
+
+          valueAccess must beTreeEqual(projectStrKey("group_source"))
+
+          autojoinCondition must beTreeEqual(makeMap("group_source", "group_key_0"))
       }
     }
 
@@ -176,16 +251,15 @@ object ExtractFreeMapSpec extends Qspec with QSUTTypes[Fix] {
               NEL((fm1, SortDir.Ascending), ICons((fm2, SortDir.Descending), INil()))),
             valueAccess)) => {
 
-          val genName: String = (fm2.resume match {
-            case -\/(MFC(MapFuncsCore.ProjectKey(_, MapFuncsCore.StrLit(name)))) => name.some
-            case _ => None
-          }).get
+          fm must beTreeEqual(key2)
 
-          fm must_= key2
-          fm1 must_= key1 >> projectStrKey("sort_source")
-          fm2 must_= projectStrKey(genName)
-          valueAccess must_= projectStrKey("sort_source")
-          autojoinCondition must_= makeMap("sort_source", genName)
+          fm1 must beTreeEqual(key1 >> projectStrKey("sort_source"))
+
+          fm2 must beTreeEqual(projectStrKey("sort_key_0"))
+
+          valueAccess must beTreeEqual(projectStrKey("sort_source"))
+
+          autojoinCondition must beTreeEqual(makeMap("sort_source", "sort_key_0"))
         }
       }
     }
@@ -220,27 +294,25 @@ object ExtractFreeMapSpec extends Qspec with QSUTTypes[Fix] {
                 (fm1, SortDir.Ascending), ICons((fm2, SortDir.Descending), ICons((fm3, SortDir.Descending), ICons((fm4, SortDir.Ascending), INil()))))),
             valueAccess)) => {
 
-          val genName2: String = (fm2.resume match {
-            case -\/(MFC(MapFuncsCore.ProjectKey(_, MapFuncsCore.StrLit(name)))) => name.some
-            case _ => None
-          }).get
+          innerFM must beTreeEqual(key2)
 
-          val genName4: String = (fm4.resume match {
-            case -\/(MFC(MapFuncsCore.ProjectKey(_, MapFuncsCore.StrLit(name)))) => name.some
-            case _ => None
-          }).get
+          outerFM must beTreeEqual(key4)
 
-          innerFM must_= key2
-          outerFM must_= key4
-          fm1 must_= key1 >> projectStrKey("sort_source")
-          fm2 must_= projectStrKey(genName2)
-          fm3 must_= key3 >> projectStrKey("sort_source")
-          fm4 must_= projectStrKey(genName4)
-          valueAccess must_= projectStrKey("sort_source")
-          innerAutojoinCondition must_= makeMap("sort_source", genName2)
-          outerAutojoinCondition must_= func.ConcatMaps(
+          fm1 must beTreeEqual(key1 >> projectStrKey("sort_source"))
+
+          fm2 must beTreeEqual(projectStrKey("sort_key_0"))
+
+          fm3 must beTreeEqual(key3 >> projectStrKey("sort_source"))
+
+          fm4 must beTreeEqual(projectStrKey("sort_key_1"))
+
+          valueAccess must beTreeEqual(projectStrKey("sort_source"))
+
+          innerAutojoinCondition must beTreeEqual(makeMap("sort_source", "sort_key_0"))
+
+          outerAutojoinCondition must beTreeEqual(func.ConcatMaps(
             func.LeftSide,
-            func.MakeMap(func.Constant(ejs.str(genName4)), func.RightSide))
+            func.MakeMap(func.Constant(ejs.str("sort_key_1")), func.RightSide)))
         }
       }
     }

--- a/connector/src/test/scala/quasar/qscript/qsu/ReifyBucketsSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/ReifyBucketsSpec.scala
@@ -173,7 +173,111 @@ object ReifyBucketsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
         func.ProjectKeyS(func.ProjectKeyS(func.Hole, "grouped"), "city") map (Access.value[Fix[EJson], Hole](_))
 
       val expSumExpr =
-        func.ProjectKeyS(func.Hole, "reduce_expr")
+        func.ProjectKeyS(func.Hole, "reduce_expr_0")
+
+      reifyBuckets(tree) must beLike {
+        case \/-(
+          AutoJoin2(
+            AutoJoin2(
+              city,
+              QSReduce(
+                LeftShift(
+                  Read(_),
+                  Embed(CoEnv(-\/(SrcHole))),
+                  ExcludeId,
+                  _,
+                  _,
+                  Rotation.ShiftMap),
+                List(arbBucket),
+                List(ReduceFuncs.Arbitrary(arbExpr)),
+                _),
+              _),
+            AutoJoin2(
+              str1,
+              QSReduce(
+                AutoJoin2(
+                  LeftShift(
+                    Read(_),
+                    Embed(CoEnv(-\/(SrcHole))),
+                    ExcludeId,
+                    _,
+                    _,
+                    Rotation.ShiftMap),
+                  LeftShift(
+                    AutoJoin2(
+                      LeftShift(
+                        Read(_),
+                        Embed(CoEnv(-\/(SrcHole))),
+                        ExcludeId,
+                        _,
+                        _,
+                        Rotation.ShiftMap),
+                      loc,
+                      _),
+                    Embed(CoEnv(-\/(SrcHole))),
+                    ExcludeId,
+                    tgt,
+                    _,
+                    Rotation.FlattenArray),
+                  _),
+                List(sumBucket),
+                List(ReduceFuncs.Sum(sumExpr)),
+                _),
+              _),
+            _)) =>
+
+          arbBucket must beTreeEqual(expArbBucket)
+          arbExpr must beTreeEqual(expArbExpr)
+          sumBucket must beTreeEqual(expSumBucket)
+          sumExpr must beTreeEqual(expSumExpr)
+      }
+    }
+
+    "greedily extract mappable regions from  dimension-altering reduce expressions" >> {
+      // select city, sum(baz[*].quux) from zips group by city
+      val src =
+        qsu.dimEdit(
+          qsu.tread1("zips"),
+          DTrans.Group(func.ProjectKeyS(func.Hole, "city")))
+
+      val tree =
+        qsu.autojoin2((
+          qsu.autojoin2((
+            qsu.cstr("city"),
+            qsu.lpReduce(
+              qsu.autojoin2((
+                src,
+                qsu.cstr("city"),
+                _(MapFuncsCore.ProjectKey(_, _)))),
+              ReduceFuncs.Arbitrary(())),
+            _(MapFuncsCore.MakeMap(_, _)))),
+          qsu.autojoin2((
+            qsu.cstr("1"),
+            qsu.lpReduce(
+              qsu.map(
+                qsu.transpose(
+                  qsu.autojoin2((
+                    src,
+                    qsu.cstr("baz"),
+                    _(MapFuncsCore.ProjectKey(_, _)))),
+                  Retain.Values,
+                  Rotation.FlattenArray),
+                func.ProjectKeyS(func.Hole, "quux")),
+              ReduceFuncs.Sum(())),
+            _(MapFuncsCore.MakeMap(_, _)))),
+          _(MapFuncsCore.ConcatMaps(_, _))))
+
+      val expArbBucket =
+        func.ProjectKeyS(func.Hole, "city") map (Access.value[Fix[EJson], Hole](_))
+
+      val expArbExpr =
+        func.ProjectKeyS(func.Hole, "city")
+
+      val expSumBucket =
+        func.ProjectKeyS(func.ProjectKeyS(func.Hole, "grouped"), "city") map (Access.value[Fix[EJson], Hole](_))
+
+      val expSumExpr =
+        func.ProjectKeyS(func.ProjectKeyS(func.Hole, "reduce_expr_0"), "quux")
 
       reifyBuckets(tree) must beLike {
         case \/-(

--- a/it/src/main/resources/tests/havingWithMultipleProjections.test
+++ b/it/src/main/resources/tests/havingWithMultipleProjections.test
@@ -3,10 +3,6 @@
     "backends": {
         "couchbase":         "pending",
         "marklogic_json":    "pending",
-        "marklogic_xml":     "pending",
-        "mongodb_3_2":       "pending",
-        "mongodb_3_4":       "pending",
-        "mongodb_read_only": "pending",
         "spark_cassandra":   "pending"
     },
     "data": "extraSmallZips.data",

--- a/it/src/main/resources/tests/subselectDistinctWhere.test
+++ b/it/src/main/resources/tests/subselectDistinctWhere.test
@@ -4,10 +4,14 @@
     "couchbase":         "skip",
     "marklogic_json":    "skip",
     "marklogic_xml":     "skip",
-    "mimir":             "ignoreFieldOrder"
+    "mimir":             "ignoreFieldOrder",
+    "mongodb_3_2":       "pending",
+    "mongodb_3_4":       "pending",
+    "mongodb_read_only": "pending"
   },
   "NB": "skipped on couchbase due to lack of general join",
   "NB": "skipped on marklogic due to timeout",
+  "NB": "pending for mongodb due to MongoDB Error: Command failed with error 13070: 'value too large to reduce'",
   "data": ["demo/patients.data", "zips.data"],
   "query": "SELECT first_name, last_name FROM `demo/patients` AS p where state in (SELECT DISTINCT state FROM zips) ORDER BY last_name, first_name",
   "predicate": "initial",

--- a/it/src/main/resources/tests/subselectWhere.test
+++ b/it/src/main/resources/tests/subselectWhere.test
@@ -4,10 +4,14 @@
     "couchbase":         "skip",
     "marklogic_json":    "skip",
     "marklogic_xml":     "skip",
-    "mimir":             "ignoreFieldOrder"
+    "mimir":             "ignoreFieldOrder",
+    "mongodb_3_2":       "pending",
+    "mongodb_3_4":       "pending",
+    "mongodb_read_only": "pending"
   },
   "NB": "skipped on couchbase due to lack of general join",
   "NB": "skipped on marklogic due to timeout",
+  "NB": "pending for mongodb due to MongoDB Error: Command failed with error 13070: 'value too large to reduce'",
   "data": ["demo/patients.data", "extraSmallZips.data"],
   "query": "SELECT first_name, last_name FROM `demo/patients` AS p where state in (SELECT state FROM extraSmallZips) ORDER BY last_name, first_name",
   "predicate": "initial",


### PR DESCRIPTION
When building functions for various constructs (filter predicates, sort keys, group keys, reducer expressions), when we run into an operation that cannot be expressed as a function, we're forced to create an autojoin. However, there may be operations prior to the problematic one that _can_ be expressed as a function, this PR ensures those operations are extracted as a function prior to autojoining.

#qz-3320 Done
#qz-3331 Done