### PR TITLE
Fixed invalid json in tests

### DIFF
--- a/it/src/main/resources/tests/demo/nestedreductionsonnull.test
+++ b/it/src/main/resources/tests/demo/nestedreductionsonnull.test
@@ -23,6 +23,6 @@
     { "parallel": null, "measure": 140.0, "stack": "female", "category": "ACTON" },
     { "parallel": null, "measure": 228.0, "stack": "female", "category": "ADAK" },
     { "parallel": null, "measure": 191.0, "stack": "female", "category": "ADAMANT" },
-    { "parallel": null, "measure": 164.5, "stack": "female", "category": "ADAMS" },
+    { "parallel": null, "measure": 164.5, "stack": "female", "category": "ADAMS" }
   ]
 }

--- a/it/src/main/resources/tests/flattenNestedMap.test
+++ b/it/src/main/resources/tests/flattenNestedMap.test
@@ -7,7 +7,7 @@
     },
     "NB": "this actually works on mimir, but the time mismatch makes it look like a failure",
     "NB": "unmatched expected values 'Set(\"2015-01-29T15:52:37Z\", \"2015-01-29T00:23:14Z\", \"2015-01-26T17:37:40Z\")' is not empty (file:1)",
-    "NB": "Pending for postgres connector due to LeftShift error qz-3733",
+    "NB": "Pending for postgres connector due to LeftShift error qz-3733"
     },
     "query": "select commit.author{*} from slamengine_commits",
     "predicate": "atLeast",


### PR DESCRIPTION
I found these by running `find . -name '*.test' ! -exec jq 42 -c -r {} \; -print` from `it/src/main/tests/` and ignoring the `parse error: Invalid string: control characters from U+0000 through U+001F must be escaped` errors, which appear to be spurious.