### PR TITLE
use build numbers instead of pr numbers 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ jobs:
     - stage: clean
       env:
       script:
-        - ./scripts/s3Cache cleanup
+        - ./scripts/s3Cache cacheCleanUp
         - ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} clean
 
     - stage: compile

--- a/scripts/s3Cache
+++ b/scripts/s3Cache
@@ -6,7 +6,7 @@ fi
 
 TARGETS=".targets"
 HOARDER=".hoarder-cache"
-PRNUM=$TRAVIS_PULL_REQUEST
+NUM=$TRAVIS_BUILD_NUMBER
 TRAVISIP=$(curl -s checkip.dyndns.org | sed -e 's/.*Current IP Address: //' -e 's/<.*$//')
 
 export AWS_ACCESS_KEY_ID=$(openssl rsautl -inkey ./scripts/key.txt -decrypt < ./scripts/aws-access-key-id.bin)
@@ -15,19 +15,32 @@ export AWS_SECRET_ACCESS_KEY=$(openssl rsautl -inkey ./scripts/key.txt -decrypt 
 echo "Travis public IP is: $TRAVISIP"
 
 if [[ "$1" = "upload" ]]; then
-  echo "uploading $TARGETS and $HOARDER to s3://quasar-build-cache/$PRNUM ..."
-  aws s3 --only-show-errors cp $TARGETS s3://quasar-build-cache/$PRNUM/$TARGETS --recursive
-  aws s3 --only-show-errors cp $HOARDER s3://quasar-build-cache/$PRNUM/$HOARDER --recursive
+  echo "uploading $TARGETS and $HOARDER to s3://quasar-build-cache/$NUM ..."
+  aws s3 --only-show-errors cp $TARGETS s3://quasar-build-cache/$NUM/$TARGETS --recursive
+  aws s3 --only-show-errors cp $HOARDER s3://quasar-build-cache/$NUM/$HOARDER --recursive
   echo "done uploading!"
 elif [[ "$1" = "download" ]]; then
-  echo "downloading $TARGETS and $HOARDER from s3://quasar-build-cache/$PRNUM ..."
-  aws s3 --only-show-errors cp s3://quasar-build-cache/$PRNUM/$TARGETS $TARGETS --recursive
-  aws s3 --only-show-errors cp s3://quasar-build-cache/$PRNUM/$HOARDER $HOARDER --recursive
+  echo "downloading $TARGETS and $HOARDER from s3://quasar-build-cache/$NUM ..."
+  aws s3 --only-show-errors cp s3://quasar-build-cache/$NUM/$TARGETS $TARGETS --recursive
+  aws s3 --only-show-errors cp s3://quasar-build-cache/$NUM/$HOARDER $HOARDER --recursive
   echo "done downloading!"
 elif [[ "$1" = "cleanup" ]]; then
-  echo "cleaning up s3://quasar-build-cache/$PRNUM ..."
-  aws s3 --only-show-errors rm s3://quasar-build-cache/$PRNUM --recursive
+  echo "cleaning up s3://quasar-build-cache/$NUM ..."
+  aws s3 --only-show-errors rm s3://quasar-build-cache/$NUM --recursive
   echo "done cleaning up!"
+elif [[ "$1" = "cacheCleanUp" ]]; then
+  LIST=$(aws s3 ls s3://quasar-build-cache --profile slamdata-bot |  awk '{print $2}' | cut -d"/" -f1)
+  OLDBUILDNUM=$((NUM + 50))
+  echo "cleaning up old s3 caches"
+  while read -r buildNum;
+  do
+    if (( $buildNum >= $OLDBUILDNUM ));
+    then
+      echo "cleaning up cache s3://quasar-build-cache/$buildNum ..."
+      aws s3 --only-show-errors rm s3://quasar-build-cache/$OLDBUILDNUM --recursive
+    fi
+  done <<< "$LIST"
+  echo "done cleaning up $buildNum"
 else
   echo "Usage: ./scripts/s3Cache upload | download | cleanup"
 fi


### PR DESCRIPTION
Use travis build numbers as the directory names in s3 bucket.
Use cleanup stage during master build to delete really old caches lingering in s3 bucket.