### PR TITLE
[qz-3613, qz-3188] Elide superfluous guards in a guarded expression.

### DIFF
--- a/connector/src/main/scala/quasar/qscript/MapFuncCore.scala
+++ b/connector/src/main/scala/quasar/qscript/MapFuncCore.scala
@@ -23,6 +23,7 @@ import quasar.ejson._
 import quasar.ejson.implicits._
 import quasar.fp._
 import quasar.fp.ski._
+import quasar.qscript.rewrites.{DedupeGuards, ExtractFiltering}
 import quasar.std.TemporalPart
 
 import matryoshka._
@@ -336,9 +337,11 @@ object MapFuncCore {
 
   def normalize[T[_[_]]: BirecursiveT: EqualT, A: Equal]
       : CoMapFuncR[T, A] => CoMapFuncR[T, A] =
+    orOriginal(DedupeGuards[T, A]) <<<
     repeatedly(applyTransforms(
       foldConstant[T, A].apply(_) ∘ (const => rollMF[T, A](MFC(Constant(const)))),
-      rewrite[T, A]))
+      rewrite[T, A],
+      ExtractFiltering[T, A]))
 
   def replaceJoinSides[T[_[_]]: BirecursiveT](left: Symbol, right: Symbol)
       : CoMapFuncR[T, JoinSide] => CoMapFuncR[T, JoinSide] =

--- a/connector/src/main/scala/quasar/qscript/rewrites/DedupeGuards.scala
+++ b/connector/src/main/scala/quasar/qscript/rewrites/DedupeGuards.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.rewrites
+
+import slamdata.Predef.{Array, Option, SuppressWarnings}
+import quasar.Type
+import quasar.ejson.implicits._
+import quasar.fp.coproductEqual
+import quasar.qscript.{
+  ExtractFunc,
+  FreeMapA,
+  MFC,
+  MapFuncCore,
+  MapFuncsCore,
+  TTypes
+}
+import MapFuncCore.{rollMF, CoMapFuncR}
+import MapFuncsCore.{Guard, Undefined}
+
+import matryoshka._
+import matryoshka.data.free._
+import matryoshka.implicits._
+import matryoshka.patterns.CoEnv
+import scalaz.{\/, Equal, Free, NonEmptyList}
+import scalaz.std.option._
+import scalaz.std.tuple._
+import scalaz.syntax.foldable._
+import scalaz.syntax.std.option._
+
+final class DedupeGuards[T[_[_]]: BirecursiveT: EqualT] private () extends TTypes[T] {
+  def apply[A: Equal](mf: CoMapFuncR[T, A]): Option[CoMapFuncR[T, A]] =
+    some(mf) collect {
+      case DedupeGuards.Guarded(preds @ NonEmptyList((c, t), _), cont) =>
+        val substituted = cont.elgotApo[FreeMapA[A]](substituteGuardedExpression(preds))
+        rollMF[T, A](MFC(Guard(c, t, substituted, Free.roll(MFC(Undefined())))))
+    }
+
+  ////
+
+  private def guardedExpression[A: Equal](
+      preds: NonEmptyList[(FreeMapA[A], Type)],
+      fm: FreeMapA[A])
+      : Option[FreeMapA[A]] =
+    some(fm) collect {
+      case ExtractFunc(Guard(c, t, e, ExtractFunc(Undefined()))) if preds.element((c, t)) => e
+    }
+
+  private def substituteGuardedExpression[A: Equal](
+      preds: NonEmptyList[(FreeMapA[A], Type)])
+      : ElgotCoalgebra[FreeMapA[A] \/ ?, CoEnv[A, MapFunc, ?], FreeMapA[A]] =
+    fm => guardedExpression(preds, fm) <\/ fm.project
+}
+
+object DedupeGuards {
+  def apply[T[_[_]]: BirecursiveT: EqualT, A: Equal]: CoMapFuncR[T, A] => Option[CoMapFuncR[T, A]] =
+    new DedupeGuards[T].apply[A] _
+
+  @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
+  object Guarded {
+    def unapply[T[_[_]]: BirecursiveT, A](f: CoMapFuncR[T, A]): Option[(NonEmptyList[(FreeMapA[T, A], Type)], FreeMapA[T, A])] =
+      f.run.toOption collect {
+        case MFC(Guard(c @ Embed(Guarded(conds, _)), t, e, ExtractFunc(Undefined()))) =>
+          ((c, t) <:: conds, e)
+
+        case MFC(Guard(c, t, e, ExtractFunc(Undefined()))) =>
+          (NonEmptyList((c, t)), e)
+      }
+  }
+}

--- a/connector/src/main/scala/quasar/qscript/rewrites/ExtractFiltering.scala
+++ b/connector/src/main/scala/quasar/qscript/rewrites/ExtractFiltering.scala
@@ -104,5 +104,5 @@ object ExtractFiltering {
     */
   def apply[T[_[_]]: BirecursiveT: EqualT, A: Equal]
       : CoMapFuncR[T, A] => Option[CoMapFuncR[T, A]] =
-    new ExtractFiltering[T].apply[A](_)
+    new ExtractFiltering[T].apply[A] _
 }

--- a/connector/src/main/scala/quasar/qscript/rewrites/Normalizable.scala
+++ b/connector/src/main/scala/quasar/qscript/rewrites/Normalizable.scala
@@ -91,7 +91,6 @@ class NormalizableT[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends T
 
   def freeMF[A: Equal: Show](fm: Free[MapFunc, A]): Free[MapFunc, A] =
     fm.transCata[Free[MapFunc, A]](MapFuncCore.normalize[T, A])
-      .transCata[Free[MapFunc, A]](repeatedly(ExtractFiltering[T, A]))
 
   def makeNorm[A, B, C](
     lOrig: A, rOrig: B)(

--- a/connector/src/test/scala/quasar/qscript/MapFuncCoreSpec.scala
+++ b/connector/src/test/scala/quasar/qscript/MapFuncCoreSpec.scala
@@ -17,7 +17,7 @@
 package quasar.qscript
 
 import slamdata.Predef._
-import quasar.{Qspec, TreeMatchers}
+import quasar.{Qspec, TreeMatchers, Type}
 import quasar.ejson.{EJson, Fixed}
 import quasar.ejson.implicits._
 import quasar.fp.{coproductEqual, coproductShow}
@@ -282,6 +282,167 @@ final class MapFuncCoreSpec extends Qspec with TTypes[Fix] with TreeMatchers {
           func.ProjectKeyS(func.Hole, "baz"))
 
       normalize(expr) must beTreeEqual(expect)
+    }
+
+    "elide identical inner guard from defined expression of nested guards" >> {
+      val innerGuard =
+        func.Guard(
+          func.ProjectKeyS(func.Hole, "foo"),
+          Type.AnyObject,
+          func.ProjectKeyS(func.ProjectKeyS(func.Hole, "foo"), "bar"),
+          func.Undefined)
+
+      val nestedGuards =
+        func.Guard(
+          innerGuard,
+          Type.Str,
+          func.Upper(innerGuard),
+          func.Undefined)
+
+      val expect =
+        func.Guard(
+          innerGuard,
+          Type.Str,
+          func.Upper(func.ProjectKeyS(func.ProjectKeyS(func.Hole, "foo"), "bar")),
+          func.Undefined)
+
+      normalize(nestedGuards) must beTreeEqual(expect)
+    }
+
+    "leave inner guard in defined expression when different from inner nested" >> {
+      val guardA =
+        func.Guard(
+          func.ProjectKeyS(func.Hole, "foo"),
+          Type.AnyObject,
+          func.ProjectKeyS(func.ProjectKeyS(func.Hole, "foo"), "bar"),
+          func.Undefined)
+
+      val guardB =
+        func.Guard(
+          func.ProjectKeyS(func.Hole, "quux"),
+          Type.Numeric,
+          func.Add(func.ProjectKeyS(func.Hole, "quux"), func.Constant(ejs.int(3))),
+          func.Undefined)
+
+      val nestedGuards =
+        func.Guard(guardA, Type.Str, guardB, func.Undefined)
+
+      normalize(nestedGuards) must beTreeEqual(nestedGuards)
+    }
+
+    "elide inner guard with same type test from defined expression of nested guards" >> {
+      val guardA =
+        func.Guard(
+          func.ProjectKeyS(func.Hole, "foo"),
+          Type.AnyObject,
+          func.ProjectKeyS(func.ProjectKeyS(func.Hole, "foo"), "bar"),
+          func.Undefined)
+
+      val guardB =
+        func.Guard(
+          func.ProjectKeyS(func.Hole, "foo"),
+          Type.AnyObject,
+          func.Upper(func.ProjectKeyS(func.ProjectKeyS(func.Hole, "foo"), "bar")),
+          func.Undefined)
+
+      val nestedGuards =
+        func.Guard(guardA, Type.Str, guardB, func.Undefined)
+
+      val expect =
+        func.Guard(
+          guardA,
+          Type.Str,
+          func.Upper(func.ProjectKeyS(func.ProjectKeyS(func.Hole, "foo"), "bar")),
+          func.Undefined)
+
+      normalize(nestedGuards) must beTreeEqual(expect)
+    }
+
+    "leave inner guard with different type test in outer defined expression" >> {
+      val guardA =
+        func.Guard(
+          func.ProjectKeyS(func.Hole, "foo"),
+          Type.AnyObject,
+          func.ProjectKeyS(func.ProjectKeyS(func.Hole, "foo"), "bar"),
+          func.Undefined)
+
+      val guardB =
+        func.Guard(
+          func.ProjectKeyS(func.Hole, "foo"),
+          Type.Numeric,
+          func.Add(func.ProjectKeyS(func.Hole, "quux"), func.Constant(ejs.int(3))),
+          func.Undefined)
+
+      val nestedGuards =
+        func.Guard(guardA, Type.Str, guardB, func.Undefined)
+
+      normalize(nestedGuards) must beTreeEqual(nestedGuards)
+    }
+
+    "elide inner guard with same type test from defined expression of single guard" >> {
+      val guarded =
+        func.Guard(
+          func.ProjectKeyS(func.Hole, "foo"),
+          Type.AnyObject,
+          func.ProjectKeyS(
+            func.Guard(
+              func.ProjectKeyS(func.Hole, "foo"),
+              Type.AnyObject,
+              func.ProjectKeyS(func.Hole, "foo"),
+              func.Undefined),
+            "bar"),
+          func.Undefined)
+
+      val expect =
+        func.Guard(
+          func.ProjectKeyS(func.Hole, "foo"),
+          Type.AnyObject,
+          func.ProjectKeyS(func.ProjectKeyS(func.Hole, "foo"), "bar"),
+          func.Undefined)
+
+      normalize(guarded) must beTreeEqual(expect)
+    }
+
+    "elide multiple guards from outermost's continuation" >> {
+      val guardA =
+        func.Guard(
+          func.ProjectKeyS(func.Hole, "foo"),
+          Type.AnyObject,
+          func.ProjectKeyS(func.Hole, "foo"),
+          func.Undefined)
+
+      val guardB =
+        func.Guard(
+          func.ProjectKeyS(guardA, "bar"),
+          Type.AnyArray,
+          func.ProjectIndexI(func.ProjectKeyS(guardA, "bar"), 3),
+          func.Undefined)
+
+      val guardC =
+        func.Guard(
+          guardB,
+          Type.Numeric,
+          func.Add(guardB, func.Constant(ejs.int(42))),
+          func.Undefined)
+
+      val expect =
+        func.Guard(
+          func.Guard(
+            func.Guard(
+              func.ProjectKeyS(func.Hole, "foo"),
+              Type.AnyObject,
+              func.ProjectKeyS(func.ProjectKeyS(func.Hole, "foo"), "bar"),
+              func.Undefined),
+            Type.AnyArray,
+            func.ProjectIndexI(func.ProjectKeyS(func.ProjectKeyS(func.Hole, "foo"), "bar"), 3),
+            func.Undefined),
+          Type.Numeric,
+          func.Add(
+            func.ProjectIndexI(func.ProjectKeyS(func.ProjectKeyS(func.Hole, "foo"), "bar"), 3),
+            func.Constant(ejs.int(42))),
+          func.Undefined)
+
+      normalize(guardC) must beTreeEqual(expect)
     }
   }
 }

--- a/mongodb/src/test/resources/planner/plan_filter_on_date.txt
+++ b/mongodb/src/test/resources/planner/plan_filter_on_date.txt
@@ -15,19 +15,6 @@ Chain
       │  │  ╰─ Expr($ts -> Type(Date))
       │  ╰─ Doc
       │     ╰─ Expr($ts -> Type(Bool))
-      ├─ Or
-      │  ├─ Doc
-      │  │  ╰─ Expr($ts -> Type(Int32))
-      │  ├─ Doc
-      │  │  ╰─ Expr($ts -> Type(Int64))
-      │  ├─ Doc
-      │  │  ╰─ Expr($ts -> Type(Dec))
-      │  ├─ Doc
-      │  │  ╰─ Expr($ts -> Type(Text))
-      │  ├─ Doc
-      │  │  ╰─ Expr($ts -> Type(Date))
-      │  ╰─ Doc
-      │     ╰─ Expr($ts -> Type(Bool))
       ╰─ Or
          ├─ And
          │  ├─ Doc

--- a/mongodb/src/test/scala/quasar/physical/mongodb/PlannerSql2ExactSpec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/PlannerSql2ExactSpec.scala
@@ -49,7 +49,7 @@ class PlannerSql2ExactSpec extends
     PendingWithActualTracking {
 
   //to write the new actuals:
-  // override val mode = WriteMode
+  //override val mode = WriteMode
 
   import Grouped.grouped
   import Reshape.reshape
@@ -121,14 +121,14 @@ class PlannerSql2ExactSpec extends
               func.Guard(
                 func.Guard(func.LeftSide, Type.AnyObject, func.LeftSide, func.Undefined),
                 Type.AnyObject,
-                func.Guard(func.LeftSide, Type.AnyObject, func.ProjectKeyS(func.LeftSide, "name"), func.Undefined),
+                func.ProjectKeyS(func.LeftSide, "name"),
                 func.Undefined)),
             func.MakeMap(
               func.Constant(json.str("year")),
               func.Guard(
                 func.Guard(func.RightSide, Type.AnyObject, func.RightSide, func.Undefined),
                 Type.AnyObject,
-                func.Guard(func.RightSide, Type.AnyObject, func.ProjectKeyS(func.RightSide, "year"), func.Undefined),
+                func.ProjectKeyS(func.RightSide, "year"),
                 func.Undefined))))).some,
       chain[Workflow](
         $read(collection("db", "cars")),
@@ -969,15 +969,12 @@ class PlannerSql2ExactSpec extends
          $read(collection("db", "zips")),
          $match(
            Selector.And(
-             // TODO: eliminate duplication
              isNumeric(BsonField.Name("pop")),
-             Selector.And(
-               isNumeric(BsonField.Name("pop")),
-               Selector.Or(
-                 Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
-                   BsonField.Name("pop") -> Selector.NotExpr(Selector.Gt(Bson.Int32(0))))),
-                 Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
-                   BsonField.Name("pop") -> Selector.NotExpr(Selector.Lt(Bson.Int32(1000)))))))))))
+             Selector.Or(
+               Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
+                 BsonField.Name("pop") -> Selector.NotExpr(Selector.Gt(Bson.Int32(0))))),
+               Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
+                 BsonField.Name("pop") -> Selector.NotExpr(Selector.Lt(Bson.Int32(1000))))))))))
     }
 
     "plan filter with not and equality" in {


### PR DESCRIPTION
Adds a `DedupeGuards` rewrite for `FreeMap`s that elides any guards in the continuation of a guard that were evaluated in the predicate of the guard, including any nested guards.

#qz-3613 Done.
#qz-3575 Done.