### PR TITLE
Restored support for decoding (but not encoding!) old precise

### DIFF
--- a/frontend/src/main/scala/quasar/codec.scala
+++ b/frontend/src/main/scala/quasar/codec.scala
@@ -54,6 +54,7 @@ trait DataCodec {
   def encode(data: Data): Option[Json]
   def decode(json: Json): DataEncodingError \/ Data
 }
+
 object DataCodec {
   import DataEncodingError._
 
@@ -63,7 +64,71 @@ object DataCodec {
   def render(data: Data)(implicit C: DataCodec): Option[String] =
     C.encode(data).map(_.pretty(minspace))
 
-  val Precise = new DataCodec {
+  // this is just copy-pasted from the old version; we should remove it eventually
+  def OldPrecise(recDecode: Json => DataEncodingError \/ Data) = new DataCodec {
+    val TimestampKey = "$timestamp"
+    val DateKey = "$date"
+    val TimeKey = "$time"
+    val IntervalKey = "$interval"
+    val BinaryKey = "$binary"
+    val ObjKey = "$obj"
+    val IdKey = "$oid"
+
+    // we really only care about decoding old precise
+    def encode(data: Data): Option[Json] = None
+
+    @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
+    def decode(json: Json): DataEncodingError \/ Data =
+      json.fold(
+        \/-(Data.Null),
+        bool => \/-(Data.Bool(bool)),
+        num => num match {
+          case JsonLong(x) => \/-(Data.Int(x))
+          case _           => \/-(Data.Dec(num.toBigDecimal))
+        },
+        str => \/-(Data.Str(str)),
+        arr => arr.traverse(recDecode).map(Data.Arr(_)),
+        obj => {
+          import std.DateLib._
+
+          def unpack[A](a: Option[A], expected: String)(f: A => DataEncodingError \/ Data) =
+            (a \/> UnexpectedValueError(expected, json)) flatMap f
+
+          def decodeObj(obj: JsonObject): DataEncodingError \/ Data =
+            obj.toList.traverse { case (k, v) => recDecode(v).map(k -> _) }.map(pairs => Data.Obj(ListMap(pairs: _*)))
+
+          obj.toList match {
+            case (`TimestampKey`, value) :: Nil => unpack(value.string, "string value for $timestamp")(parseTimestamp(_).leftMap(err => ParseError(err.message)))
+            case (`DateKey`, value) :: Nil      => unpack(value.string, "string value for $date")(parseLocalDate(_).leftMap(err => ParseError(err.message)))
+            case (`TimeKey`, value) :: Nil      => unpack(value.string, "string value for $time")(parseLocalTime(_).leftMap(err => ParseError(err.message)))
+            case (`IntervalKey`, value) :: Nil  => unpack(value.string, "string value for $interval")(parseInterval(_).leftMap(err => ParseError(err.message)))
+            case (`ObjKey`, value) :: Nil       => unpack(value.obj,    "object value for $obj")(decodeObj)
+            case (`BinaryKey`, value) :: Nil    => unpack(value.string, "string value for $binary") { str =>
+              \/.fromTryCatchNonFatal(Data.Binary.fromArray(new sun.misc.BASE64Decoder().decodeBuffer(str))).leftMap(_ => UnexpectedValueError("BASE64-encoded data", json))
+            }
+            case (`IdKey`, value) :: Nil        => unpack(value.string, "string value for $oid")(str => \/-(Data.Id(str)))
+            case _ => obj.fields.find(_.startsWith("$")).fold(decodeObj(obj))(κ(-\/(UnescapedKeyError(json))))
+          }
+        })
+  }
+
+  /*
+   * The purpose behind the explicit fixed-point here is to allow interleaved
+   * composition at depth.  Specifically, we want to be able to write the `orElse`
+   * combinator and have it apply not just at the top level, but also at *every*
+   * level of the recursive hierarchy.  Thus, we need to ensure that recursive
+   * calls to decode delegate to the orElse'd codec, and not the current
+   * specialized one.  This is the difference between singular backtracking and
+   * recursive backtracking.  Take note of the "decode timestamp AND localdatetimp
+   * within array" test, which is impossible to satisfy without this trick.
+   *
+   * Note that only decoding is composed in this way.  Encoding is still singular
+   * in its backtracking.  This is mostly because I'm lazy and we relaly don't
+   * need recursive backtracking on encoding... YET.  If you need to add this
+   * (i.e. because of a situation analogous to the decoding test I referenced),
+   * then you can add it using a very similar trick.
+   */
+  def NewPrecise(recDecode: Json => DataEncodingError \/ Data) = new DataCodec {
     val LocalDateTimeKey = "$localdatetime"
     val LocalDateKey = "$localdate"
     val LocalTimeKey = "$localtime"
@@ -114,7 +179,7 @@ object DataCodec {
           case _           => \/-(Data.Dec(num.toBigDecimal))
         },
         str => \/-(Data.Str(str)),
-        arr => arr.traverse(decode).map(Data.Arr(_)),
+        arr => arr.traverse(recDecode).map(Data.Arr(_)),
         obj => {
           import std.DateLib._
 
@@ -122,7 +187,7 @@ object DataCodec {
             (a \/> UnexpectedValueError(expected, json)) flatMap f
 
           def decodeObj(obj: JsonObject): DataEncodingError \/ Data =
-            obj.toList.traverse { case (k, v) => decode(v).map(k -> _) }.map(pairs => Data.Obj(ListMap(pairs: _*)))
+            obj.toList.traverse { case (k, v) => recDecode(v).map(k -> _) }.map(pairs => Data.Obj(ListMap(pairs: _*)))
 
           obj.toList match {
             case (`OffsetDateTimeKey`, value) :: Nil => unpack(value.string, "string value for $offsetdatetime")(parseOffsetDateTime(_).leftMap(err => ParseError(err.message)))
@@ -141,6 +206,8 @@ object DataCodec {
           }
         })
   }
+
+  val Precise = orElse(NewPrecise _, OldPrecise _)
 
   val Readable = new DataCodec {
     @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
@@ -216,5 +283,20 @@ object DataCodec {
     case Data.Arr(list)                                     => list.forall(representable(_, codec))
     case Data.Obj(map)                                      => map.values.forall(representable(_, codec))
     case _                                                  => true
+  }
+
+  // TODO enable support for fixpoint encoding as well
+  private def orElse(
+      selfF: (Json => DataEncodingError \/ Data) => DataCodec,
+      otherF: (Json => DataEncodingError \/ Data) => DataCodec): DataCodec = new DataCodec {
+
+    private lazy val self = selfF(decode)
+    private lazy val other = otherF(decode)
+
+    def encode(data: Data): Option[Json] =
+      self.encode(data).orElse(other.encode(data))
+
+    def decode(json: Json): DataEncodingError \/ Data =
+      self.decode(json).orElse(other.decode(json))
   }
 }

--- a/frontend/src/main/scala/quasar/std/date.scala
+++ b/frontend/src/main/scala/quasar/std/date.scala
@@ -39,6 +39,13 @@ import scalaz.syntax.either._
 import shapeless.{Data => _, _}
 
 trait DateLib extends Library with Serializable {
+
+  // legacy function for parsing Instants
+  def parseTimestamp(str: String): SemanticError \/ Data.OffsetDateTime =
+    \/.fromTryCatchNonFatal(Instant.parse(str).atOffset(ZoneOffset.UTC)).bimap(
+      κ(DateFormatError(OffsetDateTime, str, None)),
+      Data.OffsetDateTime.apply)
+
   def parseOffsetDateTime(str: String): SemanticError \/ Data.OffsetDateTime =
     \/.fromTryCatchNonFatal(JOffsetDateTime.parse(str)).bimap(
       κ(DateFormatError(OffsetDateTime, str, None)),

--- a/frontend/src/test/scala/quasar/codec.scala
+++ b/frontend/src/test/scala/quasar/codec.scala
@@ -92,6 +92,40 @@ class DataCodecSpecs extends quasar.Qspec {
         roundTrip(Data.Int(LargeInt)) must beSome(Data.Dec(new java.math.BigDecimal(LargeInt.underlying)).right[DataEncodingError])
       }
 
+      "decode timestamp" in { DataCodec.parse("""{ "$timestamp": "2015-01-31T10:30:00.000Z" }""").toOption must beSome(Data.OffsetDateTime(OffsetDateTime.parse("2015-01-31T10:30:00Z"))) }
+      "decode date"      in { DataCodec.parse("""{ "$date": "2015-01-31" }""").toOption must beSome(Data.LocalDate(LocalDate.parse("2015-01-31"))) }
+      "decode time"      in { DataCodec.parse("""{ "$time": "10:30:00.000" }""").toOption must beSome(Data.LocalTime(LocalTime.parse("10:30:00.000"))) }
+
+      "decode localdatetime" in { DataCodec.parse("""{ "$localdatetime": "2015-01-31T10:30" }""").toOption must beSome(Data.LocalDateTime(LocalDateTime.parse("2015-01-31T10:30:00"))) }
+      "decode localdate" in { DataCodec.parse("""{ "$localdate": "2015-01-31" }""").toOption must beSome(Data.LocalDate(LocalDate.parse("2015-01-31"))) }
+      "decode localtime" in { DataCodec.parse("""{ "$localtime": "10:30" }""").toOption must beSome(Data.LocalTime(LocalTime.parse("10:30:00.000"))) }
+      "decode offsetdatetime" in { DataCodec.parse("""{ "$offsetdatetime": "2015-01-31T10:30Z" }""").toOption must beSome(Data.OffsetDateTime(OffsetDateTime.parse("2015-01-31T10:30:00Z"))) }
+      "decode offsetdate" in { DataCodec.parse("""{ "$offsetdate": "2015-01-31Z" }""").toOption must beSome(Data.OffsetDate(OffsetDate.parse("2015-01-31Z"))) }
+      "decode offsettime" in { DataCodec.parse("""{ "$offsettime": "10:30Z" }""").toOption must beSome(Data.OffsetTime(OffsetTime.parse("10:30:00.000Z"))) }
+
+      "decode timestamp within array" in {
+        val input = """[{ "$timestamp": "2015-01-31T10:30:00.000Z" }]"""
+
+        val results = DataCodec.parse(input).toOption
+        val expected = Data.Arr(List(Data.OffsetDateTime(OffsetDateTime.parse("2015-01-31T10:30:00Z"))))
+
+        results must beSome(expected)
+      }
+
+      "decode timestamp AND localdatetime within array" in {
+        val input = """[{ "$timestamp": "2015-01-31T10:30:00.000Z" }, { "$localdatetime": "2015-01-31T10:30" }]"""
+
+        val results = DataCodec.parse(input).toOption
+
+        val expected = Data.Arr(
+          List(
+            Data.OffsetDateTime(OffsetDateTime.parse("2015-01-31T10:30:00Z")),
+            Data.LocalDateTime(LocalDateTime.parse("2015-01-31T10:30:00"))))
+
+        results must beSome(expected)
+      }
+
+
       // Some invalid inputs:
 
       "fail with unescaped leading '$'" in {


### PR DESCRIPTION
It also supports mixed-mode data structures (i.e. arrays/objects which contain *both* the old format and the new).  Now that I think about it, that's probably not actually necessary, but it's still cool.  😁