### PR TITLE
Update testing.conf and README.md to reflect changes to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Quasar supports the following datastores:
 quasar_mongodb_read_only
 quasar_mongodb_3_2
 quasar_mongodb_3_4
+quasar_mongodb_3_4_13
+quasar_mongodb_3_6
 quasar_metastore
 quasar_marklogic_xml
 quasar_marklogic_json
@@ -75,7 +77,8 @@ if you wanted to run integration tests with mongo, marklogic, and couchbase you 
 ./setupContainers -u quasar_metastore,quasar_mongodb_3_4,quasar_marklogic_xml,quasar_couchbase
 ```
 
-Note: `quasar_metastore` is always needed to run integration tests.
+Note: `quasar_metastore` is always needed to run integration
+tests. `quasar_mongodb_3_4` refers to MongoDB ≤ 3.4.4
 
 This command will pull docker images, create containers running the specified backends, and configure them appropriately for Quasar testing.
 

--- a/it/testing.conf.example
+++ b/it/testing.conf.example
@@ -1,6 +1,8 @@
 #postgresql_metastore = "{\"host\":\"localhost\",\"port\":5432,\"database\":\"metastore_test\",\"userName\":\"postgres\",\"password\":\"postgres\"}"
 #mongodb_3_2       ="mongodb://<host>:<port>"
 #mongodb_3_4       ="mongodb://<host>:<port>"
+#mongodb_3_4_13    ="mongodb://<host>:<port>"
+#mongodb_3_6       ="mongodb://<host>:<port>"
 #mongodb_read_only ="mongodb://<host>:<port>"
 #spark_local       ="<path_to_folder>"
 #spark_hdfs        ="spark://<spark_host>:<spark_port>?hdfsUrl=hdfs://<hdfs_host>:<hdfs_port>&rootPath=<root_path>"


### PR DESCRIPTION
I decided against renaming `quasar_mongodb_3_4` to `quasar_mongodb_3_4_3` and `quasar_mongodb_3_4_13` to `quasar_mongodb_3_4` since that'd be inconsistent with the architecture of the Mongo connector. 

The connector uses the convention ) that higher versions can handle everything lower versions can, which means `quasar_mongodb_3_4_3` has more capabilities than `quasar_mongodb_3_4` which is backwards. Worth noting this is strictly a convention, no code enforces this.

My idea now is to rename:

`quasar_mongodb_3_4_13` to `quasar_mongodb_3_4_4` 

and

`quasar_mongodb_3_4` to `quasar_mongodb_3_4_3`

WDYT: @rintcius, @nic? I don't like the current status quo since `mongob_3_6` and `mongodb_3_2` refers to the last minor versions of each, while `mongodb_3_4` refers specifically to MongoDB 3.4.3.