### PR TITLE
add test cases for date, timestamp and to_timestamp filters (next-major)

### DIFF
--- a/it/src/main/resources/tests/temporal/simple_date_filter.test
+++ b/it/src/main/resources/tests/temporal/simple_date_filter.test
@@ -8,11 +8,11 @@
     "ignoreResultOrder": true,
     "expected":
       [
-        { "$timestamp": "2014-08-18T07:00:00.000Z" },
-        { "$timestamp": "2014-08-19T08:00:00.000Z" },
-        { "$timestamp": "2014-08-20T09:00:00.000Z" },
-        { "$timestamp": "2014-08-21T10:00:00.000Z" },
-        { "$timestamp": "2014-08-22T11:00:00.000Z" },
-        { "$timestamp": "2014-08-23T12:00:00.000Z" }
+        { "$offsetdatetime": "2014-08-18T07:00Z" },
+        { "$offsetdatetime": "2014-08-19T08:00Z" },
+        { "$offsetdatetime": "2014-08-20T09:00Z" },
+        { "$offsetdatetime": "2014-08-21T10:00Z" },
+        { "$offsetdatetime": "2014-08-22T11:00Z" },
+        { "$offsetdatetime": "2014-08-23T12:00Z" }
       ]
 }

--- a/it/src/main/resources/tests/temporal/simple_timestamp_filter.test
+++ b/it/src/main/resources/tests/temporal/simple_timestamp_filter.test
@@ -7,12 +7,12 @@
     "predicate": "exactly",
     "ignoreResultOrder": true,
     "expected": [
-      { "$timestamp": "2014-08-17T06:00:00.000Z" },
-      { "$timestamp": "2014-08-18T07:00:00.000Z" },
-      { "$timestamp": "2014-08-19T08:00:00.000Z" },
-      { "$timestamp": "2014-08-20T09:00:00.000Z" },
-      { "$timestamp": "2014-08-21T10:00:00.000Z" },
-      { "$timestamp": "2014-08-22T11:00:00.000Z" },
-      { "$timestamp": "2014-08-23T12:00:00.000Z" }
+      { "$offsetdatetime": "2014-08-17T06:00Z" },
+      { "$offsetdatetime": "2014-08-18T07:00Z" },
+      { "$offsetdatetime": "2014-08-19T08:00Z" },
+      { "$offsetdatetime": "2014-08-20T09:00Z" },
+      { "$offsetdatetime": "2014-08-21T10:00Z" },
+      { "$offsetdatetime": "2014-08-22T11:00Z" },
+      { "$offsetdatetime": "2014-08-23T12:00Z" }
     ]
 }

--- a/it/src/main/resources/tests/temporal/simple_to_timestamp_filter.test
+++ b/it/src/main/resources/tests/temporal/simple_to_timestamp_filter.test
@@ -9,12 +9,12 @@
     "ignoreResultOrder": true,
     "expected":
       [
-        { "$timestamp": "2014-08-17T06:00:00.000Z" },
-        { "$timestamp": "2014-08-18T07:00:00.000Z" },
-        { "$timestamp": "2014-08-19T08:00:00.000Z" },
-        { "$timestamp": "2014-08-20T09:00:00.000Z" },
-        { "$timestamp": "2014-08-21T10:00:00.000Z" },
-        { "$timestamp": "2014-08-22T11:00:00.000Z" },
-        { "$timestamp": "2014-08-23T12:00:00.000Z" }
+        { "$offsetdatetime": "2014-08-17T06:00Z" },
+        { "$offsetdatetime": "2014-08-18T07:00Z" },
+        { "$offsetdatetime": "2014-08-19T08:00Z" },
+        { "$offsetdatetime": "2014-08-20T09:00Z" },
+        { "$offsetdatetime": "2014-08-21T10:00Z" },
+        { "$offsetdatetime": "2014-08-22T11:00Z" },
+        { "$offsetdatetime": "2014-08-23T12:00Z" }
       ]
 }


### PR DESCRIPTION
add test cases for date, timestamp and to_timestamp filters

This is #3501 adapted for next-major

Relates to #sdbe-314, #sdbe-315, #sdbe-316