### PR TITLE
Elide superfluous guards in guarded expressions

### DIFF
--- a/connector/src/main/scala/quasar/qscript/MapFuncCore.scala
+++ b/connector/src/main/scala/quasar/qscript/MapFuncCore.scala
@@ -416,6 +416,18 @@ object MapFuncCore {
 
       case ConcatMaps(Embed(lhs), Embed(rhs)) if lhs ≟ rhs => lhs.some
 
+      case Guard(
+        inner @ ExtractFunc(Guard(_, _, eIn, ExtractFunc(Undefined()))),
+        tOut,
+        eOut,
+        undef @ ExtractFunc(Undefined()))
+          if eOut.elgotPara(count(inner)) > 0 =>
+        some(rollMF[T, A](MFC(Guard(
+          inner,
+          tOut,
+          eOut.elgotApo[FreeMapA[T, A]](substitute(inner, eIn) andThen (_.map(_.project))),
+          undef))))
+
       case _ => none
     }
 


### PR DESCRIPTION
Simplifies nested guards of the form `Guard(inner @ Guard(ci, ti, ei, Undefined), t, inner, Undefined)` to `Guard(Guard(ci, ti, ei, Undefined), t, ei, Undefined)`, avoiding evaluating the inner condition twice.

Also elides guards from a guarded expression having the same condition as the outer guard.

#qz-3613 Done
#qz-3575 Done