### PR TITLE
Correct identity/value access when reifying shift ids

### DIFF
--- a/connector/src/main/scala/quasar/qscript/construction.scala
+++ b/connector/src/main/scala/quasar/qscript/construction.scala
@@ -16,19 +16,20 @@
 
 package quasar.qscript
 
-import qsu.{Access, QAccess, QScriptUniform => QSU}
 import slamdata.Predef._
+import quasar.common.{JoinType, SortDir}
+import quasar.{ejson, qscript}
+import quasar.ejson.EJson
+import quasar.qscript.qsu.{Access, QAccess}
+import quasar.qscript.qsu.QScriptUniform.ShiftTarget
+import quasar.std.TemporalPart
+
 import matryoshka._
 import matryoshka.data.Fix
-
 import scalaz._
 import scalaz.Leibniz.===
 import scalaz.std.tuple._
 import scalaz.syntax.bifunctor._
-import quasar.{ejson, qscript}
-import quasar.common.{JoinType, SortDir}
-import quasar.std.TemporalPart
-import quasar.ejson.EJson
 
 object construction {
   final case class Func[T[_[_]]]()(implicit birec: BirecursiveT[T]) {
@@ -208,12 +209,12 @@ object construction {
     def Hole: FreeMap[T] = Free.pure(SrcHole)
     def AccessHole: FreeMapA[T, QAccess[T, Hole]] =
       Free.pure(Access.valueHole(SrcHole))
-    def LeftTarget: FreeMapA[T, QSU.ShiftTarget[T]] =
-      Free.pure(QSU.LeftTarget[T]())
-    def RightTarget: FreeMapA[T, QSU.ShiftTarget[T]] =
-      Free.pure(QSU.RightTarget[T]())
-    def AccessLeftTarget(f: Hole => QAccess[T, Hole]): FreeMapA[T, QSU.ShiftTarget[T]] =
-      Free.pure(QSU.AccessLeftTarget(f(SrcHole)))
+    def LeftTarget: FreeMapA[T, ShiftTarget[T]] =
+      Free.pure(ShiftTarget.LeftTarget[T]())
+    def RightTarget: FreeMapA[T, ShiftTarget[T]] =
+      Free.pure(ShiftTarget.RightTarget[T]())
+    def AccessLeftTarget(f: Hole => QAccess[T, Hole]): FreeMapA[T, ShiftTarget[T]] =
+      Free.pure(ShiftTarget.AccessLeftTarget(f(SrcHole)))
     def LeftSide: JoinFunc[T] = Free.pure(qscript.LeftSide)
     def RightSide: JoinFunc[T] = Free.pure(qscript.RightSide)
     def ReduceIndex(i: Int \/ Int): FreeMapA[T, ReduceIndex] = Free.pure(qscript.ReduceIndex(i))

--- a/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ApplyProvenance.scala
@@ -29,6 +29,7 @@ import quasar.qscript.{construction, ExcludeId, HoleF, IdOnly, IdStatus, OnUndef
 
 import matryoshka._
 import matryoshka.implicits._
+import monocle.macros.Lenses
 import pathy.Path
 import scalaz.{Applicative, Cord, Functor, IList, Monad, Show, StateT, ValidationNel}
 import scalaz.Scalaz._
@@ -257,6 +258,7 @@ object ApplyProvenance {
       : F[QDims[T]] =
     new ApplyProvenance[T].computeProvenance[F](graph)
 
+  @Lenses
   final case class AuthenticatedQSU[T[_[_]]](graph: QSUGraph[T], auth: QAuth[T])
 
   object AuthenticatedQSU {

--- a/connector/src/main/scala/quasar/qscript/qsu/Graduate.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/Graduate.scala
@@ -194,9 +194,9 @@ final class Graduate[T[_[_]]: BirecursiveT: ShowT] private () extends QSUTTypes[
             // this would be nicer with a tri-state Access type.
             resolvedRepair <-
               resolveAccess(repair) {
-                case QSU.AccessLeftTarget(access) => access.map[JoinSide](_ => LeftSide).left
-                case QSU.LeftTarget() => (LeftSide: JoinSide).right
-                case QSU.RightTarget() => (RightSide: JoinSide).right
+                case QSU.ShiftTarget.AccessLeftTarget(access) => access.map[JoinSide](_ => LeftSide).left
+                case QSU.ShiftTarget.LeftTarget() => (LeftSide: JoinSide).right
+                case QSU.ShiftTarget.RightTarget() => (RightSide: JoinSide).right
               }(κ(source.root))
 
             shiftType = rot match {

--- a/connector/src/main/scala/quasar/qscript/qsu/LPtoQS.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/LPtoQS.scala
@@ -32,31 +32,34 @@ final class LPtoQS[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends QS
   def apply[F[_]: Monad: PlannerErrorME: NameGenerator](lp: T[LogicalPlan])
       : F[T[QScriptEducated]] = {
 
+    val agraph =
+      ApplyProvenance.AuthenticatedQSU.graph[T]
+
     val lpToQs =
-      K(ReadLP[T, F])                 >==>
-      debug("ReadLP: ")               >==>
-      RewriteGroupByArrays[T, F]      >==>
-      debug("RewriteGBArrays: ")      >-
-      EliminateUnary[T]               >==>
-      debug("EliminateUnary: ")       >-
-      RecognizeDistinct[T]            >==>
-      debug("RecognizeDistinct: ")    >==>
-      ExtractFreeMap[T, F]            >==>
-      debug("ExtractFreeMap: ")       >==>
-      ApplyProvenance[T, F]           >==>
-      debug("ApplyProv: ")            >==>
-      ReifyBuckets[T, F]              >==>
-      debug("ReifyBuckets: ")         >==>
-      MinimizeAutoJoins[T, F]         >==>
-      debug("MinimizeAJ: ")           >==>
-      ReifyAutoJoins[T, F]            >==>
-      debug("ReifyAutoJoins: ")       >==>
-      ExpandShifts[T, F]              >==>
-      debug("ExpandShifts: ")         >-
-      ResolveOwnIdentities[T]         >==>
-      debug("ResolveOwnIdentities: ") >==>
-      ReifyIdentities[T, F]           >==>
-      debug("ReifyIdentities: ")      >==>
+      K(ReadLP[T, F])                        >==>
+      debug("ReadLP: ")                      >==>
+      RewriteGroupByArrays[T, F]             >==>
+      debug("RewriteGBArrays: ")             >-
+      EliminateUnary[T]                      >==>
+      debug("EliminateUnary: ")              >-
+      RecognizeDistinct[T]                   >==>
+      debug("RecognizeDistinct: ")           >==>
+      ExtractFreeMap[T, F]                   >==>
+      debug("ExtractFreeMap: ")              >==>
+      ApplyProvenance[T, F]                  >==>
+      debug("ApplyProv: ")                   >==>
+      ReifyBuckets[T, F]                     >==>
+      debug("ReifyBuckets: ")                >==>
+      MinimizeAutoJoins[T, F]                >==>
+      debug("MinimizeAJ: ")                  >==>
+      ReifyAutoJoins[T, F]                   >==>
+      debug("ReifyAutoJoins: ")              >==>
+      ExpandShifts[T, F]                     >==>
+      debug("ExpandShifts: ")                >-
+      agraph.modify(ResolveOwnIdentities[T]) >==>
+      debug("ResolveOwnIdentities: ")        >==>
+      ReifyIdentities[T, F]                  >==>
+      debug("ReifyIdentities: ")             >==>
       Graduate[T, F]
 
     lpToQs(lp)

--- a/connector/src/main/scala/quasar/qscript/qsu/ReifyIdentities.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ReifyIdentities.scala
@@ -36,7 +36,7 @@ import quasar.qscript.{
   ReduceFunc}
 import quasar.qscript.MapFuncCore.{EmptyMap, StaticMap}
 import quasar.qscript.provenance.JoinKey
-import quasar.qscript.qsu.{QScriptUniform => QSU}
+import quasar.qscript.qsu.{QScriptUniform => QSU}, QSU.ShiftTarget
 import quasar.qscript.qsu.ApplyProvenance.AuthenticatedQSU
 
 import matryoshka.{showTShow, BirecursiveT, ShowT}
@@ -100,9 +100,9 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT: ShowT] private () extends QSU
       ISet.singleton(access.symbolic(κ(src)))
     }
 
-  private def shiftTargetAccess(src: Symbol, bucket: FreeMapA[QSU.ShiftTarget[T]]): ISet[QAccess[Symbol]] =
+  private def shiftTargetAccess(src: Symbol, bucket: FreeMapA[ShiftTarget[T]]): ISet[QAccess[Symbol]] =
     Foldable[FreeMapA].foldMap(bucket) {
-      case QSU.AccessLeftTarget(access) => ISet.singleton(access.symbolic(κ(src)))
+      case ShiftTarget.AccessLeftTarget(access) => ISet.singleton(access.symbolic(κ(src)))
       case _ => ISet.empty
     }
 
@@ -166,10 +166,10 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT: ShowT] private () extends QSU
     def isReferenced(access: QAccess[Symbol]): G[Boolean] =
       G.gets(_.refs.accessed.member(access))
 
-    def includeIdRepair(oldRepair: FreeMapA[QSU.ShiftTarget[T]], oldIdStatus: IdStatus): FreeMapA[QSU.ShiftTarget[T]] =
+    def includeIdRepair(oldRepair: FreeMapA[ShiftTarget[T]], oldIdStatus: IdStatus): FreeMapA[ShiftTarget[T]] =
       if (oldIdStatus === ExcludeId)
         oldRepair >>= {
-          case QSU.RightTarget() => func.ProjectIndexI(func.RightTarget, 1)
+          case ShiftTarget.RightTarget() => func.ProjectIndexI(func.RightTarget, 1)
           case tgt => tgt.pure[FreeMapA]
         }
       else oldRepair

--- a/connector/src/main/scala/quasar/qscript/qsu/ReifyIdentities.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ReifyIdentities.scala
@@ -265,16 +265,16 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT: ShowT] private () extends QSU
           case (true, true) =>
             onNeedsIV(g) as {
               val (newStatus, newRepair) = idStatus match {
-                case IdOnly | IncludeId =>
+                case IdOnly =>
                   (
                     idStatus,
                     updateIV(
                       func.LeftTarget,
                       makeI1(g.root, func.RightTarget),
-                      includeIdRepair(repair, idStatus))
+                      repair)
                   )
 
-                case ExcludeId =>
+                case ExcludeId | IncludeId =>
                   (
                     IncludeId : IdStatus,
                     updateIV(
@@ -300,11 +300,11 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT: ShowT] private () extends QSU
               val newStatus =
                 if (idStatus === ExcludeId) IncludeId else idStatus
 
-              val getValue =
+              val getId =
                 if (idStatus === ExcludeId) func.ProjectIndexI(func.RightTarget, 0) else func.RightTarget
 
               val newRepair = makeIV(
-                makeI1(g.root, getValue),
+                makeI1(g.root, getId),
                 includeIdRepair(repair, idStatus))
 
               g.overwriteAtRoot(O.leftShift(source.root, struct, newStatus, onUndefined, newRepair, rot))

--- a/connector/src/main/scala/quasar/qscript/qsu/ReifyIdentities.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/ReifyIdentities.scala
@@ -299,12 +299,13 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT: ShowT] private () extends QSU
             onNeedsIV(g) as {
               val newStatus =
                 if (idStatus === ExcludeId) IncludeId else idStatus
+
               val getValue =
                 if (idStatus === ExcludeId) func.ProjectIndexI(func.RightTarget, 0) else func.RightTarget
+
               val newRepair = makeIV(
                 makeI1(g.root, getValue),
-                includeIdRepair(repair, idStatus)
-              )
+                includeIdRepair(repair, idStatus))
 
               g.overwriteAtRoot(O.leftShift(source.root, struct, newStatus, onUndefined, newRepair, rot))
             }

--- a/connector/src/main/scala/quasar/qscript/qsu/minimizers/CollapseShifts.scala
+++ b/connector/src/main/scala/quasar/qscript/qsu/minimizers/CollapseShifts.scala
@@ -34,7 +34,7 @@ import quasar.qscript.{
   RightSide,
   SrcHole
 }
-import quasar.qscript.qsu.{QScriptUniform => QSU}
+import quasar.qscript.qsu.{QScriptUniform => QSU}, QSU.ShiftTarget
 import quasar.qscript.rewrites.NormalizableT
 import slamdata.Predef._
 
@@ -86,10 +86,10 @@ final class CollapseShifts[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] pr
             val struct2 = struct >> fm
 
             val repair2 = repair flatMap {
-              case QSU.AccessLeftTarget(Access.Value(_)) => fm.map[QSU.ShiftTarget[T]](κ(QSU.AccessLeftTarget[T](Access.valueHole(SrcHole))))
-              case access @ QSU.AccessLeftTarget(_) => (access: QSU.ShiftTarget[T]).pure[FreeMapA]
-              case QSU.LeftTarget() => scala.sys.error("QSU.LeftTarget in CollapseShifts")
-              case QSU.RightTarget() => func.RightTarget
+              case ShiftTarget.AccessLeftTarget(Access.Value(_)) => fm.map[ShiftTarget[T]](κ(ShiftTarget.AccessLeftTarget[T](Access.valueHole(SrcHole))))
+              case access @ ShiftTarget.AccessLeftTarget(_) => (access: ShiftTarget[T]).pure[FreeMapA]
+              case ShiftTarget.LeftTarget() => scala.sys.error("ShiftTarget.LeftTarget in CollapseShifts")
+              case ShiftTarget.RightTarget() => func.RightTarget
             }
 
             updateGraph[T, G](QSU.LeftShift(src.root, struct2, idStatus, onUndefined, repair2, rot)) map { rewritten =>
@@ -246,12 +246,12 @@ final class CollapseShifts[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] pr
             val struct2 = struct >> func.ProjectKeyS(func.Hole, ResultsField)
 
             val repair2 = repair flatMap {
-              case QSU.AccessLeftTarget(Access.Value(_)) =>
+              case ShiftTarget.AccessLeftTarget(Access.Value(_)) =>
                 func.ProjectKeyS(func.AccessLeftTarget(Access.valueHole[T[EJson]](_)), ResultsField)
-              case QSU.AccessLeftTarget(access) =>
+              case ShiftTarget.AccessLeftTarget(access) =>
                 func.AccessLeftTarget(access.as(_))
-              case QSU.LeftTarget() => scala.sys.error("QSU.LeftTarget in CollapseShifts")
-              case QSU.RightTarget() => func.RightTarget
+              case ShiftTarget.LeftTarget() => scala.sys.error("ShiftTarget.LeftTarget in CollapseShifts")
+              case ShiftTarget.RightTarget() => func.RightTarget
             }
 
             val repair3 = func.StaticMapS(
@@ -344,15 +344,15 @@ final class CollapseShifts[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] pr
       }
 
       def fixSingleRepairForMulti(
-          repair: FreeMapA[QSU.ShiftTarget[T]],
+          repair: FreeMapA[ShiftTarget[T]],
           offset: Int,
           side: JoinSide): FreeMapA[QAccess[Hole] \/ Int] = {
 
         repair flatMap {
-          case QSU.LeftTarget() =>
-            scala.sys.error("QSU.LeftTarget in CollapseShifts")
+          case ShiftTarget.LeftTarget() =>
+            scala.sys.error("ShiftTarget.LeftTarget in CollapseShifts")
 
-          case QSU.AccessLeftTarget(access) =>
+          case ShiftTarget.AccessLeftTarget(access) =>
             val hole = Free.pure[MapFunc, QAccess[Hole] \/ Int](access.left[Int])
 
             if (hasParent)
@@ -360,21 +360,21 @@ final class CollapseShifts[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] pr
             else
               hole
 
-          case QSU.RightTarget() =>
+          case ShiftTarget.RightTarget() =>
             Free.pure(offset.right[QAccess[Hole]])
         }
       }
 
       def fixSingleRepairForSingle(
-          repair: FreeMapA[QSU.ShiftTarget[T]],
-          side: JoinSide): FreeMapA[QSU.ShiftTarget[T]] = {
+          repair: FreeMapA[ShiftTarget[T]],
+          side: JoinSide): FreeMapA[ShiftTarget[T]] = {
 
         repair flatMap {
-          case target @ (QSU.LeftTarget() | QSU.RightTarget()) =>
+          case target @ (ShiftTarget.LeftTarget() | ShiftTarget.RightTarget()) =>
             Free.pure(target)
 
-          case access @ QSU.AccessLeftTarget(_) =>
-            val hole = Free.pure[MapFunc, QSU.ShiftTarget[T]](access)
+          case access @ ShiftTarget.AccessLeftTarget(_) =>
+            val hole = Free.pure[MapFunc, ShiftTarget[T]](access)
 
             if (hasParent)
               func.ProjectKeyS(hole, name(side))
@@ -737,10 +737,10 @@ final class CollapseShifts[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] pr
         val struct2 = struct >> fm
 
         val repair2 = repair flatMap {
-          case alt @ QSU.AccessLeftTarget(Access.Value(_)) =>
-            fm.map(_ => alt: QSU.ShiftTarget[T])
+          case alt @ ShiftTarget.AccessLeftTarget(Access.Value(_)) =>
+            fm.map(_ => alt: ShiftTarget[T])
 
-          case t => Free.pure[MapFunc, QSU.ShiftTarget[T]](t)
+          case t => Free.pure[MapFunc, ShiftTarget[T]](t)
         }
 
         Some((parent, -\/(QSU.LeftShift[T, QSUGraph](oparent, struct2, idStatus, onUndefined, repair2, rot)) <:: inners))

--- a/connector/src/test/scala/quasar/qscript/qsu/ResolveOwnIdentitiesSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/qsu/ResolveOwnIdentitiesSpec.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.qsu
+
+import slamdata.Predef._
+
+import quasar.{Qspec, TreeMatchers}
+import quasar.contrib.pathy.AFile
+import quasar.ejson.EJson
+import quasar.ejson.implicits._
+import quasar.fp.coproductEqual
+import quasar.fp.ski.κ
+import quasar.qscript.{construction, ExcludeId, Hole, IdOnly, IncludeId, OnUndefined, SrcHole}
+
+import matryoshka.data.Fix
+import matryoshka.data.free._
+import monocle.syntax.fields._1
+import pathy.Path._
+
+object ResolveOwnIdentitiesSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
+  import QScriptUniform.{Rotation, ShiftTarget}
+  import QSUGraph.Extractors._
+
+  type J = Fix[EJson]
+
+  val qsu = QScriptUniform.AnnotatedDsl[Fix, Symbol]
+  val func = construction.Func[Fix]
+
+  val foo: AFile = rootDir </> file("foo")
+
+  val resolveIds = ResolveOwnIdentities[Fix]_
+
+  def renameAccess(qg: QSUGraph, rns: QSUGraph.Renames): QSUGraph =
+    qg rewrite {
+      case g @ LeftShift(src, struct, id, undef, rep, rot) =>
+        val renamedRep = rep map {
+          case ShiftTarget.AccessLeftTarget(access) =>
+            val renamedAccess =
+              Access.identityHole[J]
+                .composeLens(_1)
+                .composePrism(IdAccess.identity[J])
+                .modify(rns)
+
+            ShiftTarget.AccessLeftTarget[Fix](renamedAccess(access))
+
+          case other => other
+        }
+
+        g.overwriteAtRoot(QScriptUniform.LeftShift(src.root, struct, id, undef, renamedRep, rot))
+    }
+
+  "resolving own left shift identity" should {
+    val ownAccess: QAccess[Hole] =
+      Access.identityHole[J](IdAccess.identity[J]('ls), SrcHole)
+
+    val initialRepair =
+      func.ConcatArrays(
+        func.MakeArray(func.AccessLeftTarget(κ(ownAccess))),
+        func.MakeArray(func.RightTarget))
+
+    "replace own identity access when IdStatus = ExcludeId" >> {
+      val expectedRepair =
+        func.ConcatArrays(
+          func.MakeArray(func.ProjectIndexI(func.RightTarget, 0)),
+          func.MakeArray(func.ProjectIndexI(func.RightTarget, 1)))
+
+      val (remap, lshift) = QSUGraph.fromAnnotatedTree[Fix](
+        qsu.leftShift('ls, (
+          qsu.read('r, foo),
+          func.ProjectKeyS(func.Hole, "bar"),
+          ExcludeId,
+          OnUndefined.Omit,
+          initialRepair,
+          Rotation.ShiftArray)) map (Some(_)))
+
+      resolveIds(renameAccess(lshift, remap)) must beLike {
+        case LeftShift(_, _, IncludeId, _, r, _) =>
+          r must beTreeEqual(expectedRepair)
+      }
+    }
+
+    "replace own identity access when IdStatus = IdOnly" >> {
+      val expectedRepair =
+        func.ConcatArrays(
+          func.MakeArray(func.RightTarget),
+          func.MakeArray(func.RightTarget))
+
+      val (remap, lshift) = QSUGraph.fromAnnotatedTree[Fix](
+        qsu.leftShift('ls, (
+          qsu.read('r, foo),
+          func.ProjectKeyS(func.Hole, "bar"),
+          IdOnly,
+          OnUndefined.Omit,
+          initialRepair,
+          Rotation.ShiftArray)) map (Some(_)))
+
+      resolveIds(renameAccess(lshift, remap)) must beLike {
+        case LeftShift(_, _, IdOnly, _, r, _) =>
+          r must beTreeEqual(expectedRepair)
+      }
+    }
+  }
+}

--- a/it/src/main/resources/tests/multilevelFlatten.test
+++ b/it/src/main/resources/tests/multilevelFlatten.test
@@ -1,0 +1,25 @@
+{
+    "name": "flatten keys and values from multiple levels of the same root",
+    "backends": {
+        "couchbase":         "pending",
+        "marklogic_json":    "pendingIgnoreFieldOrder",
+        "marklogic_xml":     "pending",
+        "mimir":             "pendingIgnoreFieldOrder",
+        "mongodb_3_2":       "pending",
+        "mongodb_3_4":       "pending",
+        "mongodb_read_only": "pending",
+        "spark_hdfs":        "pending",
+        "spark_local":       "pending",
+        "spark_cassandra":   "pending"
+    },
+    "data": "nested.data",
+    "NB": "Not passing in mimir due to mimir not respecting the shift type.",
+    "NB": "Not passing in mongo (and likely others) due to https://slamdata.myjetbrains.com/youtrack/issue/qz-3659",
+    "query": "select topObj{_:} as k1, topObj{_}{_:} as k2, topObj{_}{_} as v2 from nested",
+    "predicate": "exactly",
+    "ignoreResultOrder": true,
+    "expected": [
+      { "k2": "botArr", "v2": [13, 14, 15], "k1": "midObj" }
+    , { "k2": "botObj", "v2": {"a": "m", "b": "n", "c": "o"}, "k1": "midObj" }
+    ]
+}

--- a/it/src/main/resources/tests/multistageFlatten.test
+++ b/it/src/main/resources/tests/multistageFlatten.test
@@ -5,9 +5,6 @@
         "marklogic_json":      "pending",
         "marklogic_xml":       "pending",
         "mimir":               "pending",
-        "mongodb_3_2":         "pending",
-        "mongodb_3_4":         "pending",
-        "mongodb_read_only":   "pending",
         "spark_local":         "pending",
         "spark_hdfs":          "pending",
         "spark_cassandra":     "pending"


### PR DESCRIPTION
Corrects an issue where we were incorrectly rewriting access to identities in `LeftShift`.

#qz-3647 Done.