### PR TITLE
Improve performance when accessing mount metadata

### DIFF
--- a/core/src/main/scala/quasar/fs/mount/MountType.scala
+++ b/core/src/main/scala/quasar/fs/mount/MountType.scala
@@ -57,6 +57,12 @@ object MountType {
       case ModuleMount => ()
     } (κ(ModuleMount))
 
+  val fromConfig: MountConfig => MountType = {
+    case MountConfig.ViewConfig(_, _)         => viewMount()
+    case MountConfig.FileSystemConfig(tpe, _) => fileSystemMount(tpe)
+    case MountConfig.ModuleConfig(_)          => moduleMount()
+  }
+
   implicit val order: Order[MountType] =
     Order.orderBy(mt => (viewMount.nonEmpty(mt), fileSystemMount.getOption(mt)))
 

--- a/core/src/main/scala/quasar/fs/mount/module/package.scala
+++ b/core/src/main/scala/quasar/fs/mount/module/package.scala
@@ -18,16 +18,38 @@ package quasar.fs.mount
 
 import slamdata.Predef._
 import quasar.contrib.pathy._
+import quasar.contrib.scalaz._
 import quasar.fp._
+import quasar.fp.ski.ι
 import quasar.fp.numeric._
 import quasar.fp.free._
-import quasar.fs._, FileSystemError._, PathError._, MountType._
+import quasar.fs._, FileSystemError._, PathError._
 import quasar.fs.mount.cache.VCache.VCacheKVS
 
 import pathy.Path._
 import scalaz.{Failure => _, Node => _, _}, Scalaz._
 
 package object module {
+  import MountConfig.{ModuleConfig, moduleConfig}
+
+  private def moduleAncestor[S[_]](f: AFile)(implicit S: Mounting :<: S): Free[S, Option[ModuleConfig]] = {
+    val mount = Mounting.Ops[S]
+
+    val dirs =
+      EphemeralStream
+        .iterate(fileParent(f))(d => parentDir(d) getOrElse d)
+        .takeWhile(_ =/= rootDir)
+
+    val r = dirs traverse_ { d =>
+      mount.lookupConfig(d)
+        .toOption
+        .squash
+        .map(c => moduleConfig.getOption(c).map(ModuleConfig(_)))
+        .toLeft(())
+    }
+
+    r.as(none[ModuleConfig]).merge
+  }
 
   /** Intercept and fail any read to a module path; all others are passed untouched. */
   def readFile[S[_]](
@@ -38,18 +60,18 @@ package object module {
     import ReadFile._
 
     val readUnsafe = ReadFile.Unsafe[S]
-    val mount = Mounting.Ops[S]
 
     λ[ReadFile ~> Free[S, ?]] {
       case Open(file, off, lim) =>
-        mount.havingPrefix(rootDir).flatMap { map =>
-          val modules = map.filter { case (k, v) => v ≟ ModuleMount.right }
-          if(modules.keys.exists { path => refineType(path).fold(dir => file.relativeTo(dir).isDefined, _ => false) })
-            pathErr(invalidPath(file, "Cannot read file in a module.")).left.point[Free[S, ?]]
-          else readUnsafe.open(file, off, lim).run
-        }
-      case Read(handle)  => readUnsafe.read(handle).run
-      case Close(handle) => readUnsafe.close(handle)
+        OptionT(moduleAncestor(file)).isDefined.ifM(
+          pathErr(invalidPath(file, "Cannot read file in a module.")).left.point[Free[S, ?]],
+          readUnsafe.open(file, off, lim).run)
+
+      case Read(handle)  =>
+        readUnsafe.read(handle).run
+
+      case Close(handle) =>
+        readUnsafe.close(handle)
     }
   }
 
@@ -58,12 +80,10 @@ package object module {
     implicit
     S0: WriteFile :<: S,
     S1: Mounting :<: S
-  ): WriteFile ~> Free[S, ?] = {
-    val mount = Mounting.Ops[S]
+  ): WriteFile ~> Free[S, ?] =
     nonFsMounts.failSomeWrites(
-      on = file => mount.lookupType(file).run.run.map(_.filter(_ ≟ ModuleMount.right).isDefined),
+      on = file => OptionT(moduleAncestor(file)).isDefined,
       message = "Cannot write to a module.")
-  }
 
   /** Overlay modules when enumerating files and directories. */
   def queryFile[S[_]](
@@ -126,6 +146,23 @@ package object module {
     }
   }
 
+  def manageFile[S[_]](
+    implicit
+    VC: VCacheKVS.Ops[S],
+    S0: ManageFile :<: S,
+    S1: QueryFile :<: S,
+    S2: Mounting :<: S,
+    S3: MountingFailure :<: S,
+    S4: PathMismatchFailure :<: S
+  ): ManageFile ~> Free[S, ?] = {
+    val mount = Mounting.Ops[S]
+
+    nonFsMounts.manageFile { dir =>
+      (mount.modulesHavingPrefix_(dir) |@| mount.lookupConfig(dir).toOption.run.run)(
+        (children, self) => children.map(ι[RPath]) ++ self.join.as(currentDir).toSet)
+    }
+  }
+
   def fileSystem[S[_]](
     implicit
     S0: ReadFile :<: S,
@@ -136,16 +173,10 @@ package object module {
     S7: Mounting :<: S,
     S8: MountingFailure :<: S,
     S9: PathMismatchFailure :<: S
-  ): FileSystem ~> Free[S, ?] = {
-    val mount = Mounting.Ops[S]
-    // Module is a directory so we want to add "ourselves" to the result of `modulesHavingPrefix`
-    val manageFile = nonFsMounts.manageFile { dir =>
-      (mount.modulesHavingPrefix_(dir).map(paths => paths.map(p => (p: RPath))) |@| mount.lookupConfig(dir).toOption.run.run)((children, self) =>
-        children ++ self.join.as(currentDir).toSet)
-    }
+  ): FileSystem ~> Free[S, ?] =
     interpretFileSystem[Free[S, ?]](queryFile, readFile, writeFile, manageFile)
-  }
-  // FIX-ME
+
+  // FIXME
   def backendEffect[S[_]](
     implicit
     S0: ReadFile :<: S,
@@ -157,7 +188,6 @@ package object module {
     S8: MountingFailure :<: S,
     S9: PathMismatchFailure :<: S,
     S10: Analyze :<: S
-  ): BackendEffect ~> Free[S, ?] = {
-    (injectFT[Analyze, S]) :+: fileSystem[S]
-  }
+  ): BackendEffect ~> Free[S, ?] =
+    injectFT[Analyze, S] :+: fileSystem[S]
 }

--- a/core/src/main/scala/quasar/metastore/MetaStoreAccess.scala
+++ b/core/src/main/scala/quasar/metastore/MetaStoreAccess.scala
@@ -38,8 +38,10 @@ trait MetaStoreAccess {
   def mounts: ConnectionIO[List[PathedMountConfig]] =
     Queries.mounts.list
 
-  def mountsHavingPrefix(dir: ADir): ConnectionIO[Map[APath, MountType]] =
-    Queries.mountsHavingPrefix(dir).list.map(_.toMap)
+  def mountsHavingPrefix(dir: ADir): ConnectionIO[Map[APath, MountingError \/ MountType]] =
+    Queries.mountsHavingPrefix(dir).list map { xs =>
+      xs.toMap.mapValues(m => Mount.toMountConfig(m) as m.`type`)
+    }
 
   def lookupMountType(path: APath): ConnectionIO[Option[MountType]] =
     Queries.lookupMountType(path).option

--- a/core/src/main/scala/quasar/metastore/Queries.scala
+++ b/core/src/main/scala/quasar/metastore/Queries.scala
@@ -36,12 +36,12 @@ trait Queries {
   def mounts: Query0[PathedMountConfig]  =
     sql"SELECT * FROM Mounts".query[PathedMountConfig]
 
-  def mountsHavingPrefix(dir: ADir): Query0[(APath, MountType)] = {
+  def mountsHavingPrefix(dir: ADir): Query0[(APath, Mount)] = {
     val patternChars = List("\\\\", "_", "%") // NB: Order is important here to avoid double-escaping
     val patternEscaped = patternChars.foldLeft(posixCodec.printPath(dir))((s, c) =>
                            s.replaceAll(c, s"\\\\$c"))
-    sql"SELECT path, type FROM Mounts WHERE path LIKE ${patternEscaped + "_%"}"
-      .query[(APath, MountType)]
+    sql"SELECT path, type, connectionUri FROM Mounts WHERE path LIKE ${patternEscaped + "_%"}"
+      .query[(APath, Mount)]
   }
 
   def lookupMountType(path: APath): Query0[MountType] =

--- a/core/src/test/scala/quasar/fs/mount/module/ModuleFileSystemSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/module/ModuleFileSystemSpec.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.fs.mount.module
+
+import slamdata.Predef._
+import quasar.Data
+import quasar.contrib.pathy.{AFile, APath}
+import quasar.effect.KeyValueStore
+import quasar.fp.evalNT
+import quasar.fp.free._
+import quasar.fs.{FileSystemError, PathError, ReadFile, WriteFile}
+import quasar.fs.mount.{module, Mounter, Mounting, MountConfig, MountConfigs}
+import quasar.sql._
+
+import eu.timepit.refined.auto._
+import matryoshka.data.Fix
+import monocle.Lens
+import monocle.syntax.fields._
+import pathy.Path._
+import scalaz.{~>, \/, -\/, \/-, Coproduct, Free, Id, State}, Id.Id
+import scalaz.syntax.either._
+import scalaz.syntax.equal._
+
+class ModuleFileSystemSpec extends quasar.Qspec {
+  type S0[A] = Coproduct[ReadFile, Mounting, A]
+  type S[A]  = Coproduct[WriteFile, S0, A]
+  type M = Map[APath, MountConfig]
+
+  val modDir = rootDir </> dir("foo") </> dir("bar")
+  val query = sqlE"select * from quux"
+  val fun = Statement.functionDecl[Fix[Sql]](CIName("baz"), Nil, query)
+  val mod = MountConfig.moduleConfig(List(fun))
+  val mounts: M = Map(modDir -> mod)
+
+  val runRead: ReadFile ~> Id =
+    λ[ReadFile ~> Id] {
+      case ReadFile.Open(f, _, _) => ReadFile.ReadHandle(f, 0L).right
+      case ReadFile.Read(_)       => Vector.empty[Data].right
+      case ReadFile.Close(_)      => ()
+    }
+
+  val runWrite: WriteFile ~> Id =
+    λ[WriteFile ~> Id] {
+      case WriteFile.Open(f)     => WriteFile.WriteHandle(f, 0L).right
+      case WriteFile.Write(_, _) => Vector.empty[FileSystemError]
+      case WriteFile.Close(_)    => ()
+    }
+
+  val runS: Free[S, ?] ~> Id = {
+    val mt =
+      Mounter.trivial[MountConfigs]
+        .andThen(foldMapNT(KeyValueStore.impl.toState[State[M, ?]](Lens.id[M])))
+        .andThen(evalNT[Id, M](mounts))
+
+    foldMapNT(runWrite :+: runRead :+: mt)
+  }
+
+  def openR(f: AFile): Free[S, FileSystemError \/ ReadFile.ReadHandle] =
+    ReadFile.Unsafe[ReadFile]
+      .open(f, 0L, None)
+      .run
+      .flatMapSuspension(module.readFile[S])
+
+  def openW(f: AFile): Free[S, FileSystemError \/ WriteFile.WriteHandle] =
+    WriteFile.Unsafe[WriteFile]
+      .open(f)
+      .run
+      .flatMapSuspension(module.writeFile[S])
+
+  val invalidPath =
+    FileSystemError.pathErr composePrism
+    PathError.invalidPath   composeLens
+    _1
+
+  "module filesystem" should {
+    "readfile" >> {
+      "fails when file refers to a module function" >> {
+        val baz = rootDir </> dir("foo") </> dir("bar") </> file("baz")
+        runS(openR(baz)) must beLike {
+          case -\/(err) => invalidPath.exist(_ ≟ baz)(err) must beTrue
+        }
+      }
+
+      "fails when file refers to a path within a module" >> {
+        val quux = rootDir </> dir("foo") </> dir("bar") </> dir("baat") </> file("quux")
+        runS(openR(quux)) must beLike {
+          case -\/(err) => invalidPath.exist(_ ≟ quux)(err) must beTrue
+        }
+      }
+
+      "succeeds when file not in a module" >> {
+        val tps = rootDir </> dir("foo") </> dir("reports") </> file("tps")
+        runS(openR(tps)) must beLike {
+          case \/-(ReadFile.ReadHandle(f, _)) => f must equal(tps)
+        }
+      }
+    }
+
+    "writefile" >> {
+      "fails when attempt to write to a module function" >> {
+        val baz = rootDir </> dir("foo") </> dir("bar") </> file("baz")
+        runS(openW(baz)) must beLike {
+          case -\/(err) => invalidPath.exist(_ ≟ baz)(err) must beTrue
+        }
+      }
+
+      "fails when attempt to write within a module" >> {
+        val quux = rootDir </> dir("foo") </> dir("bar") </> dir("baat") </> file("quux")
+        runS(openW(quux)) must beLike {
+          case -\/(err) => invalidPath.exist(_ ≟ quux)(err) must beTrue
+        }
+      }
+
+      "succeeds when file not in a module" >> {
+        val tps = rootDir </> dir("foo") </> dir("reports") </> file("tps")
+        runS(openW(tps)) must beLike {
+          case \/-(WriteFile.WriteHandle(f, _)) => f must equal(tps)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
A couple of performance improvements related to accessing mount metadata

1. Improve the metastore implementation of `havingPrefix` to only require a single query instead of N+1.
2. Avoid loading all mounts on every read in the module filesystem, instead just check parents until a mount is found.

Also corrects error generating behavior for writes to a module.

#qz-3732 Done