### PR TITLE
Bump sbt-slamdata plugin to enable bintray publishing

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,10 @@
 resolvers += Resolver.sonatypeRepo("releases")
+resolvers += Resolver.bintrayRepo("slamdata-inc", "maven-public")
 
 addSbtPlugin("com.eed3si9n"          % "sbt-assembly"  % "0.14.5")
 addSbtPlugin("com.eed3si9n"          % "sbt-buildinfo" % "0.7.0")
 addSbtPlugin("io.get-coursier"       % "sbt-coursier"  % "1.0.0-RC12")
 addSbtPlugin("org.scoverage"         % "sbt-scoverage" % "1.5.1")
-addSbtPlugin("com.slamdata"          % "sbt-slamdata"  % "0.5.7")
+addSbtPlugin("com.slamdata"          % "sbt-slamdata"  % "0.6.1")
 addSbtPlugin("pl.project13.scala"    % "sbt-jmh"       % "0.2.27")
 addSbtPlugin("com.github.romanowski" % "hoarder"       % "1.0.2-RC2")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,4 +1,5 @@
 resolvers += Resolver.sonatypeRepo("releases")
+resolvers += Resolver.bintrayRepo("slamdata-inc", "maven-public")
 
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC12")
-addSbtPlugin("com.slamdata"    % "sbt-slamdata" % "0.5.7")
+addSbtPlugin("com.slamdata"    % "sbt-slamdata" % "0.6.1")


### PR DESCRIPTION
This PR is a part of overall migration to bintray.

Here, the sbt-slamdata plugin dependency was bumped.
On next release quasar should be published to bintray repo "slamdata-inc/maven-public", and hopefully synchronzied with maven (this part is not tested as it requires sonatype credentials).

Note that before creating this PR I prepared packages on bintray manually:
I used sbt task `bintrayEnsureBintrayPackageExists`
I removed redundant packages it created (this task also creates packages for modules that will not be published)
For each such package I requested linking it to jCenter. It is required for sync with maven central
Those steps will be required when for example a new module is introduced. It is also required for any project that is published via the sbt-slamdata plugin. In case of private repositories, the jCenter linking step is not needed though.

I am happy to document if needed, just let me know where.

Hopefully sbt-slamdata will be  published to sbt/sbt-plugin-releases, then it will be possible to remove `
+resolvers += Resolver.bintrayRepo("slamdata-inc", "maven-public")` lines.