### PR TITLE
Fix PUTting existing cached view

### DIFF
--- a/core/src/main/scala/quasar/fs/mount/cache/ViewCache.scala
+++ b/core/src/main/scala/quasar/fs/mount/cache/ViewCache.scala
@@ -49,6 +49,26 @@ object ViewCache {
     implicit val equal: Equal[Status] = Equal.equalRef
   }
 
+  def mk(
+    viewConfig: MountConfig.ViewConfig,
+    maxAgeSeconds: Long,
+    refreshAfter: Instant,
+    dataFile: AFile)
+      : ViewCache =
+    ViewCache(
+      viewConfig = viewConfig,
+      lastUpdate = none,
+      executionMillis = none,
+      cacheReads = 0,
+      assignee = none,
+      assigneeStart = none,
+      maxAgeSeconds = maxAgeSeconds,
+      refreshAfter = refreshAfter,
+      status = Status.Pending,
+      errorMsg = none,
+      dataFile = dataFile,
+      tmpDataFile = none)
+
   // Hard coded to 80% of maxAge for now
   def expireAt(ts: Instant, maxAge: Duration): Throwable \/ Instant =
     \/.fromTryCatchNonFatal(ts.plus(JDuration.ofMillis((maxAge.toMillis.toDouble * 0.8).toLong)))

--- a/core/src/main/scala/quasar/metastore/Queries.scala
+++ b/core/src/main/scala/quasar/metastore/Queries.scala
@@ -119,7 +119,7 @@ trait Queries {
   def staleCachedViews(now: Instant): Query0[PathedViewCache] =
     sql"""SELECT *
           FROM view_cache
-          WHERE last_update IS NULL OR ($now > refresh_after)""".query[PathedViewCache]
+          WHERE $now > refresh_after""".query[PathedViewCache]
 
   def cacheRefreshAssigneStart(path: AFile, assigneeId: String, start: Instant, tmpDataPath: AFile): Update0 =
     sql"""UPDATE view_cache

--- a/web/src/main/scala/quasar/api/services/mount.scala
+++ b/web/src/main/scala/quasar/api/services/mount.scala
@@ -173,17 +173,16 @@ object mount {
 
   private def modifyViewCache(nw: ViewCache)(old: ViewCache): ViewCache =
     // TODO we should not recreate the cache if the ViewConfig hasn't changed
-    // However `if (MountConfig.equal.equal(nw.viewConfig, old.viewConfig))`
-    // only tests whether the toplevel definition has changed.
-    // At the moment we cannot detect any changes in underlying definitions.
-    // As soon as we support this, code can be changed to something like this:
-    // if (cacheDefinitionChanged)
-    //   <existing code>
-    // else
+    // However, we first need to invalidate caches when an underlying view or
+    // module changes, otherwise caches don't get invalidated when they should.
+    // When this is implemented we can use something like this:
+    // if (MountConfig.equal.equal(nw.viewConfig, old.viewConfig))
     //   // only update maxAgeSeconds and refreshAfter (relative to maxAgeSeconds)
     //   old.copy(
     //     maxAgeSeconds = nw.maxAgeSeconds,
     //     refreshAfter = old.refreshAfter.plusSeconds(nw.maxAgeSeconds - old.maxAgeSeconds))
+    // else
+    //   nw
     if (MountConfig.equal.equal(nw.viewConfig, old.viewConfig))
       // Let's keep the old cacheReads & lastUpdate if toplevel definition
       // is unchanged


### PR DESCRIPTION
Problem was that when updating a cached view `view_cache.last_update` was still filled with a value from the old entry, whereas `view_cache.refresh_after` was set to a value in the future calculated from `maxAge`. This meant that when checking for `staleCachedViews` (based on the query `SELECT *
FROM view_cache WHERE last_update IS NULL OR ($now > refresh_after)`) these entries were not going to be repaired until somewhere in the future (i.e. a broken cache for this period). They must be repaired immediately instead.

The fix sets `view_cache.refresh_after` to `now` when creating or updating the cache and simplifies the `staleCachedViews`check by stopping to look at `last_update` in the query.

#qz-3694 Done
#qz-3695 Done