### PR TITLE
Add new mongo versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,7 @@ env:
     - CONNECTOR=mimir
     - CONNECTOR=mongodb_3_2
     - CONNECTOR=mongodb_3_4
-    - CONNECTOR=mongodb_3_4_3
-    - CONNECTOR=mongodb_3_4_4
+    - CONNECTOR=mongodb_3_4_13
     - CONNECTOR=mongodb_3_6
     - CONNECTOR=mongodb_read_only
     # - CONNECTOR=spark_local_test # no spark for 2.12

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ env:
     - CONNECTOR=mimir
     - CONNECTOR=mongodb_3_2
     - CONNECTOR=mongodb_3_4
+    - CONNECTOR=mongodb_3_4_3
+    - CONNECTOR=mongodb_3_4_4
+    - CONNECTOR=mongodb_3_6
     - CONNECTOR=mongodb_read_only
     # - CONNECTOR=spark_local_test # no spark for 2.12
     # - CONNECTOR=spark_hdfs # no spark for 2.12

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,38 +9,31 @@ services:
 
   quasar_mongodb_3_2:
     container_name: quasar_mongodb_3_2
-    image: mongo:3.2
+    image: mongo:3.2.19
     command: ["mongod", "--smallfiles", "--storageEngine", "ephemeralForTest"]
     ports:
       - "27021:27017"
 
   quasar_mongodb_3_4:
     container_name: quasar_mongodb_3_4
-    image: mongo:3.4
+    image: mongo:3.4.3
     command: ["mongod", "--smallfiles", "--storageEngine", "ephemeralForTest"]
     ports:
       - "27022:27017"
 
-  quasar_mongodb_3_4_3:
-    container_name: quasar_mongodb_3_4_3
-    image: mongo:3.4.3
+  quasar_mongodb_3_4_13:
+    container_name: quasar_mongodb_3_4_13
+    image: mongo:3.4.13
     command: ["mongod", "--smallfiles", "--storageEngine", "ephemeralForTest"]
     ports:
       - "27023:27017"
 
-  quasar_mongodb_3_4_4:
-    container_name: quasar_mongodb_3_4_4
-    image: mongo:3.4.4
+  quasar_mongodb_3_6:
+    container_name: quasar_mongodb_3_6
+    image: mongo:3.6.3
     command: ["mongod", "--smallfiles", "--storageEngine", "ephemeralForTest"]
     ports:
       - "27024:27017"
-
-  quasar_mongodb_3_6:
-    container_name: quasar_mongodb_3_6
-    image: mongo:3.6
-    command: ["mongod", "--smallfiles", "--storageEngine", "ephemeralForTest"]
-    ports:
-      - "27025:27017"
 
   quasar_metastore:
     container_name: quasar_metastore

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,6 +21,27 @@ services:
     ports:
       - "27022:27017"
 
+  quasar_mongodb_3_4_3:
+    container_name: quasar_mongodb_3_4_3
+    image: mongo:3.4.3
+    command: ["mongod", "--smallfiles", "--storageEngine", "ephemeralForTest"]
+    ports:
+      - "27023:27017"
+
+  quasar_mongodb_3_4_4:
+    container_name: quasar_mongodb_3_4_4
+    image: mongo:3.4.4
+    command: ["mongod", "--smallfiles", "--storageEngine", "ephemeralForTest"]
+    ports:
+      - "27024:27017"
+
+  quasar_mongodb_3_6:
+    container_name: quasar_mongodb_3_6
+    image: mongo:3.6
+    command: ["mongod", "--smallfiles", "--storageEngine", "ephemeralForTest"]
+    ports:
+      - "27025:27017"
+
   quasar_metastore:
     container_name: quasar_metastore
     image: postgres:9.6.5

--- a/docker/scripts/assembleTestingConf
+++ b/docker/scripts/assembleTestingConf
@@ -79,9 +79,8 @@ configure_mongo() {
   if [[ $CONTAINERNAME == "mongodb_read_only" ]]; then echo "$CONTAINERNAME=\"mongodb://${DOCKERIP}:27020\"" >> $CONFIGFILE; fi
   if [[ $CONTAINERNAME == "mongodb_3_2"       ]]; then echo "$CONTAINERNAME=\"mongodb://${DOCKERIP}:27021\"" >> $CONFIGFILE; fi
   if [[ $CONTAINERNAME == "mongodb_3_4"       ]]; then echo "$CONTAINERNAME=\"mongodb://${DOCKERIP}:27022\"" >> $CONFIGFILE; fi
-  if [[ $CONTAINERNAME == "mongodb_3_4_3"     ]]; then echo "$CONTAINERNAME=\"mongodb://${DOCKERIP}:27023\"" >> $CONFIGFILE; fi
-  if [[ $CONTAINERNAME == "mongodb_3_4_4"     ]]; then echo "$CONTAINERNAME=\"mongodb://${DOCKERIP}:27024\"" >> $CONFIGFILE; fi
-  if [[ $CONTAINERNAME == "mongodb_3_6"       ]]; then echo "$CONTAINERNAME=\"mongodb://${DOCKERIP}:27025\"" >> $CONFIGFILE; fi
+  if [[ $CONTAINERNAME == "mongodb_3_4_13"    ]]; then echo "$CONTAINERNAME=\"mongodb://${DOCKERIP}:27023\"" >> $CONFIGFILE; fi
+  if [[ $CONTAINERNAME == "mongodb_3_6"       ]]; then echo "$CONTAINERNAME=\"mongodb://${DOCKERIP}:27024\"" >> $CONFIGFILE; fi
 }
 
 

--- a/docker/scripts/assembleTestingConf
+++ b/docker/scripts/assembleTestingConf
@@ -79,6 +79,9 @@ configure_mongo() {
   if [[ $CONTAINERNAME == "mongodb_read_only" ]]; then echo "$CONTAINERNAME=\"mongodb://${DOCKERIP}:27020\"" >> $CONFIGFILE; fi
   if [[ $CONTAINERNAME == "mongodb_3_2"       ]]; then echo "$CONTAINERNAME=\"mongodb://${DOCKERIP}:27021\"" >> $CONFIGFILE; fi
   if [[ $CONTAINERNAME == "mongodb_3_4"       ]]; then echo "$CONTAINERNAME=\"mongodb://${DOCKERIP}:27022\"" >> $CONFIGFILE; fi
+  if [[ $CONTAINERNAME == "mongodb_3_4_3"     ]]; then echo "$CONTAINERNAME=\"mongodb://${DOCKERIP}:27023\"" >> $CONFIGFILE; fi
+  if [[ $CONTAINERNAME == "mongodb_3_4_4"     ]]; then echo "$CONTAINERNAME=\"mongodb://${DOCKERIP}:27024\"" >> $CONFIGFILE; fi
+  if [[ $CONTAINERNAME == "mongodb_3_6"       ]]; then echo "$CONTAINERNAME=\"mongodb://${DOCKERIP}:27025\"" >> $CONFIGFILE; fi
 }
 
 

--- a/it/src/main/resources/tests/backendStatuses.test
+++ b/it/src/main/resources/tests/backendStatuses.test
@@ -5,6 +5,7 @@
         "marklogic_json":    "skip",
         "marklogic_xml":     "skip",
         "mongodb_3_2":       "pending",
+        "mongodb_3_4":       "pending",
         "spark_hdfs":        "skip",
         "spark_local":       "skip",
         "spark_cassandra":   "skip"

--- a/it/src/main/resources/tests/concatArrayWithLiteral.test
+++ b/it/src/main/resources/tests/concatArrayWithLiteral.test
@@ -5,6 +5,8 @@
         "mimir":             "ignoreFieldOrder",
         "mongodb_3_2":       "ignoreFieldOrder",
         "mongodb_3_4":       "ignoreFieldOrder",
+        "mongodb_3_4_13":    "ignoreFieldOrder",
+        "mongodb_3_6":       "ignoreFieldOrder",
         "mongodb_read_only": "pending"
     },
     "data": "largeZips.data",

--- a/it/src/main/resources/tests/couchbase/leftKeyJoin.test
+++ b/it/src/main/resources/tests/couchbase/leftKeyJoin.test
@@ -7,6 +7,8 @@
         "mimir":             "skip",
         "mongodb_3_2":       "skip",
         "mongodb_3_4":       "skip",
+        "mongodb_3_4_13":    "skip",
+        "mongodb_3_6":       "skip",
         "mongodb_read_only": "skip",
         "spark_hdfs":        "skip",
         "spark_local":       "skip",

--- a/it/src/main/resources/tests/couchbase/leftKeyJoinMultipleSelect.test
+++ b/it/src/main/resources/tests/couchbase/leftKeyJoinMultipleSelect.test
@@ -7,6 +7,8 @@
         "mimir":             "skip",
         "mongodb_3_2":       "skip",
         "mongodb_3_4":       "skip",
+        "mongodb_3_4_13":    "skip",
+        "mongodb_3_6":       "skip",
         "mongodb_read_only": "skip",
         "spark_hdfs":        "skip",
         "spark_local":       "skip",

--- a/it/src/main/resources/tests/couchbase/rightKeyJoin.test
+++ b/it/src/main/resources/tests/couchbase/rightKeyJoin.test
@@ -7,6 +7,8 @@
         "mimir":             "skip",
         "mongodb_3_2":       "skip",
         "mongodb_3_4":       "skip",
+        "mongodb_3_4_13":    "skip",
+        "mongodb_3_6":       "skip",
         "mongodb_read_only": "skip",
         "spark_hdfs":        "skip",
         "spark_local":       "skip",

--- a/it/src/main/resources/tests/demo/ordersByPricePaid.test
+++ b/it/src/main/resources/tests/demo/ordersByPricePaid.test
@@ -7,6 +7,8 @@
         "mimir":             "pendingIgnoreFieldOrder",
         "mongodb_3_2":       "skip",
         "mongodb_3_4":       "skip",
+        "mongodb_3_4_13":    "skip",
+        "mongodb_3_6":       "skip",
         "mongodb_read_only": "skip",
         "postgres":          "pending"
     },

--- a/it/src/main/resources/tests/distinctStar.test
+++ b/it/src/main/resources/tests/distinctStar.test
@@ -5,6 +5,8 @@
         "mimir":"ignoreFieldOrder",
         "mongodb_3_2":       "pendingIgnoreFieldOrder",
         "mongodb_3_4":       "pendingIgnoreFieldOrder",
+        "mongodb_3_4_13":    "pendingIgnoreFieldOrder",
+        "mongodb_3_6":       "pendingIgnoreFieldOrder",
         "mongodb_read_only": "pendingIgnoreFieldOrder"
     },
     "NB": "Skipped for couchbase due to #2329 failure to load test data.",

--- a/it/src/main/resources/tests/fieldWithReduction.test
+++ b/it/src/main/resources/tests/fieldWithReduction.test
@@ -5,6 +5,8 @@
         "couchbase":         "pending",
         "mongodb_3_2":       "ignoreFieldOrder",
         "mongodb_3_4":       "ignoreFieldOrder",
+        "mongodb_3_4_13":    "ignoreFieldOrder",
+        "mongodb_3_6":       "ignoreFieldOrder",
         "mongodb_read_only": "ignoreFieldOrder"
     },
 

--- a/it/src/main/resources/tests/flattenGroupedObject.test
+++ b/it/src/main/resources/tests/flattenGroupedObject.test
@@ -6,6 +6,8 @@
         "mimir":             "ignoreFieldOrder",
         "mongodb_3_2":       "pending",
         "mongodb_3_4":       "pending",
+        "mongodb_3_4_13":    "pending",
+        "mongodb_3_6":       "pending",
         "mongodb_read_only": "pending",
         "spark_cassandra":   "pending"
     },

--- a/it/src/main/resources/tests/groupByFlatten.test
+++ b/it/src/main/resources/tests/groupByFlatten.test
@@ -7,6 +7,8 @@
         "mimir":             "pendingIgnoreFieldOrder",
         "mongodb_3_2":       "pending",
         "mongodb_3_4":       "pending",
+        "mongodb_3_4_13":    "pending",
+        "mongodb_3_6":       "pending",
         "mongodb_read_only": "pending",
         "postgres":          "pending",
         "spark_hdfs":        "pending",

--- a/it/src/main/resources/tests/groupBySimpleExpression.test
+++ b/it/src/main/resources/tests/groupBySimpleExpression.test
@@ -6,6 +6,8 @@
         "mimir":             "ignoreFieldOrder",
         "mongodb_3_2":       "ignoreFieldOrder",
         "mongodb_3_4":       "ignoreFieldOrder",
+        "mongodb_3_4_13":    "ignoreFieldOrder",
+        "mongodb_3_6":       "ignoreFieldOrder",
         "mongodb_read_only": "pending"
     },
     "data": "extraSmallZips.data",

--- a/it/src/main/resources/tests/havingWithMultipleProjections.test
+++ b/it/src/main/resources/tests/havingWithMultipleProjections.test
@@ -7,6 +7,8 @@
         "mimir":             "pendingIgnoreFieldOrder",
         "mongodb_3_2":       "pending",
         "mongodb_3_4":       "pending",
+        "mongodb_3_4_13":    "pending",
+        "mongodb_3_6":       "pending",
         "mongodb_read_only": "pending",
         "spark_cassandra":   "pending"
     },

--- a/it/src/main/resources/tests/mapKeys.test
+++ b/it/src/main/resources/tests/mapKeys.test
@@ -2,9 +2,9 @@
     "name": "select map keys",
     "backends": {
         "marklogic_xml":     "pending",
-        "mongodb_3_2":       "pending"
+        "mongodb_3_2":       "pending",
+        "mongodb_3_4":       "pending"
     },
-    "NB": "working on mongo_3_4 because it uses version >= 3.4.4. Expected to still fail on version < 3.4.4",
     "data": "newTests.data",
     "query": "select distinct backends{_:} from newTests",
     "predicate": "exactly",

--- a/it/src/main/resources/tests/multilevelFlatten.test
+++ b/it/src/main/resources/tests/multilevelFlatten.test
@@ -5,6 +5,7 @@
         "marklogic_json":    "pendingIgnoreFieldOrder",
         "marklogic_xml":     "pending",
         "mongodb_3_2":       "pending",
+        "mongodb_3_4":       "pending",
         "spark_hdfs":        "pending",
         "spark_local":       "pending",
         "spark_cassandra":   "pending"

--- a/it/src/main/resources/tests/multitypeFlatten.test
+++ b/it/src/main/resources/tests/multitypeFlatten.test
@@ -7,6 +7,8 @@
         "mimir":             "skip",
         "mongodb_3_2":       "skip",
         "mongodb_3_4":       "skip",
+        "mongodb_3_4_13":    "skip",
+        "mongodb_3_6":       "skip",
         "mongodb_read_only": "skip",
         "spark_hdfs":        "skip",
         "spark_local":       "skip",

--- a/it/src/main/resources/tests/null/nullTestExprsWithMissing.test
+++ b/it/src/main/resources/tests/null/nullTestExprsWithMissing.test
@@ -7,6 +7,8 @@
         "mimir":"pendingIgnoreFieldOrder",
         "mongodb_3_2":       "pendingIgnoreFieldOrder",
         "mongodb_3_4":       "pendingIgnoreFieldOrder",
+        "mongodb_3_4_13":    "pendingIgnoreFieldOrder",
+        "mongodb_3_6":       "pendingIgnoreFieldOrder",
         "mongodb_read_only": "pendingIgnoreFieldOrder",
         "spark_hdfs":        "pending",
         "spark_local":       "pending",

--- a/it/src/main/resources/tests/qa/s02_functions/coercions.test
+++ b/it/src/main/resources/tests/qa/s02_functions/coercions.test
@@ -9,6 +9,8 @@
     "mimir":             "skip",
     "mongodb_3_2":       "skip",
     "mongodb_3_4":       "skip",
+    "mongodb_3_4_13":    "skip",
+    "mongodb_3_6":       "skip",
     "mongodb_read_only": "skip",
     "spark_hdfs":        "skip"
   },

--- a/it/src/main/resources/tests/qa/s04_subset/select_with_limit_and_then_offset.test
+++ b/it/src/main/resources/tests/qa/s04_subset/select_with_limit_and_then_offset.test
@@ -8,6 +8,8 @@
        "mimir":             "pending",
        "mongodb_3_2":       "pending",
        "mongodb_3_4":       "pending",
+       "mongodb_3_4_13":    "pending",
+       "mongodb_3_6":       "pending",
        "mongodb_read_only": "pending",
        "spark_hdfs":        "pending",
        "spark_local":       "pending"

--- a/it/src/main/resources/tests/qa/s07_join/changedTestStatus.test
+++ b/it/src/main/resources/tests/qa/s07_join/changedTestStatus.test
@@ -8,6 +8,8 @@
         "mimir":             "pendingIgnoreFieldOrder",
         "mongodb_3_2":       "pendingIgnoreFieldOrder",
         "mongodb_3_4":       "pendingIgnoreFieldOrder",
+        "mongodb_3_4_13":    "pendingIgnoreFieldOrder",
+        "mongodb_3_6":       "pendingIgnoreFieldOrder",
         "mongodb_read_only": "pendingIgnoreFieldOrder",
         "spark_hdfs":        "pending",
         "spark_local":       "pending",

--- a/it/src/main/resources/tests/qa/s07_join/changedTestStatusInterim.test
+++ b/it/src/main/resources/tests/qa/s07_join/changedTestStatusInterim.test
@@ -2,7 +2,6 @@
     "name": "[qa_s07] select tests that have changed status (interim)",
     "NB": "This is a workaround for a QScript issue in changedTestStatus.test
            and should be removed when some connectors start passing that test.",
-    "NB": "Working on mongo_3_4 because it uses version >= 3.4.4. Expected to still fail on version < 3.4.4",
     "NB": "Skipped on mimir due to timeout.",
     "backends": {
         "couchbase":         "pending",
@@ -10,6 +9,7 @@
         "marklogic_xml":     "pending",
         "mimir":             "skip",
         "mongodb_3_2":       "pendingIgnoreFieldOrder",
+        "mongodb_3_4":       "pending",
         "spark_hdfs":        "pending",
         "spark_local":       "pending",
         "spark_cassandra":   "pending",

--- a/it/src/main/resources/tests/qa/s07_join/nonJsJoinCondition.test
+++ b/it/src/main/resources/tests/qa/s07_join/nonJsJoinCondition.test
@@ -8,6 +8,8 @@
         "mimir":             "pending",
         "mongodb_3_2":       "pending",
         "mongodb_3_4":       "pending",
+        "mongodb_3_4_13":    "pending",
+        "mongodb_3_6":       "pending",
         "mongodb_read_only": "pending",
         "spark_hdfs":        "pending",
         "spark_local":       "pending",

--- a/it/src/main/resources/tests/qa/s07_join/simple_join.test
+++ b/it/src/main/resources/tests/qa/s07_join/simple_join.test
@@ -7,6 +7,8 @@
         "marklogic_xml":     "timeout",
         "mongodb_3_2":       "ignoreFieldOrder",
         "mongodb_3_4":       "ignoreFieldOrder",
+        "mongodb_3_4_13":    "ignoreFieldOrder",
+        "mongodb_3_6":       "ignoreFieldOrder",
         "mongodb_read_only": "ignoreFieldOrder",
         "mimir":             "ignoreFieldOrder",
 	    "postgres":          "pending"

--- a/it/src/main/resources/tests/qa/s07_join/symmetricNonJsJoinCondition.test
+++ b/it/src/main/resources/tests/qa/s07_join/symmetricNonJsJoinCondition.test
@@ -8,6 +8,8 @@
         "mimir":             "pending",
         "mongodb_3_2":       "pending",
         "mongodb_3_4":       "pending",
+        "mongodb_3_4_13":    "pending",
+        "mongodb_3_6":       "pending",
         "mongodb_read_only": "pending",
         "spark_hdfs":        "pending",
         "spark_local":       "pending",

--- a/it/src/main/resources/tests/qa/s08_reduce/ordered_distinct_asterix.test
+++ b/it/src/main/resources/tests/qa/s08_reduce/ordered_distinct_asterix.test
@@ -7,6 +7,8 @@
        "mimir":             "ignoreFieldOrder",
        "mongodb_3_2":       "pending",
        "mongodb_3_4":       "pending",
+       "mongodb_3_4_13":    "pending",
+       "mongodb_3_6":       "pending",
        "mongodb_read_only": "pending"
     },
     "NB": "Mongo pending because values are correct but there are some issues with equal on BigDecimal",

--- a/it/src/main/resources/tests/range.test
+++ b/it/src/main/resources/tests/range.test
@@ -6,6 +6,8 @@
         "marklogic_xml":     "pending",
         "mongodb_3_2":       "pending",
         "mongodb_3_4":       "pending",
+        "mongodb_3_4_13":    "pending",
+        "mongodb_3_6":       "pending",
         "mongodb_read_only": "pending"
     },
     "data": "nested.data",

--- a/it/src/main/resources/tests/resultFile/basicAnalyticQuery.test
+++ b/it/src/main/resources/tests/resultFile/basicAnalyticQuery.test
@@ -6,6 +6,8 @@
         "mimir":             "ignoreFieldOrder",
         "mongodb_3_2":       "skip",
         "mongodb_3_4":       "skip",
+        "mongodb_3_4_13":    "skip",
+        "mongodb_3_6":       "skip",
         "mongodb_read_only": "skip",
         "spark_cassandra":   "pending"
     },

--- a/it/src/main/resources/tests/selectCount.test
+++ b/it/src/main/resources/tests/selectCount.test
@@ -5,6 +5,8 @@
         "mimir":"ignoreFieldOrder",
         "mongodb_3_2":       "ignoreFieldOrder",
         "mongodb_3_4":       "ignoreFieldOrder",
+        "mongodb_3_4_13":    "ignoreFieldOrder",
+        "mongodb_3_6":       "ignoreFieldOrder",
         "mongodb_read_only": "ignoreFieldOrder"
     },
     "data": "slamengine_commits.data",

--- a/it/src/main/resources/tests/servlet.test
+++ b/it/src/main/resources/tests/servlet.test
@@ -7,6 +7,8 @@
         "mimir":"pendingIgnoreFieldOrder",
         "mongodb_3_2":       "pendingIgnoreFieldOrder",
         "mongodb_3_4":       "pendingIgnoreFieldOrder",
+        "mongodb_3_4_13":    "pendingIgnoreFieldOrder",
+        "mongodb_3_6":       "pendingIgnoreFieldOrder",
         "mongodb_read_only": "pendingIgnoreFieldOrder",
         "spark_hdfs":        "pending",
         "spark_local":       "pending",

--- a/it/src/main/resources/tests/simpleProjectWithOneRenamed.test
+++ b/it/src/main/resources/tests/simpleProjectWithOneRenamed.test
@@ -5,6 +5,8 @@
         "couchbase":    "ignoreFieldOrder",
         "mongodb_3_2":       "ignoreFieldOrder",
         "mongodb_3_4":       "ignoreFieldOrder",
+        "mongodb_3_4_13":    "ignoreFieldOrder",
+        "mongodb_3_6":       "ignoreFieldOrder",
         "mongodb_read_only": "ignoreFieldOrder"
     },
 

--- a/it/src/main/resources/tests/subqueryGroupBy.test
+++ b/it/src/main/resources/tests/subqueryGroupBy.test
@@ -7,6 +7,8 @@
         "mimir":             "ignoreFieldOrder",
         "mongodb_3_2":       "pending",
         "mongodb_3_4":       "pending",
+        "mongodb_3_4_13":    "pending",
+        "mongodb_3_6":       "pending",
         "mongodb_read_only": "pending"
     },
     "NB": "pending on mongo due to sorting issues",

--- a/it/src/main/resources/tests/subselectDistinctWhere.test
+++ b/it/src/main/resources/tests/subselectDistinctWhere.test
@@ -7,6 +7,8 @@
     "mimir":             "ignoreFieldOrder",
     "mongodb_3_2":       "pending",
     "mongodb_3_4":       "pending",
+    "mongodb_3_4_13":    "pending",
+    "mongodb_3_6":       "pending",
     "mongodb_read_only": "pending",
     "postgres":          "pending"
   },

--- a/it/src/main/resources/tests/subselectWhere.test
+++ b/it/src/main/resources/tests/subselectWhere.test
@@ -7,6 +7,8 @@
     "mimir":             "ignoreFieldOrder",
     "mongodb_3_2":       "pending",
     "mongodb_3_4":       "pending",
+    "mongodb_3_4_13":    "pending",
+    "mongodb_3_6":       "pending",
     "mongodb_read_only": "pending"
   },
   "NB": "skipped on couchbase due to lack of general join",

--- a/it/src/main/resources/tests/sumDistinct.test
+++ b/it/src/main/resources/tests/sumDistinct.test
@@ -6,6 +6,8 @@
         "marklogic_xml":     "pending",
         "mongodb_3_2":       "ignoreFieldOrder",
         "mongodb_3_4":       "ignoreFieldOrder",
+        "mongodb_3_4_13":    "ignoreFieldOrder",
+        "mongodb_3_6":       "ignoreFieldOrder",
         "mongodb_read_only": "pending",
         "spark_cassandra":   "pending"
     },

--- a/it/src/main/resources/tests/temporal/time.test
+++ b/it/src/main/resources/tests/temporal/time.test
@@ -6,6 +6,8 @@
         "mimir":"pendingIgnoreFieldOrder",
         "mongodb_3_2":       "pendingIgnoreFieldOrder",
         "mongodb_3_4":       "pendingIgnoreFieldOrder",
+        "mongodb_3_4_13":    "pendingIgnoreFieldOrder",
+        "mongodb_3_6":       "pendingIgnoreFieldOrder",
         "mongodb_read_only": "pendingIgnoreFieldOrder"
     },
 

--- a/it/src/main/resources/tests/temporal/toFromString.test
+++ b/it/src/main/resources/tests/temporal/toFromString.test
@@ -6,6 +6,8 @@
         "mimir":"pendingIgnoreFieldOrder",
         "mongodb_3_2":       "pendingIgnoreFieldOrder",
         "mongodb_3_4":       "pendingIgnoreFieldOrder",
+        "mongodb_3_4_13":    "pendingIgnoreFieldOrder",
+        "mongodb_3_6":       "pendingIgnoreFieldOrder",
         "mongodb_read_only": "pendingIgnoreFieldOrder"
     },
     "data": "../days.data",

--- a/it/src/main/resources/tests/typeOf.test
+++ b/it/src/main/resources/tests/typeOf.test
@@ -5,6 +5,8 @@
         "mimir":             "pendingIgnoreFieldOrder",
         "mongodb_3_2":       "pending",
         "mongodb_3_4":       "pending",
+        "mongodb_3_4_13":    "pending",
+        "mongodb_3_6":       "pending",
         "mongodb_read_only": "pending"
     },
     "data": "nested_foo.data",

--- a/it/src/main/resources/tests/unifyFlattenedFieldsWithMultipleUses.test
+++ b/it/src/main/resources/tests/unifyFlattenedFieldsWithMultipleUses.test
@@ -7,6 +7,8 @@
         "mimir":             "pendingIgnoreFieldOrder",
         "mongodb_3_2":       "pending",
         "mongodb_3_4":       "pending",
+        "mongodb_3_4_13":    "pending",
+        "mongodb_3_6":       "pending",
         "mongodb_read_only": "pending",
         "spark_hdfs":        "pending",
         "spark_local":       "pending",

--- a/it/src/main/resources/tests/unsupportedTests.test
+++ b/it/src/main/resources/tests/unsupportedTests.test
@@ -4,9 +4,9 @@
         "couchbase": "skip",
         "marklogic_json": "pending",
         "mongodb_3_2": "pending",
+        "mongodb_3_4": "pending",
         "mongodb_read_only": "skip"
     },
-    "NB": "working on mongo_3_4 because it uses version >= 3.4.4. Expected to still fail on version < 3.4.4",
     "NB": "pending on mimir due to sparse arrays",
     "NB": "disabled on couchbase due to lack of general join",
     "NB": "skipped on mongodb_read_only because of 👻",

--- a/it/src/test/scala/quasar/TestConfig.scala
+++ b/it/src/test/scala/quasar/TestConfig.scala
@@ -54,6 +54,8 @@ object TestConfig {
   val MIMIR           = ExternalBackendRef(BackendRef(BackendName("mimir")            , BackendCapability.All), mimir.Mimir.Type)
   val MONGO_3_2       = ExternalBackendRef(BackendRef(BackendName("mongodb_3_2")      , BackendCapability.All), FileSystemType("mongodb"))
   val MONGO_3_4       = ExternalBackendRef(BackendRef(BackendName("mongodb_3_4")      , BackendCapability.All), FileSystemType("mongodb"))
+  val MONGO_3_4_13    = ExternalBackendRef(BackendRef(BackendName("mongodb_3_4_13")   , BackendCapability.All), FileSystemType("mongodb"))
+  val MONGO_3_6       = ExternalBackendRef(BackendRef(BackendName("mongodb_3_6")      , BackendCapability.All), FileSystemType("mongodb"))
   val MONGO_READ_ONLY = ExternalBackendRef(BackendRef(BackendName("mongodb_read_only"), ISet singleton BackendCapability.query()), FileSystemType("mongodb"))
   val SPARK_HDFS      = ExternalBackendRef(BackendRef(BackendName("spark_hdfs")       , BackendCapability.All), FileSystemType("spark-hdfs"))
   val SPARK_LOCAL     = ExternalBackendRef(BackendRef(BackendName("spark_local")      , BackendCapability.All), FileSystemType("spark-local"))
@@ -65,7 +67,7 @@ object TestConfig {
     COUCHBASE,
     MARKLOGIC_JSON, MARKLOGIC_XML,
     MIMIR,
-    MONGO_3_2, MONGO_3_4, MONGO_READ_ONLY,
+    MONGO_3_2, MONGO_3_4, MONGO_3_4_13, MONGO_3_6, MONGO_READ_ONLY,
     SPARK_HDFS, SPARK_LOCAL, SPARK_ELASTIC, SPARK_CASSANDRA, POSTGRES)
 
   final case class UnsupportedFileSystemConfig(c: MountConfig)

--- a/mongoIt/src/test/scala/quasar/physical/mongodb/MongoDbStdLibSpec.scala
+++ b/mongoIt/src/test/scala/quasar/physical/mongodb/MongoDbStdLibSpec.scala
@@ -63,6 +63,8 @@ abstract class MongoDbStdLibSpec extends StdLibSpec {
 
   def is3_2(backend: BackendName): Boolean = backend ≟ TestConfig.MONGO_3_2.name
   def is3_4(backend: BackendName): Boolean = backend ≟ TestConfig.MONGO_3_4.name
+  def is3_4_13(backend: BackendName): Boolean = backend ≟ TestConfig.MONGO_3_4_13.name
+  def is3_6(backend: BackendName): Boolean = backend ≟ TestConfig.MONGO_3_6.name
 
   MongoDbSpec.clientShould(MongoDb.Type) { (backend, prefix, setupClient, testClient) =>
     import MongoDbIO._


### PR DESCRIPTION
Include Mongo 3.4.3, 3.4.4, and 3.6 in build system and testing.

#qz-3569 Done