### PR TITLE
Capture character distribution within strings in SSTs

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,6 +730,7 @@ a schema document might look like
 ```json
 {
   "measure" : {
+    "kind" : "collection",
     "count" : 1000.0,
     "minLength" : 5.0,
     "maxLength" : 5.0
@@ -739,17 +740,33 @@ a schema document might look like
     "of" : {
       "city" : {
         "measure" : {
+          "kind" : "collection",
           "count" : 1000.0,
-          "min" : "ABBEVILLE",
-          "max" : "YOUNGSVILLE",
           "minLength" : 3.0,
           "maxLength" : 16.0
         },
         "structure" : {
+          "tag" : "_structural.string",
           "type" : "array",
           "of" : {
             "measure" : {
-              "count" : 1000.0
+              "count" : 8693.0,
+              "distribution" : {
+                "state" : {
+                  "centralMoment4" : 893992600.3364398,
+                  "size" : 8693.0,
+                  "centralMoment3" : -18773123.74002289,
+                  "centralMoment2" : 876954.1582882765,
+                  "centralMoment1" : 74.29506499482345
+                },
+                "variance" : 100.89210288636407,
+                "kurtosis" : 10.111128909991152,
+                "mean" : 74.29506499482345,
+                "skewness" : -2.1317240928957726
+              },
+              "min" : " ",
+              "max" : "Z",
+              "kind" : "char"
             },
             "structure" : {
               "type" : "character"
@@ -759,17 +776,33 @@ a schema document might look like
       },
       "state" : {
         "measure" : {
+          "kind" : "collection",
           "count" : 1000.0,
-          "min" : "AK",
-          "max" : "WY",
           "minLength" : 2.0,
           "maxLength" : 2.0
         },
         "structure" : {
+          "tag" : "_structural.string",
           "type" : "array",
           "of" : {
             "measure" : {
-              "count" : 1000.0
+              "count" : 2000.0,
+              "distribution" : {
+                "state" : {
+                  "centralMoment4" : 11285757.38865178,
+                  "size" : 2000.0,
+                  "centralMoment3" : 11979.395483999382,
+                  "centralMoment2" : 103139.03800000004,
+                  "centralMoment1" : 76.19100000000014
+                },
+                "variance" : 51.59531665832919,
+                "kurtosis" : 2.1271635715970967,
+                "mean" : 76.19100000000014,
+                "skewness" : 0.01618606190840656
+              },
+              "min" : "A",
+              "max" : "Z",
+              "kind" : "char"
             },
             "structure" : {
               "type" : "character"
@@ -781,31 +814,55 @@ a schema document might look like
         "measure" : {
           "count" : 1000.0,
           "distribution" : {
-            "mean" : 8560.410999999996,
-            "variance" : 153498226.66073978,
-            "skewness" : 2.1932119902818976,
-            "kurtosis" : 8.145272163842572
+            "state" : {
+              "centralMoment4" : 2.323080620322664E+20,
+              "size" : 1000.0,
+              "centralMoment3" : 4322812032420233.5,
+              "centralMoment2" : 150795281801.8999,
+              "centralMoment1" : 8721.71000000001
+            },
+            "variance" : 150946228.02992985,
+            "kurtosis" : 10.267451061747597,
+            "mean" : 8721.71000000001,
+            "skewness" : 2.337959182172043
           },
           "min" : 0,
-          "max" : 83158
+          "max" : 94317,
+          "kind" : "decimal"
         },
         "structure" : {
-          "type" : "integer"
+          "type" : "decimal"
         }
       },
       "_id" : {
         "measure" : {
+          "kind" : "collection",
           "count" : 1000.0,
-          "min" : "01342",
-          "max" : "99744",
           "minLength" : 5.0,
           "maxLength" : 5.0
         },
         "structure" : {
+          "tag" : "_structural.string",
           "type" : "array",
           "of" : {
             "measure" : {
-              "count" : 1000.0
+              "count" : 5000.0,
+              "distribution" : {
+                "state" : {
+                  "centralMoment4" : 556673.1571508175,
+                  "size" : 5000.0,
+                  "centralMoment3" : 7962.505025040006,
+                  "centralMoment2" : 38822.78220000003,
+                  "centralMoment1" : 52.24340000000003
+                },
+                "variance" : 7.766109661932393,
+                "kurtosis" : 1.8485506875431554,
+                "mean" : 52.24340000000003,
+                "skewness" : 0.07362665279751003
+              },
+              "min" : "0",
+              "max" : "9",
+              "kind" : "char"
             },
             "structure" : {
               "type" : "character"
@@ -815,6 +872,7 @@ a schema document might look like
       },
       "loc" : {
         "measure" : {
+          "kind" : "collection",
           "count" : 1000.0,
           "minLength" : 2.0,
           "maxLength" : 2.0
@@ -826,13 +884,21 @@ a schema document might look like
               "measure" : {
                 "count" : 1000.0,
                 "distribution" : {
-                  "mean" : -90.75566306399999,
-                  "variance" : 215.8880504119835,
-                  "skewness" : -1.3085274289304345,
-                  "kurtosis" : 5.671392237003005
+                  "state" : {
+                    "centralMoment4" : 281712013.3937695,
+                    "size" : 1000.0,
+                    "centralMoment3" : -4328243.124174622,
+                    "centralMoment2" : 212160.04270665144,
+                    "centralMoment1" : -90.52571468599996
+                  },
+                  "variance" : 212.3724151217732,
+                  "kurtosis" : 6.290020275246902,
+                  "mean" : -90.52571468599996,
+                  "skewness" : -1.4027118290018674
                 },
                 "min" : -170.293408,
-                "max" : -68.031686
+                "max" : -67.396382,
+                "kind" : "decimal"
               },
               "structure" : {
                 "type" : "decimal"
@@ -842,13 +908,21 @@ a schema document might look like
               "measure" : {
                 "count" : 1000.0,
                 "distribution" : {
-                  "mean" : 39.02678901400003,
-                  "variance" : 26.66316872053294,
-                  "skewness" : -0.030243876777278023,
-                  "kurtosis" : 4.447095871155061
+                  "state" : {
+                    "centralMoment4" : 3748702.702983835,
+                    "size" : 1000.0,
+                    "centralMoment3" : 15799.696678343358,
+                    "centralMoment2" : 26853.295673558245,
+                    "centralMoment1" : 39.09175202499995
+                  },
+                  "variance" : 26.880175849407653,
+                  "kurtosis" : 5.224679782347093,
+                  "mean" : 39.09175202499995,
+                  "skewness" : 0.1137115453464455
                 },
-                "min" : 20.027748,
-                "max" : 64.840238
+                "min" : 20.907097,
+                "max" : 65.824542,
+                "kind" : "decimal"
               },
               "structure" : {
                 "type" : "decimal"

--- a/datagen/src/main/scala/quasar/datagen/generate.scala
+++ b/datagen/src/main/scala/quasar/datagen/generate.scala
@@ -25,7 +25,7 @@ import fs2.util.Suspendable
 import matryoshka.{Corecursive, Recursive}
 import scalaz.{\/, Equal, Order}
 import scalaz.Scalaz._
-import spire.algebra.{Field, NRoot}
+import spire.algebra.{Field, IsReal, NRoot}
 import spire.math.ConvertableFrom
 import spire.random.{Gaussian, Generator}
 
@@ -33,7 +33,7 @@ object generate {
   object ejson {
     def apply[F[_]] = new PartiallyApplied[F]
     final class PartiallyApplied[F[_]] {
-      def apply[J: Order, A: ConvertableFrom: Equal: Field: Gaussian: NRoot](
+      def apply[J: Order, A: ConvertableFrom: Equal: Field: Gaussian: IsReal: NRoot](
           maxCollLen: A,
           sst: PopulationSST[J, A] \/ SST[J, A])(
           implicit

--- a/datagen/src/main/scala/quasar/datagen/generate.scala
+++ b/datagen/src/main/scala/quasar/datagen/generate.scala
@@ -22,7 +22,7 @@ import quasar.sst.{PopulationSST, SST}
 
 import fs2.Stream
 import fs2.util.Suspendable
-import matryoshka.Corecursive
+import matryoshka.{Corecursive, Recursive}
 import scalaz.{\/, Equal, Order}
 import scalaz.Scalaz._
 import spire.algebra.{Field, NRoot}
@@ -38,7 +38,8 @@ object generate {
           sst: PopulationSST[J, A] \/ SST[J, A])(
           implicit
           F: Suspendable[F],
-          J: Corecursive.Aux[J, EJson])
+          JC: Corecursive.Aux[J, EJson],
+          JR: Recursive.Aux[J, EJson])
           : Option[Stream[F, J]] =
         sst
           .fold(

--- a/datagen/src/test/scala/quasar/datagen/GenerateSpec.scala
+++ b/datagen/src/test/scala/quasar/datagen/GenerateSpec.scala
@@ -23,6 +23,7 @@ import quasar.contrib.spire.random.dist._
 import quasar.ejson.{EJson, Fixed}
 import quasar.ejson.implicits._
 import quasar.fp._
+import quasar.fp.numeric.SampleStats
 import quasar.sst.{strings, SST, StructuralType, TypeStat}
 import quasar.tpe.{SimpleType, TypeF}
 
@@ -48,7 +49,7 @@ final class GenerateSpec extends quasar.Qspec {
     sst(ts, TypeF.simple(st))
 
   def sstS(n: Int, s: String): S =
-    strings.widenString[J, Double](n.toDouble, s).embed
+    strings.widen[J, Double](n.toDouble, s).embed
 
   def tsJ(n: Int, j: J): TypeStat[Double] =
     TypeStat.fromEJson(n.toDouble, j)
@@ -74,7 +75,7 @@ final class GenerateSpec extends quasar.Qspec {
     }
 
     "weighted selection from a union" >> {
-      val x = sstL(TypeStat.char(0.0, 'a', 'a'), SimpleType.Char)
+      val x = sstL(TypeStat.char(SampleStats.freq(0.0, 'a'.toDouble), 'a', 'a'), SimpleType.Char)
       val y = sstL(TypeStat.byte(100.0, 7.toByte, 7.toByte), SimpleType.Char)
       val z = sstL(TypeStat.bool(0.0, 0.0), SimpleType.Bool)
       val u = sst(TypeStat.count(100.0), TypeF.union(x, y, IList(z)))
@@ -182,9 +183,12 @@ final class GenerateSpec extends quasar.Qspec {
         val name =
           J.str("name")
 
+        val atof =
+          SampleStats.fromFoldable(IList('a', 'b', 'c', 'd', 'e', 'f') map (_.toDouble))
+
         val unkk =
           sstL(
-            TypeStat.char(5.0, 'a', 'f'),
+            TypeStat.char(atof, 'a', 'f'),
             SimpleType.Char)
 
         val msst =
@@ -231,25 +235,29 @@ final class GenerateSpec extends quasar.Qspec {
       valuesShould(csst)(J.char.exist(c => (c >= 'e') && (c <= 'l')))
     }
 
-    "str within length range and arbitrary chars" >> {
+    "str within length range and char range" >> {
       val ssst =
         NonEmptyList("foo", "quux", "xex", "orp") foldMap1 { s =>
-          val n = s.length.toDouble.some
-          strings.lubString[S, J, Double](TypeStat.coll(1.0, n, n)).embed
+          val strStat = TypeStat.fromEJson(1.0, J.str(s))
+          strings.compress[S, J, Double](strStat, s).embed
         }
 
       valuesShould(ssst)(J.str.exist { s =>
-        (s.length ≟ 4 || s.length ≟ 3)
+        (s.length ≟ 4 || s.length ≟ 3) &&
+        s.toList.all(c => c >= 'e' && c <= 'x')
       })
     }
 
-    "str within length range and char range of min/max values" >> {
+    "str within length range and positional char range" >> {
       val ssst =
         NonEmptyList("foo", "quux", "xex", "orp") foldMap1 (sstS(1, _))
 
       valuesShould(ssst)(J.str.exist { s =>
         (s.length ≟ 4 || s.length ≟ 3) &&
-        s.toList.all(c => c >= 'e' && c <= 'x')
+        (IList('f', 'q', 'x', 'o') element s(0)) &&
+        (IList('o', 'u', 'e', 'r') element s(1)) &&
+        (IList('o', 'u', 'x', 'p') element s(2)) &&
+        (s.length ≟ 4).fold(s(3) ≟ 'x', true)
       })
     }
 

--- a/ejson/src/main/scala/quasar/ejson/DecodeEJson.scala
+++ b/ejson/src/main/scala/quasar/ejson/DecodeEJson.scala
@@ -25,8 +25,10 @@ import argonaut.{DecodeJson, Json => AJson}
 import matryoshka._
 import matryoshka.implicits._
 import scalaz._
+import scalaz.std.anyVal._
 import scalaz.std.list._
 import scalaz.std.option._
+import scalaz.syntax.equal._
 import scalaz.syntax.traverse._
 import scalaz.syntax.std.boolean._
 import scalaz.syntax.std.either._
@@ -128,8 +130,11 @@ sealed abstract class DecodeEJsonInstances extends DecodeEJsonInstances0 {
 
   implicit val charDecodeEJson: DecodeEJson[SChar] =
     new DecodeEJson[SChar] {
-      def decode[J](j: J)(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): Decoded[SChar] =
-        Decoded.attempt(j, Fixed[J].char.getOption(j) \/> "Char")
+      def decode[J](j: J)(implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): Decoded[SChar] = {
+        val fromChar = Fixed[J].char.getOption(j)
+        def fromStr = Fixed[J].str.getOption(j).filter(_.length ≟ 1).map(_(0))
+        Decoded.attempt(j, (fromChar orElse fromStr) \/> "Char")
+      }
     }
 
   implicit def optionDecodeEJson[A](implicit A: DecodeEJson[A]): DecodeEJson[Option[A]] =

--- a/ejson/src/main/scala/quasar/ejson/EJson.scala
+++ b/ejson/src/main/scala/quasar/ejson/EJson.scala
@@ -94,24 +94,4 @@ object EJson {
   ): EJson[T] => EJson[T] = totally {
     case ExtEJson(Meta(v, _)) => v.project
   }
-
-  /** Replace a string with an array of characters. */
-  def replaceString[T](
-    implicit T: Corecursive.Aux[T, EJson]
-  ): EJson[T] => EJson[T] = totally {
-    case CommonEJson(Str(s)) =>
-      optics.arr[T](s.toList map (c => char[T](c)))
-  }
-
-  /** Replace an array of characters with a string. */
-  def restoreString[T](
-    implicit
-    TC: Corecursive.Aux[T, EJson],
-    TR: Recursive.Aux[T, EJson]
-  ): EJson[T] => EJson[T] = totally {
-    case a @ CommonEJson(Arr(t :: ts)) =>
-      (t :: ts)
-        .traverse(Fixed[T].char.getOption)
-        .fold(a)(cs => optics.str[T](cs.mkString))
-  }
 }

--- a/ejson/src/test/scala/quasar/ejson/DecodeEjsonSpec.scala
+++ b/ejson/src/test/scala/quasar/ejson/DecodeEjsonSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.ejson
+
+import slamdata.Predef.{Char => SChar, String}
+
+import matryoshka.data.Fix
+import org.specs2.scalaz._
+import scalaz._, Scalaz._
+
+class DecodeEJsonSpec extends Spec {
+  type J = Fix[EJson]
+  val J = Fixed[J]
+
+  "char" >> {
+    "Extension.Char" >> prop { c: SChar =>
+      DecodeEJson[SChar].decode(J.char(c)).toDisjunction ≟ c.right
+    }
+
+    "single character Common.Str" >> prop { c: SChar =>
+      DecodeEJson[SChar].decode(J.str(c.toString)).toDisjunction ≟ c.right
+    }
+
+    "fail for multicharacter Common.Str" >> prop {
+      (s: String) => (s.length > 1) ==> {
+
+      DecodeEJson[SChar].decode(J.str(s)).toDisjunction.isLeft
+    }}
+  }
+}

--- a/frontend/src/main/scala/quasar/sst/ExtractPrimary.scala
+++ b/frontend/src/main/scala/quasar/sst/ExtractPrimary.scala
@@ -50,7 +50,11 @@ object ExtractPrimary {
     implicit L: Recursive.Aux[L, EJson]
   ): ExtractPrimary[TypeF[L, ?]] =
     new ExtractPrimary[TypeF[L, ?]] {
-      def primaryTag[A](fa: TypeF[L, A]) = TypeF.primary(fa) map (_.left)
+      def primaryTag[A](fa: TypeF[L, A]) =
+        fa match {
+          case TypeF.Const(l) => some(primaryTagOf(l))
+          case _ => TypeF.primary(fa) map (_.left)
+        }
     }
 
   implicit def envTExtractPrimary[E, F[_]: ExtractPrimary]

--- a/frontend/src/main/scala/quasar/sst/StructuralType.scala
+++ b/frontend/src/main/scala/quasar/sst/StructuralType.scala
@@ -217,24 +217,6 @@ object StructuralType extends StructuralTypeInstances {
       case other =>
         TypeST(normalization.lowerConst[J, T].apply(other))
     }
-
-  /** Lift a transform over types to a transform over structural types. */
-  object typeTransform {
-    def apply[L] = new PartiallyApplied[L]
-
-    final class PartiallyApplied[L] {
-      type G[A, B] = EnvT[A, TypeF[L, ?], B]
-      val I = Inject[TypeF[L, ?], StructuralType.ST[L, ?]]
-
-      def apply[A, B](pf: PartialFunction[G[A, B], G[A, B]])
-        : STF[L, A, B] => STF[L, A, B] =
-        orOriginal((stf: STF[L, A, B]) =>
-            stf.run.traverse(I.prj)
-              .map(EnvT(_))
-              .collect(pf)
-              .map(EnvT.hmap(I)(_)))
-    }
-  }
 }
 
 sealed abstract class StructuralTypeInstances extends StructuralTypeInstances0 {

--- a/frontend/src/main/scala/quasar/sst/compression.scala
+++ b/frontend/src/main/scala/quasar/sst/compression.scala
@@ -125,11 +125,7 @@ object compression {
     JR: Recursive.Aux[J, EJson]
   ): SSTF[J, A, SST[J, A]] => SSTF[J, A, SST[J, A]] = totally {
     case EnvT((ts, TypeST(TypeF.Const(Embed(C(Str(s))))))) if s.length > maxLength.value =>
-      val newStats = TypeStat.str[A].modify {
-        case (c, n, m, _, _) => (c, n, m, "", "")
-      } (ts)
-
-      strings.lubString[SST[J, A], J, A](newStats)
+      strings.lubString[SST[J, A], J, A](ts)
   }
 
   /** Compress a union larger than `maxSize` by reducing the largest group of
@@ -196,11 +192,11 @@ object compression {
     JC: Corecursive.Aux[J, EJson],
     JR: Recursive.Aux[J, EJson]
   ): SST[J, A] = j match {
-    case SimpleEJson(s) =>
-      envT(TypeStat.fromEJson(cnt, j), TypeST(TypeF.simple[J, SST[J, A]](s))).embed
-
     case Embed(C(Str(_))) =>
       strings.lubString[SST[J, A], J, A](TypeStat.fromEJson(cnt, j)).embed
+
+    case SimpleEJson(s) =>
+      envT(TypeStat.fromEJson(cnt, j), TypeST(TypeF.simple[J, SST[J, A]](s))).embed
 
     case _ => SST.fromEJson(cnt, j)
   }

--- a/frontend/src/main/scala/quasar/sst/package.scala
+++ b/frontend/src/main/scala/quasar/sst/package.scala
@@ -76,7 +76,7 @@ package object sst {
       JC: Corecursive.Aux[J, EJson],
       JR: Recursive.Aux[J, EJson]
     ): SST[J, A] =
-      fromEJson0(count, ejson.transCata[J](elideNonTypeMetadata[J]))
+      fromEJson0(count, ejson.transAna[J](elideNonTypeMetadata[J]))
 
     def size[J, A: AdditiveSemigroup](sst: SST[J, A]): A =
       sst.copoint.size
@@ -133,6 +133,7 @@ package object sst {
   def primaryTagOf[J](ejs: J)(implicit J: Recursive.Aux[J, EJson]): PrimaryTag =
     ejs.project match {
       case E(Meta(_, Embed(EType(tag)))) => tag.right
+      case C(Str(_))                     => strings.StructuralString.right
       case _                             => primaryTypeOf(ejs).left
     }
 

--- a/frontend/src/main/scala/quasar/sst/strings.scala
+++ b/frontend/src/main/scala/quasar/sst/strings.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.sst
+
+import quasar.contrib.matryoshka.envT
+import quasar.ejson.TypeTag
+import quasar.tpe.{SimpleType, TypeF}
+
+import matryoshka.Corecursive
+import scalaz.{\/, IList}
+import scalaz.syntax.either._
+import spire.algebra.AdditiveSemigroup
+
+object strings {
+  import StructuralType.{TagST, TypeST, STF}
+
+  val StringTag = TypeTag("_ejson.string")
+
+  /** An sst annotated with the given stats for a string of unknown characters. */
+  def lubString[T, J, A: AdditiveSemigroup](ts: TypeStat[A])(
+    implicit C: Corecursive.Aux[T, SSTF[J, A, ?]]
+  ): SSTF[J, A, T] = {
+    val charSst =
+      C.embed(envT(TypeStat.count(ts.size), TypeST(TypeF.simple(SimpleType.Char))))
+
+    stringArr(ts, charSst.right)
+  }
+
+  def stringArr[T, L, V](v: V, t: IList[T] \/ T)(
+    implicit C: Corecursive.Aux[T, STF[L, V, ?]]
+  ): STF[L, V, T] =
+    envT(v, TagST[L](Tagged(StringTag, C.embed(envT(v, TypeST(TypeF.arr(t)))))))
+}

--- a/frontend/src/main/scala/quasar/sst/strings.scala
+++ b/frontend/src/main/scala/quasar/sst/strings.scala
@@ -29,7 +29,6 @@ import scalaz.syntax.foldable._
 import spire.algebra.Field
 import spire.math.ConvertableTo
 
-
 object strings {
   import StructuralType.{TagST, TypeST, STF}
 

--- a/frontend/src/main/scala/quasar/tpe/SimpleType.scala
+++ b/frontend/src/main/scala/quasar/tpe/SimpleType.scala
@@ -32,6 +32,7 @@ object SimpleType {
   final case object Bool extends SimpleType
   final case object Byte extends SimpleType
   final case object Char extends SimpleType
+  final case object Str  extends SimpleType
   final case object Int  extends SimpleType
   final case object Dec  extends SimpleType
 
@@ -41,6 +42,7 @@ object SimpleType {
       case "boolean"   => Bool
       case "byte"      => Byte
       case "character" => Char
+      case "string"    => Str
       case "integer"   => Int
       case "decimal"   => Dec
     } {
@@ -48,6 +50,7 @@ object SimpleType {
       case Bool        => "boolean"
       case Byte        => "byte"
       case Char        => "character"
+      case Str         => "string"
       case Int         => "integer"
       case Dec         => "decimal"
     }
@@ -62,7 +65,8 @@ object SimpleType {
         case Bool => Null
         case Byte => Bool
         case Char => Byte
-        case Int  => Char
+        case Str  => Char
+        case Int  => Str
         case Dec  => Int
       }
 
@@ -70,7 +74,8 @@ object SimpleType {
         case Null => Bool
         case Bool => Byte
         case Byte => Char
-        case Char => Int
+        case Char => Str
+        case Str  => Int
         case Int  => Dec
         case Dec  => Null
       }
@@ -88,8 +93,9 @@ object SimpleType {
         case Bool => 1
         case Byte => 2
         case Char => 3
-        case Int  => 4
-        case Dec  => 5
+        case Str  => 4
+        case Int  => 5
+        case Dec  => 6
       }
     }
 

--- a/frontend/src/main/scala/quasar/tpe/normalization.scala
+++ b/frontend/src/main/scala/quasar/tpe/normalization.scala
@@ -117,7 +117,6 @@ object normalization {
   }
 
   /** Normalizes EJson literals by
-    *   - Converting constant strings to arrays of characters.
     *   - Replacing `Meta` nodes with their value component.
     */
   def normalizeEJson[J: Order, T](
@@ -127,7 +126,7 @@ object normalization {
     JR: Recursive.Aux[J, EJson]
   ): TypeF[J, T] => TypeF[J, T] = {
     val norm: J => J =
-      _.transCata[J](EJson.replaceString[J] <<< EJson.elideMetadata[J])
+      _.transCata[J](EJson.elideMetadata[J])
 
     totally {
       case Const(j)     => const[J, T](norm(j))

--- a/frontend/src/main/scala/quasar/tpe/package.scala
+++ b/frontend/src/main/scala/quasar/tpe/package.scala
@@ -61,12 +61,12 @@ package object tpe {
     case C(ejs.Bool(_))    => SimpleType.Bool.left
     case E(ejs.Byte(_))    => SimpleType.Byte.left
     case E(ejs.Char(_))    => SimpleType.Char.left
+    case C(ejs.Str(_))     => SimpleType.Str.left
     case E( ejs.Int(_))    => SimpleType.Int.left
     case C( ejs.Dec(_))    => SimpleType.Dec.left
     // Composite
     case C(ejs.Arr(_))     => CompositeType.Arr.right
     case E(ejs.Map(_))     => CompositeType.Map.right
-    case C(ejs.Str(_))     => CompositeType.Arr.right
   }
 
   /** Returns the primary type of the given EJson value, if it is simple. */

--- a/frontend/src/test/scala/quasar/sst/CompressionSpec.scala
+++ b/frontend/src/test/scala/quasar/sst/CompressionSpec.scala
@@ -273,10 +273,10 @@ final class CompressionSpec extends quasar.Qspec
     "compresses strings longer than maxLen" >> prop { s: String => (s.length > 1) ==> {
       val plen: Positive = Positive(s.length.toLong) getOrElse 1L
       val lt: Positive = Positive((s.length - 1).toLong) getOrElse 1L
-      val rlen = Real(s.length)
+      val rlen = Real(s.length).some
       val str  = SST.fromEJson(Real(1), J.str(s))
 
-      val ts  = TypeStat.str(Real(1), rlen, rlen, "", "")
+      val ts  = TypeStat.coll(Real(1), rlen, rlen)
       val arr = strings.lubString[S, J, Real](ts).embed
 
       val req = str.transCata[S](compression.limitStrings(plen))

--- a/frontend/src/test/scala/quasar/sst/CompressionSpec.scala
+++ b/frontend/src/test/scala/quasar/sst/CompressionSpec.scala
@@ -276,9 +276,8 @@ final class CompressionSpec extends quasar.Qspec
       val rlen = Real(s.length)
       val str  = SST.fromEJson(Real(1), J.str(s))
 
-      val char = envT(cnt1, TypeST(TypeF.simple[J, S](SimpleType.Char))).embed
-      val ts   = TypeStat.str(Real(1), rlen, rlen, "", "")
-      val arr  = envT(ts, TypeST(TypeF.arr[J, S](char.right))).embed
+      val ts  = TypeStat.str(Real(1), rlen, rlen, "", "")
+      val arr = strings.lubString[S, J, Real](ts).embed
 
       val req = str.transCata[S](compression.limitStrings(plen))
       val rlt = str.transCata[S](compression.limitStrings(lt))

--- a/frontend/src/test/scala/quasar/sst/CompressionSpec.scala
+++ b/frontend/src/test/scala/quasar/sst/CompressionSpec.scala
@@ -281,7 +281,7 @@ final class CompressionSpec extends quasar.Qspec
       s: String => (s.length > 1) ==> {
 
       val lim: Positive = Positive((s.length - 1).toLong) getOrElse 1L
-      val stringSst = strings.widenString[J, Real](Real(1), s).embed
+      val stringSst = strings.widen[J, Real](Real(1), s).embed
 
       stringSst.elgotApo[S](compression.limitArrays(lim)) must_= stringSst
     }}
@@ -291,11 +291,9 @@ final class CompressionSpec extends quasar.Qspec
     "compresses strings longer than maxLen" >> prop { s: String => (s.length > 1) ==> {
       val plen: Positive = Positive(s.length.toLong) getOrElse 1L
       val lt: Positive = Positive((s.length - 1).toLong) getOrElse 1L
-      val rlen = Real(s.length).some
-      val str  = SST.fromEJson(Real(1), J.str(s))
 
-      val ts  = TypeStat.coll(Real(1), rlen, rlen)
-      val arr = strings.lubString[S, J, Real](ts).embed
+      val str = SST.fromEJson(Real(1), J.str(s))
+      val arr = strings.compress[S, J, Real](str.copoint, s).embed
 
       val req = str.transAna[S](compression.limitStrings(plen))
       val rlt = str.transAna[S](compression.limitStrings(lt))

--- a/frontend/src/test/scala/quasar/sst/CompressionSpec.scala
+++ b/frontend/src/test/scala/quasar/sst/CompressionSpec.scala
@@ -23,7 +23,7 @@ import quasar.contrib.matryoshka.arbitrary._
 import quasar.ejson, ejson.{EJsonArbitrary, TypeTag, z85}
 import quasar.ejson.implicits._
 import quasar.fp._
-import quasar.fp.numeric.Positive
+import quasar.fp.numeric.{Natural, Positive}
 import quasar.tpe._
 
 import scala.Predef.$conforms
@@ -116,7 +116,7 @@ final class CompressionSpec extends quasar.Qspec
       val unk = unk0.map(_.umap(_.toSst))
       val sst = envT(cnt1, TypeST(TypeF.map[J, S](m, unk))).embed
 
-      Positive(m.size.toLong).cata(
+      Natural(m.size.toLong).cata(
         l => attemptCompression(sst, compression.coalesceKeys(l)),
         sst
       ) must_= sst
@@ -264,8 +264,8 @@ final class CompressionSpec extends quasar.Qspec
     "compresses arrays longer than maxLen to the union of the members" >> prop {
       xs: NonEmptyList[BigInt] => (xs.length > 1) ==> {
 
-      val alen: Positive = Positive(xs.length.toLong) getOrElse 1L
-      val lt: Positive = Positive((xs.length - 1).toLong) getOrElse 1L
+      val alen: Natural = Natural(xs.length.toLong) getOrElse 0L
+      val lt: Natural = Natural((xs.length - 1).toLong) getOrElse 0L
       val rlen = Real(xs.length).some
       val ints = xs.map(J.int(_))
       val xsst = SST.fromEJson(Real(1), J.arr(ints.toList))
@@ -283,7 +283,7 @@ final class CompressionSpec extends quasar.Qspec
     "does not limit structural string arrays" >> prop {
       s: String => (s.length > 1) ==> {
 
-      val lim: Positive = Positive((s.length - 1).toLong) getOrElse 1L
+      val lim: Natural = Natural((s.length - 1).toLong) getOrElse 0L
       val stringSst = strings.widen[J, Real](Real(1), s).embed
 
       stringSst.elgotApo[S](compression.limitArrays(lim)) must_= stringSst
@@ -292,8 +292,8 @@ final class CompressionSpec extends quasar.Qspec
 
   "limitStrings" >> {
     "compresses strings longer than maxLen" >> prop { s: String => (s.length > 1) ==> {
-      val plen: Positive = Positive(s.length.toLong) getOrElse 1L
-      val lt: Positive = Positive((s.length - 1).toLong) getOrElse 1L
+      val plen: Natural = Natural(s.length.toLong) getOrElse 0L
+      val lt: Natural = Natural((s.length - 1).toLong) getOrElse 0L
 
       val str = SST.fromEJson(Real(1), J.str(s))
       val arr = strings.compress[S, J, Real](str.copoint, s).embed

--- a/frontend/src/test/scala/quasar/sst/StringsSpec.scala
+++ b/frontend/src/test/scala/quasar/sst/StringsSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.sst
+
+import slamdata.Predef.List
+import quasar.contrib.algebra._
+import quasar.contrib.matryoshka.envT
+import quasar.ejson.EJson
+import quasar.ejson.implicits._
+import quasar.fp._
+import quasar.tpe.{SimpleType, TypeF}
+import StructuralType.{TagST, TypeST}
+
+import matryoshka._
+import matryoshka.data.Fix
+import matryoshka.implicits._
+import scalaz.{NonEmptyList, Show}
+import scalaz.syntax.foldable1._
+import scalaz.syntax.either._
+import scalaz.syntax.std.option._
+import spire.math.Real
+
+final class StringsSpec extends quasar.Qspec {
+  type J = Fix[EJson]
+
+  implicit val realShow = Show.showFromToString[Real]
+
+  "widen string yields an array of its characters" >> {
+    val exp = EJson.arr(List('f', 'o', 'o') map (EJson.char[J](_)) : _*)
+    val wid0 = SST.fromEJson(Real(5), exp)
+    val wid = envT(wid0.copoint, TagST[J](Tagged(strings.StructuralString, wid0))).embed
+    strings.widen[J, Real](Real(5), "foo").embed must_= wid
+  }
+
+  "compress string yields a generic array sampled from its characters" >> {
+    val char0 =
+      NonEmptyList('f', 'o', 'o') foldMap1 (c => TypeStat.fromEJson(Real(1), EJson.char[J](c)))
+
+    val char =
+      envT(char0, TypeST(TypeF.simple[J, SST[J, Real]](SimpleType.Char))).embed
+
+    val ts = TypeStat.coll(Real(5), Real(3).some, Real(3).some)
+
+    val comp =
+      envT(ts, TagST[J](Tagged(
+        strings.StructuralString,
+        envT(ts, TypeST(TypeF.arr[J, SST[J, Real]](char.right))).embed))).embed
+
+    strings.compress[SST[J, Real], J, Real](ts, "foo").embed must_= comp
+  }
+}

--- a/frontend/src/test/scala/quasar/sst/TypeStatArbitrary.scala
+++ b/frontend/src/test/scala/quasar/sst/TypeStatArbitrary.scala
@@ -25,7 +25,6 @@ import scalaz.std.anyVal._
 import scalaz.std.math.bigInt._
 import scalaz.std.math.bigDecimal._
 import scalaz.std.option._
-import scalaz.std.string._
 import scalaz.syntax.apply._
 import scalaz.syntax.order._
 import scalaz.scalacheck.ScalaCheckBinding._
@@ -45,7 +44,6 @@ trait TypeStatArbitrary {
       arbitrary[A] map (count[A](_)),
       (arbitrary[A] |@| genRange[SByte])((a, r) => byte(a, r._1, r._2)),
       (arbitrary[A] |@| genRange[SChar])((a, r) => char(a, r._1, r._2)),
-      (arbitrary[A] |@| genRange[A] |@| genRange[String])((c, r, s) => str[A](c, r._1, r._2, s._1, s._2)),
       (arbitrary[SampleStats[A]] |@| genRange[BigInt])((s, r) => int[A](s, r._1, r._2)),
       (arbitrary[SampleStats[A]] |@| genRange[BigDecimal])((s, r) => dec[A](s, r._1, r._2)))
 

--- a/frontend/src/test/scala/quasar/sst/TypeStatArbitrary.scala
+++ b/frontend/src/test/scala/quasar/sst/TypeStatArbitrary.scala
@@ -43,7 +43,7 @@ trait TypeStatArbitrary {
       genColl[A],
       arbitrary[A] map (count[A](_)),
       (arbitrary[A] |@| genRange[SByte])((a, r) => byte(a, r._1, r._2)),
-      (arbitrary[A] |@| genRange[SChar])((a, r) => char(a, r._1, r._2)),
+      (arbitrary[SampleStats[A]] |@| genRange[SChar])((s, r) => char(s, r._1, r._2)),
       (arbitrary[SampleStats[A]] |@| genRange[BigInt])((s, r) => int[A](s, r._1, r._2)),
       (arbitrary[SampleStats[A]] |@| genRange[BigDecimal])((s, r) => dec[A](s, r._1, r._2)))
 

--- a/frontend/src/test/scala/quasar/sst/TypeStatSpec.scala
+++ b/frontend/src/test/scala/quasar/sst/TypeStatSpec.scala
@@ -45,14 +45,6 @@ final class TypeStatSpec extends Spec with ScalazMatchers with TypeStatArbitrary
     (x + y).size must equal(x.size + y.size)
   }
 
-  "combining string and coll treats string as collection" >> {
-    val strStat  = str[Real](Real(3), Real(3), Real(4), "foo", "quux")
-    val collStat = coll[Real](Real(2), Some(Real(2)), None)
-    val expStat  = coll[Real](Real(5), Some(Real(2)), Some(Real(4)))
-
-    (strStat + collStat) must equal(expStat)
-  }
-
   "EJson codec" >> prop { ts: TypeStat[Double] =>
     DecodeEJson[TypeStat[Double]].decode(
       EncodeEJson[TypeStat[Double]].encode[Fix[EJson]](ts)

--- a/frontend/src/test/scala/quasar/tpe/TypeFSpec.scala
+++ b/frontend/src/test/scala/quasar/tpe/TypeFSpec.scala
@@ -96,9 +96,8 @@ final class TypeFSpec extends Spec with TypeFArbitrary with EJsonArbitrary {
     }
 
     "{m} ∪ {k:v} <: {m}" >> prop { kn: IMap[J, T] =>
-      val normM = kn.mapKeys(_.transCata[J](
-        EJson.replaceString[J] <<< EJson.elideMetadata[J]
-      ))
+      val normM =
+        kn.mapKeys(_.transCata[J](EJson.elideMetadata[J]))
 
       normM.maxViewWithKey forall { case ((k, v), m) =>
         isSubtypeOf[J](
@@ -150,18 +149,6 @@ final class TypeFSpec extends Spec with TypeFArbitrary with EJsonArbitrary {
     "x <: (x ∨ y) && y <: (x ∨ y)" >> prop { (x: T, y: T) =>
       val z = lub[J](x, y)
       (isSubtypeOf[J](x, z) && isSubtypeOf[J](y, z))
-    }
-
-    "str <: char[]" >> prop { (s: String) =>
-      isSubtypeOf[J](
-        const[J, T](J.str("s" + s)).embed,
-        arr[J, T](simple[J, T](SimpleType.Char).embed.right).embed)
-    }
-
-    "[] = ''" >> {
-      val emptyArr = arr[J, T](IList().left).embed
-      val emptyStr = const[J, T](J.str("")).embed
-      emptyArr ≟ emptyStr
     }
   }
 

--- a/interface/src/main/scala/quasar/main/analysis.scala
+++ b/interface/src/main/scala/quasar/main/analysis.scala
@@ -22,7 +22,7 @@ import quasar.contrib.matryoshka._
 import quasar.contrib.pathy._
 import quasar.ejson.{EJson, EncodeEJson}
 import quasar.ejson.implicits._
-import quasar.fp.numeric.Positive
+import quasar.fp.numeric.{Natural, Positive}
 import quasar.fs._
 import quasar.fs.mount.Mounting
 import quasar.frontend.SemanticErrors
@@ -50,16 +50,16 @@ object analysis {
     * @param unionMaxSize    unions larger than this will be compressed
     */
   final case class CompressionSettings(
-    arrayMaxLength:  Positive,
-    mapMaxSize:      Positive,
-    stringMaxLength: Positive,
+    arrayMaxLength:  Natural,
+    mapMaxSize:      Natural,
+    stringMaxLength: Natural,
     unionMaxSize:    Positive
   )
 
   object CompressionSettings {
-    val DefaultArrayMaxLength:  Positive = 10L
-    val DefaultMapMaxSize:      Positive = 32L
-    val DefaultStringMaxLength: Positive =  1L
+    val DefaultArrayMaxLength:  Natural  = 10L
+    val DefaultMapMaxSize:      Natural  = 32L
+    val DefaultStringMaxLength: Natural  =  0L
     val DefaultUnionMaxSize:    Positive =  1L
 
     val Default: CompressionSettings =

--- a/interface/src/main/scala/quasar/main/analysis.scala
+++ b/interface/src/main/scala/quasar/main/analysis.scala
@@ -58,7 +58,7 @@ object analysis {
   object CompressionSettings {
     val DefaultArrayMaxLength:  Positive = 64L
     val DefaultMapMaxSize:      Positive = 64L
-    val DefaultStringMaxLength: Positive = 64L
+    val DefaultStringMaxLength: Positive = 32L
     val DefaultUnionMaxSize:    Positive =  1L
 
     val Default: CompressionSettings =

--- a/interface/src/test/scala/quasar/main/ExtractSchemaSpec.scala
+++ b/interface/src/test/scala/quasar/main/ExtractSchemaSpec.scala
@@ -26,6 +26,8 @@ import quasar.fp.numeric.SampleStats
 import quasar.sst._
 import quasar.tpe._
 
+import scala.{Byte, Char}
+
 import eu.timepit.refined.auto._
 import matryoshka.data.Fix
 import matryoshka.implicits._
@@ -34,7 +36,7 @@ import scalaz.stream.Process
 import spire.std.double._
 
 final class ExtractSchemaSpec extends quasar.Qspec {
-  import Data._, StructuralType.TypeST
+  import Data._, StructuralType.{TagST, TypeST}
 
   type J = Fix[EJson]
   type S = SST[J, Double]
@@ -84,14 +86,19 @@ final class ExtractSchemaSpec extends quasar.Qspec {
       TypeStat.coll(2.0, 1.0.some, 1.0.some),
       TypeST(TypeF.map[J, S](IMap(
         J.str("foo") -> envT(
-          TypeStat.str(1.0, 6.0, 6.0, "", ""),
-          TypeST(TypeF.arr[J, S](envT(
-            TypeStat.count(1.0),
-            TypeST(TypeF.simple[J, S](SimpleType.Char))
-          ).embed.right))).embed,
+          TypeStat.coll(1.0, 6.0.some, 6.0.some),
+          TagST[J](Tagged(
+            strings.StructuralString,
+            envT(
+              TypeStat.coll(1.0, 6.0.some, 6.0.some),
+              TypeST(TypeF.arr[J, S](envT(
+                TypeStat.char(1.0, Char.MinValue, Char.MaxValue),
+                TypeST(TypeF.simple[J, S](SimpleType.Char))).embed.right))
+            ).embed))
+          ).embed,
 
         J.str("bar") -> envT(
-          TypeStat.str(1.0, 5.0, 5.0, "abcde", "abcde"),
+          TypeStat.coll(1.0, 5.0.some, 5.0.some),
           TypeST(TypeF.const[J, S](J.str("abcde")))
         ).embed
       ), None))).embed
@@ -116,14 +123,14 @@ final class ExtractSchemaSpec extends quasar.Qspec {
         J.str("foo") -> envT(
           TypeStat.coll(1.0, l1.some, l1.some),
           TypeST(TypeF.arr[J, S](envT(
-            TypeStat.count(1.0),
+            TypeStat.byte(1.0, Byte.MinValue, Byte.MaxValue),
             TypeST(TypeF.simple[J, S](SimpleType.Byte))
           ).embed.right))).embed,
 
         J.str("bar") -> envT(
           TypeStat.coll(1.0, l2.some, l2.some),
           TypeST(TypeF.arr[J, S](envT(
-            TypeStat.count(1.0),
+            TypeStat.byte(1.0, Byte.MinValue, Byte.MaxValue),
             TypeST(TypeF.simple[J, S](SimpleType.Byte))
           ).embed.right))).embed
       ), None))).embed
@@ -143,11 +150,25 @@ final class ExtractSchemaSpec extends quasar.Qspec {
       TypeStat.coll(4.0, 1.0.some, 1.0.some),
       TypeST(TypeF.map[J, S](IMap.empty[J, S], Some((
         envT(
-          TypeStat.str(4.0, 3.0, 4.0, "bar", "quux"),
-          TypeST(TypeF.arr[J, S](envT(
-            TypeStat.count(4.0),
-            TypeST(TypeF.simple[J, S](SimpleType.Char))
-          ).embed.right))).embed,
+          TypeStat.coll(4.0, 3.0.some, 4.0.some),
+          TagST[J](Tagged(
+            strings.StructuralString,
+            envT(
+              TypeStat.coll(4.0, 3.0.some, 4.0.some),
+              TypeST(TypeF.arr[J, S](IList(
+                envT(
+                  TypeStat.char(4.0, 'b', 'q'),
+                  TypeST(TypeF.simple[J, S](SimpleType.Char))).embed,
+                envT(
+                  TypeStat.char(4.0, 'a', 'u'),
+                  TypeST(TypeF.simple[J, S](SimpleType.Char))).embed,
+                envT(
+                  TypeStat.char(4.0, 'o', 'z'),
+                  TypeST(TypeF.simple[J, S](SimpleType.Char))).embed,
+                envT(
+                  TypeStat.char(1.0, 'x', 'x'),
+                  TypeST(TypeF.const[J, S](J.char('x')))).embed
+              ).left))).embed))).embed,
         envT(
           TypeStat.int(SampleStats.freq(4.0, 1.0), BigInt(1), BigInt(1)),
           TypeST(TypeF.const[J, S](J.int(1)))
@@ -169,11 +190,25 @@ final class ExtractSchemaSpec extends quasar.Qspec {
       TypeStat.coll(4.0, 1.0.some, 1.0.some),
       TypeST(TypeF.map[J, S](IMap.empty[J, S], Some((
         envT(
-          TypeStat.str(4.0, 3.0, 4.0, "bar", "quux"),
-          TypeST(TypeF.arr[J, S](envT(
-            TypeStat.count(4.0),
-            TypeST(TypeF.simple[J, S](SimpleType.Char))
-          ).embed.right))).embed,
+          TypeStat.coll(4.0, 3.0.some, 4.0.some),
+          TagST[J](Tagged(
+            strings.StructuralString,
+            envT(
+              TypeStat.coll(4.0, 3.0.some, 4.0.some),
+              TypeST(TypeF.arr[J, S](IList(
+                envT(
+                  TypeStat.char(4.0, 'b', 'q'),
+                  TypeST(TypeF.simple[J, S](SimpleType.Char))).embed,
+                envT(
+                  TypeStat.char(4.0, 'a', 'u'),
+                  TypeST(TypeF.simple[J, S](SimpleType.Char))).embed,
+                envT(
+                  TypeStat.char(4.0, 'o', 'z'),
+                  TypeST(TypeF.simple[J, S](SimpleType.Char))).embed,
+                envT(
+                  TypeStat.char(1.0, 'x', 'x'),
+                  TypeST(TypeF.const[J, S](J.char('x')))).embed
+              ).left))).embed))).embed,
         envT(
           TypeStat.int(SampleStats.freq(4.0, 1.0), BigInt(1), BigInt(1)),
           TypeST(TypeF.const[J, S](J.int(1)))

--- a/web/src/main/scala/quasar/api/services/analyze/schema.scala
+++ b/web/src/main/scala/quasar/api/services/analyze/schema.scala
@@ -42,9 +42,9 @@ object schema {
 
   val DefaultSampleSize: Positive = 1000L
 
-  object ArrayMaxLength extends OptionalValidatingQueryParamDecoderMatcher[Positive]("arrayMaxLength")
-  object MapMaxSize extends OptionalValidatingQueryParamDecoderMatcher[Positive]("mapMaxSize")
-  object StringMaxLength extends OptionalValidatingQueryParamDecoderMatcher[Positive]("stringMaxLength")
+  object ArrayMaxLength extends OptionalValidatingQueryParamDecoderMatcher[Natural]("arrayMaxLength")
+  object MapMaxSize extends OptionalValidatingQueryParamDecoderMatcher[Natural]("mapMaxSize")
+  object StringMaxLength extends OptionalValidatingQueryParamDecoderMatcher[Natural]("stringMaxLength")
   object UnionMaxSize extends OptionalValidatingQueryParamDecoderMatcher[Positive]("unionMaxSize")
 
   def service[S[_]](


### PR DESCRIPTION
Extends the structural treatment of strings in SSTs to widen strings shorter than `stringMaxLength` to an array of their characters allowing the preservation of positional character distributions. This enables SSTs to capture much of the structure that may be embedded in a string (i.e. SSNs, phone numbers, UUIDs, temporal, etc).

#qz-3719 Done.