### PR TITLE
Typeclasses for decoding EJson

### DIFF
--- a/ejson/src/main/scala/quasar/ejson/DecodeEJson.scala
+++ b/ejson/src/main/scala/quasar/ejson/DecodeEJson.scala
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.ejson
+
+import slamdata.Predef.{Int => SInt, Char => SChar, Byte => SByte, _}
+import quasar.RenderedTree
+import quasar.contrib.argonaut._
+import quasar.ejson.implicits._
+
+import argonaut.{DecodeJson, Json => AJson}
+import matryoshka._
+import matryoshka.implicits._
+import scalaz._
+import scalaz.std.list._
+import scalaz.std.option._
+import scalaz.syntax.traverse._
+import scalaz.syntax.std.boolean._
+import scalaz.syntax.std.either._
+import scalaz.syntax.std.option._
+import simulacrum.typeclass
+
+/** Typeclass for types that can be decoded from EJson. */
+@typeclass
+trait DecodeEJson[A] {
+  def decode[J](j: J)(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): Decoded[A]
+
+  def map[B](f: A => B): DecodeEJson[B] =
+    mapDecoded(_ map f)
+
+  def mapDecoded[B](f: Decoded[A] => Decoded[B]): DecodeEJson[B] =
+    flatMapDecoded(f andThen DecodeEJson.always)
+
+  def flatMap[B](f: A => DecodeEJson[B]): DecodeEJson[B] =
+    flatMapDecoded(_.fold(DecodeEJson.failed, f))
+
+  def flatMapDecoded[B](f: Decoded[A] => DecodeEJson[B]): DecodeEJson[B] = {
+    val orig = this
+    new DecodeEJson[B] {
+      def decode[J](j: J)(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): Decoded[B] =
+        f(orig.decode(j)).decode(j)
+    }
+  }
+
+  def reinterpret[B](msg: String, f: A => Option[B]): DecodeEJson[B] = {
+    val orig = this
+    new DecodeEJson[B] {
+      def decode[J](j: J)(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): Decoded[B] =
+        orig.decode(j).setMessage(msg).flatMap(a => Decoded.attempt(j, f(a) \/> msg))
+    }
+  }
+}
+
+object DecodeEJson extends DecodeEJsonInstances {
+  def always[A](r: Decoded[A]): DecodeEJson[A] =
+    new DecodeEJson[A] {
+      def decode[J](j: J)(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): Decoded[A] =
+        r
+    }
+
+  def constant[A](a: A): DecodeEJson[A] =
+    always(Decoded.success(a))
+
+  def decodeEJsonC[T, F[_]: Traverse](implicit T: Corecursive.Aux[T, F], F: DecodeEJsonK[F]): DecodeEJson[T] =
+    new DecodeEJson[T] {
+      def decode[J](j: J)(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): Decoded[T] =
+        j.anaM[T](F.decodeK[J])
+    }
+
+  def failed[A](input: RenderedTree, msg: String): DecodeEJson[A] =
+    always(Decoded.failure(input, msg))
+
+  object failedOn {
+    def apply[A] = new PartiallyApplied[A]
+    final class PartiallyApplied[A] {
+      def apply[J](input: J, msg: String)(implicit J: Recursive.Aux[J, EJson]): DecodeEJson[A] =
+        always(Decoded.failureFor[A](input, msg))
+    }
+  }
+}
+
+sealed abstract class DecodeEJsonInstances extends DecodeEJsonInstances0 {
+  implicit val monad: Monad[DecodeEJson] =
+    new Monad[DecodeEJson] {
+      override def map[A, B](fa: DecodeEJson[A])(f: A => B) =
+        fa map f
+
+      def bind[A, B](fa: DecodeEJson[A])(f: A => DecodeEJson[B]) =
+        fa flatMap f
+
+      def point[A](a: => A) =
+        DecodeEJson.constant(a)
+    }
+
+  implicit val bigIntDecodeEJson: DecodeEJson[BigInt] =
+    new DecodeEJson[BigInt] {
+      def decode[J](j: J)(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): Decoded[BigInt] =
+        Decoded.attempt(j, Fixed[J].int.getOption(j) \/> "BigInt")
+    }
+
+  implicit val intDecodeEJson: DecodeEJson[SInt] =
+    bigIntDecodeEJson.reinterpret("Int", bi => bi.isValidInt option bi.intValue)
+
+  implicit val longDecodeEJson: DecodeEJson[Long] =
+    bigIntDecodeEJson.reinterpret("Long", bi => bi.isValidLong option bi.longValue)
+
+  implicit val shortDecodeEJson: DecodeEJson[Short] =
+    bigIntDecodeEJson.reinterpret("Short", bi => bi.isValidShort option bi.shortValue)
+
+  implicit val byteDecodeEJson: DecodeEJson[SByte] =
+    new DecodeEJson[SByte] {
+      def decode[J](j: J)(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): Decoded[SByte] =
+        Decoded.attempt(j, Fixed[J].byte.getOption(j) \/> "Byte")
+    }
+
+  implicit val charDecodeEJson: DecodeEJson[SChar] =
+    new DecodeEJson[SChar] {
+      def decode[J](j: J)(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): Decoded[SChar] =
+        Decoded.attempt(j, Fixed[J].char.getOption(j) \/> "Char")
+    }
+
+  implicit def optionDecodeEJson[A](implicit A: DecodeEJson[A]): DecodeEJson[Option[A]] =
+    new DecodeEJson[Option[A]] {
+      def decode[J](j: J)(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): Decoded[Option[A]] =
+        A.decode[J](j).map(some(_))
+          .orElse(Decoded.attempt(j, Fixed[J].nul.getOption(j).as(none[A]) \/> "Option[A]"))
+    }
+
+  implicit def listDecodeEJson[A](implicit A: DecodeEJson[A]): DecodeEJson[List[A]] =
+    new DecodeEJson[List[A]] {
+      def decode[J](j: J)(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): Decoded[List[A]] =
+        Decoded.attempt(j, j.array \/> "[A]List[A]") flatMap (_.traverse(_.decodeAs[A]))
+    }
+
+  implicit def decodeEJsonT[T[_[_]]: CorecursiveT, F[_]: Traverse: DecodeEJsonK]: DecodeEJson[T[F]] =
+    DecodeEJson.decodeEJsonC[T[F], F]
+}
+
+sealed abstract class DecodeEJsonInstances0 {
+  implicit def decodeJsonEJson[A: DecodeJson]: DecodeEJson[A] =
+    new DecodeEJson[A] {
+      def decode[J](j: J)(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): Decoded[A] = {
+        val ojson = j.transAnaM[Option, AJson, Json](EJson.toJson(Fixed[J].str.getOption(_)))
+        Decoded.attempt(j, ojson \/> "JSON") flatMap { js =>
+          Decoded.attempt(j, DecodeJson.of[A].decodeJson(js).toEither.disjunction leftMap (_._1))
+        }
+      }
+    }
+}

--- a/ejson/src/main/scala/quasar/ejson/DecodeEJsonK.scala
+++ b/ejson/src/main/scala/quasar/ejson/DecodeEJsonK.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.ejson
+
+import slamdata.Predef._
+import quasar.contrib.matryoshka.{envT => cenvT}
+
+import matryoshka._
+import matryoshka.implicits._
+import matryoshka.patterns.EnvT
+import scalaz._
+import scalaz.syntax.applicative._
+import scalaz.syntax.plus._
+import simulacrum.typeclass
+
+/** Typeclass for higher-kinded types that can be decoded from EJson. */
+@typeclass
+trait DecodeEJsonK[F[_]] {
+  def decodeK[J](implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): CoalgebraM[Decoded, F, J]
+
+  def mapK[G[_]](f: F ~> G): DecodeEJsonK[G] = {
+    val orig = this
+    new DecodeEJsonK[G] {
+      def decodeK[J](implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): CoalgebraM[Decoded, G, J] =
+        j => orig.decodeK[J].apply(j) map f
+    }
+  }
+}
+
+object DecodeEJsonK extends DecodeEJsonKInstances {
+  def envT[E: DecodeEJson, F[_]: DecodeEJsonK](
+    askLabel: String,
+    lowerLabel: String
+  ): DecodeEJsonK[EnvT[E, F, ?]] =
+    new DecodeEJsonK[EnvT[E, F, ?]] {
+      def decodeK[J](implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): CoalgebraM[Decoded, EnvT[E, F, ?], J] = {
+        val J = Fixed[J]
+        val F = DecodeEJsonK[F].decodeK[J]
+
+        _ match {
+          case J.map((J.str(`askLabel`), ask) :: (J.str(`lowerLabel`), lower) :: Nil) =>
+            (DecodeEJson[E].decode[J](ask) |@| F(lower))(cenvT)
+
+          case J.map((J.str(`lowerLabel`), lower) :: (J.str(`askLabel`), ask) :: Nil) =>
+            (DecodeEJson[E].decode[J](ask) |@| F(lower))(cenvT)
+
+          case j =>
+            Decoded.failureFor[EnvT[E, F, J]](j, s"EnvT($askLabel, $lowerLabel).")
+        }
+      }
+    }
+}
+
+sealed abstract class DecodeEJsonKInstances {
+  implicit val ejsonDecodeEJsonK: DecodeEJsonK[EJson] =
+    new DecodeEJsonK[EJson] {
+      def decodeK[J](implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): CoalgebraM[Decoded, EJson, J] =
+        _.project.point[Decoded]
+    }
+
+  implicit def coproductDecodeEJsonK[F[_], G[_]](
+    implicit
+    F: DecodeEJsonK[F],
+    G: DecodeEJsonK[G]
+  ): DecodeEJsonK[Coproduct[F, G, ?]] =
+    new DecodeEJsonK[Coproduct[F, G, ?]] {
+      def decodeK[J](implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): CoalgebraM[Decoded, Coproduct[F, G, ?], J] =
+        j => F.decodeK[J].apply(j).map(Coproduct.left[G](_)) <+>
+             G.decodeK[J].apply(j).map(Coproduct.right[F](_))
+    }
+}

--- a/ejson/src/main/scala/quasar/ejson/Decoded.scala
+++ b/ejson/src/main/scala/quasar/ejson/Decoded.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.ejson
+
+import slamdata.Predef.String
+import quasar.{RenderTree, RenderedTree}
+import quasar.fp.ski.κ
+
+import matryoshka.Recursive
+import scalaz.{\/, -\/, \/-, Applicative, Monad, Plus, Traverse}
+import scalaz.std.tuple._
+import scalaz.syntax.functor._
+
+/** The result of attempting to decode a `A` from EJson. */
+final case class Decoded[A](toDisjunction: (RenderedTree, String) \/ A) {
+  def fold[B](f: (RenderedTree, String) => B, s: A => B): B =
+    toDisjunction.fold(t => f(t._1, t._2), s)
+
+  def map[B](f: A => B): Decoded[B] =
+    Decoded(toDisjunction map f)
+
+  def flatMap[B](f: A => Decoded[B]): Decoded[B] =
+    Decoded(toDisjunction flatMap (f andThen (_.toDisjunction)))
+
+  def orElse(other: => Decoded[A]): Decoded[A] =
+    Decoded(toDisjunction orElse other.toDisjunction)
+
+  def setMessage(msg: String): Decoded[A] =
+    withMessage(κ(msg))
+
+  def withMessage(f: String => String): Decoded[A] =
+    Decoded(toDisjunction.leftMap(_.map(f)))
+}
+
+object Decoded extends DecodedInstances {
+  def attempt[J, A](j: J, r: String \/ A)(implicit J: Recursive.Aux[J, EJson]): Decoded[A] =
+    r.fold(Decoded.failureFor[A](j, _), Decoded.success)
+
+  def failure[A](input: RenderedTree, msg: String): Decoded[A] =
+    Decoded(-\/((input, msg)))
+
+  object failureFor {
+    def apply[A] = new PartiallyApplied[A]
+    final class PartiallyApplied[A] {
+      def apply[J](input: J, msg: String)(implicit J: Recursive.Aux[J, EJson]): Decoded[A] =
+        failure[A](RenderTree.recursive.render(input), msg)
+    }
+  }
+
+  def success[A](a: A): Decoded[A] =
+    Decoded(\/-(a))
+}
+
+sealed abstract class DecodedInstances {
+  implicit val covariant: Monad[Decoded] with Traverse[Decoded] =
+    new Monad[Decoded] with Traverse[Decoded] {
+      override def map[A, B](fa: Decoded[A])(f: A => B) =
+        fa map f
+
+      def bind[A, B](fa: Decoded[A])(f: A => Decoded[B]) =
+        fa flatMap f
+
+      def point[A](a: => A) =
+        Decoded.success(a)
+
+      def traverseImpl[F[_]: Applicative, A, B](fa: Decoded[A])(f: A => F[B]): F[Decoded[B]] =
+        fa.toDisjunction.traverse(f).map(Decoded(_))
+    }
+
+  implicit def equal[A: Equal]: Equal[Decoded[A]] =
+    Equal.equalBy(_.toDisjunction)
+
+  implicit val plus: Plus[Decoded] =
+    new Plus[Decoded] {
+      def plus[A](a: Decoded[A], b: => Decoded[A]): Decoded[A] =
+        a orElse b
+    }
+
+  implicit def show[A: Show]: Show[Decoded[A]] =
+    Show.show(d => Cord("Decoded") ++ d.fold(
+      (t, m) => (t, m).show,
+      a => Cord("(") ++ a.show ++ Cord(")")))
+}

--- a/ejson/src/main/scala/quasar/ejson/Extension.scala
+++ b/ejson/src/main/scala/quasar/ejson/Extension.scala
@@ -22,7 +22,7 @@ import quasar.contrib.matryoshka._
 import quasar.fp._
 
 import matryoshka._
-import monocle.Prism
+import monocle.{Iso, Prism}
 import scalaz.{Applicative, Cord, Equal, IMap, Order, Scalaz, Show, Traverse}, Scalaz._
 
 /** This is an extension to JSON that allows arbitrary expressions as map (née
@@ -51,6 +51,9 @@ object Extension extends ExtensionInstances {
     def int[A] =
       Prism.partial[Extension[A], BigInt] { case Int(i) => i } (Int(_))
 
+    def imap[A: Order] =
+      map[A] composeIso listMapIso[A]
+
     def map[A] =
       Prism.partial[Extension[A], List[(A, A)]] { case Map(m) => m } (Map(_))
 
@@ -58,6 +61,11 @@ object Extension extends ExtensionInstances {
       Prism.partial[Extension[A], (A, A)] {
         case Meta(v, m) => (v, m)
       } ((Meta(_: A, _: A)).tupled)
+
+    ////
+
+    private def listMapIso[A: Order]: Iso[List[(A, A)], IMap[A, A]] =
+      Iso(IMap.fromList[A, A])(_.toList)
   }
 }
 

--- a/ejson/src/main/scala/quasar/ejson/Fixed.scala
+++ b/ejson/src/main/scala/quasar/ejson/Fixed.scala
@@ -18,9 +18,11 @@ package quasar.ejson
 
 import slamdata.Predef.{Byte => SByte, Char => SChar, Int => _, Map => _, _}
 import quasar.contrib.matryoshka.birecursiveIso
+import quasar.ejson.implicits._
 
 import matryoshka._
 import monocle.Prism
+import scalaz.==>>
 
 final class Fixed[J] private ()(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]) {
   private val iso = birecursiveIso[J, EJson]
@@ -42,6 +44,9 @@ final class Fixed[J] private ()(implicit JC: Corecursive.Aux[J, EJson], JR: Recu
 
   val int: Prism[J, BigInt] =
     iso composePrism optics.int
+
+  val imap: Prism[J, J ==>> J] =
+    iso composePrism optics.imap[J]
 
   val map: Prism[J, List[(J, J)]] =
     iso composePrism optics.map

--- a/ejson/src/main/scala/quasar/ejson/TypeTag.scala
+++ b/ejson/src/main/scala/quasar/ejson/TypeTag.scala
@@ -34,6 +34,9 @@ object TypeTag {
   val stringIso: Iso[TypeTag, String] =
     Iso[TypeTag, String](_.value)(TypeTag(_))
 
+  implicit val decodeEJson: DecodeEJson[TypeTag] =
+    DecodeEJson[String].map(TypeTag(_))
+
   implicit val encodeEJson: EncodeEJson[TypeTag] =
     EncodeEJson[String].contramap(_.value)
 

--- a/ejson/src/main/scala/quasar/ejson/optics.scala
+++ b/ejson/src/main/scala/quasar/ejson/optics.scala
@@ -20,6 +20,7 @@ import slamdata.Predef.{Byte => SByte, Char => SChar, Int => _, Map => _, _}
 import quasar.fp.PrismNT
 
 import monocle.Prism
+import scalaz.{==>>, Order}
 
 object optics {
   import Common.{Optics => CO}
@@ -48,6 +49,9 @@ object optics {
 
   def int[A]: Prism[EJson[A], BigInt] =
     ext composePrism EO.int
+
+  def imap[A: Order]: Prism[EJson[A], A ==>> A] =
+    ext composePrism EO.imap
 
   def map[A]: Prism[EJson[A], List[(A, A)]] =
     ext composePrism EO.map

--- a/ejson/src/test/scala/quasar/ejson/EJson.scala
+++ b/ejson/src/test/scala/quasar/ejson/EJson.scala
@@ -40,6 +40,7 @@ class EJsonSpecs extends Spec with EJsonArbitrary {
   implicit val params = Parameters(maxSize = 10)
 
   type J = Fix[EJson]
+  type JS = Fix[Json]
 
   checkAll("Common", order.laws[Common[String]])
   checkAll("Common", traverse.laws[Common])
@@ -80,5 +81,12 @@ class EJsonSpecs extends Spec with EJsonArbitrary {
     "only match when type and size present" >> prop { (tt: TypeTag, ys: List[(J, J)]) =>
       SizedType.unapply(addAssoc(ys)(Type[J](tt)).project) ≟ None
     }
+  }
+
+  "embeds json" >> prop { js: JS =>
+    val str = Fixed[J].str
+
+    js.transCata[J](EJson.fromJson(str(_)))
+      .transAnaM[Option, JS, Json](EJson.toJson(str.getOption(_))) ≟ js.some
   }
 }

--- a/foundation/src/main/scala/quasar/RenderedTree.scala
+++ b/foundation/src/main/scala/quasar/RenderedTree.scala
@@ -140,6 +140,13 @@ object RenderedTree {
   }
 
   implicit val renderTree: RenderTree[RenderedTree] = RenderTree.make(ι)
+
+  @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
+  implicit val equal: Equal[RenderedTree] =
+    new Equal[RenderedTree] {
+      def equal(x: RenderedTree, y: RenderedTree) =
+        (x.nodeType ≟ y.nodeType) && (x.label ≟ y.label) && (x.children ≟ y.children)
+    }
 }
 
 object Terminal {

--- a/foundation/src/main/scala/quasar/fp/numeric/SampleStats.scala
+++ b/foundation/src/main/scala/quasar/fp/numeric/SampleStats.scala
@@ -29,15 +29,20 @@ import scalaz.syntax.std.option._
 import spire.algebra.{AdditiveMonoid, Field, NRoot, Rig}
 import spire.implicits._
 
-/** Statistics based on a sample from a population. */
-final class SampleStats[A] private (
-  val size: A,
-  // Sums of powers (1-4) of differences from the mean.
-  val m1: A,
-  val m2: A,
-  val m3: A,
-  val m4: A
-) {
+/** Statistics based on a sample from a population.
+  *
+  * @param size the number of observations
+  * @param m1 the first central moment
+  * @param m2 the second central moment
+  * @param m3 the third central moment
+  * @param m4 the fourth central moment
+  */
+final case class SampleStats[A](
+    size: A,
+    m1: A,
+    m2: A,
+    m3: A,
+    m4: A) {
 
   // Sample Statistics
 
@@ -99,7 +104,7 @@ final class SampleStats[A] private (
     val `δ²/n²` = `δ/n` * `δ/n`
     val t1      = δ * `δ/n` * size
 
-    new SampleStats(
+    SampleStats(
       n,
 
       m1 + `δ/n`,
@@ -140,7 +145,7 @@ final class SampleStats[A] private (
       val `δ³`  = `δ²` *  δ
       val `δ⁴`  = `δ²` * `δ²`
 
-      new SampleStats(
+      SampleStats(
         n,
 
         ((`n₁` * m1) + (`n₂` * b.m1)) / n,
@@ -183,7 +188,7 @@ object SampleStats extends SampleStatsInstances {
 
   /** Stats over the frequency of an observation. */
   def freq[A](count: A, a: A)(implicit A: AdditiveMonoid[A]): SampleStats[A] =
-    new SampleStats[A](count, a, A.zero, A.zero, A.zero)
+    SampleStats[A](count, a, A.zero, A.zero, A.zero)
 
   /** Stats over a `Foldable` of samples. */
   def fromFoldable[F[_]: Foldable, A: Field](fa: F[A]): SampleStats[A] =

--- a/frontend/src/main/scala/quasar/sst/TypeStat.scala
+++ b/frontend/src/main/scala/quasar/sst/TypeStat.scala
@@ -17,7 +17,7 @@
 package quasar.sst
 
 import slamdata.Predef.{Byte => SByte, Char => SChar, _}
-import quasar.{ejson => ejs}, ejs.{CommonEJson => C, EJson, ExtEJson => E, EncodeEJson}
+import quasar.{ejson => ejs}, ejs.{CommonEJson => C, Decoded, DecodeEJson, EJson, ExtEJson => E, EncodeEJson}
 import quasar.ejson.implicits._
 import quasar.fp.numeric.SampleStats
 import quasar.tpe.TypeF
@@ -167,6 +167,71 @@ object TypeStat extends TypeStatInstances {
 sealed abstract class TypeStatInstances {
   import TypeStat._
 
+  implicit def decodeEJson[A](implicit A: DecodeEJson[A]): DecodeEJson[TypeStat[A]] =
+    new DecodeEJson[TypeStat[A]] {
+      def decode[J](j: J)(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]) = {
+        def minmax[B: DecodeEJson](m: J): Decoded[(A, B, B)] =
+          (m.decodedKeyS[A](CountKey) |@| m.decodedKeyS[B](MinKey) |@| m.decodedKeyS[B](MaxKey)).tupled
+
+        def dist[B: DecodeEJson](m: J): Decoded[(SampleStats[A], B, B)] = {
+          val ss = for {
+            dmap <- m.decodeKeyS(DistributionKey)
+            smap <- dmap.decodeKeyS(StateKey)
+            size <- smap.decodedKeyS[A](SizeKey)
+            m1   <- smap.decodedKeyS[A](M1Key)
+            m2   <- smap.decodedKeyS[A](M2Key)
+            m3   <- smap.decodedKeyS[A](M3Key)
+            m4   <- smap.decodedKeyS[A](M4Key)
+          } yield SampleStats(size, m1, m2, m3, m4)
+
+          (ss |@| m.decodedKeyS[B](MinKey) |@| m.decodedKeyS[B](MaxKey)).tupled
+        }
+
+        for {
+          kind <- j.decodedKeyS[String](KindKey)
+
+          ts <- kind match {
+            case "boolean" =>
+              (j.decodedKeyS[A](TrueKey) |@| j.decodedKeyS[A](FalseKey))(TypeStat.bool(_, _))
+
+            case "byte" =>
+              minmax[SByte](j) map (TypeStat.byte(_))
+
+            case "char" =>
+              minmax[SChar](j) map (TypeStat.char(_))
+
+            case "integer" =>
+              dist[BigInt](j) map (TypeStat.int(_))
+
+            case "decimal" =>
+              dist[BigDecimal](j) map (TypeStat.dec(_))
+
+            case "count" =>
+              j.decodedKeyS[A](CountKey) map (TypeStat.count(_))
+
+            case "collection" =>
+              (
+                j.decodedKeyS[A](CountKey)                |@|
+                j.keyS(MinLenKey).traverse(_.decodeAs[A]) |@|
+                j.keyS(MaxLenKey).traverse(_.decodeAs[A])
+              )(TypeStat.coll(_, _, _))
+
+            case "string" =>
+              (
+                j.decodedKeyS[A](CountKey)    |@|
+                j.decodedKeyS[A](MinLenKey)   |@|
+                j.decodedKeyS[A](MaxLenKey)   |@|
+                j.decodedKeyS[String](MinKey) |@|
+                j.decodedKeyS[String](MaxKey)
+              )(TypeStat.str(_, _, _, _, _))
+
+            case other =>
+              Decoded.failureFor[TypeStat[A]](j, s"Unknown TypeStat: $kind.")
+          }
+        } yield ts
+      }
+    }
+
   implicit def encodeEJson[A: EncodeEJson: Equal: Field: NRoot]: EncodeEJson[TypeStat[A]] =
     new EncodeEJson[TypeStat[A]] {
       def encode[J](ts: TypeStat[A])(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): J =
@@ -206,6 +271,26 @@ sealed abstract class TypeStatInstances {
 
   ////
 
+  private val CountKey = "count"
+  private val DistributionKey = "distribution"
+  private val FalseKey = "false"
+  private val KindKey = "kind"
+  private val KurtosisKey = "kurtosis"
+  private val M1Key = "centralMoment1"
+  private val M2Key = "centralMoment2"
+  private val M3Key = "centralMoment3"
+  private val M4Key = "centralMoment4"
+  private val MaxKey = "max"
+  private val MaxLenKey = "maxLength"
+  private val MeanKey = "mean"
+  private val MinKey = "min"
+  private val MinLenKey = "minLength"
+  private val SizeKey = "size"
+  private val SkewnessKey = "skewness"
+  private val StateKey = "state"
+  private val TrueKey = "true"
+  private val VarianceKey = "variance"
+
   private[sst] def encodeEJson0[A: EncodeEJson: Equal: Field: NRoot, J](
     ts: TypeStat[A],
     isPopulation: Boolean
@@ -217,7 +302,7 @@ sealed abstract class TypeStatInstances {
       ejs.Fixed[J].map(xs.toList.map(_.leftMap(_.asEJson[J])))
 
     def kmap(kind: String, rest: (String, J)*): J =
-      emap(("kind" -> kind.asEJson[J]) +: rest : _*)
+      emap((KindKey -> kind.asEJson[J]) +: rest : _*)
 
     def optEntry[B: EncodeEJson](k: String, b: Option[B]): List[(String, J)] =
       b.map(x => (k, x.asEJson[J])).toList
@@ -225,44 +310,44 @@ sealed abstract class TypeStatInstances {
     def minmax[B: EncodeEJson](kind: String, c: A, mn: B, mx: B): J =
       kmap(
         kind
-      , "count" -> c.asEJson[J]
-      , "min"   -> mn.asEJson[J]
-      , "max"   -> mx.asEJson[J])
+      , CountKey -> c.asEJson[J]
+      , MinKey   -> mn.asEJson[J]
+      , MaxKey   -> mx.asEJson[J])
 
     def sstats(ss: SampleStats[A]): J = {
 			val state =
 				emap(
-					"size"           -> ss.size.asEJson[J]
-				, "centralMoment1" -> ss.m1.asEJson[J]
-				, "centralMoment2" -> ss.m2.asEJson[J]
-				, "centralMoment3" -> ss.m3.asEJson[J]
-				, "centralMoment4" -> ss.m4.asEJson[J])
+					SizeKey -> ss.size.asEJson[J]
+				, M1Key   -> ss.m1.asEJson[J]
+				, M2Key   -> ss.m2.asEJson[J]
+				, M3Key   -> ss.m3.asEJson[J]
+				, M4Key   -> ss.m4.asEJson[J])
 
       emap(
-				("state", state)                                         ::
-        ("mean", ss.mean.asEJson[J])                             ::
-        optEntry("variance",
+				(StateKey, state)                                         ::
+        (MeanKey, ss.mean.asEJson[J])                             ::
+        optEntry(VarianceKey,
           isPopulation.fold(ss.variance, ss.populationVariance)) :::
-        optEntry("skewness",
+        optEntry(SkewnessKey,
           isPopulation.fold(ss.skewness, ss.populationSkewness)) :::
-        optEntry("kurtosis",
+        optEntry(KurtosisKey,
           isPopulation.fold(ss.kurtosis, ss.populationKurtosis)) : _*)
     }
 
     def dist[B: EncodeEJson](kind: String, ss: SampleStats[A], mn: B, mx: B): J =
       kmap(
         kind
-      , "count"        -> ss.size.asEJson[J]
-      , "distribution" -> sstats(ss)
-      , "min"          -> mn.asEJson[J]
-      , "max"          -> mx.asEJson[J])
+      , CountKey        -> ss.size.asEJson[J]
+      , DistributionKey -> sstats(ss)
+      , MinKey          -> mn.asEJson[J]
+      , MaxKey          -> mx.asEJson[J])
 
     ts match {
       case Bool(t, f) =>
         kmap(
           "boolean"
-        , "true"  -> t.asEJson[J]
-        , "false" -> f.asEJson[J])
+        , TrueKey  -> t.asEJson[J]
+        , FalseKey -> f.asEJson[J])
 
       case Byte(c, mn, mx) =>
         minmax("byte", c, mn, mx)
@@ -277,23 +362,23 @@ sealed abstract class TypeStatInstances {
         dist("decimal", s, mn, mx)
 
       case Count(c) =>
-        kmap("count", "count" -> c.asEJson[J])
+        kmap("count", CountKey -> c.asEJson[J])
 
       case Coll(c, mnl, mxl) =>
         kmap(
           "collection",
-          ("count" -> c.asEJson[J])  ::
-          optEntry("minLength", mnl) :::
-          optEntry("maxLength", mxl) : _*)
+          (CountKey -> c.asEJson[J]) ::
+          optEntry(MinLenKey, mnl)   :::
+          optEntry(MaxLenKey, mxl) : _*)
 
       case Str(c, mnl, mxl, mn, mx) =>
         kmap(
           "string"
-        , "count"     -> c.asEJson[J]
-        , "minLength" -> mnl.asEJson[J]
-        , "maxLength" -> mxl.asEJson[J]
-        , "min"       -> mn.asEJson[J]
-        , "max"       -> mx.asEJson[J])
+        , CountKey  -> c.asEJson[J]
+        , MinLenKey -> mnl.asEJson[J]
+        , MaxLenKey -> mxl.asEJson[J]
+        , MinKey    -> mn.asEJson[J]
+        , MaxKey    -> mx.asEJson[J])
     }
   }
 }

--- a/frontend/src/test/scala/quasar/sst/StructuralTypeSpec.scala
+++ b/frontend/src/test/scala/quasar/sst/StructuralTypeSpec.scala
@@ -20,7 +20,7 @@ import slamdata.Predef._
 import quasar.contrib.matryoshka._
 import quasar.contrib.matryoshka.arbitrary._
 import quasar.{ejson => ejs}
-import quasar.ejson.EJsonArbitrary
+import quasar.ejson.{Decoded, DecodeEJson, EJson, EJsonArbitrary, EncodeEJson}
 import quasar.ejson.implicits._
 import quasar.fp._
 import quasar.tpe._
@@ -141,5 +141,11 @@ final class StructuralTypeSpec extends Spec
       val z = envT(2, TypeST(TypeF.coproduct[J, S](x, y))).embed
       (x |+| y) must equal(z)
     }
+  }
+
+  "EJson codec" >> prop { st: StructuralType[Fix[EJson], Int] =>
+    DecodeEJson[StructuralType[Fix[EJson], Int]].decode(
+      EncodeEJson[StructuralType[Fix[EJson], Int]].encode[Fix[EJson]](
+        st)) ≟ st.point[Decoded]
   }
 }

--- a/frontend/src/test/scala/quasar/sst/TypeStatSpec.scala
+++ b/frontend/src/test/scala/quasar/sst/TypeStatSpec.scala
@@ -18,12 +18,16 @@ package quasar.sst
 
 import slamdata.Predef._
 import quasar.contrib.algebra._
+import quasar.ejson.{Decoded, DecodeEJson, EJson, EncodeEJson}
 
+import matryoshka.data.Fix
 import org.specs2.scalaz._
 import scalaz.Show
+import scalaz.std.anyVal._
 import scalaz.scalacheck.{ScalazProperties => propz}
 import spire.laws.arb._
 import spire.math.Real
+import spire.std.double._
 
 final class TypeStatSpec extends Spec with ScalazMatchers with TypeStatArbitrary {
   import TypeStat._
@@ -47,5 +51,11 @@ final class TypeStatSpec extends Spec with ScalazMatchers with TypeStatArbitrary
     val expStat  = coll[Real](Real(5), Some(Real(2)), Some(Real(4)))
 
     (strStat + collStat) must equal(expStat)
+  }
+
+  "EJson codec" >> prop { ts: TypeStat[Double] =>
+    DecodeEJson[TypeStat[Double]].decode(
+      EncodeEJson[TypeStat[Double]].encode[Fix[EJson]](ts)
+    ) must equal(Decoded.success(ts))
   }
 }

--- a/frontend/src/test/scala/quasar/sst/TypedEJson.scala
+++ b/frontend/src/test/scala/quasar/sst/TypedEJson.scala
@@ -17,7 +17,20 @@
 package quasar.sst
 
 import quasar.contrib.matryoshka.arbitrary._
-import quasar.ejson.{EJson, Common, Extension, CommonEJson, ExtEJson, Meta, Type => EType, SizedType => ESizedType, EJsonArbitrary, Null => ENull}
+import quasar.ejson.{
+  DecodeEJson,
+  EJson,
+  EncodeEJson,
+  Common,
+  Extension,
+  CommonEJson,
+  ExtEJson,
+  Meta,
+  Type => EType,
+  SizedType => ESizedType,
+  EJsonArbitrary,
+  Null => ENull
+}
 import quasar.ejson.implicits._
 import quasar.fp._
 import quasar.pkg.tests._
@@ -56,6 +69,12 @@ sealed abstract class TypedEJsonInstances extends TypedEJsonInstances0 {
     corecursiveArbitrary[T[TypedEJson.TEJson], TypedEJson.TEJson] map { v =>
       TypedEJson(v.transCata[T[EJson]](TypedEJson.absorbMetadata[T[EJson]]))
     }
+
+  implicit def decodeEJson[T[_[_]]: BirecursiveT]: DecodeEJson[TypedEJson[T]] =
+    DecodeEJson.decodeEJsonC[TypedEJson[T], EJson]
+
+  implicit def encodeEJson[T[_[_]]: BirecursiveT]: EncodeEJson[TypedEJson[T]] =
+    EncodeEJson.encodeEJsonR[TypedEJson[T], EJson]
 
   implicit def order[T[_[_]]: BirecursiveT]: Order[TypedEJson[T]] =
     Order[T[EJson]].contramap(_.ejson)

--- a/frontend/src/test/scala/quasar/tpe/TypeFSpec.scala
+++ b/frontend/src/test/scala/quasar/tpe/TypeFSpec.scala
@@ -20,7 +20,7 @@ import slamdata.Predef._
 import quasar.contrib.algebra._
 import quasar.contrib.matryoshka._
 import quasar.contrib.matryoshka.arbitrary._
-import quasar.ejson.{EJson, EJsonArbitrary, Fixed}
+import quasar.ejson.{Decoded, DecodeEJson, EncodeEJson, EJson, EJsonArbitrary, Fixed}
 import quasar.ejson.implicits._
 import quasar.fp._, Helpers._
 
@@ -163,5 +163,9 @@ final class TypeFSpec extends Spec with TypeFArbitrary with EJsonArbitrary {
       val emptyStr = const[J, T](J.str("")).embed
       emptyArr ≟ emptyStr
     }
+  }
+
+  "EJson codec" >> prop { t: T =>
+    DecodeEJson[T].decode(EncodeEJson[T].encode[J](t)) ≟ t.point[Decoded]
   }
 }


### PR DESCRIPTION
Adds `DecodeEJson` and `DecodeEJsonK` typeclasses for decoding values from `EJson` along with instances for types that had already defined an `EncodeEJson` instance.