### PR TITLE
Implement auto PR to bump sdbe on release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,7 +129,7 @@ concurrentRestrictions in Global := {
 concurrentRestrictions in Global += Tags.exclusive(ExclusiveTest)
 
 lazy val publishSettings = commonPublishSettings ++ Seq(
-  performSonatypeSync := false,   // basically just ignores all the sonatype sync parts of things
+  performMavenCentralSync := false,   // publishes quasar to bintray only, skipping sonatype and maven central
   organizationName := "SlamData Inc.",
   organizationHomepage := Some(url("http://quasar-analytics.org")),
   homepage := Some(url("https://github.com/quasar-analytics/quasar")),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,10 @@
 resolvers += Resolver.sonatypeRepo("releases")
 resolvers += Resolver.bintrayRepo("slamdata-inc", "maven-public")
-resolvers += Resolver.bintrayIvyRepo("djspiewak", "ivy")
 
 addSbtPlugin("com.eed3si9n"          % "sbt-assembly"  % "0.14.5")
 addSbtPlugin("com.eed3si9n"          % "sbt-buildinfo" % "0.7.0")
 addSbtPlugin("io.get-coursier"       % "sbt-coursier"  % "1.0.0-RC12")
 addSbtPlugin("org.scoverage"         % "sbt-scoverage" % "1.5.1")
-addSbtPlugin("com.slamdata"          % "sbt-slamdata"  % "0.7.1")
+addSbtPlugin("com.slamdata"          % "sbt-slamdata"  % "0.8.1")
 addSbtPlugin("pl.project13.scala"    % "sbt-jmh"       % "0.2.27")
 addSbtPlugin("com.github.romanowski" % "hoarder"       % "1.0.2-RC2")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,6 +1,5 @@
 resolvers += Resolver.sonatypeRepo("releases")
 resolvers += Resolver.bintrayRepo("slamdata-inc", "maven-public")
-resolvers += Resolver.bintrayIvyRepo("djspiewak", "ivy")
 
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC12")
-addSbtPlugin("com.slamdata"    % "sbt-slamdata" % "0.7.1")
+addSbtPlugin("com.slamdata"    % "sbt-slamdata" % "0.8.1")

--- a/scripts/quasarPublishAndTag
+++ b/scripts/quasarPublishAndTag
@@ -9,3 +9,8 @@ source scripts/constants
 
 # Set TRAVIS_JOB_NUMBER as a workaround to meet sbt-slamdata's publishAndTag assumption
 TRAVIS_JOB_NUMBER=1 scripts/publishAndTag 'quasar-analytics/quasar'
+
+
+bumpInSlamdataBackend() { echo $1 > quasar-version; }
+export -f bumpInSlamdataBackend
+scripts/bumpDependentProject slamdata slamdata-backend bumpInSlamdataBackend


### PR DESCRIPTION
This PR depends on https://github.com/slamdata/slamdata-backend/pull/325 and https://github.com/slamdata/sbt-slamdata/pull/46
plugin version needs to be bumped to a real one once it is released.