### PR TITLE
Remove unmanaged jar path for jdbm snapshot

### DIFF
--- a/project/Precog.scala
+++ b/project/Precog.scala
@@ -70,8 +70,6 @@ object Build {
       serialTests scalacPlugins (kindProjector) scalacArgs (defaultArgSet: _*) also(
         organization := "org.quasar-analytics",
         scalaVersion := "2.12.4",
-        logBuffered in Test := false,
-        // fork in Test := true,
-        unmanagedJars in Compile += (baseDirectory in ThisBuild).value / "lib" / "jdbm-3.0-SNAPSHOT.jar"))
+        logBuffered in Test := false))
   }
 }


### PR DESCRIPTION
We were never actually putting the jar at that path; instead we manage the jar:
```
"org.apache.jdbm" %  "jdbm" % "3.0-alpha5"
```