### PR TITLE
New plugin loading

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -208,8 +208,8 @@ def isolatedBackendSettings(classnames: String*) = Seq(
   isolatedBackends in Global ++=
     classnames.map(_ -> (fullClasspath in Compile).value.files),
 
-  packageOptions in assembly +=
-    Package.ManifestAttributes(new java.util.jar.Attributes.Name("Backend-Module") -> classnames.mkString(" ")))
+  packageOptions in (Compile, packageBin) +=
+    Package.ManifestAttributes("Backend-Module" -> classnames.mkString(" ")))
 
 lazy val isCIBuild               = settingKey[Boolean]("True when building in any automated environment (e.g. Travis)")
 lazy val isIsolatedEnv           = settingKey[Boolean]("True if running in an isolated environment")

--- a/interface/src/main/scala/quasar/main/BackendConfig.scala
+++ b/interface/src/main/scala/quasar/main/BackendConfig.scala
@@ -50,11 +50,13 @@ object BackendConfig {
   }
 
   /**
-   * A single directory containing jars, each of which will be
-   * loaded as a backend.  With each jar, the `BackendModule` class
-   * name will be determined from the `Manifest.mf` file.
+   * A single directory containing plugin files, each of which will be
+   * loaded as a backend. Plugin is defined by a json file containing
+   * a path to the main plugin jar from which `BackendModule` class
+   * name will be determined using the `Manifest.mf` file. The other thing
+   * in plugin file is a classpath that will be loaded for this plugin.
    */
-  final case class JarDirectory(dir: File) extends BackendConfig
+  final case class PluginDirectory(dir: File) extends BackendConfig
 
   /**
    * Any files in the classpath will be loaded as jars; any directories

--- a/interface/src/main/scala/quasar/main/package.scala
+++ b/interface/src/main/scala/quasar/main/package.scala
@@ -138,25 +138,29 @@ package object main extends Logging {
     }
 
     val isolatedFS: Task[BackendDef[Task]] = config match {
-      case JarDirectory(directory) =>
+      case PluginDirectory(directory) =>
         import java.util.jar.JarFile
-        import java.nio.file.Files
+        import java.io.File
+        import java.nio.file.{Files, Paths, Path}
+        import java.nio.charset.StandardCharsets
         import argonaut._, Argonaut._
 
-        final case class Plugin(mainJar: jPath, classPath: List[jPath]) {
-          private def absolute(relative: jPath): jPath = directory.toPath.toAbsolutePath.resolve(relative)
+        final case class Plugin(mainJar: Path, classPath: List[Path]) {
+          private def absolute(relative: Path): Path = directory.toPath.toAbsolutePath.resolve(relative)
           def withAbsolutePaths = Plugin(absolute(mainJar), classPath.map(absolute))
         }
 
-        implicit val pathDecodeJson:   DecodeJson[jPath]  = optionDecoder(json => json.string.map(jPath), "Path")
-        implicit val pluginDecodeJson: DecodeJson[Plugin] = jdecode2L(Plugin.apply)("main_jar", "classpath")
+        object Plugin {
+          implicit val pathDecodeJson:   DecodeJson[Path]  = optionDecoder(json => json.string.map(Paths.get(_)), "Path")
+          implicit val pluginDecodeJson: DecodeJson[Plugin] = jdecode2L(Plugin.apply)("main_jar", "classpath")
+        }
 
-        def load(pluginFile: jFile): Task[Option[BackendDef[Task]]] = {
+        def load(pluginFile: File): Task[Option[BackendDef[Task]]] = {
           val backend: OptionT[Task, BackendDef[Task]] = for {
-            contents <- Task.delay(new String(Files.readAllBytes(pluginFile.toPath))).liftM[OptionT]
-            plugin <- OptionT(Task.delay(contents.decodeOption[Plugin].map(_.withAbsolutePaths)))
+            contents <- Task.delay(new String(Files.readAllBytes(pluginFile.toPath), StandardCharsets.UTF_8)).liftM[OptionT]
+            plugin <- OptionT(Task.now(contents.decodeOption[Plugin].map(_.withAbsolutePaths)))
             classLoader <- Task.delay(new URLClassLoader(plugin.classPath.map(_.toUri.toURL).toArray, ParentCL)).liftM[OptionT]
-            mainJar <- Task.delay(new JarFile(plugin.mainJar.toFile)).liftM[OptionT]
+            mainJar = new JarFile(plugin.mainJar.toFile)
             backendModuleAttr <- OptionT(Task.delay(Option(mainJar.getManifest.getMainAttributes.getValue("Backend-Module"))))
             backendModules = backendModuleAttr.split(" ").toList.toIList
             defs <- backendModules.traverse(loadBackend(_, classLoader))
@@ -170,10 +174,12 @@ package object main extends Logging {
           } yield result
         }
 
+        val pluginFileExtension = ".plugin"
+
         for {
           children <- Task.delay(directory.listFiles().toList.toIList)
-          pluginFiles = children.filter(_.getName.endsWith(".plugin"))
-          loaded <- pluginFiles.traverse(pluginFile => load(pluginFile))
+          pluginFiles = children.filter(_.getName.endsWith(pluginFileExtension))
+          loaded <- pluginFiles.traverse(load)
         } yield loaded.flatMap(_.toIList).fold
 
       case ExplodedDirs(backends) =>

--- a/web/src/main/scala/quasar/server/Server.scala
+++ b/web/src/main/scala/quasar/server/Server.scala
@@ -67,7 +67,7 @@ object Server {
         { plugins =>
           val err = Task.fail(new RuntimeException("plugin directory does not exist (or is a file)"))
           val check = Task.delay(plugins.exists() && !plugins.isFile())
-          check.ifM(Task.now(BackendConfig.JarDirectory(plugins)), err)
+          check.ifM(Task.now(BackendConfig.PluginDirectory(plugins)), err)
         },
         backends => BackendConfig.fromBackends(IList.fromList(backends)))
 


### PR DESCRIPTION
This PR prepares quasar to work with new installers. Note that when it is merged installers PR also has to be merged. It won't be possible to build valid installers with old installer scripts and this version of quasar, because plugin resolution behavior changes. 

# Backend-Module
This attribute was originally only added to fat jar, now it is added to thin jars as well. It was done in order to allow quasar to resolve plugin main classes from thin jars, that will replace fat jars.

# Plugin loading

The previous behavior of `--plugins/-P` option was to find all fat jars in specified directory with Backend-Module attributes and load them.

Now this option behaves differently. It looks for files with .plugin extension. Those should be json files looking like this:

```
{
  "main_jar": "https/dl.bintray.com/slamdata-inc/maven-public/org/quasar-analytics/quasar-marklogic-internal_2.12/0.0.7/quasar-marklogic-internal_2.12-0.0.7.jar",
  "classpath": [
    "http/developer.marklogic.com/maven2/com/marklogic/marklogic-xcc/8.0.5/marklogic-xcc-8.0.5.jar",
    "https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.4.4/jackson-core-2.4.4.jar",
    "https/dl.bintray.com/slamdata-inc/maven-public/org/quasar-analytics/quasar-marklogic-internal_2.12/0.0.7/quasar-marklogic-internal_2.12-0.0.7.jar",
    "https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.4.0/jackson-annotations-2.4.0.jar",
    "https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.4.4/jackson-databind-2.4.4.jar",
    "https/repo1.maven.org/maven2/com/slamdata/xml-names-core_2.12/0.0.1/xml-names-core_2.12-0.0.1.jar",
    "https/repo1.maven.org/maven2/eu/timepit/refined-scalaz_2.12/0.8.3/refined-scalaz_2.12-0.8.3.jar"
  ]
}
```

`main_jar` entry is for the main jar that contains the MANIFEST.MF file with Backend-Module attribute.
`classpath` is a list of paths representing the classpath. It includes the main jar, but excludes what is already on quasar's classpath.

All those paths are relative to the specified plugin directory.
For example we could run quasar with `--plugins /tmp/cache/plugins`. Using the above example of marklogic, `ls /tmp/cache/plugins` should return `marklogic.plugin http https`.