### PR TITLE
Log critical Quasar errors and unhandled connector exceptions

### DIFF
--- a/interface/src/main/scala/quasar/main/logging.scala
+++ b/interface/src/main/scala/quasar/main/logging.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.main
+
+import slamdata.Predef.{PartialFunction, Some, Unit}
+
+import quasar.Planner, Planner.PlannerError
+import quasar.connector.EnvironmentError
+import quasar.effect.{Capture, Failure}
+import quasar.fp.free
+import quasar.fs.{FileSystemError, PhysicalError, UnhandledFSError}
+import quasar.fs.mount.MountingError
+import quasar.fs.mount.module.Module
+
+import org.slf4s.Logger
+import scalaz.{~>, :<:, Applicative, Free, Show}
+import scalaz.syntax.apply._
+import scalaz.syntax.foldable._
+import scalaz.syntax.show._
+import scalaz.std.option._
+
+object logging {
+  def logFailure[E, F[_]: Applicative: Capture, S[_]](
+      f: PartialFunction[E, Logger => Unit])(
+      implicit
+      E: Failure[E, ?] :<: S,
+      F: F :<: S)
+      : Logger => (Failure[E, ?] ~> Free[S, ?]) =
+    log => λ[Failure[E, ?] ~> Free[S, ?]] {
+      case Failure.Fail(e) =>
+        free.lift(f.lift(e).traverse_(g => Capture[F].capture(g(log))))
+          .into[S] *> Failure.Ops[E, S].fail(e)
+    }
+
+  def logPhysicalError[F[_]: Applicative: Capture, S[_]](
+      logger: Logger)(
+      implicit
+      E: Failure[PhysicalError, ?] :<: S,
+      F: F :<: S)
+      : Failure[PhysicalError, ?] ~> Free[S, ?] =
+    logFailure[PhysicalError, F, S] {
+      case UnhandledFSError(e) =>
+        _.error("Physical Error.", e)
+    } apply logger
+
+  def logFatalFileSystemError[F[_]: Applicative: Capture, S[_]](
+      logger: Logger)(
+      implicit
+      E: Failure[FileSystemError, ?] :<: S,
+      F: F :<: S)
+      : Failure[FileSystemError, ?] ~> Free[S, ?] =
+    logFailure[FileSystemError, F, S](logFileSystemError) apply logger
+
+  def logFatalMountingError[F[_]: Applicative: Capture, S[_]](
+      logger: Logger)(
+      implicit
+      E: Failure[MountingError, ?] :<: S,
+      F: F :<: S)
+      : Failure[MountingError, ?] ~> Free[S, ?] =
+    logFailure[MountingError, F, S] {
+      case MountingError.EError(EnvironmentError.ConnectionFailed(cause)) =>
+        _.error("Connection failed.", cause)
+
+      case MountingError.EError(ee) =>
+        _.error(Show[EnvironmentError].shows(ee))
+
+      case err @ MountingError.InvalidMount(_, _) =>
+        _.error(Show[MountingError].shows(err))
+    } apply logger
+
+  def logFatalModuleError[F[_]: Applicative: Capture, S[_]](
+      logger: Logger)(
+      implicit
+      E: Failure[Module.Error, ?] :<: S,
+      F: F :<: S)
+      : Failure[Module.Error, ?] ~> Free[S, ?] =
+    logFailure[Module.Error, F, S] {
+      case Module.Error.FSError(e) =>
+        logFileSystemError.lift(e) getOrElse noop
+    } apply logger
+
+  ////
+
+  private val noop: Logger => Unit = _ => ()
+
+  private def logFileSystemError: PartialFunction[FileSystemError, Logger => Unit] = {
+    case FileSystemError.PathErr(_) | FileSystemError.UnsupportedOperation(_) =>
+      noop
+
+    case FileSystemError.ExecutionFailed(_, rsn, _, Some(UnhandledFSError(e))) =>
+      _.error(rsn, e)
+
+    case FileSystemError.PlanningFailed(_, e) =>
+      logPlannerError.lift(e) getOrElse noop
+
+    case FileSystemError.QScriptPlanningFailed(e) =>
+      logPlannerError.lift(e) getOrElse noop
+
+    case other =>
+      _.error(other.shows)
+  }
+
+  private def logPlannerError: PartialFunction[PlannerError, Logger => Unit] = {
+    case Planner.InternalError(msg, cause) =>
+      l => cause.fold(l.error(msg))(l.error(msg, _))
+  }
+}

--- a/interface/src/main/scala/quasar/main/package.scala
+++ b/interface/src/main/scala/quasar/main/package.scala
@@ -493,6 +493,16 @@ package object main extends Logging {
           (liftMT[Task, MainErrT] compose Write.fromTaskRef(r)) :+:
           liftMT[Task, MainErrT]                                :+:
           QErrs.toCatchable[MainTask]))
+
+    val logFatalErrors: QErrs_CRW_Task ~> QErrs_CRW_TaskM =
+      injectFT[VCacheExpR, QErrs_CRW_Task] :+:
+      injectFT[VCacheExpW, QErrs_CRW_Task] :+:
+      injectFT[Task, QErrs_CRW_Task] :+:
+      logging.logPhysicalError[Task, QErrs_CRW_Task](log) :+:
+      logging.logFatalModuleError[Task, QErrs_CRW_Task](log) :+:
+      injectFT[PathMismatchFailure, QErrs_CRW_Task] :+:
+      logging.logFatalMountingError[Task, QErrs_CRW_Task](log) :+:
+      logging.logFatalFileSystemError[Task, QErrs_CRW_Task](log)
   }
 
   final case class CmdLineConfig(configPath: Option[FsFile], loadConfig: BackendConfig, cmd: Cmd)

--- a/repl/src/main/resources/log4j.properties
+++ b/repl/src/main/resources/log4j.properties
@@ -3,4 +3,4 @@ log4j.appender.FILE=org.apache.log4j.FileAppender
 log4j.appender.FILE.File=/tmp/quasar.log
 log4j.appender.FILE.Append=true
 log4j.appender.FILE.layout=org.apache.log4j.PatternLayout
-log4j.appender.FILE.layout.ConversionPattern=%5p [%t] (%F:%L) - %m%n
+log4j.appender.FILE.layout.ConversionPattern=%d %5p [%t] (%F:%L) - %m%n

--- a/web/src/main/resources/log4j.properties
+++ b/web/src/main/resources/log4j.properties
@@ -1,4 +1,4 @@
 log4j.rootLogger=ERROR, STDOUT
 log4j.appender.STDOUT=org.apache.log4j.ConsoleAppender
 log4j.appender.STDOUT.layout=org.apache.log4j.PatternLayout
-log4j.appender.STDOUT.layout.ConversionPattern=%5p [%t] (%F:%L) - %m%n
+log4j.appender.STDOUT.layout.ConversionPattern=%d %5p [%t] (%F:%L) - %m%n

--- a/web/src/main/scala/quasar/api/FailedResponse.scala
+++ b/web/src/main/scala/quasar/api/FailedResponse.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api
+
+import slamdata.Predef.{RuntimeException, Throwable}
+import quasar.effect.Failure
+import quasar.api.ToQResponse.ops._
+
+import org.http4s.Response
+import scalaz.{~>, EitherT, NaturalTransformation, Monad, Need, Show}
+
+final class FailedResponse private (throwable0: Need[Throwable], response0: Need[Response]) {
+  def toResponse: Response = response0.value
+  def toThrowable: Throwable = throwable0.value
+}
+
+object FailedResponse {
+  def apply(t: => Throwable, r: => Response): FailedResponse =
+    new FailedResponse(Need(t), Need(r))
+
+  /** Interpret a `Failure` effect into `FailedResponseOr` given evidence the
+    * failure type can be converted to a `QResponse`.
+    */
+  def fromFailure[F[_]: Monad, E](f: E => Throwable)(implicit E: ToQResponse[E, FailedResponseOr])
+      : Failure[E, ?] ~> FailedResponseT[F, ?] = {
+
+    def errToResp(e: E): FailedResponse =
+      FailedResponse(
+        f(e),
+        e.toResponse[FailedResponseOr].toHttpResponse(NaturalTransformation.refl))
+
+    Failure.toError[EitherT[F, FailedResponse, ?], FailedResponse]
+      .compose(Failure.mapError(errToResp))
+  }
+
+  def fromFailureMessage[F[_]: Monad, E: Show](implicit E: ToQResponse[E, FailedResponseOr])
+      : Failure[E, ?] ~> FailedResponseT[F, ?] =
+    fromFailure[F, E](e => new RuntimeException(Show[E].shows(e)))
+}

--- a/web/src/main/scala/quasar/api/services/RestApi.scala
+++ b/web/src/main/scala/quasar/api/services/RestApi.scala
@@ -95,13 +95,13 @@ object RestApi {
   }
 
   def toHttpServices[S[_]](
-    f: S ~> ResponseOr,
+    f: S ~> FailedResponseOr,
     svcs: Map[String, QHttpService[S]])
     : Map[String, HttpService] =
     toHttpServicesF(foldMapNT(f), svcs)
 
   def toHttpServicesF[S[_]](
-    f: Free[S, ?] ~> ResponseOr,
+    f: Free[S, ?] ~> FailedResponseOr,
     svcs: Map[String, QHttpService[S]])
     : Map[String, HttpService] =
     svcs.mapValues(_.toHttpServiceF(f))
@@ -135,6 +135,6 @@ object RestApi {
       case msgFail: MessageFailure =>
         msgFail.toApiError
           .toResponse[Task]
-          .toHttpResponse(liftMT[Task, ResponseT])
+          .toHttpResponse(liftMT[Task, FailedResponseT])
     })
 }

--- a/web/src/main/scala/quasar/server/package.scala
+++ b/web/src/main/scala/quasar/server/package.scala
@@ -28,10 +28,10 @@ import scalaz.{~>, Monad}
 package object server {
   import Mounting.PathTypeMismatch
 
-  def qErrsToResponseT[F[_]: Monad]: QErrs ~> ResponseT[F, ?] =
-    failureResponseT[F, PhysicalError]    :+:
-    failureResponseT[F, Module.Error]     :+:
-    failureResponseT[F, PathTypeMismatch] :+:
-    failureResponseT[F, MountingError]    :+:
-    failureResponseT[F, FileSystemError]
+  def qErrsToResponseT[F[_]: Monad]: QErrs ~> FailedResponseT[F, ?] =
+    FailedResponse.fromFailure[F, PhysicalError](_.cause)  :+:
+    FailedResponse.fromFailureMessage[F, Module.Error]     :+:
+    FailedResponse.fromFailureMessage[F, PathTypeMismatch] :+:
+    FailedResponse.fromFailureMessage[F, MountingError]    :+:
+    FailedResponse.fromFailureMessage[F, FileSystemError]
 }

--- a/web/src/test/scala/quasar/api/services/Fixture.scala
+++ b/web/src/test/scala/quasar/api/services/Fixture.scala
@@ -17,7 +17,7 @@
 package quasar.api.services
 
 import slamdata.Predef._
-import quasar.api.{ResponseOr, ResponseT}
+import quasar.api.{FailedResponseOr, FailedResponseT}
 import quasar.contrib.pathy._
 import quasar.fp._
 import quasar.fp.free._
@@ -91,7 +91,7 @@ object Fixture {
     mounts: MountingsConfig = MountingsConfig.empty,
     metaRefT: Task[TaskRef[MetaStore]] = MetaStoreFixture.createNewTestMetastore().flatMap(TaskRef(_)),
     persist: quasar.db.DbConnectionConfig => MainTask[Unit] = _ => ().point[MainTask]
-  ): Task[CoreEffIO ~> ResponseOr] =
+  ): Task[CoreEffIO ~> FailedResponseOr] =
     inMemFSWebInspect(state, mounts, metaRefT, persist).map{ case (inter, ref) => inter }
 
   def inMemFSWebInspect(
@@ -99,8 +99,8 @@ object Fixture {
     mounts: MountingsConfig = MountingsConfig.empty,
     metaRefT: Task[TaskRef[MetaStore]] = MetaStoreFixture.createNewTestMetastore().flatMap(TaskRef(_)),
     persist: quasar.db.DbConnectionConfig => MainTask[Unit] = _ => ().point[MainTask]
-  ): Task[(CoreEffIO ~> ResponseOr, Task[(InMemState, Map[APath, MountConfig])])] =
+  ): Task[(CoreEffIO ~> FailedResponseOr, Task[(InMemState, Map[APath, MountConfig])])] =
     inMemFSEvalInspect(state, mounts, metaRefT, persist).map { case (inter, ref) =>
-      (foldMapNT(liftMT[Task, ResponseT] :+: qErrsToResponseT[Task]) compose (injectFT[Task, QErrs_Task] :+: inter), ref)
+      (foldMapNT(liftMT[Task, FailedResponseT] :+: qErrsToResponseT[Task]) compose (injectFT[Task, QErrs_Task] :+: inter), ref)
     }
 }

--- a/web/src/test/scala/quasar/api/services/MetastoreServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/MetastoreServiceSpec.scala
@@ -62,7 +62,7 @@ class MetastoreServiceSpec extends quasar.Qspec {
         password = "bobIsAwesome",
         parameters = Map.empty)
       type Eff[A] = Coproduct[Task, MetaStoreLocation, A]
-      val inter = liftMT[Task, ResponseT] compose (reflNT[Task] :+: MetaStoreLocation.impl.constant(dbConfig))
+      val inter = liftMT[Task, FailedResponseT] compose (reflNT[Task] :+: MetaStoreLocation.impl.constant(dbConfig))
       val service = quasar.api.services.metastore.service[Eff].toHttpService(inter).orNotFound
       val get = Request()
       val resp = service(get).unsafePerformSync

--- a/web/src/test/scala/quasar/api/services/MountServiceSpec.scala
+++ b/web/src/test/scala/quasar/api/services/MountServiceSpec.scala
@@ -96,14 +96,14 @@ class MountServiceSpec extends quasar.Qspec with Http4s {
         reflNT[Task] :+: KeyValueStore.impl.fromTaskRef(configsRef)
 
       (vcacheInterp ⊛ InMemory.runFs(InMemory.InMemState.empty)) { (vci, fsi) =>
-        val effR: Eff ~> ResponseOr =
-          liftMT[Task, ResponseT]                                                        :+:
-          (liftMT[Task, ResponseT] compose timingInterp)                                 :+:
-          (liftMT[Task, ResponseT] compose vci)                                          :+:
-          (liftMT[Task, ResponseT] compose fsi compose injectNT[ManageFile, FileSystem]) :+:
-          (liftMT[Task, ResponseT] compose (foldMapNT(meff) compose mounter))            :+:
-          failureResponseOr[MountingError]                                               :+:
-          failureResponseOr[PathTypeMismatch]
+        val effR: Eff ~> FailedResponseOr =
+          liftMT[Task, FailedResponseT]                                                        :+:
+          (liftMT[Task, FailedResponseT] compose timingInterp)                                 :+:
+          (liftMT[Task, FailedResponseT] compose vci)                                          :+:
+          (liftMT[Task, FailedResponseT] compose fsi compose injectNT[ManageFile, FileSystem]) :+:
+          (liftMT[Task, FailedResponseT] compose (foldMapNT(meff) compose mounter))            :+:
+          FailedResponse.fromFailureMessage[Task, MountingError]                               :+:
+          FailedResponse.fromFailureMessage[Task, PathTypeMismatch]
 
         val effT: Eff ~> Task =
           reflNT[Task]                                   :+:

--- a/web/src/test/scala/quasar/api/services/RestApiSpecs.scala
+++ b/web/src/test/scala/quasar/api/services/RestApiSpecs.scala
@@ -41,8 +41,8 @@ class RestApiSpecs extends quasar.Qspec {
   val service =
     (Fixture.inMemFSWeb() ⊛ TaskRef(Tags.Min(Option.empty[VCache.Expiration])))((runEff, r) =>
       RestApi.finalizeServices(RestApi.toHttpServices(
-        (liftMT[Task, ResponseT] compose Read.fromTaskRef(r))  :+:
-        (liftMT[Task, ResponseT] compose Write.fromTaskRef(r)) :+:
+        (liftMT[Task, FailedResponseT] compose Read.fromTaskRef(r))  :+:
+        (liftMT[Task, FailedResponseT] compose Write.fromTaskRef(r)) :+:
         runEff,
         RestApi.coreServices[CoreEffIORW, Nothing](executionIdRef, timingRepo)
       )).orNotFound)

--- a/web/src/test/scala/quasar/api/services/VCacheFixture.scala
+++ b/web/src/test/scala/quasar/api/services/VCacheFixture.scala
@@ -69,7 +69,7 @@ trait VCacheFixture extends H2MetaStoreFixture {
   def evalViewTest[A](
     now: Instant, mounts: Map[APath, MountConfig], inMemState: InMemState
   )(
-    p: (ViewEff ~> Task, ViewEff ~> ResponseOr) => Task[A]
+    p: (ViewEff ~> Task, ViewEff ~> FailedResponseOr) => Task[A]
   ): Task[A] = {
     def viewFs: Task[ViewEff ~> Task] =
       (runFs(inMemState)                                         ⊛
@@ -125,7 +125,7 @@ trait VCacheFixture extends H2MetaStoreFixture {
         foldMapNT(viewInterp) compose viewInterpF
       }
 
-    viewFs >>= (fs => p(fs, liftMT[Task, ResponseT] compose fs))
+    viewFs >>= (fs => p(fs, liftMT[Task, FailedResponseT] compose fs))
   }
 }
 


### PR DESCRIPTION
Improves the logging story in Quasar by logging unhandled critical errors and making exception information available to be logged when an error occurs in the middle of streaming an HTTP response body.

#qz-3715 Done.