### PR TITLE
Implemented using local sbt in publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ env:
     # - CONNECTOR=spark_hdfs # no spark for 2.12
   global:
     - COURSIER_PROGRESS=0
+    - SBT="./sbt"
 
 # this is also the test stage :eyeroll:
 script:

--- a/scripts/constants
+++ b/scripts/constants
@@ -7,8 +7,6 @@ SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 WS_DIR="$SCRIPT_DIR/.."
 
-SBT="$WS_DIR/sbt"
-
 TEMP_DIR="$WS_DIR/tmp"
 
 mkdir -p "$TEMP_DIR"


### PR DESCRIPTION
The goal is to use local sbt script everywhere. In quasar it was used very consistently. The only place was publishAndTag script that is created by sbt-slamdata. Plugin was updated so that it requires `$SBT` with sbt path to work.
I exported this variable from env.global section of travis file. As all scripts are run from the main directory, this should work.
Alternative way is to add `export` to the line in scripts/constants that I deleted. But I think that travis env looks more predictable. 