### PR TITLE
Enable logging of HTTP request lines by default

### DIFF
--- a/web/src/main/resources/log4j.properties
+++ b/web/src/main/resources/log4j.properties
@@ -2,3 +2,6 @@ log4j.rootLogger=ERROR, STDOUT
 log4j.appender.STDOUT=org.apache.log4j.ConsoleAppender
 log4j.appender.STDOUT.layout=org.apache.log4j.PatternLayout
 log4j.appender.STDOUT.layout.ConversionPattern=%d %5p [%t] (%F:%L) - %m%n
+
+# Log HTTP request lines, set to TRACE to include headers.
+log4j.logger.quasar.api.services.request=DEBUG

--- a/web/src/main/scala/quasar/api/Destination.scala
+++ b/web/src/main/scala/quasar/api/Destination.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api
+
+import slamdata.Predef.{Option, String}
+
+import org.http4s.{Header, HeaderKey, ParseResult}
+import org.http4s.util.CaseInsensitiveString
+import scalaz.syntax.equal._
+import scalaz.syntax.std.boolean._
+
+object Destination extends HeaderKey.Singleton {
+  type HeaderT = Header
+
+  val name = CaseInsensitiveString("Destination")
+
+  override def matchHeader(header: Header): Option[HeaderT] =
+    (header.name ≟ name) option header
+
+  override def parse(s: String): ParseResult[Header] =
+    ParseResult.success(Header.Raw(name, s))
+}

--- a/web/src/main/scala/quasar/api/HeaderParam.scala
+++ b/web/src/main/scala/quasar/api/HeaderParam.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api
+
+import slamdata.Predef._
+
+import argonaut.{DecodeResult => _, _}, Argonaut._
+import org.http4s.{Header, Headers, HttpService, Request, Service}
+import org.http4s.argonaut._
+import org.http4s.dsl._
+import org.http4s.server._
+import org.http4s.util.CaseInsensitiveString
+import scalaz.{\/, -\/, \/-}
+import scalaz.std.either._
+import scalaz.std.list._
+import scalaz.syntax.bifunctor._
+import scalaz.syntax.traverse._
+import scalaz.syntax.std.either._
+import scalaz.syntax.std.option._
+
+object HeaderParam extends HttpMiddleware {
+  type HeaderValues = Map[CaseInsensitiveString, List[String]]
+
+  def parse(param: String): String \/ HeaderValues = {
+    def strings(json: Json): String \/ List[String] =
+      json.string.map(str => \/-(str :: Nil)).getOrElse(
+        json.array.map { vs =>
+          vs.traverse(v => v.string \/> (s"expected string in array; found: $v"))
+        }.getOrElse(-\/(s"expected a string or array of strings; found: $json")))
+
+    for {
+      json <- Parse.parse(param).leftMap("parse error (" + _ + ")").disjunction
+      obj <- json.obj \/> (s"expected a JSON object; found: $json")
+      values <- obj.toList.traverse { case (k, v) =>
+        strings(v).map(CaseInsensitiveString(k) -> _)
+      }
+    } yield Map(values: _*)
+  }
+
+  def rewrite(headers: Headers, param: HeaderValues): Headers =
+    Headers(
+      param.toList.flatMap {
+        case (k, vs) => vs.map(v => Header.Raw(CaseInsensitiveString(k), v))
+      } ++
+      headers.toList.filterNot(h => param contains h.name))
+
+  def apply(service: HttpService): HttpService =
+    Service.lift { req =>
+      (req.params.get("request-headers").fold[String \/ Request](\/-(req)) { v =>
+        parse(v).map(hv => req.withHeaders(rewrite(req.headers, hv)))
+      }).fold(
+        err => BadRequest(Json("error" := "invalid request-headers: " + err)),
+        service.run)
+    }
+}

--- a/web/src/main/scala/quasar/api/Prefix.scala
+++ b/web/src/main/scala/quasar/api/Prefix.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api
+
+import slamdata.Predef._
+
+import monocle.Lens
+import monocle.macros.GenLens
+import org.http4s.{HttpService, Pass, Request, Service, Uri}
+import scalaz.std.option._
+import scalaz.syntax.std.boolean._
+
+object Prefix {
+  def apply(prefix: String)(service: HttpService): HttpService = {
+    val stripChars = prefix match {
+      case "/"                    => 0
+      case x if x.startsWith("/") => x.length
+      case x                      => x.length + 1
+    }
+
+    def rewrite(path: String): Option[String] =
+      path.startsWith(prefix) option path.substring(stripChars)
+
+    Service.lift { req: Request =>
+      _uri_path.modifyF(rewrite)(req) match {
+        case Some(req1) => service(req1)
+        case None       => Pass.now
+      }
+    }
+  }
+
+  private val uriLens = Lens[Request, Uri](_.uri)(uri => req => req.withUri(uri))
+  private val _uri_path = uriLens composeLens GenLens[Uri](_.path)
+}

--- a/web/src/main/scala/quasar/api/RFC5987ContentDispositionRender.scala
+++ b/web/src/main/scala/quasar/api/RFC5987ContentDispositionRender.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api
+
+import slamdata.Predef._
+
+import org.http4s.{Header, HttpService, Response}
+import org.http4s.headers.`Content-Disposition`
+import org.http4s.server._
+import scalaz.syntax.equal._
+import scalaz.syntax.traverse._
+import scalaz.syntax.std.boolean._
+import scalaz.syntax.std.option._
+
+// [#1861] Workaround to support a small slice of RFC 5987 for this isolated case
+object RFC5987ContentDispositionRender extends HttpMiddleware {
+  // NonUnitStatements due to http4s's Writer
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+  final case class ContentDisposition(dispositionType: String, parameters: Map[String, String])
+    extends Header.Parsed {
+    import org.http4s.util.Writer
+    override def key = `Content-Disposition`
+    override lazy val value = super.value
+    override def renderValue(writer: Writer): writer.type = {
+      writer.append(dispositionType)
+      parameters.foreach(p =>
+        p._1.endsWith("*").fold(
+          writer << "; " << p._1 << "=" << p._2,
+          writer << "; " << p._1 << "=\"" << p._2 << '"'))
+      writer
+    }
+  }
+
+  def apply(service: HttpService): HttpService =
+    service.map {
+      case resp: Response =>
+        resp.headers.get(`Content-Disposition`).cata(
+          i => resp.copy(headers = resp.headers
+            .filter(_.name ≠ `Content-Disposition`.name)
+            .put(ContentDisposition(i.dispositionType, i.parameters))),
+          resp)
+      case pass => pass
+    }
+}

--- a/web/src/main/scala/quasar/api/RequestLogging.scala
+++ b/web/src/main/scala/quasar/api/RequestLogging.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api
+
+import slamdata.Predef._
+
+import org.http4s.Headers
+import org.http4s.server.{HttpMiddleware, Middleware}
+import org.http4s.util.CaseInsensitiveString
+import org.slf4j.Logger
+import scalaz.concurrent.Task
+import scalaz.syntax.apply._
+
+/** Logs the details of requests using the provided logger, redacting the value of
+  * the specified headers in addition to `Authorization` and cookie-related headers.
+  *
+  * The request line is logged at DEBUG level, headers are included at TRACE level.
+  */
+object RequestLogging {
+  def apply(log: Logger, redactHeaders: Set[CaseInsensitiveString]): HttpMiddleware =
+    Middleware { (req, svc) =>
+      val logged = Task.delay {
+        if (log.isDebugEnabled) {
+          val requestLine =
+            s"${req.method} ${req.uri} ${req.httpVersion}"
+
+          if (log.isTraceEnabled) {
+            val withHeaders =
+              req.headers
+                .redactSensitive(redactHeaders ++ Headers.SensitiveHeaders)
+                .foldLeft(requestLine)((l, h) => l + s" | $h")
+
+            log.trace(withHeaders)
+          } else {
+            log.debug(requestLine)
+          }
+        }
+      }
+
+      logged *> svc(req)
+    }
+}

--- a/web/src/main/scala/quasar/api/XFileName.scala
+++ b/web/src/main/scala/quasar/api/XFileName.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api
+
+import slamdata.Predef.{Option, String}
+
+import org.http4s.{Header, HeaderKey, ParseResult}
+import org.http4s.util.CaseInsensitiveString
+import scalaz.syntax.equal._
+import scalaz.syntax.std.boolean._
+
+object XFileName extends HeaderKey.Singleton {
+  type HeaderT = Header
+
+  val name = CaseInsensitiveString("X-File-Name")
+
+  override def matchHeader(header: Header): Option[HeaderT] =
+    (header.name ≟ name) option header
+
+  override def parse(s: String): ParseResult[Header] =
+    ParseResult.success(Header.Raw(name, s))
+}

--- a/web/src/main/scala/quasar/api/services/RestApi.scala
+++ b/web/src/main/scala/quasar/api/services/RestApi.scala
@@ -38,6 +38,7 @@ import org.http4s.dsl._
 import org.http4s.server.HttpMiddleware
 import org.http4s.server.middleware.{CORS, CORSConfig, GZip}
 import org.http4s.server.syntax._
+import org.slf4j.LoggerFactory
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 
@@ -112,7 +113,8 @@ object RestApi {
     RFC5987ContentDispositionRender compose
     HeaderParam                     compose
     passOptions                     compose
-    errorHandling
+    errorHandling                   compose
+    requestLogging
 
   val cors: HttpMiddleware =
     CORS(_, CORSConfig(
@@ -137,4 +139,7 @@ object RestApi {
           .toResponse[Task]
           .toHttpResponse(liftMT[Task, FailedResponseT])
     })
+
+  val requestLogging: HttpMiddleware =
+    RequestLogging(LoggerFactory.getLogger("quasar.api.services.request"), Set.empty)
 }


### PR DESCRIPTION
Adds a `RequestLogging` middleware for http4s and enables it by default to log HTTP request lines.

#sdbe-325 Done