### PR TITLE
Enable mimir fs tests

### DIFF
--- a/it/src/test/scala/quasar/fs/QueryFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/QueryFilesSpec.scala
@@ -61,7 +61,7 @@ class QueryFilesSpec extends FileSystemTest[BackendEffect](FileSystemTest.allFsU
 
       "executing query to an existing file overwrites with results" >> ifSupports(fs,
         BackendCapability.query(),
-        BackendCapability.write()) { pendingFor(fs)(Set("mimir")) {
+        BackendCapability.write()) {
 
         val d = queryPrefix </> dir("execappends")
         val a = d </> file("afile")
@@ -80,7 +80,7 @@ class QueryFilesSpec extends FileSystemTest[BackendEffect](FileSystemTest.allFsU
 
         runLogT(fs.testInterpM, p).runEither must
           beRight(completelySubsume(Vector[Data](Data.Obj("c" -> Data._int(2)))))
-      } }
+      }
 
       "listing directory returns immediate child nodes" >> {
         val d = queryPrefix </> dir("lsch")
@@ -106,7 +106,7 @@ class QueryFilesSpec extends FileSystemTest[BackendEffect](FileSystemTest.allFsU
         runT(nonChFs.testInterpM)(query.ls(rootDir)).runEither must beRight
       }
 
-      "listing nonexistent directory returns dir NotFound" >> pendingFor(fs)(Set("mimir")) {
+      "listing nonexistent directory returns dir NotFound" >> {
         val d = queryPrefix </> dir("lsdne")
         runT(fs.testInterpM)(query.ls(d)).runEither must beLeft(pathErr(pathNotFound(d)))
       }

--- a/it/src/test/scala/quasar/fs/ReadFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/ReadFilesSpec.scala
@@ -114,8 +114,7 @@ class ReadFilesSpec extends FileSystemTest[BackendEffect](FileSystemTest.allFsUT
         r.run_\/ must_= Vector.empty.right
       }
 
-      // disabled for mimir, not because it doesn't work, but because it's absurdly slow
-      "scan with offset k > 0 and no limit skips first k data" >> pendingFor(fs)(Set("mimir")) {
+      "scan with offset k > 0 and no limit skips first k data" >> {
         prop { k: Int Refined RPositive =>
           val rFull = runLogT(run, read.scan(smallFile.file, 0L, None)).run_\/
           val r     = runLogT(run, read.scan(smallFile.file, widenPositive(k), None)).run_\/


### PR DESCRIPTION
These are all passing locally and do not run slowly (at least not more slowly than other tests in the suite).