### PR TITLE
FederatingQueryEvaluator

### DIFF
--- a/api/src/main/scala/quasar/api/ResourceDiscovery.scala
+++ b/api/src/main/scala/quasar/api/ResourceDiscovery.scala
@@ -16,7 +16,7 @@
 
 package quasar.api
 
-import slamdata.Predef.Boolean
+import slamdata.Predef.{Boolean, Stream}
 import quasar.api.ResourceError.CommonError
 
 import scalaz.{\/, IMap, Tree}
@@ -32,7 +32,7 @@ trait ResourceDiscovery[F[_]] {
   /** Returns the descendants of the specified resource path or an error if it
     * does not exist.
     */
-  def descendants(path: ResourcePath): F[CommonError \/ Tree[(ResourceName, ResourcePathType)]]
+  def descendants(path: ResourcePath): F[CommonError \/ Stream[Tree[ResourceName]]]
 
   /** Returns whether the specified resource path refers to a resource. */
   def isResource(path: ResourcePath): F[Boolean]

--- a/api/src/main/scala/quasar/api/ResourcePath.scala
+++ b/api/src/main/scala/quasar/api/ResourcePath.scala
@@ -16,14 +16,13 @@
 
 package quasar.api
 
-import slamdata.Predef.{Product, Serializable, Unit}
-import quasar.contrib.pathy.{AFile, APath}
+import slamdata.Predef._
+import quasar.contrib.pathy.{firstSegmentName, rebaseA, stripPrefixA, AFile, APath}
 import quasar.fp.ski.{ι, κ}
 
 import monocle.Prism
 import pathy.Path._
-import scalaz.{Cord, Order, Show}
-import scalaz.syntax.show._
+import scalaz.{Order, Show}
 
 /** Identifies a resource in a datasource. */
 sealed trait ResourcePath extends Product with Serializable {
@@ -44,8 +43,20 @@ sealed trait ResourcePath extends Product with Serializable {
         ResourcePath.leaf(rootDir </> file(name.value))
     }
 
+  def /: (name: ResourceName): ResourcePath =
+    this match {
+      case ResourcePath.Leaf(f) =>
+        ResourcePath.leaf(rebaseA(rootDir </> dir(name.value))(f))
+
+      case ResourcePath.Root =>
+        ResourcePath.leaf(rootDir </> file(name.value))
+    }
+
   def toPath: APath =
     fold(ι, rootDir)
+
+  def uncons: Option[(ResourceName, ResourcePath)] =
+    ResourcePath.leaf.getOption(this) map (ResourcePath.unconsLeaf)
 }
 
 object ResourcePath extends ResourcePathInstances {
@@ -67,6 +78,20 @@ object ResourcePath extends ResourcePathInstances {
       case (parent, name) =>
         leaf(parent </> file1(name.valueOr(d => FileName(d.value))))
     }
+
+  def unconsLeaf(file: AFile): (ResourceName, ResourcePath) = {
+    val (n, p) = firstSegmentName(fileParent(file)) match {
+      case None =>
+        (fileName(file).value, ResourcePath.root())
+
+      case Some(seg) =>
+        val str = seg.fold(_.value, _.value)
+        val fileAsDir = fileParent(file) </> dir(fileName(file).value)
+        (str, ResourcePath.fromPath(stripPrefixA(rootDir </> dir(str))(fileAsDir)))
+    }
+
+    (ResourceName(n), p)
+  }
 }
 
 sealed abstract class ResourcePathInstances {
@@ -74,7 +99,7 @@ sealed abstract class ResourcePathInstances {
     Order.orderBy(_.toPath)
 
   implicit val show: Show[ResourcePath] =
-    Show.show { rp =>
-      Cord("ResourcePath(") ++ rp.toPath.show ++ Cord(")")
+    Show.shows { rp =>
+      s"ResourcePath(${posixCodec.printPath(rp.toPath)})"
     }
 }

--- a/api/src/main/scala/quasar/api/ResourcePath.scala
+++ b/api/src/main/scala/quasar/api/ResourcePath.scala
@@ -32,7 +32,7 @@ sealed trait ResourcePath extends Product with Serializable {
       case ResourcePath.Root    => root
     }
 
-  def / (name: ResourceName): ResourcePath =
+  def /(name: ResourceName): ResourcePath =
     this match {
       case ResourcePath.Leaf(f) =>
         val d = fileParent(f)
@@ -43,7 +43,7 @@ sealed trait ResourcePath extends Product with Serializable {
         ResourcePath.leaf(rootDir </> file(name.value))
     }
 
-  def /: (name: ResourceName): ResourcePath =
+  def /:(name: ResourceName): ResourcePath =
     this match {
       case ResourcePath.Leaf(f) =>
         ResourcePath.leaf(rebaseA(rootDir </> dir(name.value))(f))
@@ -56,7 +56,7 @@ sealed trait ResourcePath extends Product with Serializable {
     fold(ι, rootDir)
 
   def uncons: Option[(ResourceName, ResourcePath)] =
-    ResourcePath.leaf.getOption(this) map (ResourcePath.unconsLeaf)
+    ResourcePath.leaf.getOption(this).map(ResourcePath.unconsLeaf)
 }
 
 object ResourcePath extends ResourcePathInstances {

--- a/api/src/test/scala/quasar/api/MockQueryEvaluator.scala
+++ b/api/src/test/scala/quasar/api/MockQueryEvaluator.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api
+
+import slamdata.Predef.{tailrec, Boolean, None, Option, Some, Unit}
+import quasar.api.ResourceError._
+import quasar.fp.ski.κ
+
+import scalaz.{\/, Applicative, IMap, Order, Tree}
+import scalaz.std.stream._
+import scalaz.syntax.applicative._
+import scalaz.syntax.either._
+import scalaz.syntax.equal._
+import scalaz.syntax.std.option._
+
+final class MockQueryEvaluator[F[_]: Applicative, Q, R] private (
+    resources: Tree[ResourceName],
+    eval: Q => F[ReadError \/ R])
+  extends QueryEvaluator[F, Q, R] {
+
+  def children(path: ResourcePath): F[CommonError \/ IMap[ResourceName, ResourcePathType]] = {
+    val progeny = subtreeAt(path) map { t =>
+      IMap.fromFoldable(t.subForest map { k =>
+        val typ =
+          if (k.subForest.isEmpty) ResourcePathType.resource
+          else ResourcePathType.resourcePrefix
+
+        (k.rootLabel, typ)
+      })
+    }
+
+    (progeny \/> (PathNotFound(path) : CommonError)).point[F]
+  }
+
+  def descendants(path: ResourcePath): F[CommonError \/ Tree[ResourceName]] =
+    (subtreeAt(path) \/> (PathNotFound(path) : CommonError)).point[F]
+
+  def isResource(path: ResourcePath): F[Boolean] =
+    subtreeAt(path).exists(_.subForest.isEmpty).point[F]
+
+  def evaluate(query: Q): F[ReadError \/ R] =
+    eval(query)
+
+  ////
+
+  private def subtreeAt(path: ResourcePath): Option[Tree[ResourceName]] = {
+    @tailrec
+    def go(p: ResourcePath, t: Tree[ResourceName]): Option[Tree[ResourceName]] =
+      path.uncons match {
+        case Some((n, p1)) =>
+          t.subForest.find(_.rootLabel === n) match {
+            case Some(t0) => go(p1, t0)
+            case None => None
+          }
+
+        case None => Some(t)
+      }
+
+    go(path, resources)
+  }
+}
+
+object MockQueryEvaluator {
+  def apply[F[_]: Applicative, Q, R](
+      resources: Tree[ResourceName],
+      eval: Q => F[ReadError \/ R])
+      : QueryEvaluator[F, Q, R] =
+    new MockQueryEvaluator(resources, eval)
+
+  def fromResponseIMap[F[_]: Applicative, Q: Order, R](
+      resources: Tree[ResourceName],
+      responses: IMap[Q, R])
+      : QueryEvaluator[F, Q, R] =
+    apply(resources, q => (responses.lookup(q) \/> rootNotFound).point[F])
+
+  def resourceDiscovery[F[_]: Applicative](
+      resources: Tree[ResourceName])
+      : ResourceDiscovery[F] =
+    apply(resources, κ(rootNotFound.left[Unit].point[F]))
+
+  ////
+
+  private val rootNotFound: ReadError =
+    PathNotFound(ResourcePath.root())
+}

--- a/api/src/test/scala/quasar/api/ResourceNameGenerator.scala
+++ b/api/src/test/scala/quasar/api/ResourceNameGenerator.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api
+
+import quasar.pkg.tests._
+
+trait ResourceNameGenerator {
+  implicit val resourceNameArbitrary: Arbitrary[ResourceName] =
+    Arbitrary(genString map (ResourceName(_)))
+}
+
+object ResourceNameGenerator extends ResourceNameGenerator

--- a/api/src/test/scala/quasar/api/ResourcePathGenerator.scala
+++ b/api/src/test/scala/quasar/api/ResourcePathGenerator.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api
+
+import quasar.contrib.pathy.AFile
+import quasar.pkg.tests._
+
+import pathy.scalacheck.PathyArbitrary._
+
+trait ResourcePathGenerator {
+  implicit val resourcePathArbitrary: Arbitrary[ResourcePath] =
+    Arbitrary(for {
+      n <- choose(1, 10)
+      p <- if (n > 2) arbitrary[AFile].map(ResourcePath.leaf(_))
+           else const(ResourcePath.root())
+    } yield p)
+}
+
+object ResourcePathGenerator extends ResourcePathGenerator

--- a/api/src/test/scala/quasar/api/ResourcePathSpec.scala
+++ b/api/src/test/scala/quasar/api/ResourcePathSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api
+
+import slamdata.Predef.Some
+
+import pathy.Path._
+import scalaz.std.option._
+import scalaz.std.tuple._
+
+final class ResourcePathSpec extends quasar.Qspec {
+  import ResourceNameGenerator._
+
+  "append name" >> prop { (x: ResourceName, y: ResourceName) =>
+    val f = rootDir </> dir(x.value) </> file(y.value)
+    (ResourcePath.root() / x / y) must_= ResourcePath.leaf(f)
+  }
+
+  "prepend name" >> prop { (x: ResourceName, y: ResourceName) =>
+    val f = rootDir </> dir(x.value) </> file(y.value)
+    (x /: y /: ResourcePath.root()) must_= ResourcePath.leaf(f)
+  }
+
+  "uncons" >> prop { (x: ResourceName, y: ResourceName) =>
+    val p = ResourcePath.root() / x / y
+    p.uncons must_= Some((x, ResourcePath.root() / y))
+  }
+
+  "uncons root" >> {
+    ResourcePath.root().uncons must beNone
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -424,6 +424,7 @@ lazy val core = project
   .dependsOn(
     connector % BothScopes,
     sql,
+    api       % "test->test",
     effect    % "test->test",
     fs        % "test->test")
   .settings(commonSettings)

--- a/core/src/main/scala/quasar/FederatedQuery.scala
+++ b/core/src/main/scala/quasar/FederatedQuery.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar
+
+import slamdata.Predef.Option
+import quasar.contrib.pathy.AFile
+import quasar.qscript.QScriptRead
+
+import monocle.macros.Lenses
+import scalaz.{Functor, Show}
+
+/** A QScript query over possibly many sources.
+  *
+  * NB: This encoding exists due to the cost incurred when extending
+  *     `QScriptTotal`, both in compilation time and boilerplate.
+  *
+  *     If we're ever able to get rid of `QScriptTotal`, we could just use
+  *     a variant of QScript containing `Const[Read[Source[S]], ?]` instead.
+  */
+@Lenses
+final case class FederatedQuery[T[_[_]], S](
+    query: T[QScriptRead[T, ?]],
+    sources: AFile => Option[Source[S]])
+
+object FederatedQuery extends FederatedQueryInstances
+
+sealed abstract class FederatedQueryInstances {
+  implicit def functor[T[_[_]]]: Functor[FederatedQuery[T, ?]] =
+    new Functor[FederatedQuery[T, ?]] {
+      def map[A, B](fa: FederatedQuery[T, A])(f: A => B) =
+        FederatedQuery(fa.query, p => fa.sources(p).map(_.map(f)))
+    }
+
+  implicit def show[T[_[_]], A]: Show[FederatedQuery[T, A]] =
+    Show.shows(_ => "FederatedQuery")
+}

--- a/core/src/main/scala/quasar/FederatingQueryEvaluator.scala
+++ b/core/src/main/scala/quasar/FederatingQueryEvaluator.scala
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar
+
+import slamdata.Predef.{List, Option}
+import quasar.api._, ResourceError._
+import quasar.contrib.pathy._
+import quasar.qscript._
+
+import matryoshka._
+import matryoshka.implicits._
+import scalaz.{Const, EitherT, IMap, Inject, Monad, OptionT, Tree}
+import scalaz.Scalaz._
+
+/** A `QueryEvaluator` capable of executing queries against multiple sources. */
+final class FederatingQueryEvaluator[T[_[_]]: BirecursiveT, F[_]: Monad, S, R] private (
+    queryFederation: QueryFederation[T, F, S, R],
+    sources: F[IMap[ResourceName, (ResourceDiscovery[F], S)]])
+    extends QueryEvaluator[F, T[QScriptRead[T, ?]], R] {
+
+  def children(path: ResourcePath) =
+    path match {
+      case ResourcePath.Root =>
+        for {
+          rds <- discoveries
+
+          pairs <- rds.traverse { case (n, rd) =>
+            rd.isResource(ResourcePath.root()) map { b =>
+              (n, b.fold(ResourcePathType.resource, ResourcePathType.resourcePrefix))
+            }
+          }
+        } yield IMap.fromFoldable(pairs).right[CommonError]
+
+      case ResourcePath.Leaf(f) =>
+        (for {
+          x <- lookupLeaf[CommonError](f)
+
+          (p, d, s) = x
+
+          r <- EitherT(d.children(p)) leftMap prefixCommonError(s.name)
+        } yield r).run
+    }
+
+  def descendants(path: ResourcePath) =
+    (path match {
+      case ResourcePath.Root =>
+        for {
+          rds <- discoveries.liftM[EitherT[?[_], CommonError, ?]]
+
+          subTrees <- rds.traverse {
+            case (n, rd) =>
+              EitherT(rd.descendants(ResourcePath.root())) map (Tree.Node(n, _))
+          }
+        } yield subTrees.toStream
+
+      case ResourcePath.Leaf(f) =>
+        for {
+          x <- lookupLeaf[CommonError](f)
+
+          (p, d, s) = x
+
+          r <- EitherT(d.descendants(p)) leftMap prefixCommonError(s.name)
+        } yield r
+    }).run
+
+  def isResource(path: ResourcePath) =
+    path match {
+      case ResourcePath.Root =>
+        false.point[F]
+
+      case ResourcePath.Leaf(f) =>
+        lookupLeaf[CommonError](f) flatMap {
+          case (p, d, _) => EitherT.rightT(d.isResource(p))
+        } getOrElse false
+    }
+
+  def evaluate(q: T[QScriptRead[T, ?]]) = {
+    type G[A] = EitherT[F, ReadError, A]
+
+    val qsFederated = q.transCataM[G, T[QScriptFederated[T, S, ?]], QScriptFederated[T, S, ?]] {
+      case ReadPath(p) =>
+        val rp = ResourcePath.fromPath(p)
+
+        for {
+          f <- EitherT.fromDisjunction[F] {
+            ResourcePath.leaf.getOption(rp) \/> notAResource[ReadError](ResourcePath.root())
+          }
+
+          l <- lookupLeaf[ReadError](f)
+
+          (rp, _, s) = l
+
+        } yield QScriptFederated.RD(rp, s)
+
+      case RQC(qc) =>
+        QScriptFederated.QC(qc).point[G]
+
+      case RTJ(tj) =>
+        QScriptFederated.TJ(tj).point[G]
+    }
+
+    qsFederated.flatMapF(queryFederation.evaluateFederated).run
+  }
+
+  ////
+
+  private object ReadPath {
+    val RD = Inject[Const[Read[ADir], ?], QScriptRead[T, ?]]
+    val RF = Inject[Const[Read[AFile], ?], QScriptRead[T, ?]]
+
+    def unapply[A](qr: QScriptRead[T, A]): Option[APath] =
+      RD.prj(qr).map(_.getConst.path) orElse RF.prj(qr).map(_.getConst.path)
+  }
+
+  private object RQC {
+    def unapply[A](qr: QScriptRead[T, A]): Option[QScriptCore[T, A]] =
+      Inject[QScriptCore[T, ?], QScriptRead[T, ?]].prj(qr)
+  }
+
+  private object RTJ {
+    def unapply[A](qr: QScriptRead[T, A]): Option[ThetaJoin[T, A]] =
+      Inject[ThetaJoin[T, ?], QScriptRead[T, ?]].prj(qr)
+  }
+
+  private def discoveries: F[List[(ResourceName, ResourceDiscovery[F])]] =
+    sources.map(_.map(_._1).toAscList)
+
+  private def lookupLeaf[E >: CommonError](file: AFile)
+      : EitherT[F, E, (ResourcePath, ResourceDiscovery[F], Source[S])] = {
+
+    val (n, p) = ResourcePath.unconsLeaf(file)
+
+    OptionT(sources map (_ lookup n))
+      .map({ case (rd, s) => (p, rd, Source(n, s)) })
+      .toRight(pathNotFound[E](ResourcePath.leaf(file)))
+  }
+
+  private def prefixCommonError(pfx: ResourceName): CommonError => CommonError = {
+    case PathNotFound(p) => PathNotFound(pfx /: p)
+  }
+}
+
+object FederatingQueryEvaluator {
+  def apply[T[_[_]]: BirecursiveT, F[_]: Monad, S, R](
+    queryFederation: QueryFederation[T, F, S, R],
+    sources: F[IMap[ResourceName, (ResourceDiscovery[F], S)]])
+    : QueryEvaluator[F, T[QScriptRead[T, ?]], R] =
+  new FederatingQueryEvaluator(queryFederation, sources)
+}

--- a/core/src/main/scala/quasar/QueryFederation.scala
+++ b/core/src/main/scala/quasar/QueryFederation.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar
+
+/** Represents the ability to evaluate QScript over potentially many sources. */
+trait QueryFederation[T[_[_]], F[_], S, R] {
+  def evaluateFederated(q: T[QScriptFederated[T, F, S, R, ?]]): F[R]
+}

--- a/core/src/main/scala/quasar/QueryFederation.scala
+++ b/core/src/main/scala/quasar/QueryFederation.scala
@@ -16,7 +16,11 @@
 
 package quasar
 
+import quasar.api.ResourceError.ReadError
+
+import scalaz.\/
+
 /** Represents the ability to evaluate QScript over potentially many sources. */
 trait QueryFederation[T[_[_]], F[_], S, R] {
-  def evaluateFederated(q: T[QScriptFederated[T, F, S, R, ?]]): F[R]
+  def evaluateFederated(q: T[QScriptFederated[T, S, ?]]): F[ReadError \/ R]
 }

--- a/core/src/main/scala/quasar/QueryFederation.scala
+++ b/core/src/main/scala/quasar/QueryFederation.scala
@@ -22,5 +22,5 @@ import scalaz.\/
 
 /** Represents the ability to evaluate QScript over potentially many sources. */
 trait QueryFederation[T[_[_]], F[_], S, R] {
-  def evaluateFederated(q: T[QScriptFederated[T, S, ?]]): F[ReadError \/ R]
+  def evaluateFederated(q: FederatedQuery[T, S]): F[ReadError \/ R]
 }

--- a/core/src/main/scala/quasar/Source.scala
+++ b/core/src/main/scala/quasar/Source.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar
+
+import quasar.api.ResourceName
+
+final case class Source[F[_], A, B](name: ResourceName, f: A => F[B])

--- a/core/src/main/scala/quasar/Source.scala
+++ b/core/src/main/scala/quasar/Source.scala
@@ -18,4 +18,4 @@ package quasar
 
 import quasar.api.ResourceName
 
-final case class Source[F[_], A, B](name: ResourceName, f: A => F[B])
+final case class Source[A](name: ResourceName, src: A)

--- a/core/src/main/scala/quasar/package.scala
+++ b/core/src/main/scala/quasar/package.scala
@@ -15,7 +15,6 @@
  */
 
 import slamdata.Predef._
-import quasar.api._
 import quasar.common.{PhaseResult, PhaseResultW}
 import quasar.contrib.pathy._
 import quasar.contrib.scalaz.eitherT._
@@ -28,7 +27,6 @@ import quasar.fs.{CompileM, FileSystemError, FileSystemErrT}
 import quasar.fs.FileSystemError._
 import quasar.fs.PathError._
 import quasar.fs.mount.Mounting
-import quasar.qscript.{QScriptCore, Read => QRead, ThetaJoin}
 import quasar.sql._
 import quasar.std.StdLib.set._
 
@@ -40,37 +38,6 @@ import scalaz._, Scalaz._
 package object quasar {
 
   type QuasarErrT[M[_], A] = EitherT[M, QuasarError, A]
-
-  type QScriptFederated[T[_[_]], S, A] =
-    (QScriptCore[T, ?] :\: ThetaJoin[T, ?] :/: Const[QRead[(ResourcePath, Source[S])], ?])#M[A]
-
-  object QScriptFederated {
-    object QC {
-      def apply[T[_[_]], S, A](qc: QScriptCore[T, A]): QScriptFederated[T, S, A] =
-        Inject[QScriptCore[T, ?], QScriptFederated[T, S, ?]].inj(qc)
-
-      def unapply[T[_[_]], S, A](qf: QScriptFederated[T, S, A]): Option[QScriptCore[T, A]] =
-        Inject[QScriptCore[T, ?], QScriptFederated[T, S, ?]].prj(qf)
-    }
-
-    object TJ {
-      def apply[T[_[_]], S, A](tj: ThetaJoin[T, A]): QScriptFederated[T, S, A] =
-        Inject[ThetaJoin[T, ?], QScriptFederated[T, S, ?]].inj(tj)
-
-      def unapply[T[_[_]], S, A](qf: QScriptFederated[T, S, A]): Option[ThetaJoin[T, A]] =
-        Inject[ThetaJoin[T, ?], QScriptFederated[T, S, ?]].prj(qf)
-    }
-
-    object RD {
-      def apply[T[_[_]], S, A](p: ResourcePath, s: Source[S]): QScriptFederated[T, S, A] =
-        Inject[Const[QRead[(ResourcePath, Source[S])], ?], QScriptFederated[T, S, ?]]
-          .inj(Const(QRead((p, s))))
-
-      def unapply[T[_[_]], S, A](qf: QScriptFederated[T, S, A]): Option[(ResourcePath, Source[S])] =
-        Inject[Const[QRead[(ResourcePath, Source[S])], ?], QScriptFederated[T, S, ?]]
-          .prj(qf).map(_.getConst.path)
-    }
-  }
 
   private def phase[A: RenderTree](label: String, r: SemanticErrors \/ A):
       CompileM[A] =

--- a/core/src/main/scala/quasar/package.scala
+++ b/core/src/main/scala/quasar/package.scala
@@ -40,6 +40,9 @@ package object quasar {
 
   type QuasarErrT[M[_], A] = EitherT[M, QuasarError, A]
 
+  type QScriptFederated[T[_[_]], F[_], S, R, A] =
+    (QScriptCore[T, ?] :\: ThetaJoin[T, ?] :/: Const[Read[(ResourcePath, Source[F, S, R])], ?])#M[A]
+
   private def phase[A: RenderTree](label: String, r: SemanticErrors \/ A):
       CompileM[A] =
     EitherT(r.point[PhaseResultW]) flatMap { a =>

--- a/core/src/test/scala/quasar/FederatingQueryEvaluatorSpec.scala
+++ b/core/src/test/scala/quasar/FederatingQueryEvaluatorSpec.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar
+
+import slamdata.Predef._
+import quasar.api._, ResourceError._
+
+import matryoshka.data.Fix
+import scalaz.{Id, IMap, Show, Tree}, Id.Id
+import scalaz.std.stream._
+import scalaz.syntax.applicative._
+import scalaz.syntax.either._
+
+final class FederatingQueryEvaluatorSpec extends quasar.Qspec {
+
+  implicit val showTree: Show[Tree[ResourceName]] =
+    Show.shows(_.drawTree)
+
+  val abForest =
+    Stream(
+      Tree.Node(ResourceName("b"), Stream(
+        Tree.Leaf(ResourceName("a")))),
+      Tree.Leaf(ResourceName("a")))
+
+  val xyForest =
+    Stream(
+      Tree.Node(ResourceName("x"), Stream(
+        Tree.Leaf(ResourceName("y")))),
+      Tree.Node(ResourceName("y"), Stream(
+        Tree.Leaf(ResourceName("y")))))
+
+  val abs = MockQueryEvaluator.resourceDiscovery[Id](abForest)
+
+  val xys = MockQueryEvaluator.resourceDiscovery[Id](xyForest)
+
+  val qfed = new QueryFederation[Fix, Id, Int, Fix[QScriptFederated[Fix, Int, ?]]] {
+    def evaluateFederated(q: Fix[QScriptFederated[Fix, Int, ?]]) = q.right[ReadError]
+  }
+
+  val fqe =
+    FederatingQueryEvaluator(qfed, IMap(
+      ResourceName("abs") -> ((abs, 1)),
+      ResourceName("xys") -> ((xys, 2))).point[Id])
+
+  "children" >> {
+    "returns possible keys for root" >> {
+      val progeny =
+        IMap(
+          ResourceName("abs") -> ResourcePathType.resourcePrefix,
+          ResourceName("xys") -> ResourcePathType.resourcePrefix)
+
+      fqe.children(ResourcePath.root()) must_= progeny.right
+    }
+
+    "returns PNF when no source" >> {
+      val dne = ResourcePath.root() / ResourceName("foo") / ResourceName("bar")
+
+      fqe.children(dne) must_= pathNotFound(dne).left
+    }
+
+    "returns correctly prefixed PNF from source" >> {
+      val abx = ResourcePath.root() / ResourceName("abs") / ResourceName("a") / ResourceName("x")
+
+      fqe.children(abx) must_= pathNotFound(abx).left
+    }
+
+    "returns results" >> {
+      val xx = ResourcePath.root() / ResourceName("xys") / ResourceName("x")
+
+      val expect = IMap(ResourceName("y") -> ResourcePathType.resource)
+
+      fqe.children(xx) must_= expect.right
+    }
+  }
+
+  "descendants" >> {
+    "returns from all sources for root" >> {
+      val expect = Stream(
+        Tree.Node(ResourceName("abs"), abForest),
+        Tree.Node(ResourceName("xys"), xyForest))
+
+      fqe.descendants(ResourcePath.root()) must_= expect.right
+    }
+
+    "returns PNF when no source" >> {
+      val dne = ResourcePath.root() / ResourceName("foo") / ResourceName("bar")
+
+      fqe.descendants(dne) must_= pathNotFound(dne).left
+    }
+
+    "returns correctly prefixed PNF from source" >> {
+      val yz = ResourcePath.root() / ResourceName("xys") / ResourceName("y") / ResourceName("z")
+
+      fqe.descendants(yz) must_= pathNotFound(yz).left
+    }
+
+    "returns results" >> {
+      fqe.descendants(ResourcePath.root() / ResourceName("abs")) must_= abForest.right
+    }
+  }
+
+  "isResource" >> {
+    "returns false for root" >> {
+      fqe.isResource(ResourcePath.root()) must beFalse
+    }
+
+    "returns false when no source" >> {
+      val noSource = ResourcePath.root() / ResourceName("baz") / ResourceName("bar")
+
+      fqe.isResource(noSource) must beFalse
+    }
+
+    "returns false when not a resource" >> {
+      val prefix = ResourcePath.root() / ResourceName("xys") / ResourceName("x")
+
+      fqe.isResource(prefix) must beFalse
+    }
+
+    "returns true when a resource" >> {
+      val resource = ResourcePath.root() / ResourceName("abs") / ResourceName("a")
+
+      fqe.isResource(resource) must beTrue
+    }
+  }
+
+  "evaluate" >> {
+    "returns PNF when no source" >> todo
+
+    "returns PNF when no source in branch" >> todo
+
+    "builds federated qscript when all sources found" >> todo
+  }
+}


### PR DESCRIPTION
Adds a `QueryEvaluator` capable of executing queries over multiple sources. Handles the routing of operations to sources and ensuring all sources referenced in a query exist.

The actual work of executing a `FederatedQuery` is left up to an instance of `QueryFederation`, to eventually be implemented for `mimir`.