### PR TITLE
[qz-3635] Correct parsing of join conditions

### DIFF
--- a/frontend/src/main/scala/quasar/sql/parser.scala
+++ b/frontend/src/main/scala/quasar/sql/parser.scala
@@ -422,7 +422,7 @@ private[sql] class SQLParser[T[_[_]]: BirecursiveT]
     })
 
   def std_join_relation: Parser[SqlRelation[T[Sql]] => SqlRelation[T[Sql]]] =
-    opt(join_type) ~ keyword("join") ~ simple_relation ~ keyword("on") ~ expr ^^
+    opt(join_type) ~ keyword("join") ~ simple_relation ~ keyword("on") ~ defined_expr ^^
       { case tpe ~ _ ~ r2 ~ _ ~ e => r1 => JoinRelation(r1, r2, tpe.getOrElse(JoinType.Inner), e) }
 
   def cross_join_relation: Parser[SqlRelation[T[Sql]] => SqlRelation[T[Sql]]] =

--- a/frontend/src/test/scala/quasar/sql/SqlParserSpec.scala
+++ b/frontend/src/test/scala/quasar/sql/SqlParserSpec.scala
@@ -17,6 +17,7 @@
 package quasar.sql
 
 import slamdata.Predef._
+import quasar.common.JoinType
 import quasar.fp._
 import quasar.RenderTree.ops._
 import quasar.specs2.QuasarMatchers._
@@ -433,6 +434,34 @@ class SQLParserSpec extends quasar.Qspec {
       "should not allow single limit" in {
         val q = "limit 6"
         parse(q) must beLeftDisjunction
+      }
+
+      "limited join" in {
+        val q = "select * from a inner join b on a.id = b.id limit 10"
+
+        parse(q) must beRightDisjunction(
+          Limit(
+            SelectR(
+              SelectAll,
+              List(Proj(SpliceR(None), None)),
+              Some(JoinRelation(
+                TableRelationAST(file("a"), None),
+                TableRelationAST(file("b"), None),
+                JoinType.Inner,
+                BinopR(
+                  BinopR(
+                    IdentR("a"),
+                    StringLiteralR("id"),
+                    KeyDeref),
+                  BinopR(
+                    IdentR("b"),
+                    StringLiteralR("id"),
+                    KeyDeref),
+                  Eq))),
+              None,
+              None,
+              None),
+            IntLiteralR(10)).embed)
       }
     }
 


### PR DESCRIPTION
Corrects an issue when parsing join conditions where sub-queries weren't required to be enclosed in parentheses, causing subsequent terms from the outer query to be incorrectly considered part of the join condition.

#qz-3635 Done.