### PR TITLE
rename cache data files

### DIFF
--- a/connector/src/main/scala/quasar/connector/BackendModule.scala
+++ b/connector/src/main/scala/quasar/connector/BackendModule.scala
@@ -139,7 +139,7 @@ trait BackendModule {
         ManageFileModule.move(pathPair, semantics).run.value
       case ManageFile.Copy(pathPair) => ManageFileModule.copy(pathPair).run.value
       case ManageFile.Delete(path) => ManageFileModule.delete(path).run.value
-      case ManageFile.TempFile(near) => ManageFileModule.tempFile(near).run.value
+      case ManageFile.TempFile(near, prefix) => ManageFileModule.tempFile(near, prefix).run.value
     }
 
     qfInter :+: rfInter :+: wfInter :+: mfInter
@@ -255,7 +255,7 @@ trait BackendModule {
     def move(pair: PathPair, semantics: MoveSemantics): Backend[Unit]
     def copy(pair: PathPair): Backend[Unit]
     def delete(path: APath): Backend[Unit]
-    def tempFile(near: APath): Backend[AFile]
+    def tempFile(near: APath, prefix: Option[TempFilePrefix]): Backend[AFile]
   }
 
   def ManageFileModule: ManageFileModule

--- a/connector/src/main/scala/quasar/fs/Empty.scala
+++ b/connector/src/main/scala/quasar/fs/Empty.scala
@@ -55,7 +55,7 @@ object Empty {
     case ManageFile.Move(scn, _) => fsPathNotFound(scn.src)
     case ManageFile.Copy(pair)   => fsPathNotFound(pair.src)
     case ManageFile.Delete(p)    => fsPathNotFound(p)
-    case ManageFile.TempFile(p)  => (refineType(p).swap.valueOr(fileParent) </> file("tmp")).right.point[F]
+    case ManageFile.TempFile(p, prefix)  => (refineType(p).swap.valueOr(fileParent) </> file(s"${prefix}_tmp")).right.point[F]
   }
 
   def queryFile[F[_]: Applicative]: QueryFile ~> F =

--- a/connector/src/main/scala/quasar/fs/Empty.scala
+++ b/connector/src/main/scala/quasar/fs/Empty.scala
@@ -28,6 +28,7 @@ import matryoshka.data.Fix
 import matryoshka.implicits._
 import pathy.Path._
 import scalaz.{~>, \/, Applicative, Bind}
+import scalaz.std.string._
 import scalaz.syntax.equal._
 import scalaz.syntax.applicative._
 import scalaz.syntax.either._
@@ -51,11 +52,14 @@ object Empty {
     case WriteFile.Close(_)       => ().point[F]
   }
 
+  val defaultPrefix = TempFilePrefix("")
+
   def manageFile[F[_]: Applicative] = λ[ManageFile ~> F] {
-    case ManageFile.Move(scn, _) => fsPathNotFound(scn.src)
-    case ManageFile.Copy(pair)   => fsPathNotFound(pair.src)
-    case ManageFile.Delete(p)    => fsPathNotFound(p)
-    case ManageFile.TempFile(p, prefix)  => (refineType(p).swap.valueOr(fileParent) </> file(s"${prefix}_tmp")).right.point[F]
+    case ManageFile.Move(scn, _)   => fsPathNotFound(scn.src)
+    case ManageFile.Copy(pair)     => fsPathNotFound(pair.src)
+    case ManageFile.Delete(p)      => fsPathNotFound(p)
+    case ManageFile.TempFile(n, p) =>
+      TmpFile.tmpFile0(n, p.getOrElse(defaultPrefix), "tmp").right.point[F]
   }
 
   def queryFile[F[_]: Applicative]: QueryFile ~> F =

--- a/connector/src/main/scala/quasar/fs/InMemory.scala
+++ b/connector/src/main/scala/quasar/fs/InMemory.scala
@@ -151,10 +151,10 @@ object InMemory {
       case Delete(path) =>
         refineType(path).fold(deleteDir, deleteFile)
 
-      case TempFile(path) =>
+      case TempFile(path, prefix) =>
         nextSeq map (n => refineType(path).fold(
-          _ </> file(tmpName(n)),
-          renameFile(_, κ(FileName(tmpName(n))))
+          _ </> file(tmpName(prefix, n)),
+          renameFile(_, κ(FileName(tmpName(prefix, n))))
         ).right[FileSystemError])
     }
   }
@@ -280,7 +280,8 @@ object InMemory {
 
   private val lpr = new LogicalPlanR[Fix[LogicalPlan]]
 
-  private def tmpName(n: Long) = s"__quasar.gen_$n"
+  private def tmpName(prefix: Option[TempFilePrefix], n: Long) =
+    prefix.map(_.prefix).getOrElse("__quasar.gen_") + n.toString
 
   private val seqL: InMemState @> Long =
     Lens.lensg(s => n => s.copy(seq = n), _.seq)

--- a/connector/src/main/scala/quasar/fs/InMemory.scala
+++ b/connector/src/main/scala/quasar/fs/InMemory.scala
@@ -152,10 +152,8 @@ object InMemory {
         refineType(path).fold(deleteDir, deleteFile)
 
       case TempFile(path, prefix) =>
-        nextSeq map (n => refineType(path).fold(
-          _ </> file(tmpName(prefix, n)),
-          renameFile(_, κ(FileName(tmpName(prefix, n))))
-        ).right[FileSystemError])
+        nextSeq map (
+          TmpFile.tmpFile0(path, prefix.getOrElse(defaultPrefix), _).right[FileSystemError])
     }
   }
 
@@ -280,8 +278,7 @@ object InMemory {
 
   private val lpr = new LogicalPlanR[Fix[LogicalPlan]]
 
-  private def tmpName(prefix: Option[TempFilePrefix], n: Long) =
-    prefix.map(_.prefix).getOrElse("__quasar.gen_") + n.toString
+  private val defaultPrefix = TempFilePrefix("__quasar.gen_")
 
   private val seqL: InMemState @> Long =
     Lens.lensg(s => n => s.copy(seq = n), _.seq)

--- a/connector/src/main/scala/quasar/fs/ManageFile.scala
+++ b/connector/src/main/scala/quasar/fs/ManageFile.scala
@@ -68,7 +68,7 @@ object ManageFile {
   final case class Delete(path: APath)
     extends ManageFile[FileSystemError \/ Unit]
 
-  final case class TempFile(near: APath)
+  final case class TempFile(near: APath, prefix: Option[TempFilePrefix])
     extends ManageFile[FileSystemError \/ AFile]
 
   final class Ops[S[_]](implicit S: ManageFile :<: S)
@@ -113,8 +113,8 @@ object ManageFile {
     /** Returns the path to a new temporary file as physically close to the
       * supplied path as possible.
       */
-    def tempFile(near: APath): M[AFile] =
-      EitherT(lift(TempFile(near)))
+    def tempFile(near: APath, prefix: Option[TempFilePrefix]): M[AFile] =
+      EitherT(lift(TempFile(near, prefix)))
   }
 
   object Ops {
@@ -132,7 +132,8 @@ object ManageFile {
         case Copy(pair) => NonTerminal(List("Copy"), None,
           List(pair.src.render, pair.dst.render))
         case Delete(path) => NonTerminal(List("Delete"), None, List(path.render))
-        case TempFile(nearTo) => NonTerminal(List("TempFile"), None, List(nearTo.render))
+        case TempFile(nearTo, prefix) =>
+          NonTerminal(List("TempFile"), None, List(nearTo.render, prefix.render))
       }
     }
 }

--- a/connector/src/main/scala/quasar/fs/TempFilePrefix.scala
+++ b/connector/src/main/scala/quasar/fs/TempFilePrefix.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.fs
+
+import slamdata.Predef._
+import quasar._
+import quasar.fp._
+
+import scalaz._
+
+final case class TempFilePrefix(prefix: String) extends AnyVal
+
+object TempFilePrefix {
+
+  implicit val showTempFilePrefix: Show[TempFilePrefix] =
+    Show.shows(_.prefix)
+
+  implicit val renderTreeTempFilePrefix: RenderTree[TempFilePrefix] =
+    RenderTree.fromShow("TempFilePrefix")
+
+}

--- a/connector/src/main/scala/quasar/fs/TmpFile.scala
+++ b/connector/src/main/scala/quasar/fs/TmpFile.scala
@@ -16,28 +16,19 @@
 
 package quasar.fs
 
-import slamdata.Predef._
-import quasar._
-import quasar.fp._
+import quasar.contrib.pathy._
 
-import scalaz._
+import pathy.Path._
+import scalaz._, Scalaz._
 
-final case class TempFilePrefix(s: String) extends AnyVal
+object TmpFile {
 
-object TempFilePrefix {
+  def tmpFilename[A: Show](prefix: TempFilePrefix, a: A): FileName =
+    FileName(prefix.s + a.shows)
 
-  implicit val showTempFilePrefix: Show[TempFilePrefix] =
-    Show.shows(_.s)
+  def tmpFile[A: Show](dir: ADir, prefix: TempFilePrefix, a: A): AFile =
+    dir </> file1(tmpFilename(prefix, a))
 
-  implicit val renderTreeTempFilePrefix: RenderTree[TempFilePrefix] =
-    RenderTree.fromShow("TempFilePrefix")
-
-  implicit val monoidTempFilePrefix: Monoid[TempFilePrefix] =
-    new Monoid[TempFilePrefix] {
-      val zero = TempFilePrefix("")
-
-      def append(p1: TempFilePrefix, p2: => TempFilePrefix) =
-        TempFilePrefix(p1.s + p2.s)
-    }
-
+  def tmpFile0[A: Show](near: APath, prefix: TempFilePrefix, a: A): AFile =
+    tmpFile(nearDir(near), prefix, a)
 }

--- a/connector/src/main/scala/quasar/fs/WriteFile.scala
+++ b/connector/src/main/scala/quasar/fs/WriteFile.scala
@@ -218,7 +218,7 @@ object WriteFile {
       def cleanupTmp(tmp: AFile)(t: Throwable): Process[M, Nothing] =
         Process.eval_(MF.deleteOrIgnore(tmp).liftM[FileSystemErrT]).causedBy(Cause.Error(t))
 
-      MF.tempFile(dst).liftM[Process] flatMap { tmp =>
+      MF.tempFile(dst, none).liftM[Process] flatMap { tmp =>
         appendChunked(tmp, src)
           .map(some).append(Process.emit(none))
           // Since `appendChunked` only streams errors we only need to look at the first one
@@ -236,7 +236,7 @@ object WriteFile {
                           (implicit MF: ManageFile.Ops[S])
                           : M[Unit] = {
       for {
-        tmp  <- MF.tempFile(dst)
+        tmp  <- MF.tempFile(dst, none)
         errs <- appendThese(tmp, data)
         _    <- errs.headOption.fold(
                   MF.moveFile(tmp, dst, sem))(

--- a/connector/src/main/scala/quasar/fs/package.scala
+++ b/connector/src/main/scala/quasar/fs/package.scala
@@ -16,13 +16,14 @@
 
 package quasar
 
-import quasar.contrib.pathy.PathSegment
+import quasar.contrib.pathy._
 import quasar.contrib.scalaz.MonadError_
 import quasar.effect.Failure
 import quasar.fp._
 import quasar.fp.free._
+import quasar.fp.ski._
 
-import pathy.Path.{FileName, DirName}
+import pathy.Path._
 import scalaz.{Failure => _, _}, Scalaz._
 
 package object fs extends PhysicalErrorPrisms {
@@ -103,5 +104,8 @@ package object fs extends PhysicalErrorPrisms {
     m: ManageFile ~> M
   ): BackendEffect ~> M =
     a :+: q :+: r :+: w :+: m
+
+  def nearDir(path: APath): ADir =
+    refineType(path).fold(ι, fileParent)
 
 }

--- a/connector/src/main/scala/quasar/fs/transformPaths.scala
+++ b/connector/src/main/scala/quasar/fs/transformPaths.scala
@@ -133,8 +133,8 @@ object transformPaths {
           .leftMap(transformErrorPath(outPath))
           .run
 
-      case TempFile(p) =>
-        M.tempFile(inPath(p))
+      case TempFile(p, prefix) =>
+        M.tempFile(inPath(p), prefix)
           .bimap(transformErrorPath(outPath), outPath(_))
           .run
     }

--- a/core/src/main/scala/quasar/fs/mount/cache/VCache.scala
+++ b/core/src/main/scala/quasar/fs/mount/cache/VCache.scala
@@ -20,7 +20,7 @@ import slamdata.Predef._
 import quasar.contrib.pathy.AFile
 import quasar.effect.{Failure, KeyValueStore, Read, Write}
 import quasar.fp.free.injectFT
-import quasar.fs.{FileSystemError, FileSystemFailure, ManageFile}
+import quasar.fs.{FileSystemError, FileSystemFailure, ManageFile, TempFilePrefix}
 import quasar.fs.FileSystemError.PathErr
 import quasar.fs.PathError.PathNotFound
 import quasar.metastore._, KeyValueStore._, MetaStoreAccess._
@@ -57,6 +57,14 @@ object VCache {
   object Expiration {
     implicit val order: Order[Expiration] =
       Order.order((a, b) => Ordering.fromInt(a.v compareTo b.v))
+  }
+
+  def cacheFile[S[_]](
+    viewPath: AFile)(
+    implicit MF: ManageFile.Ops[S])
+      : EitherT[Free[S, ?], FileSystemError, AFile]  = {
+    val f = pathy.Path.fileName(viewPath).value
+    MF.tempFile(viewPath, TempFilePrefix(s"cache_${f}_").some)
   }
 
   def deleteFiles[S[_]](

--- a/core/src/main/scala/quasar/fs/mount/hierarchical.scala
+++ b/core/src/main/scala/quasar/fs/mount/hierarchical.scala
@@ -187,11 +187,11 @@ object hierarchical {
       case Delete(path) =>
         refineType(path).fold(deleteDir, deleteFile)
 
-      case TempFile(near) =>
+      case TempFile(near, prefix) =>
         EitherT.fromDisjunction[M](
           lookup(near) toRightDisjunction noMountError(near)
         ).flatMapF { case (_, g) =>
-          g(TempFile(near))
+          g(TempFile(near, prefix))
         }.run
     }
   }

--- a/core/src/main/scala/quasar/fs/mount/nonFsMounts.scala
+++ b/core/src/main/scala/quasar/fs/mount/nonFsMounts.scala
@@ -213,8 +213,8 @@ object nonFsMounts {
       case Delete(path) =>
         mountDelete(path)
 
-      case TempFile(nearTo) =>
-        manage.tempFile(nearTo).run
+      case TempFile(nearTo, prefix) =>
+        manage.tempFile(nearTo, prefix).run
     }
   }
 

--- a/core/src/test/scala/quasar/fs/TraceFS.scala
+++ b/core/src/test/scala/quasar/fs/TraceFS.scala
@@ -87,6 +87,8 @@ object TraceFS {
         }))
   }
 
+  val defaultPrefix = TempFilePrefix("")
+
   def mfTrace = new (ManageFile ~> Trace) {
     import ManageFile._
 
@@ -96,8 +98,8 @@ object TraceFS {
           case Move(scenario, semantics) => \/-(())
           case Copy(pair)                => \/-(())
           case Delete(path)              => \/-(())
-          case TempFile(near) =>
-            \/-(refineType(near).fold(ι, fileParent) </> file("tmp"))
+          case TempFile(near, prefix) =>
+            \/-(TmpFile.tmpFile0(near, prefix.getOrElse(defaultPrefix), "tmp"))
         }))
   }
 

--- a/couchbase/src/main/scala/quasar/physical/couchbase/fs/managefile.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/fs/managefile.scala
@@ -65,9 +65,10 @@ abstract class managefile {
       _         <- ME.unattempt(lift(deleteHavingPrefix(ctx, col.v)).into[Eff].liftB)
     } yield ()
 
-  def tempFile(near: APath): Backend[AFile] =
+  def tempFile(near: APath, prefix: Option[TempFilePrefix]): Backend[AFile] =
     MonotonicSeq.Ops[Eff].next.map { i =>
-      val tmpFilename = file(s"__quasar_tmp_$i")
+      val tmpFilename = file(
+        prefix.map(_.prefix).getOrElse("__quasar_tmp_") + i.toString)
       refineType(near).fold(
         d => d </> tmpFilename,
         f => fileParent(f) </> tmpFilename)

--- a/couchbase/src/main/scala/quasar/physical/couchbase/fs/managefile.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/fs/managefile.scala
@@ -24,7 +24,6 @@ import quasar.fp.free._
 import quasar.fs._, ManageFile._
 import quasar.physical.couchbase._, common._, Couchbase._
 
-import pathy.Path._
 import scalaz._, Scalaz._
 
 abstract class managefile {
@@ -65,12 +64,9 @@ abstract class managefile {
       _         <- ME.unattempt(lift(deleteHavingPrefix(ctx, col.v)).into[Eff].liftB)
     } yield ()
 
+  val defaultPrefix = TempFilePrefix("__quasar_tmp_")
+
   def tempFile(near: APath, prefix: Option[TempFilePrefix]): Backend[AFile] =
-    MonotonicSeq.Ops[Eff].next.map { i =>
-      val tmpFilename = file(
-        prefix.map(_.prefix).getOrElse("__quasar_tmp_") + i.toString)
-      refineType(near).fold(
-        d => d </> tmpFilename,
-        f => fileParent(f) </> tmpFilename)
-    }.liftB
+    MonotonicSeq.Ops[Eff].next.map(
+      TmpFile.tmpFile0(near, prefix.getOrElse(defaultPrefix), _)).liftB
 }

--- a/interface/src/main/scala/quasar/main/ViewCacheRefresh.scala
+++ b/interface/src/main/scala/quasar/main/ViewCacheRefresh.scala
@@ -25,7 +25,7 @@ import quasar.frontend.SemanticErrsT
 import quasar.fp.free
 import quasar.fs.FileSystemError, FileSystemError._
 import quasar.fs.mount.{MountConfig, Mounting}
-import quasar.fs.mount.cache.ViewCache
+import quasar.fs.mount.cache.{ViewCache, VCache}
 import quasar.fs.MoveSemantics.Overwrite
 import quasar.fs.PathError._
 import quasar.fs.{ManageFile, QueryFile, WriteFile}
@@ -71,7 +71,7 @@ object ViewCacheRefresh {
 
     for {
       vc  <- getCachedView
-      tf  <- lift(M.tempFile(viewPath).run)
+      tf  <- lift(VCache.cacheFile(viewPath).run)
       ts1 <- lift(T.timestamp ∘ (_.right[FileSystemError]))
       _   <- lift(assigneeStart(viewPath, assigneeId, ts1, tf) ∘ (_.right[FileSystemError]))
       _   <- writeViewCache[S](fileParent(viewPath), tf, vc.viewConfig)

--- a/it/src/test/scala/quasar/ResultFileQueryRegressionSpec.scala
+++ b/it/src/test/scala/quasar/ResultFileQueryRegressionSpec.scala
@@ -16,6 +16,7 @@
 
 package quasar
 
+import slamdata.Predef._
 import quasar.common._
 import quasar.contrib.pathy._
 import quasar.fp.liftMT
@@ -52,7 +53,7 @@ class ResultFileQueryRegressionSpec
       execToCompExec compose[M] Hoist[FileSystemErrT].hoist[F, G](liftMT[F, PhaseResultT])
 
     for {
-      tmpFile <- hoistM(manage.tempFile(DataDir)).liftM[Process]
+      tmpFile <- hoistM(manage.tempFile(DataDir, None)).liftM[Process]
       _       <- fsQ.executeQuery(expr, vars, basePath, tmpFile).liftM[Process]
       cleanup =  hoistM(
                    query.fileExists(tmpFile).liftM[FileSystemErrT].ifM(

--- a/it/src/test/scala/quasar/fs/ManageFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/ManageFilesSpec.scala
@@ -306,7 +306,7 @@ class ManageFilesSpec extends FileSystemTest[BackendEffect](allFsUT.map(_ filter
         val f = d </> file("somefile")
 
         val p = write.save(f, oneDoc.toProcess).drain ++
-                manage.tempFile(f).liftM[Process] flatMap { tf =>
+                manage.tempFile(f, None).liftM[Process] flatMap { tf =>
                   write.save(tf, anotherDoc.toProcess).drain ++
                   read.scanAll(tf) ++
                   manage.delete(tf).liftM[Process].drain
@@ -318,7 +318,7 @@ class ManageFilesSpec extends FileSystemTest[BackendEffect](allFsUT.map(_ filter
       "write/read from temp dir near non existing" >> {
         val d = managePrefix </> dir("tmpnear2")
         val f = d </> file("somefile")
-        val p = manage.tempFile(f).liftM[Process] flatMap { tf =>
+        val p = manage.tempFile(f, None).liftM[Process] flatMap { tf =>
                   write.save(tf, anotherDoc.toProcess).drain ++
                   read.scanAll(tf) ++
                   manage.delete(tf).liftM[Process].drain
@@ -330,7 +330,7 @@ class ManageFilesSpec extends FileSystemTest[BackendEffect](allFsUT.map(_ filter
       "temp file should be generated in hint directory" >> prop { rdir: RDir =>
         val hintDir = managePrefix </> rdir
 
-        runT(run)(manage.tempFile(hintDir))
+        runT(run)(manage.tempFile(hintDir, None))
           .map(_ relativeTo hintDir)
           .runEither must beRight(beSome[RFile])
       }
@@ -339,7 +339,7 @@ class ManageFilesSpec extends FileSystemTest[BackendEffect](allFsUT.map(_ filter
         val hintFile = managePrefix </> rfile
         val hintDir  = fileParent(hintFile)
 
-        runT(run)(manage.tempFile(hintFile))
+        runT(run)(manage.tempFile(hintFile, None))
           .map(_ relativeTo hintDir)
           .runEither must beRight(beSome[RFile])
       }

--- a/it/src/test/scala/quasar/fs/ManageFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/ManageFilesSpec.scala
@@ -306,7 +306,7 @@ class ManageFilesSpec extends FileSystemTest[BackendEffect](allFsUT.map(_ filter
         val f = d </> file("somefile")
 
         val p = write.save(f, oneDoc.toProcess).drain ++
-                manage.tempFile(f, None).liftM[Process] flatMap { tf =>
+                manage.tempFile(f, TempFilePrefix("some_prefix_").some).liftM[Process] flatMap { tf =>
                   write.save(tf, anotherDoc.toProcess).drain ++
                   read.scanAll(tf) ++
                   manage.delete(tf).liftM[Process].drain

--- a/marklogic/src/main/scala/quasar/physical/marklogic/MarkLogic.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/MarkLogic.scala
@@ -306,13 +306,12 @@ sealed class MarkLogic protected (readChunkSize: Positive, writeChunkSize: Posit
         ).void
       }
 
+    val defaultPrefix = TempFilePrefix("temp-")
+
     def tempFile(path: APath, prefix: Option[TempFilePrefix]): Backend[AFile] =
       // Take my hand, scalac
       UuidReader[FileSystemErrT[PhaseResultT[Configured, ?], ?]] asks { uuid =>
-        val fname = prefix.map(_.prefix).getOrElse("temp-") + uuid.toString
-        refineType(path).fold(
-          d => d </> file(fname),
-          f => fileParent(f) </> file(fname))
+        TmpFile.tmpFile0(path, prefix.getOrElse(defaultPrefix), uuid.toString)
       }
 
     ////

--- a/marklogic/src/main/scala/quasar/physical/marklogic/MarkLogic.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/MarkLogic.scala
@@ -306,10 +306,10 @@ sealed class MarkLogic protected (readChunkSize: Positive, writeChunkSize: Posit
         ).void
       }
 
-    def tempFile(path: APath): Backend[AFile] =
+    def tempFile(path: APath, prefix: Option[TempFilePrefix]): Backend[AFile] =
       // Take my hand, scalac
       UuidReader[FileSystemErrT[PhaseResultT[Configured, ?], ?]] asks { uuid =>
-        val fname = s"temp-$uuid"
+        val fname = prefix.map(_.prefix).getOrElse("temp-") + uuid.toString
         refineType(path).fold(
           d => d </> file(fname),
           f => fileParent(f) </> file(fname))

--- a/mimir/src/main/scala/quasar/mimir/SlamDB.scala
+++ b/mimir/src/main/scala/quasar/mimir/SlamDB.scala
@@ -479,10 +479,10 @@ object Mimir extends BackendModule with Logging with DefaultAnalyzeModule {
       } yield ()
     }
 
-    def tempFile(near: APath): Backend[AFile] = {
+    def tempFile(near: APath, prefix: Option[TempFilePrefix]): Backend[AFile] = {
       for {
         seed <- Task.delay(UUID.randomUUID().toString).liftM[MT].liftB
-      } yield refineType(near).fold(p => p, fileParent) </> file(seed)
+      } yield refineType(near).fold(p => p, fileParent) </> file(prefix.map(_.prefix).getOrElse("") + seed)
     }
   }
 }

--- a/mimir/src/main/scala/quasar/mimir/SlamDB.scala
+++ b/mimir/src/main/scala/quasar/mimir/SlamDB.scala
@@ -479,10 +479,12 @@ object Mimir extends BackendModule with Logging with DefaultAnalyzeModule {
       } yield ()
     }
 
+    val defaultPrefix = TempFilePrefix("")
+
     def tempFile(near: APath, prefix: Option[TempFilePrefix]): Backend[AFile] = {
       for {
-        seed <- Task.delay(UUID.randomUUID().toString).liftM[MT].liftB
-      } yield refineType(near).fold(p => p, fileParent) </> file(prefix.map(_.prefix).getOrElse("") + seed)
+        uuid <- Task.delay(UUID.randomUUID().toString).liftM[MT].liftB
+      } yield TmpFile.tmpFile0(near, prefix.getOrElse(defaultPrefix), uuid)
     }
   }
 }

--- a/mongoIt/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
+++ b/mongoIt/src/test/scala/quasar/physical/mongodb/fs/MongoDbFileSystemSpec.scala
@@ -340,7 +340,7 @@ class MongoDbFileSystemSpec
             val pdir = rootDir </> dir(s"db${esc}name")
 
             run((for {
-              tfile  <- manage.tempFile(pdir)
+              tfile  <- manage.tempFile(pdir, None)
               dbName <- EitherT.fromDisjunction[manage.FreeS](
                           Collection.dbNameFromPath(tfile).leftMap(pathErr(_)))
             } yield dbName).run).unsafePerformSync must_=== Collection.dbNameFromPath(pdir).leftMap(pathErr(_))

--- a/mongodb/src/main/scala/quasar/physical/mongodb/MongoDb.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/MongoDb.scala
@@ -294,14 +294,9 @@ object MongoDb
         EitherT.fromDisjunction[MongoManage](Collection.dbNameFromPath(near))
           .bimap(FileSystemError.pathErr(_), κ(()))
 
-      val mkTemp =
-        freshName(prefix).liftM[FileSystemErrT] map { n =>
-          pathy.Path.refineType(near).fold(
-            _ </> pathy.Path.file(n),
-            f => pathy.Path.fileParent(f) </> pathy.Path.file(n))
-        }
+      val mm: MongoManage[FileSystemError \/ AFile] =
+        checkPath.flatMap(κ(freshFile(near, prefix).liftM[FileSystemErrT])).run
 
-      val mm: MongoManage[FileSystemError \/ AFile] = checkPath.flatMap(κ(mkTemp)).run
       toBackend(mm)
     }
   }

--- a/mongodb/src/main/scala/quasar/physical/mongodb/MongoDb.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/MongoDb.scala
@@ -289,13 +289,13 @@ object MongoDb
       toBackend(mm)
     }
 
-    def tempFile(near: APath): Backend[AFile] = {
+    def tempFile(near: APath, prefix: Option[TempFilePrefix]): Backend[AFile] = {
       val checkPath =
         EitherT.fromDisjunction[MongoManage](Collection.dbNameFromPath(near))
           .bimap(FileSystemError.pathErr(_), κ(()))
 
       val mkTemp =
-        freshName.liftM[FileSystemErrT] map { n =>
+        freshName(prefix).liftM[FileSystemErrT] map { n =>
           pathy.Path.refineType(near).fold(
             _ </> pathy.Path.file(n),
             f => pathy.Path.fileParent(f) </> pathy.Path.file(n))

--- a/mongodb/src/main/scala/quasar/physical/mongodb/fs/managefile.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/fs/managefile.scala
@@ -152,7 +152,7 @@ object managefile {
   val defaultPrefix = TempFilePrefix("__quasar.tmp_")
 
   def saltedPrefix(salt: Salt, prefix: Option[TempFilePrefix]): TempFilePrefix =
-    prefix.getOrElse(defaultPrefix) |+| TempFilePrefix(salt.s)
+    prefix.getOrElse(defaultPrefix) |+| TempFilePrefix(salt.s + "_")
 
   def freshFile(near: APath, prefix: Option[TempFilePrefix]): MongoManage[AFile] = {
     for {

--- a/mongodb/src/main/scala/quasar/physical/mongodb/fs/package.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/fs/package.scala
@@ -68,7 +68,7 @@ package object fs {
       Collection.dbNameFromPath(path).map(DefaultDb(_)).toOption
   }
 
-  final case class TmpPrefix(run: String) extends scala.AnyVal
+  final case class Salt(s: String) extends scala.AnyVal
 
   type PhysFsEff[A]  = Coproduct[Task, PhysErr, A]
 

--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsManageFile.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsManageFile.scala
@@ -158,12 +158,13 @@ trait RdbmsManageFile
         .getOrElse(().point[Backend])
     }
 
-    override def tempFile(near: APath): Backend[AFile] = {
+    override def tempFile(near: APath, prefix: Option[TempFilePrefix]): Backend[AFile] = {
       MonotonicSeq
         .Ops[Eff]
         .next
         .map { i =>
-          val tmpFilename = file(s"__quasar_tmp_table_$i")
+          val tmpFilename = file(
+            prefix.map(_.prefix).getOrElse("__quasar_tmp_table_") + i.toString)
           refineType(near).fold(d => {
             d </> tmpFilename
           }, f => fileParent(f) </> tmpFilename)

--- a/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsManageFile.scala
+++ b/rdbms/src/main/scala/quasar/physical/rdbms/fs/RdbmsManageFile.scala
@@ -44,6 +44,8 @@ trait RdbmsManageFile
   this: Rdbms =>
   implicit def MonadM: Monad[M]
 
+  val defaultPrefix = TempFilePrefix("__quasar_tmp_table_")
+
   def dropTableIfExists(table: TablePath): ConnectionIO[Unit]
 
   def dropTable(table: TablePath): ConnectionIO[Unit] = {
@@ -158,18 +160,9 @@ trait RdbmsManageFile
         .getOrElse(().point[Backend])
     }
 
-    override def tempFile(near: APath, prefix: Option[TempFilePrefix]): Backend[AFile] = {
-      MonotonicSeq
-        .Ops[Eff]
-        .next
-        .map { i =>
-          val tmpFilename = file(
-            prefix.map(_.prefix).getOrElse("__quasar_tmp_table_") + i.toString)
-          refineType(near).fold(d => {
-            d </> tmpFilename
-          }, f => fileParent(f) </> tmpFilename)
-        }
-        .liftB
-    }
+    override def tempFile(near: APath, prefix: Option[TempFilePrefix]): Backend[AFile] =
+      MonotonicSeq.Ops[Eff].next.map(
+        TmpFile.tmpFile0(near, prefix.getOrElse(defaultPrefix), _)).liftB
+
   }
 }

--- a/skeleton/src/main/scala/quasar/physical/skeleton/fs/Skeleton.scala
+++ b/skeleton/src/main/scala/quasar/physical/skeleton/fs/Skeleton.scala
@@ -108,6 +108,6 @@ object Skeleton extends BackendModule with DefaultAnalyzeModule {
     def move(scenario: PathPair, semantics: MoveSemantics): Backend[Unit] = ???
     def copy(pair: PathPair): Backend[Unit] = ???
     def delete(path: APath): Backend[Unit] = ???
-    def tempFile(near: APath): Backend[AFile] = ???
+    def tempFile(near: APath, prefix: Option[TempFilePrefix]): Backend[AFile] = ???
   }
 }

--- a/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/sparkcore.scala
+++ b/sparkcore/src/main/scala/quasar/physical/sparkcore/fs/sparkcore.scala
@@ -270,10 +270,11 @@ trait SparkCore extends BackendModule with DefaultAnalyzeModule {
     def copy(pair: PathPair): Backend[Unit] =
       unsupportedOperation("Spark connector does not currently support copy operation").left[Unit].point[M].liftB.unattempt
 
-    def tempFile(near: APath): Backend[AFile] = lift(Task.delay {
-      val parent: ADir = refineType(near).fold(d => d, fileParent(_))
+    val defaultPrefix = TempFilePrefix("quasar-")
+
+    def tempFile(near: APath, prefix: Option[TempFilePrefix]): Backend[AFile] = lift(Task.delay {
       val random = scala.util.Random.nextInt().toString
-        (parent </> file(s"quasar-$random.tmp")).right[FileSystemError]
+      TmpFile.tmpFile0(near, prefix.getOrElse(defaultPrefix), s"$random.tmp").right[FileSystemError]
     }
     ).into[Eff].liftB.unattempt
   }

--- a/web/src/main/scala/quasar/api/services/mount.scala
+++ b/web/src/main/scala/quasar/api/services/mount.scala
@@ -163,9 +163,9 @@ object mount {
     S1: VCacheKVS :<: S
   ): EitherT[Free[S, ?], ApiError, Unit] =
     for {
-      dataFile      <- MF.tempFile(viewPath).leftMap(_.toApiError)
+      cacheFile     <- VCache.cacheFile(viewPath).leftMap(_.toApiError)
       refreshAfter  <- T.timestamp.liftM[ApiErrT]
-      newViewCache  =  ViewCache.mk(viewConfig, maxAge.toSeconds, refreshAfter, dataFile)
+      newViewCache  =  ViewCache.mk(viewConfig, maxAge.toSeconds, refreshAfter, cacheFile)
       _             <- vcache.get(viewPath).fold(
                           κ(vcache.modify(viewPath, modifyViewCache(newViewCache))),
                           vcache.put(viewPath, newViewCache)).join.liftM[ApiErrT]


### PR DESCRIPTION
The template of cache data files is now `cache_<viewFileName>_<connectorSpecificId>`, e.g for mongo it is now `cache_<viewFileName>_<salt>_<seqnr>`

#qz-3747 Done