### PR TITLE
Always format times verbosely, use Time#toString more often

### DIFF
--- a/frontend/src/main/scala/quasar/std/string.scala
+++ b/frontend/src/main/scala/quasar/std/string.scala
@@ -23,7 +23,6 @@ import quasar.fp.ski._
 import quasar.frontend.logicalplan.{LogicalPlan => LP, _}
 
 import scala.util.matching.Regex
-import java.time.format.DateTimeFormatter
 
 import matryoshka._
 import matryoshka.implicits._
@@ -346,15 +345,15 @@ trait StringLib extends Library {
         case Data.OffsetDate(t) =>
           success(t.toString)
         case Data.OffsetDateTime(t) =>
-          success(t.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.nnnnnnnnnXXX")))
+          success(t.toString)
         case Data.OffsetTime(t) =>
-          success(t.format(DateTimeFormatter.ofPattern("HH:mm:ss.nnnnnnnnnXXX")))
+          success(t.toString)
         case Data.LocalDate(t) =>
-          success(t.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+          success(t.toString)
         case Data.LocalDateTime(t) =>
-          success(t.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.nnnnnnnnn")))
+          success(t.toString)
         case Data.LocalTime(t) =>
-          success(t.format(DateTimeFormatter.ofPattern("HH:mm:ss.nnnnnnnnn")))
+          success(t.toString)
 
         case Data.Interval(i) => success(i.toString)
         case Data.Id(i) => success(i.toString)

--- a/frontend/src/test/scala/quasar/codec.scala
+++ b/frontend/src/test/scala/quasar/codec.scala
@@ -47,12 +47,12 @@ class DataCodecSpecs extends quasar.Qspec {
       "encode int"       in { DataCodec.render(Data.Int(0))   must beSome("0") }
       "encode dec"       in { DataCodec.render(Data.Dec(1.1)) must beSome("1.1") }
       "encode dec with no fractional part" in { DataCodec.render(Data.Dec(2.0)) must beSome("2.0") }
-      "encode localdatetime" in { DataCodec.render(Data.LocalDateTime(LocalDateTime.parse("2015-01-31T10:30:00"))) must beSome("""{ "$localdatetime": "2015-01-31T10:30" }""") }
+      "encode localdatetime" in { DataCodec.render(Data.LocalDateTime(LocalDateTime.parse("2015-01-31T10:30:00"))) must beSome("""{ "$localdatetime": "2015-01-31T10:30:00.000000000" }""") }
       "encode localdate" in { DataCodec.render(Data.LocalDate(LocalDate.parse("2015-01-31")))              must beSome("""{ "$localdate": "2015-01-31" }""") }
-      "encode localtime" in { DataCodec.render(Data.LocalTime(LocalTime.parse("10:30:00.000")))            must beSome("""{ "$localtime": "10:30" }""") }
-      "encode offsetdatetime" in { DataCodec.render(Data.OffsetDateTime(OffsetDateTime.parse("2015-01-31T10:30:00Z"))) must beSome("""{ "$offsetdatetime": "2015-01-31T10:30Z" }""") }
+      "encode localtime" in { DataCodec.render(Data.LocalTime(LocalTime.parse("10:30:00")))            must beSome("""{ "$localtime": "10:30:00.000000000" }""") }
+      "encode offsetdatetime" in { DataCodec.render(Data.OffsetDateTime(OffsetDateTime.parse("2015-01-31T10:30:00Z"))) must beSome("""{ "$offsetdatetime": "2015-01-31T10:30:00.000000000Z" }""") }
       "encode offsetdate" in { DataCodec.render(Data.OffsetDate(OffsetDate.parse("2015-01-31Z")))              must beSome("""{ "$offsetdate": "2015-01-31Z" }""") }
-      "encode offsettime" in { DataCodec.render(Data.OffsetTime(OffsetTime.parse("10:30:00.000Z")))            must beSome("""{ "$offsettime": "10:30Z" }""") }
+      "encode offsettime" in { DataCodec.render(Data.OffsetTime(OffsetTime.parse("10:30:00.000Z")))            must beSome("""{ "$offsettime": "10:30:00.000000000Z" }""") }
       "encode interval"  in {
         (for {
           interval <- DateTimeInterval.parse("PT12H34M")
@@ -66,7 +66,7 @@ class DataCodecSpecs extends quasar.Qspec {
       }
       "encode obj with leading '$'s" in {
         DataCodec.render(Data.Obj(ListMap("$a" -> Data.Int(1), "$date" -> Data.LocalDateTime(LocalDateTime.parse("2015-01-31T10:30"))))) must
-          beSome("""{ "$obj": { "$a": 1, "$date": { "$localdatetime": "2015-01-31T10:30" } } }""")
+          beSome("""{ "$obj": { "$a": 1, "$date": { "$localdatetime": "2015-01-31T10:30:00.000000000" } } }""")
       }
       "encode obj with $obj" in {
         DataCodec.render(Data.Obj(ListMap("$obj" -> Data.Obj(ListMap("$obj" -> Data.Int(1)))))) must

--- a/frontend/src/test/scala/quasar/std/StdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/StdLibSpec.scala
@@ -43,7 +43,6 @@ import java.time.{
   Period,
   ZoneOffset
 }
-import java.time.format.DateTimeFormatter
 import scala.collection.Traversable
 import scala.math.abs
 import scala.util.matching.Regex
@@ -341,7 +340,7 @@ abstract class StdLibSpec extends Qspec {
           def test(x: JOffsetDateTime) = unary(
             ToString(_).embed,
             Data.OffsetDateTime(x),
-            Data.Str(x.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.nnnnnnnnnXXX"))))
+            Data.Str(x.toString))
 
           "zero fractional seconds" >> test(Instant.EPOCH.atOffset(ZoneOffset.UTC))
 
@@ -352,7 +351,7 @@ abstract class StdLibSpec extends Qspec {
           def test(x: JOffsetTime) = unary(
             ToString(_).embed,
             Data.OffsetTime(x),
-            Data.Str(x.format(DateTimeFormatter.ofPattern("HH:mm:ss.nnnnnnnnnXXX"))))
+            Data.Str(x.toString))
 
           "zero fractional seconds" >> test(JOffsetTime.ofInstant(Instant.EPOCH, ZoneOffset.UTC))
 
@@ -363,14 +362,14 @@ abstract class StdLibSpec extends Qspec {
           unary(
             ToString(_).embed,
             Data.LocalDate(x),
-            Data.Str(x.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))))
+            Data.Str(x.toString))
         }
 
         "LocalDateTime" >> {
           def test(x: JLocalDateTime) = unary(
             ToString(_).embed,
             Data.LocalDateTime(x),
-            Data.Str(x.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.nnnnnnnnn"))))
+            Data.Str(x.toString))
 
           "zero fractional seconds" >> test(JLocalDateTime.ofInstant(Instant.EPOCH, ZoneOffset.UTC))
 
@@ -381,7 +380,7 @@ abstract class StdLibSpec extends Qspec {
           def test(x: JLocalTime) = unary(
             ToString(_).embed,
             Data.LocalTime(x),
-            Data.Str(x.format(DateTimeFormatter.ofPattern("HH:mm:ss.nnnnnnnnn"))))
+            Data.Str(x.toString))
 
           "zero fractional seconds" >> test(JLocalTime.NOON)
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/bsoncodec.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/bsoncodec.scala
@@ -144,7 +144,7 @@ object BsonCodec {
           extract(map.get(DateTimeConstants.offset), Bson._int32)) {
             (h, m, s, n, o) =>
               Bson.Text(
-                JOffsetTime.of(h, m, s, n,ZoneOffset.ofTotalSeconds(o)).format(DateTimeFormatter.ISO_OFFSET_TIME))
+                JOffsetTime.of(h, m, s, n,ZoneOffset.ofTotalSeconds(o)).toString)
           } \/> NonRepresentableEJson(value.shows + " is not a valid OffsetTime")
 
       case (EJsonType(TypeTag.OffsetDate.value), Bson.Doc(map)) =>


### PR DESCRIPTION
Did you know there's *nine* digits for sub-second precision in the default formatter? Neither did I.

I hope there are no unfortunate consequences of using a different `toFormatter` overload than is used in the JDK (the one they use is package-private).