### PR TITLE
Default DataSources implementation

### DIFF
--- a/api/src/main/scala/quasar/api/DataSourceMetadata.scala
+++ b/api/src/main/scala/quasar/api/DataSourceMetadata.scala
@@ -16,7 +16,7 @@
 
 package quasar.api
 
-import slamdata.Predef.Exception
+import slamdata.Predef.{Exception, Option}
 import quasar.Condition
 
 import monocle.macros.Lenses
@@ -26,9 +26,12 @@ import scalaz.syntax.show._
 @Lenses
 final case class DataSourceMetadata(
     kind: DataSourceType,
-    condition: Condition[Exception])
+    status: Condition[Exception])
 
-object DataSourceMetadata extends DataSourceMetadataInstances
+object DataSourceMetadata extends DataSourceMetadataInstances {
+  def fromOption(kind: DataSourceType, optErr: Option[Exception]): DataSourceMetadata =
+    DataSourceMetadata(kind, Condition.optionIso.reverseGet(optErr))
+}
 
 sealed abstract class DataSourceMetadataInstances {
   implicit val show: Show[DataSourceMetadata] = {

--- a/api/src/test/scala/quasar/api/DataSourcesSpec.scala
+++ b/api/src/test/scala/quasar/api/DataSourcesSpec.scala
@@ -1,0 +1,323 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api
+
+import slamdata.Predef.{None, Some, String}
+import quasar.{Condition, ConditionMatchers, Qspec}
+
+import scala.Predef.assert
+
+import eu.timepit.refined.auto._
+import org.specs2.execute.AsResult
+import org.specs2.matcher.Matcher
+import org.specs2.specification.core.Fragment
+import scalaz.{\/, \/-, ~>, Equal, Id, Monad, Show}, Id.Id
+import scalaz.syntax.equal._
+import scalaz.syntax.monad._
+
+abstract class DataSourcesSpec[F[_]: Monad, C: Equal: Show]
+    extends Qspec
+    with ConditionMatchers {
+
+  import DataSourceError._
+
+  def datasources: DataSources[F, C]
+
+  def supportedType: DataSourceType
+
+  // Must be distinct.
+  def validConfigs: (C, C)
+
+  def run: F ~> Id
+
+  assert(configA =/= configB, "validConfigs must be distinct!")
+
+  "add" >> {
+    "lookup on success" >>* {
+      for {
+        cond <- datasources.add(
+          foo,
+          supportedType,
+          configA,
+          ConflictResolution.Preserve)
+
+        r <- datasources.lookup(foo)
+      } yield {
+        cond must beNormal
+        r must beConfigured(configA)
+      }
+    }
+
+    "metadata on success" >>* {
+      for {
+        cond <- datasources.add(
+          foo,
+          supportedType,
+          configA,
+          ConflictResolution.Preserve)
+
+        m <- datasources.metadata
+      } yield {
+        cond must beNormal
+
+        m.lookup(foo) must beLike {
+          case Some(DataSourceMetadata(t, None)) =>
+            t must_= supportedType
+        }
+      }
+    }
+
+    "replace existing" >>* {
+      for {
+        afoo <- datasources.add(
+          foo,
+          supportedType,
+          configA,
+          ConflictResolution.Preserve)
+
+        a <- datasources.lookup(foo)
+
+        bfoo <- datasources.add(
+          foo,
+          supportedType,
+          configB,
+          ConflictResolution.Replace)
+
+        b <- datasources.lookup(foo)
+      } yield {
+        a must beConfigured(configA)
+        b must beConfigured(configB)
+      }
+    }
+
+    "preserve existing" >>* {
+      for {
+        afoo <- datasources.add(
+          foo,
+          supportedType,
+          configA,
+          ConflictResolution.Preserve)
+
+        a <- datasources.lookup(foo)
+
+        bfoo <- datasources.add(
+          foo,
+          supportedType,
+          configB,
+          ConflictResolution.Preserve)
+
+        b <- datasources.lookup(foo)
+      } yield {
+        a must beConfigured(configA)
+        bfoo must beAbnormal(equal[Err](DataSourceExists(foo)))
+        b must beConfigured(configA)
+      }
+    }
+
+    "unsupported" >>* {
+      val unsup = DataSourceType("--unsupported--", 17L)
+
+      for {
+        ubar <- datasources.add(
+          bar,
+          unsup,
+          configB,
+          ConflictResolution.Replace)
+
+        types <- datasources.supported
+      } yield {
+        ubar must beAbnormal(equal[Err](DataSourceUnsupported(unsup, types)))
+      }
+    }
+  }
+
+  "lookup" >> {
+    "error when not found" >>* {
+      datasources.lookup(nope).map(_ must beNotFound(nope))
+    }
+  }
+
+  "remove" >> {
+    "error when not found" >>* {
+      datasources.remove(nope)
+        .map(_ must beAbnormal(equal[Err](DataSourceNotFound(nope))))
+    }
+
+    "lookup fails on success" >>* {
+      for {
+        afoo <- datasources.add(
+          foo,
+          supportedType,
+          configA,
+          ConflictResolution.Preserve)
+
+        rfoo <- datasources.remove(foo)
+
+        a <- datasources.lookup(foo)
+      } yield {
+        afoo must beNormal
+        rfoo must beNormal
+        a must beNotFound(foo)
+      }
+    }
+
+    "not in metadata on success" >>* {
+      for {
+        afoo <- datasources.add(
+          foo,
+          supportedType,
+          configA,
+          ConflictResolution.Preserve)
+
+        rfoo <- datasources.remove(foo)
+
+        meta <- datasources.metadata
+      } yield {
+        afoo must beNormal
+        rfoo must beNormal
+        meta.member(foo) must beFalse
+      }
+    }
+  }
+
+  "rename" >> {
+    "source nonexistent" >>* {
+      datasources.rename(foo, bar, ConflictResolution.Preserve)
+        .map(_ must beAbnormal(equal[Err](DataSourceNotFound(foo))))
+    }
+
+    "destination nonexistent" >>* {
+      for {
+        afoo <- datasources.add(
+          foo,
+          supportedType,
+          configA,
+          ConflictResolution.Preserve)
+
+        rn <- datasources.rename(foo, bar, ConflictResolution.Preserve)
+
+        x <- datasources.lookup(foo)
+        y <- datasources.lookup(bar)
+      } yield {
+        afoo must beNormal
+        rn must beNormal
+        x must beNotFound(foo)
+        y must beConfigured(configA)
+      }
+    }
+
+    "replace existing destination" >>* {
+      for {
+        afoo <- datasources.add(
+          foo,
+          supportedType,
+          configA,
+          ConflictResolution.Preserve)
+
+        bbar <- datasources.add(
+          bar,
+          supportedType,
+          configB,
+          ConflictResolution.Preserve)
+
+        rn <- datasources.rename(foo, bar, ConflictResolution.Replace)
+
+        a <- datasources.lookup(bar)
+      } yield {
+        afoo must beNormal
+        bbar must beNormal
+        rn must beNormal
+        a must beConfigured(configA)
+      }
+    }
+
+    "preserve existing destination" >>* {
+      for {
+        afoo <- datasources.add(
+          foo,
+          supportedType,
+          configA,
+          ConflictResolution.Preserve)
+
+        bbar <- datasources.add(
+          bar,
+          supportedType,
+          configB,
+          ConflictResolution.Preserve)
+
+        rn <- datasources.rename(foo, bar, ConflictResolution.Preserve)
+
+        b <- datasources.lookup(bar)
+      } yield {
+        afoo must beNormal
+        bbar must beNormal
+        rn must beAbnormal(equal[Err](DataSourceExists(bar)))
+        b must beConfigured(configB)
+      }
+    }
+
+    "metadata reflects change" >>* {
+      for {
+        afoo <- datasources.add(
+          foo,
+          supportedType,
+          configA,
+          ConflictResolution.Preserve)
+
+        rn <- datasources.rename(foo, bar, ConflictResolution.Preserve)
+
+        meta <- datasources.metadata
+      } yield {
+        afoo must beNormal
+        rn must beNormal
+        meta.member(foo) must beFalse
+        meta.member(bar) must beTrue
+      }
+    }
+  }
+
+  ////
+
+  implicit class RunExample(s: String) {
+    def >>*[A: AsResult](fa: => F[A]): Fragment =
+      s >> run(fa)
+  }
+
+  type Err = DataSourceError[C]
+
+  val foo = ResourceName("foo")
+  val bar = ResourceName("bar")
+  val nope = ResourceName("nope")
+
+  def configA: C =
+    validConfigs._1
+
+  def configB: C =
+    validConfigs._2
+
+  def nominalMeta: DataSourceMetadata =
+    DataSourceMetadata(supportedType, Condition.normal())
+
+  def beConfigured(cfg: C): Matcher[CommonError \/ (DataSourceMetadata, C)] =
+    beLike {
+      case \/-((DataSourceMetadata(t, None), c)) =>
+        (t must_= supportedType) and (c must_= cfg)
+    }
+
+  def beNotFound[A](name: ResourceName): Matcher[CommonError \/ A] =
+    be_-\/(equal[Err](DataSourceNotFound(name)))
+}

--- a/api/src/test/scala/quasar/api/DataSourcesSpec.scala
+++ b/api/src/test/scala/quasar/api/DataSourcesSpec.scala
@@ -16,7 +16,7 @@
 
 package quasar.api
 
-import slamdata.Predef.{None, Some, String}
+import slamdata.Predef.{Some, String}
 import quasar.{Condition, ConditionMatchers, Qspec}
 
 import scala.Predef.assert
@@ -75,7 +75,7 @@ abstract class DataSourcesSpec[F[_]: Monad, C: Equal: Show]
         cond must beNormal
 
         m.lookup(foo) must beLike {
-          case Some(DataSourceMetadata(t, None)) =>
+          case Some(DataSourceMetadata(t, Condition.Normal())) =>
             t must_= supportedType
         }
       }
@@ -309,12 +309,9 @@ abstract class DataSourcesSpec[F[_]: Monad, C: Equal: Show]
   def configB: C =
     validConfigs._2
 
-  def nominalMeta: DataSourceMetadata =
-    DataSourceMetadata(supportedType, Condition.normal())
-
   def beConfigured(cfg: C): Matcher[CommonError \/ (DataSourceMetadata, C)] =
     beLike {
-      case \/-((DataSourceMetadata(t, None), c)) =>
+      case \/-((DataSourceMetadata(t, Condition.Normal()), c)) =>
         (t must_= supportedType) and (c must_= cfg)
     }
 

--- a/build.sbt
+++ b/build.sbt
@@ -551,7 +551,7 @@ lazy val interface = project
 /** Implementations of the Quasar API. */
 lazy val impl = project
   .settings(name := "quasar-impl-internal")
-  .dependsOn(api)
+  .dependsOn(api % BothScopes)
   .settings(commonSettings)
   .settings(targetSettings)
   .settings(excludeTypelevelScalaLibrary)

--- a/build.sbt
+++ b/build.sbt
@@ -548,6 +548,15 @@ lazy val interface = project
   .settings(excludeTypelevelScalaLibrary)
   .enablePlugins(AutomateHeaderPlugin)
 
+/** Implementations of the Quasar API. */
+lazy val impl = project
+  .settings(name := "quasar-impl-internal")
+  .dependsOn(api)
+  .settings(commonSettings)
+  .settings(targetSettings)
+  .settings(excludeTypelevelScalaLibrary)
+  .enablePlugins(AutomateHeaderPlugin)
+
 /** An interactive REPL application for Quasar.
   */
 lazy val repl = project

--- a/common/src/test/scala/quasar/fs/PathErrorSpec.scala
+++ b/common/src/test/scala/quasar/fs/PathErrorSpec.scala
@@ -16,7 +16,8 @@
 
 package quasar.fs
 
-import org.specs2.scalaz.Spec
+import quasar.contrib.specs2.Spec
+
 import scalaz.scalacheck.ScalazProperties
 
 class PathErrorSpec extends Spec {

--- a/core/src/main/scala/quasar/evaluate/FederatedQuery.scala
+++ b/core/src/main/scala/quasar/evaluate/FederatedQuery.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package quasar
+package quasar.evaluate
 
 import slamdata.Predef.Option
 import quasar.contrib.pathy.AFile

--- a/core/src/main/scala/quasar/evaluate/FederatingQueryEvaluator.scala
+++ b/core/src/main/scala/quasar/evaluate/FederatingQueryEvaluator.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package quasar
+package quasar.evaluate
 
 import slamdata.Predef.{Boolean, List, Option, Stream}
 import quasar.api._, ResourceError._

--- a/core/src/main/scala/quasar/evaluate/QueryFederation.scala
+++ b/core/src/main/scala/quasar/evaluate/QueryFederation.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package quasar
+package quasar.evaluate
 
 import quasar.api.ResourceError.ReadError
 

--- a/core/src/main/scala/quasar/evaluate/Source.scala
+++ b/core/src/main/scala/quasar/evaluate/Source.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package quasar
+package quasar.evaluate
 
 import quasar.api.ResourcePath
 

--- a/core/src/test/scala/quasar/compile/CompilerSpec.scala
+++ b/core/src/test/scala/quasar/compile/CompilerSpec.scala
@@ -1657,7 +1657,7 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
     }.pendingUntilFixed
 
     "fail with ambiguous reference" in {
-      compile(sqlE"select foo from bar, baz") must beLeftDisjunction(
+      compile(sqlE"select foo from bar, baz") must be_-\/(
         NonEmptyList(
           SemanticError.AmbiguousReference(
             ident[Fix[Sql]]("foo").embed,
@@ -1667,11 +1667,11 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
     }
 
     "fail with ambiguous reference in cond" in {
-      compile(sqlE"""select (case when a = 1 then "ok" else "reject" end) from bar, baz""") must beLeftDisjunction
+      compile(sqlE"""select (case when a = 1 then "ok" else "reject" end) from bar, baz""") must be_-\/
     }
 
     "fail with ambiguous reference in else" in {
-      compile(sqlE"""select (case when bar.a = 1 then "ok" else foo end) from bar, baz""") must beLeftDisjunction
+      compile(sqlE"""select (case when bar.a = 1 then "ok" else foo end) from bar, baz""") must be_-\/
     }
 
     "fail with duplicate alias" in {
@@ -1800,7 +1800,7 @@ class CompilerSpec extends quasar.Qspec with CompilerHelpers {
 
   List("avg", "sum") foreach { fn =>
     s"passing a literal set of the wrong type to '${fn.toUpperCase}' fails" >> {
-      fullCompile(unsafeParse(s"""select $fn(("one", "two", "three"))""")) must beLeftDisjunction
+      fullCompile(unsafeParse(s"""select $fn(("one", "two", "three"))""")) must be_-\/
     }
   }
 

--- a/core/src/test/scala/quasar/config/ConfigSpec.scala
+++ b/core/src/test/scala/quasar/config/ConfigSpec.scala
@@ -53,7 +53,7 @@ abstract class ConfigSpec[Config: Arbitrary: CodecJson: ConfigOps] extends quasa
 
   "fromString" should {
     "parse valid config" in {
-      ConfigOps.fromString(TestConfigStr) must beRightDisjunction(TestConfig)
+      ConfigOps.fromString(TestConfigStr) must be_\/-(TestConfig)
     }
   }
 
@@ -68,7 +68,7 @@ abstract class ConfigSpec[Config: Arbitrary: CodecJson: ConfigOps] extends quasa
       withTestConfigFile(fp =>
         configOps.toFile(TestConfig, Some(fp)) *>
         configOps.fromFile(fp).run
-      ).unsafePerformSync must beRightDisjunction(TestConfig)
+      ).unsafePerformSync must be_\/-(TestConfig)
     }
   }
 
@@ -78,7 +78,7 @@ abstract class ConfigSpec[Config: Arbitrary: CodecJson: ConfigOps] extends quasa
         withTestConfigFile(fp =>
           configOps.fromFile(fp).run.map((fp, _))
         ).unsafePerformSync
-      r must beLeftDisjunction(fileNotFound(p))
+      r must be_-\/(equalTo(fileNotFound(p)))
     }
   }
 

--- a/core/src/test/scala/quasar/evaluate/FederatingQueryEvaluatorSpec.scala
+++ b/core/src/test/scala/quasar/evaluate/FederatingQueryEvaluatorSpec.scala
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package quasar
+package quasar.evaluate
 
 import slamdata.Predef._
+import quasar.{Qspec, TreeMatchers}
 import quasar.api._, ResourceError._
 import quasar.contrib.pathy.{ADir, AFile}
 import quasar.fp.{constEqual, coproductEqual}

--- a/core/src/test/scala/quasar/fs/cache/ViewCacheSpec.scala
+++ b/core/src/test/scala/quasar/fs/cache/ViewCacheSpec.scala
@@ -16,7 +16,8 @@
 
 package quasar.fs.mount.cache
 
-import org.specs2.scalaz.Spec
+import quasar.contrib.specs2.Spec
+
 import scalaz.scalacheck.ScalazProperties
 
 class ViewCacheSpec extends Spec {

--- a/core/src/test/scala/quasar/fs/mount/MountTypeSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/MountTypeSpec.scala
@@ -16,7 +16,8 @@
 
 package quasar.fs.mount
 
-import org.specs2.scalaz.Spec
+import quasar.contrib.specs2.Spec
+
 import scalaz.scalacheck.ScalazProperties._
 
 final class MountTypeSpec extends Spec {

--- a/core/src/test/scala/quasar/fs/mount/MountingErrorSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/MountingErrorSpec.scala
@@ -16,7 +16,8 @@
 
 package quasar.fs.mount
 
-import org.specs2.scalaz.Spec
+import quasar.contrib.specs2.Spec
+
 import scalaz.scalacheck.ScalazProperties
 
 class MountingErrorSpec extends Spec {

--- a/core/src/test/scala/quasar/fs/mount/MountsSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/MountsSpec.scala
@@ -26,18 +26,18 @@ class MountsSpec extends quasar.Qspec {
   "Mounts" should {
     "adding entries" >> {
       "fails when dir is a prefix of existing" >> prop { mnt: AbsDir[Sandboxed] =>
-        Mounts.singleton(mnt </> dir("c1"), 1).add(mnt, 2) must beLeftDisjunction
+        Mounts.singleton(mnt </> dir("c1"), 1).add(mnt, 2) must be_-\/
       }
 
       "fails when dir is prefixed by existing" >> prop { mnt: AbsDir[Sandboxed] =>
-        Mounts.singleton(mnt, 1).add(mnt </> dir("c2"), 2) must beLeftDisjunction
+        Mounts.singleton(mnt, 1).add(mnt </> dir("c2"), 2) must be_-\/
       }
 
       "succeeds when dir not a prefix of existing" >> {
         val mnt1: AbsDir[Sandboxed] = rootDir </> dir("one")
         val mnt2: AbsDir[Sandboxed] = rootDir </> dir("two")
 
-        Mounts.fromFoldable(List((mnt1, 1), (mnt2, 2))) must beRightDisjunction
+        Mounts.fromFoldable(List((mnt1, 1), (mnt2, 2))) must be_\/-
       }
 
       "succeeds when replacing value at existing" >> prop { mnt: AbsDir[Sandboxed] =>

--- a/core/src/test/scala/quasar/fs/mount/ViewFileSystemSpec.scala
+++ b/core/src/test/scala/quasar/fs/mount/ViewFileSystemSpec.scala
@@ -612,14 +612,14 @@ class ViewFileSystemSpec extends quasar.Qspec with TreeMatchers {
 
     "no match" >> {
       resolvedRefs(Map(), lpf.read(rootDir </> file("zips"))) must
-        beRightDisjunction.like { case r => r must beTreeEqual(lpf.read(rootDir </> file("zips"))) }
+        be_\/-.like { case r => r must beTreeEqual(lpf.read(rootDir </> file("zips"))) }
     }
 
     "trivial read" >> {
       val p = rootDir </> dir("view") </> file("justZips")
       val vs = Map[AFile, Fix[Sql]](p -> sqlE"select * from `/zips`")
 
-      resolvedRefs(vs, lpf.read(p)) must beRightDisjunction.like {
+      resolvedRefs(vs, lpf.read(p)) must be_\/-.like {
         case r => r must beTreeEqual(
           Fix(Squash(lpf.read(rootDir </> file("zips"))))
         )
@@ -634,7 +634,7 @@ class ViewFileSystemSpec extends quasar.Qspec with TreeMatchers {
           MountConfig.ViewConfig(sqlB"α", Variables.empty), None, None, 0, None, None,
           4.seconds.toSeconds, nineteenSixty, ViewCache.Status.Successful, None, fb, None)
 
-      resolvedRefsVC(Map.empty, Map(fa -> viewCache), lpf.read(fa)) must beRightDisjunction.like {
+      resolvedRefsVC(Map.empty, Map(fa -> viewCache), lpf.read(fa)) must be_\/-.like {
         case r => r must beTreeEqual(
           lpf.read(rootDir </> file("b")))
       }
@@ -644,7 +644,7 @@ class ViewFileSystemSpec extends quasar.Qspec with TreeMatchers {
       val p = rootDir </> dir("foo") </> file("justZips")
       val vs = Map[AFile, Fix[Sql]](p -> sqlE"select * from zips")
 
-      resolvedRefs(vs, lpf.read(p)) must beRightDisjunction.like {
+      resolvedRefs(vs, lpf.read(p)) must be_\/-.like {
         case r => r must beTreeEqual(
           Fix(Squash(lpf.read(rootDir </> dir("foo") </> file("zips"))))
         )
@@ -675,7 +675,7 @@ class ViewFileSystemSpec extends quasar.Qspec with TreeMatchers {
             lpf.constant(Data.Int(5))).embed,
           lpf.constant(Data.Int(10))).embed).value.toOption.get
 
-      resolvedRefs(vs, outer) must beRightDisjunction.like {
+      resolvedRefs(vs, outer) must be_\/-.like {
         case r => r must beTreeEqual(exp)
       }
     }
@@ -688,7 +688,7 @@ class ViewFileSystemSpec extends quasar.Qspec with TreeMatchers {
           sqlE"select * from view1")
 
       resolvedRefs(vs, lpf.read(rootDir </> dir("view") </> file("view2"))) must
-        beRightDisjunction.like { case r => r must beTreeEqual(
+        be_\/-.like { case r => r must beTreeEqual(
           Squash(lpf.read(rootDir </> file("zips"))).embed)
         }
     }
@@ -705,7 +705,7 @@ class ViewFileSystemSpec extends quasar.Qspec with TreeMatchers {
           MountConfig.ViewConfig(sqlB"α", Variables.empty), None, None, 0, None, None,
           4.seconds.toSeconds, nineteenSixty, ViewCache.Status.Successful, None, dest, None))
 
-      resolvedRefsVC(vs, vcache, lpf.read(rootDir </> file("view"))) must beRightDisjunction.like {
+      resolvedRefsVC(vs, vcache, lpf.read(rootDir </> file("view"))) must be_\/-.like {
         case r => r must beTreeEqual(
           Squash(lpf.read(dest)).embed)
       }
@@ -735,7 +735,7 @@ class ViewFileSystemSpec extends quasar.Qspec with TreeMatchers {
         JoinType.Inner,
         JoinCondition('__leftJoin2, '__rightJoin3, lpf.constant(Data.Bool(true))))
 
-      resolvedRefs(vs, q) must beRightDisjunction.like { case r => r must beTreeEqual(exp) }
+      resolvedRefs(vs, q) must be_\/-.like { case r => r must beTreeEqual(exp) }
     }
 
     "self reference" >> {
@@ -752,7 +752,7 @@ class ViewFileSystemSpec extends quasar.Qspec with TreeMatchers {
 
       val vs = Map[AFile, Fix[Sql]](p -> q)
 
-      resolvedRefs(vs, lpf.read(p)) must beRightDisjunction.like { case r => r must beTreeEqual(qlp) }
+      resolvedRefs(vs, lpf.read(p)) must be_\/-.like { case r => r must beTreeEqual(qlp) }
     }
 
     "circular reference" >> {
@@ -770,7 +770,7 @@ class ViewFileSystemSpec extends quasar.Qspec with TreeMatchers {
         v1p -> unsafeParse(s"select * from `${posixCodec.printPath(v2p)}` offset 5"),
         v2p -> unsafeParse(s"select * from `${posixCodec.printPath(v1p)}` limit 10"))
 
-      resolvedRefs(vs, lpf.read(v2p)) must beRightDisjunction.like {
+      resolvedRefs(vs, lpf.read(v2p)) must be_\/-.like {
         case r => r must beTreeEqual(
           Take(
             Squash(Drop(

--- a/couchbase/src/test/scala/quasar/physical/couchbase/N1QLSpec.scala
+++ b/couchbase/src/test/scala/quasar/physical/couchbase/N1QLSpec.scala
@@ -18,14 +18,14 @@ package quasar.physical.couchbase
 
 import slamdata.Predef._
 import quasar.{Data => QData}
-import quasar.common.{JoinType, SortDir}, SortDir._
 import quasar.DataGenerators._
+import quasar.common.{JoinType, SortDir}, SortDir._
+import quasar.contrib.specs2.Spec
 import quasar.physical.couchbase.N1QL.{Eq, Id, Split, _}, Case._, Select.{Value, _}
 
 import scala.Predef.$conforms
 
 import org.scalacheck._
-import org.specs2.scalaz.Spec
 import scalaz.scalacheck.ScalazArbitrary._
 import scalaz.scalacheck.ScalaCheckBinding._
 import scalaz.scalacheck.ScalazProperties, ScalazProperties._

--- a/couchbaseIt/src/test/scala/quasar/physical/couchbase/CouchbaseStdLibSpec.scala
+++ b/couchbaseIt/src/test/scala/quasar/physical/couchbase/CouchbaseStdLibSpec.scala
@@ -127,7 +127,7 @@ class CouchbaseStdLibSpec extends StdLibSpec {
       } yield (rq, r)
     ).run.run.run(cfg).foldMap(fs.interp.unsafePerformSync).unsafePerformSync._2
 
-    (r must beRightDisjunction.like { case (q, Vector(d)) =>
+    (r must be_\/-.like { case (q, Vector(d)) =>
       d must beCloseTo(expected).updateMessage(_ ⊹ s"\nquery: $q")
     }).toResult
   }

--- a/ejson/src/test/scala/quasar/ejson/DecodeEjsonSpec.scala
+++ b/ejson/src/test/scala/quasar/ejson/DecodeEjsonSpec.scala
@@ -17,9 +17,9 @@
 package quasar.ejson
 
 import slamdata.Predef.{Char => SChar, String}
+import quasar.contrib.specs2.Spec
 
 import matryoshka.data.Fix
-import org.specs2.scalaz._
 import scalaz._, Scalaz._
 
 class DecodeEJsonSpec extends Spec {

--- a/ejson/src/test/scala/quasar/ejson/EJson.scala
+++ b/ejson/src/test/scala/quasar/ejson/EJson.scala
@@ -19,6 +19,7 @@ package quasar.ejson
 import slamdata.Predef.{Int => SInt, _}
 import quasar.contrib.matryoshka._
 import quasar.contrib.matryoshka.arbitrary._
+import quasar.contrib.specs2.Spec
 import quasar.ejson.implicits._
 import quasar.fp._, Helpers._
 
@@ -29,9 +30,8 @@ import matryoshka._
 import matryoshka.data.Fix
 import matryoshka.implicits._
 import org.specs2.scalacheck._
-import org.specs2.scalaz._
 import scalaz._, Scalaz._
-import scalaz.scalacheck.ScalazProperties._
+import scalaz.scalacheck.ScalazProperties.{equal => eql, _}
 
 class EJsonSpecs extends Spec with EJsonArbitrary {
   import Extension.Optics.meta
@@ -50,7 +50,7 @@ class EJsonSpecs extends Spec with EJsonArbitrary {
 
   checkAll("Extension", traverse.laws[Extension](implicitly, implicitly, Extension.structuralOrder(Order[SInt])))
   checkAll("Extension", order.laws[Extension[SInt]](Extension.structuralOrder(Order[SInt]), implicitly))
-  checkAll("Extension", equal.laws[Extension[SInt]](Extension.structuralEqual(Equal[SInt]), implicitly))
+  checkAll("Extension", eql.laws[Extension[SInt]](Extension.structuralEqual(Equal[SInt]), implicitly))
 
   checkAll("EJson", order.laws[J])
 

--- a/ejson/src/test/scala/quasar/ejson/EqMapSpec.scala
+++ b/ejson/src/test/scala/quasar/ejson/EqMapSpec.scala
@@ -17,13 +17,13 @@
 package quasar.ejson
 
 import slamdata.Predef.{Int => SInt, _}
+import quasar.contrib.specs2.Spec
 
-import org.specs2.scalaz._
 import scalaz._, Scalaz._
-import scalaz.scalacheck.ScalazProperties._
+import scalaz.scalacheck.ScalazProperties
 
 class EqMapSpec extends Spec with EqMapArbitrary {
-  checkAll(equal.laws[EqMap[SInt, String]])
+  checkAll(ScalazProperties.equal.laws[EqMap[SInt, String]])
 
   "operations" >> {
     "insert" >> prop { (m: EqMap[SInt, String], k: SInt, v: String) =>

--- a/foundation/src/main/scala/quasar/Condition.scala
+++ b/foundation/src/main/scala/quasar/Condition.scala
@@ -57,6 +57,12 @@ object Condition extends ConditionInstances {
       case Normal() => ()
     } (κ(Normal()))
 
+  def disjunctionIso[E]: Iso[Condition[E], E \/ Unit] =
+    Iso[Condition[E], E \/ Unit] {
+      case Abnormal(e) => e.left
+      case Normal()    => ().right
+    } (_.fold(Abnormal(_), κ(Normal())))
+
   def optionIso[E]: Iso[Condition[E], Option[E]] =
     Iso[Condition[E], Option[E]] {
       case Abnormal(e) => Some(e)

--- a/foundation/src/main/scala/quasar/Void.scala
+++ b/foundation/src/main/scala/quasar/Void.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar
+
+/** A type with zero inhabitants. */
+sealed abstract class Void

--- a/foundation/src/test/scala/quasar/CIStringSpec.scala
+++ b/foundation/src/test/scala/quasar/CIStringSpec.scala
@@ -17,11 +17,12 @@
 package quasar
 
 import slamdata.Predef.String
+import quasar.contrib.specs2.Spec
 
 import argonaut.CodecJson
 import org.scalacheck.{Arbitrary, Gen}
-import org.specs2.scalaz._
 import scalaz.scalacheck.ScalazProperties._
+import scalaz.syntax.equal._
 
 class CIStringSpec extends Spec with CIStringArbitrary {
   import CIStringSpec.AlphaStr
@@ -33,7 +34,7 @@ class CIStringSpec extends Spec with CIStringArbitrary {
   }
 
   "equal must ignore case for ascii characters" >> prop { as: AlphaStr =>
-    CIString(as.value) equals CIString(as.value.toUpperCase)
+    CIString(as.value) === CIString(as.value.toUpperCase)
   }
 }
 

--- a/foundation/src/test/scala/quasar/ConditionMatchers.scala
+++ b/foundation/src/test/scala/quasar/ConditionMatchers.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar
+
+import org.specs2.matcher._
+
+trait ConditionMatchers {
+  def beAbnormal[A](check: ValueCheck[A]): Matcher[Condition[A]] =
+    new OptionLikeCheckedMatcher[Condition, A, A](
+      "Abnormal",
+      Condition.abnormal[A].getOption(_),
+      check)
+
+  def beNormal[A]: Matcher[Condition[A]] =
+    new Matcher[Condition[A]] {
+      def apply[S <: Condition[A]](value: Expectable[S]) =
+        result(Condition.normal[A].nonEmpty(value.value),
+               value.description + " is Normal",
+               value.description + " is not Normal",
+               value)
+    }
+}

--- a/foundation/src/test/scala/quasar/QuasarSpecification.scala
+++ b/foundation/src/test/scala/quasar/QuasarSpecification.scala
@@ -39,9 +39,11 @@ trait QuasarSpecification extends AnyRef
         with org.specs2.matcher.MatchResultCombinators
         with org.specs2.matcher.ValueChecks
         with org.specs2.matcher.MatcherZipOperators
+        with org.specs2.matcher.DisjunctionMatchers
+        with org.specs2.matcher.ValidationMatchers
         with org.specs2.execute.PendingUntilFixed
         with org.specs2.ScalaCheck
-        with org.specs2.scalaz.ScalazMatchers
+        with quasar.contrib.specs2.ScalazEqualityMatchers
         with ScalazSpecs2Instances
 {
   outer =>

--- a/foundation/src/test/scala/quasar/contrib/specs2/ScalazEqualityMatchers.scala
+++ b/foundation/src/test/scala/quasar/contrib/specs2/ScalazEqualityMatchers.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.contrib.specs2
+
+import slamdata.Predef._
+
+import org.specs2.matcher._
+import scalaz.{Equal, Show}
+
+/** Cribbed from https://github.com/typelevel/scalaz-specs2 which doesn't allow
+  * depending on this matcher without depending on everything else. This is also
+  * the only thing we're really using.
+  */
+trait ScalazEqualityMatchers { self =>
+    /** Equality matcher with a [[scalaz.Equal]] typeclass */
+  def equal[T : Equal : Show](expected: T): Matcher[T] = new Matcher[T] {
+    def apply[S <: T](actual: Expectable[S]): MatchResult[S] = {
+      val actualT: T = actual.value
+      def test = Equal[T].equal(expected, actualT)
+      def koMessage = "%s !== %s".format(Show[T].shows(actualT), Show[T].shows(expected))
+      def okMessage = "%s === %s".format(Show[T].shows(actualT), Show[T].shows(expected))
+      Matcher.result(test, okMessage, koMessage, actual)
+    }
+  }
+
+  implicit final class ScalazBeHaveMatchers[T : Equal : Show](result: MatchResult[T]) {
+    def equal(t: T) = result.applyMatcher(self.equal[T](t))
+  }
+}
+
+object ScalazEqualityMatchers extends ScalazEqualityMatchers

--- a/foundation/src/test/scala/quasar/contrib/specs2/Spec.scala
+++ b/foundation/src/test/scala/quasar/contrib/specs2/Spec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.contrib.specs2
+
+import slamdata.Predef._
+
+import org.specs2._
+import org.specs2.matcher._
+import org.specs2.specification.core._
+import org.specs2.scalacheck._
+import org.specs2.main.{ArgumentsShortcuts, ArgumentsArgs}
+
+import org.scalacheck.{Prop, Properties}
+import org.scalacheck.util.{FreqMap, Pretty}
+
+/** A minimal version of the Specs2 mutable base class.
+  *
+  * Cribbed from https://github.com/typelevel/scalaz-specs2 which we no longer
+  * need as specs2 now includes most of its functionality.
+  *
+  * TODO: Extract the contents of this into `Qspec` and remove.
+  */
+trait Spec extends org.specs2.mutable.Spec
+    with ScalaCheck
+    with MatchersImplicits
+    with StandardMatchResults
+    with ArgumentsShortcuts
+    with ArgumentsArgs
+    with ScalazEqualityMatchers {
+
+  val ff = fragmentFactory; import ff._
+
+  setArguments(fullStackTrace)
+
+  def checkAll(name: String, props: Properties)(implicit p: Parameters, f: FreqMap[Set[Any]] => Pretty): Unit = {
+    addFragment(text(s"$name  ${props.name} must satisfy"))
+    addFragments(Fragments.foreach(props.properties) { case (name, prop) => Fragments(name in check(prop, p, f)) })
+    ()
+  }
+
+  def checkAll(props: Properties)(implicit p: Parameters, f: FreqMap[Set[Any]] => Pretty): Unit = {
+    addFragment(text(s"${props.name} must satisfy"))
+    addFragments(Fragments.foreach(props.properties) { case (name, prop) => Fragments(name in check(prop, p, f)) })
+    ()
+  }
+
+  implicit final class SpecEnrichedProperties(props: Properties) {
+    def withProp(propName: String, prop: Prop) = new Properties(props.name) {
+      for {(name, p) <- props.properties} property(name) = p
+      property(propName) = prop
+    }
+  }
+}

--- a/foundation/src/test/scala/quasar/fp/numeric/SampleStatsSpec.scala
+++ b/foundation/src/test/scala/quasar/fp/numeric/SampleStatsSpec.scala
@@ -18,9 +18,9 @@ package quasar.fp.numeric
 
 import slamdata.Predef._
 import quasar.contrib.algebra._
+import quasar.contrib.specs2.Spec
 
 import org.scalacheck.{Arbitrary, Gen}, Arbitrary.arbitrary
-import org.specs2.scalaz._
 import scalaz.scalacheck.{ScalazProperties => propz}
 import scalaz.{NonEmptyList, Show}
 import scalaz.std.option._
@@ -30,7 +30,7 @@ import scalaz.syntax.std.boolean._
 import spire.laws.arb._
 import spire.math.Real
 
-final class SampleStatsSpec extends Spec with ScalazMatchers with SampleStatsArbitrary {
+final class SampleStatsSpec extends Spec with SampleStatsArbitrary {
   implicit val showReal: Show[Real] =
     Show.showFromToString
 

--- a/foundation/src/test/scala/quasar/matchers.scala
+++ b/foundation/src/test/scala/quasar/matchers.scala
@@ -47,7 +47,7 @@ trait TreeMatchers {
   }
 }
 
-trait ValidationMatchers extends org.specs2.scalaz.ValidationMatchers {
+trait ValidationMatchers {
   def beEqualIfSuccess[E, A](expected: Validation[E, A]) =
     new Matcher[Validation[E, A]] {
       def apply[S <: Validation[E, A]](s: Expectable[S]) = {
@@ -66,7 +66,7 @@ trait ValidationMatchers extends org.specs2.scalaz.ValidationMatchers {
   }
 }
 
-trait DisjunctionMatchers extends org.specs2.scalaz.DisjunctionMatchers {
+trait DisjunctionMatchers {
   def beRightDisjOrDiff[A, B: Equal](expected: B)(implicit rb: RenderTree[B]): Matcher[A \/ B] = new Matcher[A \/ B] {
     def apply[S <: A \/ B](s: Expectable[S]) = {
       val v = s.value

--- a/frontend/src/test/scala/quasar/codec.scala
+++ b/frontend/src/test/scala/quasar/codec.scala
@@ -129,15 +129,15 @@ class DataCodecSpecs extends quasar.Qspec {
       // Some invalid inputs:
 
       "fail with unescaped leading '$'" in {
-        DataCodec.parse("""{ "$a": 1 }""") must beLeftDisjunction(UnescapedKeyError(jSingleObject("$a", jNumber(1))))
+        DataCodec.parse("""{ "$a": 1 }""") must be_-\/(UnescapedKeyError(jSingleObject("$a", jNumber(1))))
       }
 
       "fail with invalid offset date time value" in {
-        DataCodec.parse("""{ "$offsetdatetime": 123456 }""") must beLeftDisjunction
+        DataCodec.parse("""{ "$offsetdatetime": 123456 }""") must be_-\/
       }
 
       "fail with invalid offset date time string" in {
-        DataCodec.parse("""{ "$offsetdatetime": "10 o'clock this morning" }""") must beLeftDisjunction
+        DataCodec.parse("""{ "$offsetdatetime": "10 o'clock this morning" }""") must be_-\/
       }
     }
   }

--- a/frontend/src/test/scala/quasar/frontend/logicalplan/LogicalPlanSpecs.scala
+++ b/frontend/src/test/scala/quasar/frontend/logicalplan/LogicalPlanSpecs.scala
@@ -19,18 +19,18 @@ package quasar.frontend.logicalplan
 import slamdata.Predef._
 import quasar.{Data, Func}
 import quasar.DataGenerators._
+import quasar.contrib.specs2.Spec
 import quasar.fp._
 import quasar.std
 
 import matryoshka._
 import matryoshka.data.Fix
 import org.scalacheck._
-import org.specs2.scalaz.{ScalazMatchers, Spec}
 import scalaz._, Scalaz._
 import scalaz.scalacheck.ScalazProperties.{equal => _, _}
 import pathy.Path._
 
-class LogicalPlanSpecs extends Spec with ScalazMatchers {
+class LogicalPlanSpecs extends Spec {
   val lpf = new LogicalPlanR[Fix[LogicalPlan]]
 
   implicit val arbLogicalPlan: Delay[Arbitrary, LogicalPlan] =

--- a/frontend/src/test/scala/quasar/std/math.scala
+++ b/frontend/src/test/scala/quasar/std/math.scala
@@ -39,37 +39,37 @@ class MathSpec extends quasar.Qspec with TypeGenerators {
   "MathLib" should {
     "type simple add with ints" in {
       val expr = Add.tpe(Func.Input2(Type.Int, Type.Int))
-      expr should beSuccessful(Type.Int)
+      expr should beSuccess(Type.Int)
     }
 
     "type simple add with decs" in {
       val expr = Add.tpe(Func.Input2(Type.Dec, Type.Dec))
-      expr should beSuccessful(Type.Dec)
+      expr should beSuccess(Type.Dec)
     }
 
     "type simple add with promotion" in {
       val expr = Add.tpe(Func.Input2(Type.Int, Type.Dec))
-      expr should beSuccessful(Type.Dec)
+      expr should beSuccess(Type.Dec)
     }
 
     "type simple add with zero" in {
       val expr = Add.tpe(Func.Input2(Type.Numeric, TZero()))
-      expr should beSuccessful(Type.Numeric)
+      expr should beSuccess(Type.Numeric)
     }
 
     "fold simple add with int constants" in {
       val expr = Add.tpe(Func.Input2(TOne(), Const(Int(2))))
-      expr should beSuccessful(Const(Int(3)))
+      expr should beSuccess(Const(Int(3)))
     }
 
     "fold simple add with decimal constants" in {
       val expr = Add.tpe(Func.Input2(Const(Dec(1.0)), Const(Dec(2.0))))
-      expr should beSuccessful(Const(Dec(3)))
+      expr should beSuccess(Const(Dec(3)))
     }
 
     "fold simple add with promotion" in {
       val expr = Add.tpe(Func.Input2(TOne(), Const(Dec(2.0))))
-      expr should beSuccessful(Const(Dec(3)))
+      expr should beSuccess(Const(Dec(3)))
     }
 
     "simplify add with zero" in {
@@ -84,89 +84,89 @@ class MathSpec extends quasar.Qspec with TypeGenerators {
 
     "eliminate multiply by dec zero (on the right)" >> prop { (c : Const) =>
       val expr = Multiply.tpe(Func.Input2(c, Const(Dec(0.0))))
-      expr should beSuccessful(TZero())
+      expr should beSuccess(TZero())
     }
 
     "eliminate multiply by zero (on the left)" >> prop { (c : Const) =>
       val expr = Multiply.tpe(Func.Input2(TZero(), c))
-      expr should beSuccessful(TZero())
+      expr should beSuccess(TZero())
     }
 
     "fold simple division" in {
       val expr = Divide.tpe(Func.Input2(Const(Int(6)), Const(Int(3))))
-      expr should beSuccessful(Const(Int(2)))
+      expr should beSuccess(Const(Int(2)))
     }
 
     "fold non-truncating division" in {
       val expr = Divide.tpe(Func.Input2(Const(Int(5)), Const(Int(2))))
-      expr should beSuccessful(Const(Dec(2.5)))
+      expr should beSuccess(Const(Dec(2.5)))
     }
 
     "fold simple division (dec)" in {
       val expr = Divide.tpe(Func.Input2(Const(Int(6)), Const(Dec(3.0))))
-      expr should beSuccessful(Const(Dec(2.0)))
+      expr should beSuccess(Const(Dec(2.0)))
     }
 
     "fold division (dec)" in {
       val expr = Divide.tpe(Func.Input2(Const(Int(5)), Const(Dec(2))))
-      expr should beSuccessful(Const(Dec(2.5)))
+      expr should beSuccess(Const(Dec(2.5)))
     }
 
     "divide by zero" in {
       val expr = Divide.tpe(Func.Input2(TOne(), TZero()))
-      expr must beSuccessful(Type.Dec)
+      expr must beSuccess(Type.Dec)
     }
 
     "divide by zero (dec)" in {
       val expr = Divide.tpe(Func.Input2(Const(Dec(1.0)), Const(Dec(0.0))))
-      expr must beSuccessful(Type.Dec)
+      expr must beSuccess(Type.Dec)
     }
 
     "fold simple modulo" in {
       val expr = Modulo.tpe(Func.Input2(Const(Int(6)), Const(Int(3))))
-      expr should beSuccessful(TZero())
+      expr should beSuccess(TZero())
     }
 
     "fold non-zero modulo" in {
       val expr = Modulo.tpe(Func.Input2(Const(Int(5)), Const(Int(2))))
-      expr should beSuccessful(TOne())
+      expr should beSuccess(TOne())
     }
 
     "fold simple modulo (dec)" in {
       val expr = Modulo.tpe(Func.Input2(Const(Int(6)), Const(Dec(3.0))))
-      expr should beSuccessful(Const(Dec(0.0)))
+      expr should beSuccess(Const(Dec(0.0)))
     }
 
     "fold non-zero modulo (dec)" in {
       val expr = Modulo.tpe(Func.Input2(Const(Int(5)), Const(Dec(2.2))))
-      expr should beSuccessful(Const(Dec(0.6)))
+      expr should beSuccess(Const(Dec(0.6)))
     }
 
     "modulo by zero" in {
       val expr = Modulo.tpe(Func.Input2(TOne(), TZero()))
-      expr must beSuccessful(Type.Int)
+      expr must beSuccess(Type.Int)
     }
 
     "modulo by zero (dec)" in {
       val expr = Modulo.tpe(Func.Input2(Const(Dec(1.0)), Const(Dec(0.0))))
-      expr must beSuccessful(Type.Dec)
+      expr must beSuccess(Type.Dec)
     }
 
     "typecheck number raised to 0th power" >> prop { (t: Type) =>
-      Power.tpe(Func.Input2(t, TZero())) should beSuccessful(TOne())
+      Power.tpe(Func.Input2(t, TZero())) should beSuccess(TOne())
     }.setArbitrary(arbitraryNumeric)
 
     "typecheck 0 raised to any (non-zero) power" >> prop { (t: Type) =>
       (t != TZero()) ==>
-        (Power.tpe(Func.Input2(TZero(), t)) should beSuccessful(TZero()))
+        (Power.tpe(Func.Input2(TZero(), t)) should beSuccess(TZero()))
     }.setArbitrary(arbitraryNumeric)
 
     "typecheck any number raised to 1st power" >> prop { (t: Type) =>
-      Power.tpe(Func.Input2(t, TOne())) should beSuccessful(t)
+      Power.tpe(Func.Input2(t, TOne())) should beSuccess(t)
     }.setArbitrary(arbitraryNumeric)
 
     "typecheck constant raised to int constant" in {
-      Power.tpe(Func.Input2(Const(Dec(7.2)), Const(Int(2)))) should beSuccessful(Const(Dec(51.84)))
+      Power.tpe(Func.Input2(Const(Dec(7.2)), Const(Int(2)))) should beSuccess(Const(Dec(51.84)))
     }
 
     "simplify expression raised to 1st power" in {
@@ -186,36 +186,36 @@ class MathSpec extends quasar.Qspec with TypeGenerators {
                 Const(Int(8))))
         x4 <- Add.tpe(Func.Input2(x2, x3))
       } yield x4
-      expr should beSuccessful(Const(Int(42)))
+      expr should beSuccess(Const(Int(42)))
     }
 
     "fail with mismatched constants" in {
       val expr = Add.tpe(Func.Input2(TOne(), Const(Str("abc"))))
-      expr should beFailing
+      expr should beFailure
     }
 
     "fail with object and int constant" in {
       val expr = Add.tpe(Func.Input2(Type.Obj(Map("x" -> Type.Int), None), TOne()))
-      expr should beFailing
+      expr should beFailure
     }
 
     "add timestamp and interval" in {
       val expr = Add.tpe(Func.Input2(
         Type.Const(OffsetDateTime(JOffsetDateTime.parse("2015-01-21T00:00:00Z"))),
         Type.Const(Interval(DateTimeInterval.ofHours(9)))))
-      expr should beSuccessful(Type.Const(OffsetDateTime(JOffsetDateTime.parse("2015-01-21T09:00:00Z"))))
+      expr should beSuccess(Type.Const(OffsetDateTime(JOffsetDateTime.parse("2015-01-21T09:00:00Z"))))
     }
 
     def permute(f: quasar.Func.Input[Type, nat._2] => ValidationNel[ArgumentError, Type], t1: Const, t2: Const)(exp1: Const, exp2: Type) = {
-      f(Func.Input2(t1, t2)) should beSuccessful(exp1)
-      f(Func.Input2(t1, t2.value.dataType)) should beSuccessful(exp2)
-      f(Func.Input2(t1.value.dataType, t2)) should beSuccessful(exp2)
-      f(Func.Input2(t1.value.dataType, t2.value.dataType)) should beSuccessful(exp2)
+      f(Func.Input2(t1, t2)) should beSuccess(exp1)
+      f(Func.Input2(t1, t2.value.dataType)) should beSuccess(exp2)
+      f(Func.Input2(t1.value.dataType, t2)) should beSuccess(exp2)
+      f(Func.Input2(t1.value.dataType, t2.value.dataType)) should beSuccess(exp2)
 
-      f(Func.Input2(t2, t1)) should beSuccessful(exp1)
-      f(Func.Input2(t2.value.dataType, t1)) should beSuccessful(exp2)
-      f(Func.Input2(t2, t1.value.dataType)) should beSuccessful(exp2)
-      f(Func.Input2(t2.value.dataType, t1.value.dataType)) should beSuccessful(exp2)
+      f(Func.Input2(t2, t1)) should beSuccess(exp1)
+      f(Func.Input2(t2.value.dataType, t1)) should beSuccess(exp2)
+      f(Func.Input2(t2, t1.value.dataType)) should beSuccess(exp2)
+      f(Func.Input2(t2.value.dataType, t1.value.dataType)) should beSuccess(exp2)
     }
 
     "add with const and non-const Ints" in {

--- a/frontend/src/test/scala/quasar/std/relations.scala
+++ b/frontend/src/test/scala/quasar/std/relations.scala
@@ -39,61 +39,61 @@ class RelationsSpec extends quasar.Qspec with TypeGenerators {
     "type eq with matching arguments" >> prop { (t : Type) =>
       val expr = Eq.tpe(Func.Input2(t, t))
       t match {
-        case Const(_) => expr should beSuccessful(Const(Bool(true)))
-        case _ => expr should beSuccessful(Type.Bool)
+        case Const(_) => expr should beSuccess(Const(Bool(true)))
+        case _ => expr should beSuccess(Type.Bool)
       }
     }
 
     "fold integer eq" in {
       val expr = Eq.tpe(Func.Input2(Const(Int(1)), Const(Int(1))))
-      expr should beSuccessful(Const(Bool(true)))
+      expr should beSuccess(Const(Bool(true)))
     }
 
     "fold eq with mixed numeric type" in {
       val expr = Eq.tpe(Func.Input2(Const(Int(1)), Const(Dec(1.0))))
-      expr should beSuccessful(Const(Bool(true)))
+      expr should beSuccess(Const(Bool(true)))
     }
 
     "fold eq with mixed type" in {
       val expr = Eq.tpe(Func.Input2(Const(Int(1)), Const(Str("a"))))
-      expr should beSuccessful(Const(Bool(false)))
+      expr should beSuccess(Const(Bool(false)))
     }
 
     "type Eq with Top" >> prop { (t : Type) =>
-      Eq.tpe(Func.Input2(Type.Top, t)) should beSuccessful(Type.Bool)
-      Eq.tpe(Func.Input2(t, Type.Top)) should beSuccessful(Type.Bool)
+      Eq.tpe(Func.Input2(Type.Top, t)) should beSuccess(Type.Bool)
+      Eq.tpe(Func.Input2(t, Type.Top)) should beSuccess(Type.Bool)
     }
 
     "type Neq with Top" >> prop { (t : Type) =>
-      Neq.tpe(Func.Input2(Type.Top, t)) should beSuccessful(Type.Bool)
-      Neq.tpe(Func.Input2(t, Type.Top)) should beSuccessful(Type.Bool)
+      Neq.tpe(Func.Input2(Type.Top, t)) should beSuccess(Type.Bool)
+      Neq.tpe(Func.Input2(t, Type.Top)) should beSuccess(Type.Bool)
     }
 
     "fold neq with mixed type" in {
       val expr = Neq.tpe(Func.Input2(Const(Int(1)), Const(Str("a"))))
-      expr should beSuccessful(Const(Bool(true)))
+      expr should beSuccess(Const(Bool(true)))
     }
 
     // TODO: similar for the rest of the simple relations
 
     "fold cond with true" >> prop { (t1 : Type, t2 : Type) =>
       val expr = Cond.tpe(Func.Input3(Const(Bool(true)), t1, t2))
-      expr must beSuccessful(t1)
+      expr must beSuccess(t1)
     }
 
     "fold cond with false" >> prop { (t1 : Type, t2 : Type) =>
       val expr = Cond.tpe(Func.Input3(Const(Bool(false)), t1, t2))
-      expr must beSuccessful(t2)
+      expr must beSuccess(t2)
     }
 
     "find lub for cond with int" in {
       val expr = Cond.tpe(Func.Input3(Type.Bool, Type.Int, Type.Int))
-      expr must beSuccessful(Type.Int)
+      expr must beSuccess(Type.Int)
     }
 
     "find lub for cond with arbitrary args" >> prop { (t1 : Type, t2 : Type) =>
       val expr = Cond.tpe(Func.Input3(Type.Bool, t1, t2))
-      expr must beSuccessful(Type.lub(t1, t2))
+      expr must beSuccess(Type.lub(t1, t2))
     }
 
     "flip comparison ops" >> Prop.forAll(comparisonOps, arbitrary[BigInt], arbitrary[BigInt]) {

--- a/frontend/src/test/scala/quasar/std/structural.scala
+++ b/frontend/src/test/scala/quasar/std/structural.scala
@@ -40,188 +40,188 @@ class StructuralSpecs extends Qspec with ValidationMatchers {
       s.map(c => Data.Str(c.toString)).toList
 
     "type combination of arbitrary strs as str" >> prop { (st1: Type, st2: Type) =>
-      ConcatOp.tpe(Func.Input2(st1, st2)).map(Str contains _) must beSuccessful(true)
-      ConcatOp.tpe(Func.Input2(st2, st1)).map(Str contains _) must beSuccessful(true)
+      ConcatOp.tpe(Func.Input2(st1, st2)).map(Str contains _) must beSuccess(true)
+      ConcatOp.tpe(Func.Input2(st2, st1)).map(Str contains _) must beSuccess(true)
     }.setArbitrary1(arbStrType).setArbitrary2(arbStrType)
 
     "type arbitrary str || unknown as Str" >> prop { (st: Type) =>
-      ConcatOp.tpe(Func.Input2(st, unknown)) must beSuccessful(Str)
-      ConcatOp.tpe(Func.Input2(unknown, st)) must beSuccessful(Str)
+      ConcatOp.tpe(Func.Input2(st, unknown)) must beSuccess(Str)
+      ConcatOp.tpe(Func.Input2(unknown, st)) must beSuccess(Str)
     }.setArbitrary(arbStrType)
 
     "fold constant Strings" >> prop { (s1: String, s2: String) =>
       ConcatOp.tpe(Func.Input2(Const(Data.Str(s1)), Const(Data.Str(s2)))) must
-        beSuccessful(Const(Data.Str(s1 + s2)))
+        beSuccess(Const(Data.Str(s1 + s2)))
     }
 
     "type combination of arbitrary arrays as array" >> prop { (at1: Type, at2: Type) =>
-      ConcatOp.tpe(Func.Input2(at1, at2)).map(_.arrayLike) must beSuccessful(true)
-      ConcatOp.tpe(Func.Input2(at2, at1)).map(_.arrayLike) must beSuccessful(true)
+      ConcatOp.tpe(Func.Input2(at1, at2)).map(_.arrayLike) must beSuccess(true)
+      ConcatOp.tpe(Func.Input2(at2, at1)).map(_.arrayLike) must beSuccess(true)
     }.setArbitrary1(arbArrayType).setArbitrary2(arbArrayType)
 
     "type arbitrary array || unknown as array" >> prop { (at: Type) =>
-      ConcatOp.tpe(Func.Input2(at, unknown)).map(_.arrayLike) must beSuccessful(true)
-      ConcatOp.tpe(Func.Input2(unknown, at)).map(_.arrayLike) must beSuccessful(true)
+      ConcatOp.tpe(Func.Input2(at, unknown)).map(_.arrayLike) must beSuccess(true)
+      ConcatOp.tpe(Func.Input2(unknown, at)).map(_.arrayLike) must beSuccess(true)
     }.setArbitrary(arbArrayType)
 
     "fold constant arrays" >> prop { (ds1: List[Data], ds2: List[Data]) =>
       ConcatOp.tpe(Func.Input2(Const(Data.Arr(ds1)), Const(Data.Arr(ds2)))) must
-        beSuccessful(Const(Data.Arr(ds1 ++ ds2)))
+        beSuccess(Const(Data.Arr(ds1 ++ ds2)))
     }
 
     "type mixed Str and array args as array" >> prop { (st: Type, at: Type) =>
-      ConcatOp.tpe(Func.Input2(st, at)).map(_.arrayLike) must beSuccessful(true)
-      ConcatOp.tpe(Func.Input2(at, st)).map(_.arrayLike) must beSuccessful(true)
+      ConcatOp.tpe(Func.Input2(st, at)).map(_.arrayLike) must beSuccess(true)
+      ConcatOp.tpe(Func.Input2(at, st)).map(_.arrayLike) must beSuccess(true)
     }.setArbitrary1(arbStrType).setArbitrary2(arbArrayType)
 
     "fold constant string || array" >> prop { (s: String, xs: List[Data]) =>
       ConcatOp.tpe(Func.Input2(Const(Data.Str(s)), Const(Data.Arr(xs)))) must
-        beSuccessful(Const(Data.Arr(stringToList(s) ::: xs)))
+        beSuccess(Const(Data.Arr(stringToList(s) ::: xs)))
     }
 
     "fold constant array || string" >> prop { (s: String, xs: List[Data]) =>
       ConcatOp.tpe(Func.Input2(Const(Data.Arr(xs)), Const(Data.Str(s)))) must
-        beSuccessful(Const(Data.Arr(xs ::: stringToList(s))))
+        beSuccess(Const(Data.Arr(xs ::: stringToList(s))))
     }
 
     "propagate unknown types" in {
-      ConcatOp.tpe(Func.Input2(unknown, unknown)) must beSuccessful(unknown)
+      ConcatOp.tpe(Func.Input2(unknown, unknown)) must beSuccess(unknown)
     }
   }
 
   "FlattenMap" should {
     "only accept maps" >> prop { (nonMap: Type) =>
-      FlattenMap.tpe(Func.Input1(nonMap)) must beFailing
+      FlattenMap.tpe(Func.Input1(nonMap)) must beFailure
     }.setArbitrary(arbArrayType)
 
     "convert from a map type to the type of its values" in {
-      FlattenMap.tpe(Func.Input1(Obj(Map(), Str.some))) must beSuccessful(Str)
+      FlattenMap.tpe(Func.Input1(Obj(Map(), Str.some))) must beSuccess(Str)
     }
 
     "untype to a map type from some value type" in {
-      FlattenMap.untpe(Str).map(_.unsized) must beSuccessful(List(Obj(Map(), Str.some)))
+      FlattenMap.untpe(Str).map(_.unsized) must beSuccess(List(Obj(Map(), Str.some)))
     }
   }
 
   "FlattenMapKeys" should {
     "only accept maps" >> prop { (nonMap: Type) =>
-      FlattenMapKeys.tpe(Func.Input1(nonMap)) must beFailing
+      FlattenMapKeys.tpe(Func.Input1(nonMap)) must beFailure
     }.setArbitrary(arbArrayType)
 
     "convert from a map type to the type of its keys" in {
-      FlattenMapKeys.tpe(Func.Input1(Obj(Map(), Int.some))) must beSuccessful(Str)
+      FlattenMapKeys.tpe(Func.Input1(Obj(Map(), Int.some))) must beSuccess(Str)
     }
 
     "untype to a map type from some key type" in {
-      FlattenMapKeys.untpe(Str).map(_.unsized) must beSuccessful(List(Obj(Map(), Top.some)))
+      FlattenMapKeys.untpe(Str).map(_.unsized) must beSuccess(List(Obj(Map(), Top.some)))
     }
   }
 
   "FlattenArray" should {
     "only accept arrays" >> prop { (nonArr: Type) =>
-      FlattenArray.tpe(Func.Input1(nonArr)) must beFailing
+      FlattenArray.tpe(Func.Input1(nonArr)) must beFailure
     }.setArbitrary(arbStrType)
 
     "convert from an array type to the type of its values" in {
-      FlattenArray.tpe(Func.Input1(FlexArr(0, None, Str))) must beSuccessful(Str)
+      FlattenArray.tpe(Func.Input1(FlexArr(0, None, Str))) must beSuccess(Str)
     }
 
     "untype to an array type from some value type" in {
-      FlattenArray.untpe(Str).map(_.unsized) must beSuccessful(List(FlexArr(0, None, Str)))
+      FlattenArray.untpe(Str).map(_.unsized) must beSuccess(List(FlexArr(0, None, Str)))
     }
   }
 
   "FlattenArrayIndices" should {
     "only accept arrays" >> prop { (nonArr: Type) =>
-      FlattenArrayIndices.tpe(Func.Input1(nonArr)) must beFailing
+      FlattenArrayIndices.tpe(Func.Input1(nonArr)) must beFailure
     }.setArbitrary(arbStrType)
 
     "convert from an array type to int" in {
-      FlattenArrayIndices.tpe(Func.Input1(FlexArr(0, None, Str))) must beSuccessful(Int)
+      FlattenArrayIndices.tpe(Func.Input1(FlexArr(0, None, Str))) must beSuccess(Int)
     }
 
     "untype to an array type from int" in {
       FlattenArrayIndices.untpe(Int).map(_.unsized) must
-        beSuccessful(List(FlexArr(0, None, Top)))
+        beSuccess(List(FlexArr(0, None, Top)))
     }
 
   }
 
   "ShiftMap" should {
     "only accept maps" >> prop { (nonMap: Type) =>
-      ShiftMap.tpe(Func.Input1(nonMap)) must beFailing
+      ShiftMap.tpe(Func.Input1(nonMap)) must beFailure
     }.setArbitrary(arbArrayType)
 
     "convert from a map type to the type of its values" in {
-      ShiftMap.tpe(Func.Input1(Obj(Map(), Str.some))) must beSuccessful(Str)
+      ShiftMap.tpe(Func.Input1(Obj(Map(), Str.some))) must beSuccess(Str)
     }
 
     "untype to a map type from some value type" in {
-      ShiftMap.untpe(Str).map(_.unsized) must beSuccessful(List(Obj(Map(), Str.some)))
+      ShiftMap.untpe(Str).map(_.unsized) must beSuccess(List(Obj(Map(), Str.some)))
     }
   }
 
   "ShiftMapKeys" should {
     "only accept maps" >> prop { (nonMap: Type) =>
-      ShiftMapKeys.tpe(Func.Input1(nonMap)) must beFailing
+      ShiftMapKeys.tpe(Func.Input1(nonMap)) must beFailure
     }.setArbitrary(arbArrayType)
 
     "convert from a map type to the type of its keys" in {
-      ShiftMapKeys.tpe(Func.Input1(Obj(Map(), Int.some))) must beSuccessful(Str)
+      ShiftMapKeys.tpe(Func.Input1(Obj(Map(), Int.some))) must beSuccess(Str)
     }
 
     "untype to a map type from some key type" in {
-      ShiftMapKeys.untpe(Str).map(_.unsized) must beSuccessful(List(Obj(Map(), Top.some)))
+      ShiftMapKeys.untpe(Str).map(_.unsized) must beSuccess(List(Obj(Map(), Top.some)))
     }
   }
 
   "ShiftArray" should {
     "only accept arrays" >> prop { (nonArr: Type) =>
-      ShiftArray.tpe(Func.Input1(nonArr)) must beFailing
+      ShiftArray.tpe(Func.Input1(nonArr)) must beFailure
     }.setArbitrary(arbStrType)
 
     "convert from an array type to the type of its values" in {
-      ShiftArray.tpe(Func.Input1(FlexArr(0, None, Str))) must beSuccessful(Str)
+      ShiftArray.tpe(Func.Input1(FlexArr(0, None, Str))) must beSuccess(Str)
     }
 
     "untype to an array type from some value type" in {
-      ShiftArray.untpe(Str).map(_.unsized) must beSuccessful(List(FlexArr(0, None, Str)))
+      ShiftArray.untpe(Str).map(_.unsized) must beSuccess(List(FlexArr(0, None, Str)))
     }
   }
 
   "ShiftArrayIndices" should {
     "only accept arrays" >> prop { (nonArr: Type) =>
-      ShiftArrayIndices.tpe(Func.Input1(nonArr)) must beFailing
+      ShiftArrayIndices.tpe(Func.Input1(nonArr)) must beFailure
     }.setArbitrary(arbStrType)
 
     "convert from an array type to int" in {
-      ShiftArrayIndices.tpe(Func.Input1(FlexArr(0, None, Str))) must beSuccessful(Int)
+      ShiftArrayIndices.tpe(Func.Input1(FlexArr(0, None, Str))) must beSuccess(Int)
     }
 
     "untype to an array type from int" in {
       ShiftArrayIndices.untpe(Int).map(_.unsized) must
-        beSuccessful(List(FlexArr(0, None, Top)))
+        beSuccess(List(FlexArr(0, None, Top)))
     }
 
   }
 
   "UnshiftMap" should {
     "convert to a map type from some value type" in {
-      UnshiftMap.tpe(Func.Input2(Top, Str)) must beSuccessful(Obj(Map(), Str.some))
+      UnshiftMap.tpe(Func.Input2(Top, Str)) must beSuccess(Obj(Map(), Str.some))
     }
 
     "untype from a map type to the type of its values" in {
-      UnshiftMap.untpe(Obj(Map(), Str.some)).map(_.unsized) must beSuccessful(List(Top, Str))
+      UnshiftMap.untpe(Obj(Map(), Str.some)).map(_.unsized) must beSuccess(List(Top, Str))
     }
   }
 
   "UnshiftArray" should {
     "convert to an array type from some value type" in {
-      UnshiftArray.tpe(Func.Input1(Str)) must beSuccessful(FlexArr(0, None, Str))
+      UnshiftArray.tpe(Func.Input1(Str)) must beSuccess(FlexArr(0, None, Str))
     }
 
     "untype from an array type to the type of its values" in {
-      UnshiftArray.untpe(FlexArr(0, None, Str)).map(_.unsized) must beSuccessful(List(Str))
+      UnshiftArray.untpe(FlexArr(0, None, Str)).map(_.unsized) must beSuccess(List(Str))
     }
   }
 

--- a/frontend/src/test/scala/quasar/tpe/CompositeTypeSpec.scala
+++ b/frontend/src/test/scala/quasar/tpe/CompositeTypeSpec.scala
@@ -16,7 +16,8 @@
 
 package quasar.tpe
 
-import org.specs2.scalaz._
+import quasar.contrib.specs2.Spec
+
 import scalaz.scalacheck.ScalazProperties._
 
 final class CompositeTypeSpec extends Spec with CompositeTypeArbitrary {

--- a/frontend/src/test/scala/quasar/tpe/SimpleTypeSpec.scala
+++ b/frontend/src/test/scala/quasar/tpe/SimpleTypeSpec.scala
@@ -16,7 +16,8 @@
 
 package quasar.tpe
 
-import org.specs2.scalaz._
+import quasar.contrib.specs2.Spec
+
 import scalaz.scalacheck.ScalazProperties._
 
 final class SimpleTypeSpec extends Spec with SimpleTypeArbitrary {

--- a/frontend/src/test/scala/quasar/tpe/TypeFSpec.scala
+++ b/frontend/src/test/scala/quasar/tpe/TypeFSpec.scala
@@ -20,6 +20,7 @@ import slamdata.Predef._
 import quasar.contrib.algebra._
 import quasar.contrib.matryoshka._
 import quasar.contrib.matryoshka.arbitrary._
+import quasar.contrib.specs2.Spec
 import quasar.ejson.{Decoded, DecodeEJson, EncodeEJson, EJson, EJsonArbitrary, Fixed}
 import quasar.ejson.implicits._
 import quasar.fp._, Helpers._
@@ -30,9 +31,8 @@ import algebra.laws._
 import matryoshka.data.Fix
 import matryoshka.implicits._
 import org.specs2.scalacheck._
-import org.specs2.scalaz._
 import scalaz._, Scalaz._
-import scalaz.scalacheck.ScalazProperties._
+import scalaz.scalacheck.ScalazProperties.{equal => eql, _}
 import scalaz.scalacheck.ScalazArbitrary._
 
 final class TypeFSpec extends Spec with TypeFArbitrary with EJsonArbitrary {
@@ -47,10 +47,10 @@ final class TypeFSpec extends Spec with TypeFArbitrary with EJsonArbitrary {
   implicit def typeFIntEqual[A: Equal]: Equal[TypeF[Int, A]] =
     TypeF.structuralEqual(Equal[Int])(Equal[A])
 
-  checkAll("structural", equal.laws[TypeF[Int, String]])
+  checkAll("structural", eql.laws[TypeF[Int, String]])
   checkAll(traverse.laws[TypeF[Int, ?]])
   // TODO: Want to check cats.kernel.OrderLaws, but need Cogen
-  checkAll("subtyping", equal.laws[T])
+  checkAll("subtyping", eql.laws[T])
   checkAll(LatticeLaws[T].boundedDistributiveLattice.all)
   checkAll(LatticePartialOrderLaws[T].boundedLatticePartialOrder.all)
 

--- a/frontend/src/test/scala/quasar/types.scala
+++ b/frontend/src/test/scala/quasar/types.scala
@@ -89,7 +89,7 @@ class TypesSpec extends Qspec with ValidationMatchers {
     }
 
     "fail with type and non-matching constant (reversed)" in {
-      typecheck(Const(Data.Int(0)), Str) should beFailing
+      typecheck(Const(Data.Int(0)), Str) should beFailure
     }
 
     // Properties:
@@ -649,66 +649,66 @@ class TypesSpec extends Qspec with ValidationMatchers {
 
   "arrayElem" should {
     "fail for non-array type" >> prop { (t: Type) =>
-      t.arrayElem(Const(Data.Int(0))) should beFailing//WithClass[TypeError]
+      t.arrayElem(Const(Data.Int(0))) should beFailure//WithClass[TypeError]
     }.setArbitrary(arbitrarySimpleType)
 
     "fail for non-int index"  >> prop { (t: Type) =>
       // TODO: this occasionally get stuck... maybe lub() is diverging?
       lub(t, Int) != Int ==> {
         val arr = Const(Data.Arr(Nil))
-        arr.arrayElem(t) should beFailing
+        arr.arrayElem(t) should beFailure
       }
     }.setArbitrary(arbitrarySimpleType)
 
     "descend into const array with const index" in {
       val arr = Const(Data.Arr(List(Data.Int(0), Data.Str("a"), Data.True)))
-      arr.arrayElem(Const(Data.Int(1))) should beSuccessful(Const(Data.Str("a")))
+      arr.arrayElem(Const(Data.Int(1))) should beSuccess(Const(Data.Str("a")))
     }
 
     "descend into const array with unspecified index" in {
       val arr = Const(Data.Arr(List(Data.Int(0), Data.Str("a"), Data.True)))
       arr.arrayElem(Int) should
-        beSuccessful(Const(Data.Int(0)) ⨿ Const(Data.Str("a")) ⨿ Const(Data.True))
+        beSuccess(Const(Data.Int(0)) ⨿ Const(Data.Str("a")) ⨿ Const(Data.True))
     }
 
     "descend into FlexArr with const index" in {
-      FlexArr(0, None, Str).arrayElem(Const(Data.Int(0))) should beSuccessful(Str)
+      FlexArr(0, None, Str).arrayElem(Const(Data.Int(0))) should beSuccess(Str)
     }
 
     "descend into FlexArr with unspecified index" in {
-      FlexArr(0, None, Str).arrayElem(Int) should beSuccessful(Str)
+      FlexArr(0, None, Str).arrayElem(Int) should beSuccess(Str)
     }
 
     "descend into product of FlexArrs with const index" in {
       val arr = FlexArr(0, None, Int) ⨯ FlexArr(0, None, Str)
-          arr.arrayElem(Const(Data.Int(0))) should beSuccessful(Int ⨿ Str)
+          arr.arrayElem(Const(Data.Int(0))) should beSuccess(Int ⨿ Str)
     }
 
     "descend into product of FlexArrss with unspecified index" in {
       val arr = FlexArr(0, None, Int) ⨯ FlexArr(0, None, Str)
-      arr.arrayElem(Int) should beSuccessful(Int ⨿ Str)
+      arr.arrayElem(Int) should beSuccess(Int ⨿ Str)
     }
 
     "descend into FlexArr with non-int" in {
-      FlexArr(0, None, Str).arrayElem(Str) should beFailing
+      FlexArr(0, None, Str).arrayElem(Str) should beFailure
     }
 
     "descend into Arr" in {
-      Arr(List(Int, Top, Bottom, Str)).arrayElem(Const(Data.Int(3))) should beSuccessful(Str)
+      Arr(List(Int, Top, Bottom, Str)).arrayElem(Const(Data.Int(3))) should beSuccess(Str)
     }
 
     "descend into Arr with wrong index" in {
-      Arr(List(Int, Top, Bottom, Str)).arrayElem(Const(Data.Int(5))) should beSuccessful(Const(Data.NA))
+      Arr(List(Int, Top, Bottom, Str)).arrayElem(Const(Data.Int(5))) should beSuccess(Const(Data.NA))
     }
 
     "descend into multiple Arr" in {
       val arr = Arr(List(Int, Str))
-      arr.arrayElem(Const(Data.Int(1))) should beSuccessful(Str)
+      arr.arrayElem(Const(Data.Int(1))) should beSuccess(Str)
     }
 
     "descend into multi-element Arr with unspecified index" in {
       val arr = Arr(List(Int, Str))
-      arr.arrayElem(Int) should beSuccessful(Int ⨿ Str)
+      arr.arrayElem(Int) should beSuccess(Int ⨿ Str)
     }
 
     // TODO: tests for coproducts

--- a/fs/src/test/scala/quasar/fs/EnvironmentErrorSpec.scala
+++ b/fs/src/test/scala/quasar/fs/EnvironmentErrorSpec.scala
@@ -16,7 +16,8 @@
 
 package quasar.fs
 
-import org.specs2.scalaz.Spec
+import quasar.contrib.specs2.Spec
+
 import scalaz.scalacheck.ScalazProperties
 
 class EnvironmentErrorSpec extends Spec {

--- a/impl/src/main/scala/quasar/impl/datasources/DataSourceConfig.scala
+++ b/impl/src/main/scala/quasar/impl/datasources/DataSourceConfig.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.impl.datasources
+
+import quasar.api.DataSourceType
+
+import monocle.PLens
+import monocle.macros.Lenses
+import scalaz.{Apply, Cord, Equal, Order, Show, Traverse1}
+import scalaz.std.tuple._
+import scalaz.syntax.show._
+
+@Lenses
+final case class DataSourceConfig[C](kind: DataSourceType, config: C)
+
+object DataSourceConfig extends DataSourceConfigInstances {
+  def pConfig[C, D]: PLens[DataSourceConfig[C], DataSourceConfig[D], C, D] =
+    PLens[DataSourceConfig[C], DataSourceConfig[D], C, D](
+      _.config)(
+      d => _.copy(config = d))
+}
+
+sealed abstract class DataSourceConfigInstances extends DataSourceConfigInstances0 {
+  def order[C: Order]: Order[DataSourceConfig[C]] =
+    Order.orderBy(c => (c.kind, c.config))
+
+  def show[C: Show]: Show[DataSourceConfig[C]] =
+    Show.show {
+      case DataSourceConfig(t, c) =>
+        Cord("DataSourceConfig(") ++ t.show ++ Cord(", ") ++ c.show ++ Cord(")")
+    }
+
+  val traverse1: Traverse1[DataSourceConfig] =
+    new Traverse1[DataSourceConfig] {
+      def foldMapRight1[A, B](fa: DataSourceConfig[A])(z: A => B)(f: (A, => B) => B) =
+        z(fa.config)
+
+      def traverse1Impl[G[_]: Apply, A, B](fa: DataSourceConfig[A])(f: A => G[B]) =
+        DataSourceConfig.pConfig[A, B].modifyF(f)(fa)
+    }
+}
+
+sealed abstract class DataSourceConfigInstances0 {
+  def equal[C: Equal]: Equal[DataSourceConfig[C]] =
+    Equal.equalBy(c => (c.kind, c.config))
+}

--- a/impl/src/main/scala/quasar/impl/datasources/DataSourceConfigs.scala
+++ b/impl/src/main/scala/quasar/impl/datasources/DataSourceConfigs.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.impl.datasources
+
+import slamdata.Predef.{Boolean, Option, Unit}
+import quasar.api.{DataSourceType, ResourceName}
+
+import scalaz.IMap
+
+/** Provides for managing the configuration of datasources. */
+trait DataSourceConfigs[F[_], C] {
+  /** Associate the given configuration with `name`, replacing any
+    * existing association.
+    */
+  def add(name: ResourceName, config: DataSourceConfig[C]): F[Unit]
+
+  /** The set of configured datasources. */
+  def configured: F[IMap[ResourceName, DataSourceType]]
+
+  /** Returns the configuration associated with `name` or `None` if none exists. */
+  def lookup(name: ResourceName): F[Option[DataSourceConfig[C]]]
+
+  /** Removes any association with the given name, returning whether one existed. */
+  def remove(name: ResourceName): F[Boolean]
+
+  /** Renames the association of `src` to `dst`, replacing any existing
+    * association at `dst`.
+    */
+  def rename(src: ResourceName, dst: ResourceName): F[Unit]
+}

--- a/impl/src/main/scala/quasar/impl/datasources/DataSourceConfigs.scala
+++ b/impl/src/main/scala/quasar/impl/datasources/DataSourceConfigs.scala
@@ -21,7 +21,12 @@ import quasar.api.{DataSourceType, ResourceName}
 
 import scalaz.IMap
 
-/** Provides for managing the configuration of datasources. */
+/** A primitive facility for managing datasource configurations.
+  *
+  * All mutating operations overwrite existing configurations as this is intended
+  * to be used as a dependency in another context, such as `DefaultDataSources`,
+  * that decides whether doing so is appropriate.
+  */
 trait DataSourceConfigs[F[_], C] {
   /** Associate the given configuration with `name`, replacing any
     * existing association.

--- a/impl/src/main/scala/quasar/impl/datasources/DataSourceControl.scala
+++ b/impl/src/main/scala/quasar/impl/datasources/DataSourceControl.scala
@@ -23,7 +23,12 @@ import quasar.api.DataSourceError.CreateError
 
 import scalaz.ISet
 
-/** Provides for control over the lifecycle of external DataSources. */
+/** A primitive facility for managing the lifecycle of datasources.
+  *
+  * All mutating operations replace existing datasources as this is intended
+  * to be used as a dependency in another context, such as `DefaultDataSources`,
+  * that decides whether doing so is appropriate.
+  */
 trait DataSourceControl[F[_], C] {
   /** Initialize a datasource as `name` using the provided `config`. If a
     * datasource exists at `name`, it is shut down.

--- a/impl/src/main/scala/quasar/impl/datasources/DataSourceControl.scala
+++ b/impl/src/main/scala/quasar/impl/datasources/DataSourceControl.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.impl.datasources
+
+import slamdata.Predef.Unit
+import quasar.Condition
+import quasar.api.{DataSourceType, ResourceName}
+import quasar.api.DataSourceError.CreateError
+
+import scalaz.ISet
+
+/** Provides for control over the lifecycle of external DataSources. */
+trait DataSourceControl[F[_], C] {
+  /** Initialize a datasource as `name` using the provided `config`. If a
+    * datasource exists at `name`, it is shut down.
+    */
+  def init(
+      name: ResourceName,
+      config: DataSourceConfig[C])
+      : F[Condition[CreateError[C]]]
+
+  /** Stop the named datasource, discarding it and freeing any resources it may
+    * be using.
+    */
+  def shutdown(name: ResourceName): F[Unit]
+
+  /** Update the name of the datasource at `src` to `dst`. If a datasource exists
+    * at `dst`, it is shut down.
+    */
+  def rename(src: ResourceName, dst: ResourceName): F[Unit]
+
+  /** The types of datasources supported. */
+  def supported: F[ISet[DataSourceType]]
+}

--- a/impl/src/main/scala/quasar/impl/datasources/DataSourceErrors.scala
+++ b/impl/src/main/scala/quasar/impl/datasources/DataSourceErrors.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.impl.datasources
+
+import slamdata.Predef.{Exception, Option}
+import quasar.api.ResourceName
+
+import scalaz.{Functor, IMap}
+import scalaz.syntax.functor._
+
+/** Allows querying the error status of datasources. */
+trait DataSourceErrors[F[_]] {
+  /** DataSources currently in an error state. */
+  def errored: F[IMap[ResourceName, Exception]]
+
+  /** Retrieve the error associated with the named datasource. */
+  def lookup(name: ResourceName): F[Option[Exception]]
+}
+
+object DataSourceErrors {
+  def fromMap[F[_]: Functor](errors: F[IMap[ResourceName, Exception]]): DataSourceErrors[F] =
+    new DataSourceErrors[F] {
+      val errored = errors
+      def lookup(name: ResourceName) = errored.map(_.lookup(name))
+    }
+}

--- a/impl/src/main/scala/quasar/impl/datasources/DefaultDataSources.scala
+++ b/impl/src/main/scala/quasar/impl/datasources/DefaultDataSources.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.impl.datasources
+
+import slamdata.Predef.Unit
+import quasar.Condition
+import quasar.api._
+import quasar.api.DataSourceError._
+
+import scalaz.{\/, EitherT, IMap, ISet, Liskov, Monad, OptionT}, Liskov.<~<
+import scalaz.syntax.equal._
+import scalaz.syntax.monad._
+
+final class DefaultDataSources[F[_]: Monad, C](
+    configs: DataSourceConfigs[F, C],
+    errors: DataSourceErrors[F],
+    control: DataSourceControl[F, C])
+    extends DataSources[F, C] {
+
+  def add(
+      name: ResourceName,
+      kind: DataSourceType,
+      config: C,
+      onConflict: ConflictResolution)
+      : F[Condition[CreateError[C]]] = {
+
+    val dataSourceConfig =
+      DataSourceConfig(kind, config)
+
+    lookupConfig(name) flatMap { r =>
+      if (r.isRight && onConflict === ConflictResolution.Preserve)
+        Condition.abnormal[CreateError[C]](DataSourceExists(name)).point[F]
+      else
+        control.init(name, dataSourceConfig) flatMap {
+          case Condition.Abnormal(e) =>
+            Condition.abnormal[CreateError[C]](e).point[F]
+
+          case Condition.Normal() =>
+            configs.add(name, dataSourceConfig)
+              .as(Condition.normal[CreateError[C]]())
+        }
+    }
+  }
+
+  def lookup(name: ResourceName): F[CommonError \/ (DataSourceMetadata, C)] = {
+    val toResult: DataSourceConfig[C] => F[(DataSourceMetadata, C)] = {
+      case DataSourceConfig(t, c) =>
+        errors.lookup(name)
+          .map(DataSourceMetadata.fromOption(t, _))
+          .strengthR(c)
+    }
+
+    EitherT(lookupConfig(name))
+      .flatMap(cfg => EitherT.rightT(toResult(cfg)))
+      .run
+  }
+
+  def metadata: F[IMap[ResourceName, DataSourceMetadata]] =
+    (configs.configured |@| errors.errored) {
+      case (cfgs, errs) =>
+        cfgs.mapWithKey { (n, t) =>
+          DataSourceMetadata.fromOption(t, errs.lookup(n))
+        }
+    }
+
+  def remove(name: ResourceName): F[Condition[CommonError]] =
+    configs.remove(name).ifM(
+      control.shutdown(name).as(Condition.normal[CommonError]()),
+      Condition.abnormal[CommonError](DataSourceNotFound(name)).point[F])
+
+  def rename(
+      src: ResourceName,
+      dst: ResourceName,
+      onConflict: ConflictResolution)
+      : F[Condition[ExistentialError]] = {
+
+    val renamed: EitherT[F, ExistentialError, Unit] = for {
+      rsrc <- EitherT(lookupConfig(src)).leftMap(commonIsExistential)
+
+      rdst <- EitherT.rightT(lookupConfig(dst))
+
+      _ <- if (rdst.isRight && onConflict === ConflictResolution.Preserve)
+        EitherT.pureLeft[F, ExistentialError, Unit](DataSourceExists(dst))
+      else
+        EitherT.rightT[F, ExistentialError, Unit](
+          configs.rename(src, dst) >> control.rename(src, dst))
+
+    } yield ()
+
+    renamed.run.map(Condition.disjunctionIso.reverseGet(_))
+  }
+
+  def supported: F[ISet[DataSourceType]] =
+    control.supported
+
+  ////
+
+  private val commonIsExistential: CommonError <~< ExistentialError =
+    Liskov.isa[CommonError, ExistentialError]
+
+  private def lookupConfig(name: ResourceName)
+      : F[CommonError \/ DataSourceConfig[C]] =
+    OptionT(configs.lookup(name))
+      .toRight(DataSourceNotFound(name): CommonError)
+      .run
+}

--- a/impl/src/main/scala/quasar/impl/datasources/DefaultDataSources.scala
+++ b/impl/src/main/scala/quasar/impl/datasources/DefaultDataSources.scala
@@ -25,7 +25,7 @@ import scalaz.{\/, EitherT, IMap, ISet, Liskov, Monad, OptionT}, Liskov.<~<
 import scalaz.syntax.equal._
 import scalaz.syntax.monad._
 
-final class DefaultDataSources[F[_]: Monad, C](
+final class DefaultDataSources[F[_]: Monad, C] private (
     configs: DataSourceConfigs[F, C],
     errors: DataSourceErrors[F],
     control: DataSourceControl[F, C])
@@ -117,4 +117,13 @@ final class DefaultDataSources[F[_]: Monad, C](
     OptionT(configs.lookup(name))
       .toRight(DataSourceNotFound(name): CommonError)
       .run
+}
+
+object DefaultDataSources {
+  def apply[F[_]: Monad, C](
+      configs: DataSourceConfigs[F, C],
+      errors: DataSourceErrors[F],
+      control: DataSourceControl[F, C])
+      : DataSources[F, C] =
+    new DefaultDataSources(configs, errors, control)
 }

--- a/impl/src/test/scala/quasar/impl/datasources/DefaultDataSourcesSpec.scala
+++ b/impl/src/test/scala/quasar/impl/datasources/DefaultDataSourcesSpec.scala
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.impl.datasources
+
+import slamdata.Predef._
+import quasar.Condition
+import quasar.api._
+import quasar.api.DataSourceError._
+import DefaultDataSourcesSpec.DefaultM
+
+import java.io.IOException
+
+import eu.timepit.refined.auto._
+import scalaz.{~>, Id, IMap, ISet, StateT, Writer}, Id.Id
+import scalaz.std.anyVal._
+import scalaz.std.list._
+import scalaz.syntax.monad._
+
+final class DefaultDataSourcesSpec extends DataSourcesSpec[DefaultM, Int] {
+  def datasources = mkDataSources(IMap.empty)(_ => None)
+
+  def supportedType = DataSourceType("test-type", 3L)
+
+  def validConfigs = (5, 7)
+
+  def run =
+    λ[DefaultM ~> Id](_.eval(IMap.empty).eval(ISet.empty).value)
+
+  def mkDataSources(
+      errs: IMap[ResourceName, Exception])(
+      init: Int => Option[InitializationError[Int]])
+      : DataSources[DefaultM, Int] = {
+
+    val configs =
+      MockDataSourceConfigs[Int, DefaultM]
+
+    val errors =
+      DataSourceErrors.fromMap(errs.point[DefaultM])
+
+    val control =
+      MockDataSourceControl[DefaultM, Int](
+        ISet.singleton(supportedType),
+        init)
+
+    DefaultDataSources(configs, errors, control)
+  }
+
+  "implementation specific" >> {
+    "add" >> {
+      "initializes datasource" >> {
+        val addfoo = datasources.add(
+          foo,
+          supportedType,
+          configB,
+          ConflictResolution.Preserve)
+
+        addfoo.eval(IMap.empty).run(ISet.empty).value match {
+          case (inits, cond) =>
+            inits.member(foo) must beTrue
+            cond must beNormal
+        }
+      }
+
+      "doesn't store config when initialization fails" >> {
+        val err3 =
+          MalformedConfiguration(supportedType, 3, "3 isn't a config!")
+
+        val ds = mkDataSources(IMap.empty) {
+          case 3 => Some(err3)
+          case _ => None
+        }
+
+        val addfoo = ds.add(
+          foo,
+          supportedType,
+          3,
+          ConflictResolution.Preserve)
+
+        addfoo.run(IMap.empty).run(ISet.empty).value match {
+          case (inits, (cfgs, cond)) =>
+            cfgs.member(foo) must beFalse
+            inits.member(foo) must beFalse
+            cond must beAbnormal(equal[DataSourceError[Int]](err3))
+        }
+      }
+    }
+
+    "lookup" >> {
+      "includes errors" >> {
+        val errs =
+          IMap[ResourceName, Exception](bar -> new IOException())
+
+        val ds = mkDataSources(errs)(_ => None)
+
+        val lbar = for {
+          _ <- ds.add(foo, supportedType, 7, ConflictResolution.Preserve)
+          _ <- ds.add(bar, supportedType, 8, ConflictResolution.Preserve)
+          b <- ds.lookup(bar)
+        } yield b
+
+        lbar.eval(IMap.empty).eval(ISet.empty).value must be_\/-.like {
+          case (DataSourceMetadata(t, Condition.Abnormal(ex)), 8) =>
+            (t must_= supportedType) and (ex must beAnInstanceOf[IOException])
+        }
+      }
+    }
+
+    "metadata" >> {
+      "includes errors" >> {
+        val errs =
+          IMap[ResourceName, Exception](foo -> new IOException())
+
+        val ds = mkDataSources(errs)(_ => None)
+
+        val lbar = for {
+          _ <- ds.add(foo, supportedType, 7, ConflictResolution.Preserve)
+          _ <- ds.add(bar, supportedType, 8, ConflictResolution.Preserve)
+          m <- ds.metadata
+        } yield m
+
+        lbar.eval(IMap.empty).eval(ISet.empty).value.lookup(foo) must beLike {
+          case Some(DataSourceMetadata(t, Condition.Abnormal(ex))) =>
+            (t must_= supportedType) and (ex must beAnInstanceOf[IOException])
+        }
+      }
+    }
+
+    "remove" >> {
+      "shutdown existing" >> {
+        val sdown = for {
+          _ <- datasources.add(foo, supportedType, 7, ConflictResolution.Preserve)
+          cond <- datasources.remove(foo)
+        } yield cond
+
+        sdown.eval(IMap.empty).run(ISet.empty).run must beLike {
+          case (sdowns, (inits, Condition.Normal())) =>
+            inits must_= ISet.empty
+            sdowns must_= List(foo)
+        }
+      }
+    }
+
+    "rename" >> {
+      "updates control" >> {
+        val rn = for {
+          _ <- datasources.add(foo, supportedType, 5, ConflictResolution.Preserve)
+          _ <- datasources.add(bar, supportedType, 7, ConflictResolution.Preserve)
+          r <- datasources.rename(foo, bar, ConflictResolution.Replace)
+        } yield r
+
+        rn.eval(IMap.empty).run(ISet.empty).run must beLike {
+          case (sdowns, (inits, Condition.Normal())) =>
+            inits must_= ISet.singleton(bar)
+            sdowns must_= List(bar)
+        }
+      }
+    }
+  }
+}
+
+object DefaultDataSourcesSpec {
+  import MockDataSourceConfigs.Configs
+  import MockDataSourceControl.{Initialized, Shutdowns}
+
+  type DefaultM[A] = StateT[StateT[Writer[Shutdowns, ?], Initialized, ?], Configs[Int], A]
+}

--- a/impl/src/test/scala/quasar/impl/datasources/MockDataSourceConfigs.scala
+++ b/impl/src/test/scala/quasar/impl/datasources/MockDataSourceConfigs.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.impl.datasources
+
+import slamdata.Predef.{Boolean, None, Option, Some, Unit}
+import quasar.api.{DataSourceType, ResourceName}
+import quasar.contrib.scalaz.MonadState_
+import quasar.fp.ski.κ2
+import MockDataSourceConfigs.{Configs, MonadConfigs}
+
+import scalaz.{IMap, Monad}
+import scalaz.syntax.monad._
+
+final class MockDataSourceConfigs[C, F[_]: Monad: MonadConfigs[?[_], C]] private ()
+    extends DataSourceConfigs[F, C] {
+
+  private val configs = MonadState_[F, Configs[C]]
+
+  def add(name: ResourceName, config: DataSourceConfig[C]): F[Unit] =
+    configs.modify(_.insert(name, config))
+
+  def configured: F[IMap[ResourceName, DataSourceType]] =
+    configs.gets(_.map(_.kind))
+
+  def lookup(name: ResourceName): F[Option[DataSourceConfig[C]]] =
+    configs.gets(_.lookup(name))
+
+  def remove(name: ResourceName): F[Boolean] =
+    for {
+      cfgs <- configs.get
+
+      upd = cfgs.updateLookupWithKey(name, κ2(None))
+
+      (oldCfg, newCfgs) = upd
+
+      _ <- configs.put(newCfgs)
+    } yield oldCfg.isDefined
+
+  def rename(src: ResourceName, dst: ResourceName): F[Unit] =
+    configs.modify(
+      _.updateLookupWithKey(src, κ2(None)) match {
+        case (Some(cfg), m) => m.insert(dst, cfg)
+        case (None, m) => m
+      })
+}
+
+object MockDataSourceConfigs {
+  type Configs[C] = IMap[ResourceName, DataSourceConfig[C]]
+  type MonadConfigs[F[_], C] = MonadState_[F, Configs[C]]
+
+  def apply[C, F[_]: Monad: MonadConfigs[?[_], C]]: DataSourceConfigs[F, C] =
+    new MockDataSourceConfigs[C, F]()
+}

--- a/impl/src/test/scala/quasar/impl/datasources/MockDataSourceControl.scala
+++ b/impl/src/test/scala/quasar/impl/datasources/MockDataSourceControl.scala
@@ -30,7 +30,7 @@ import scalaz.syntax.std.boolean._
 /** Provides for control over the lifecycle of external DataSources. */
 final class MockDataSourceControl[F[_]: Monad: MonadInit: MonadShutdown, C] private (
     supportedTypes: ISet[DataSourceType],
-    initErrors: ResourceName => Option[InitializationError[C]])
+    initErrors: C => Option[InitializationError[C]])
     extends DataSourceControl[F, C] {
 
   private val initd = MonadState_[F, Initialized]
@@ -41,7 +41,7 @@ final class MockDataSourceControl[F[_]: Monad: MonadInit: MonadShutdown, C] priv
       config: DataSourceConfig[C])
       : F[Condition[CreateError[C]]] =
     if (supportedTypes.member(config.kind))
-      initErrors(name) match {
+      initErrors(config.config) match {
         case Some(err) =>
           Condition.abnormal[CreateError[C]](err).point[F]
 
@@ -80,7 +80,7 @@ object MockDataSourceControl {
 
   def apply[F[_]: Monad: MonadInit: MonadShutdown, C](
       supportedTypes: ISet[DataSourceType],
-      initErrors: ResourceName => Option[InitializationError[C]])
+      initErrors: C => Option[InitializationError[C]])
       : DataSourceControl[F, C] =
     new MockDataSourceControl[F, C](supportedTypes, initErrors)
 }

--- a/impl/src/test/scala/quasar/impl/datasources/MockDataSourceControl.scala
+++ b/impl/src/test/scala/quasar/impl/datasources/MockDataSourceControl.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.impl.datasources
+
+import slamdata.Predef.{List, None, Option, Some, Unit}
+import quasar.Condition
+import quasar.api.{DataSourceType, ResourceName}
+import quasar.api.DataSourceError._
+import quasar.contrib.scalaz.{MonadState_, MonadTell_}
+import MockDataSourceControl.{Initialized, MonadInit, MonadShutdown, Shutdowns}
+
+import scalaz.{ISet, Monad}
+import scalaz.syntax.monad._
+import scalaz.syntax.std.boolean._
+
+/** Provides for control over the lifecycle of external DataSources. */
+final class MockDataSourceControl[F[_]: Monad: MonadInit: MonadShutdown, C] private (
+    supportedTypes: ISet[DataSourceType],
+    initErrors: ResourceName => Option[InitializationError[C]])
+    extends DataSourceControl[F, C] {
+
+  private val initd = MonadState_[F, Initialized]
+  private val sdown = MonadTell_[F, Shutdowns]
+
+  def init(
+      name: ResourceName,
+      config: DataSourceConfig[C])
+      : F[Condition[CreateError[C]]] =
+    if (supportedTypes.member(config.kind))
+      initErrors(name) match {
+        case Some(err) =>
+          Condition.abnormal[CreateError[C]](err).point[F]
+
+        case None =>
+          for {
+            inits <- initd.get
+            _ <- inits.member(name).whenM(shutdown(name))
+            _ <- initd.put(inits.insert(name))
+          } yield Condition.normal[CreateError[C]]()
+      }
+    else
+      Condition.abnormal[CreateError[C]](
+        DataSourceUnsupported(config.kind, supportedTypes))
+        .point[F]
+
+  def shutdown(name: ResourceName): F[Unit] =
+    sdown.tell(List(name)) >> initd.modify(_.delete(name))
+
+  def rename(src: ResourceName, dst: ResourceName): F[Unit] =
+    for {
+      inits <- initd.get
+      _ <- inits.member(dst).whenM(shutdown(dst))
+      _ <- initd.put(inits.delete(src).insert(dst))
+    } yield ()
+
+  def supported: F[ISet[DataSourceType]] =
+    supportedTypes.point[F]
+}
+
+object MockDataSourceControl {
+  type Initialized = ISet[ResourceName]
+  type MonadInit[F[_]] = MonadState_[F, Initialized]
+
+  type Shutdowns = List[ResourceName]
+  type MonadShutdown[F[_]] = MonadTell_[F, Shutdowns]
+
+  def apply[F[_]: Monad: MonadInit: MonadShutdown, C](
+      supportedTypes: ISet[DataSourceType],
+      initErrors: ResourceName => Option[InitializationError[C]])
+      : DataSourceControl[F, C] =
+    new MockDataSourceControl[F, C](supportedTypes, initErrors)
+}

--- a/interface/src/test/scala/quasar/main/prettify.scala
+++ b/interface/src/test/scala/quasar/main/prettify.scala
@@ -182,18 +182,18 @@ class PrettifySpecs extends quasar.Qspec {
     }
 
     "fail with unmatched brackets" in {
-      Path.parse("foo[0") must beLeftDisjunction
-      Path.parse("foo]") must beLeftDisjunction
+      Path.parse("foo[0") must be_-\/
+      Path.parse("foo]") must be_-\/
     }
 
     "fail with bad index" in {
-      Path.parse("foo[]") must beLeftDisjunction
-      Path.parse("foo[abc]") must beLeftDisjunction
-      Path.parse("foo[-1]") must beLeftDisjunction
+      Path.parse("foo[]") must be_-\/
+      Path.parse("foo[abc]") must be_-\/
+      Path.parse("foo[-1]") must be_-\/
     }
 
     "fail with bad field" in {
-      Path.parse("foo..bar") must beLeftDisjunction
+      Path.parse("foo..bar") must be_-\/
     }
   }
 

--- a/it/src/test/scala/quasar/TaskResourceSpec.scala
+++ b/it/src/test/scala/quasar/TaskResourceSpec.scala
@@ -23,7 +23,7 @@ import scala.concurrent.duration._
 import scalaz._, Scalaz._
 import scalaz.concurrent.{Task, Strategy}
 
-class TaskResourceSpec extends QuasarSpecification {
+class TaskResourceSpec extends Qspec {
 
   "TaskResource" should {
     def loggingRsrc(ref: TaskRef[List[String]]): Task[TaskResource[Int]] =
@@ -74,7 +74,7 @@ class TaskResourceSpec extends QuasarSpecification {
 
         rez  <- rsrc.get.attempt.map(_.swap.as(()))
       } yield {
-        rez must beRightDisjunction
+        rez must be_\/-
       }).timed(1000.milliseconds).unsafePerformSync
     }
 

--- a/it/src/test/scala/quasar/server/ServiceSpec.scala
+++ b/it/src/test/scala/quasar/server/ServiceSpec.scala
@@ -138,7 +138,7 @@ class ServiceSpec extends quasar.Qspec {
           )(Task.now)
       }
 
-      r.map(_.status) must beRightDisjunction(Ok)
+      r.map(_.status) must be_\/-(Ok)
     }
 
     "PUT view" in {
@@ -158,7 +158,7 @@ class ServiceSpec extends quasar.Qspec {
           )(Task.now)
       }
 
-      r.map(_.status) must beRightDisjunction(Ok)
+      r.map(_.status) must be_\/-(Ok)
     }
 
     "[SD-1833] replace view" in withFileSystemConfigs {
@@ -213,7 +213,7 @@ class ServiceSpec extends quasar.Qspec {
           )(Task.now)
       }
 
-      r.map(_.status) must beRightDisjunction(Ok)
+      r.map(_.status) must be_\/-(Ok)
     }
   }
 
@@ -247,7 +247,7 @@ class ServiceSpec extends quasar.Qspec {
           )(Task.now)
       }
 
-      r.map(_.status) must beRightDisjunction(Ok)
+      r.map(_.status) must be_\/-(Ok)
     }
 
     "MOVE a directory containing views and files" in withFileSystemConfigs {
@@ -276,7 +276,7 @@ class ServiceSpec extends quasar.Qspec {
           )(Task.now)
       }
 
-      r.map(_.status) must beRightDisjunction(Ok)
+      r.map(_.status) must be_\/-(Ok)
     }
 
     "GET invalid view" in {
@@ -293,7 +293,7 @@ class ServiceSpec extends quasar.Qspec {
         )(Task.now)
       }
 
-      r.map(_.status) must beRightDisjunction(InternalServerError withReason "Failed to plan query.")
+      r.map(_.status) must be_\/-(InternalServerError withReason "Failed to plan query.")
     }
   }
 
@@ -322,7 +322,7 @@ class ServiceSpec extends quasar.Qspec {
           --\ "detail"
           --\ "message" := jEmptyString
         ).up.up.up.up.up.focus >>= (_.array ∘ (_.toSet))
-      ) must beRightDisjunction(
+      ) must be_\/-(
         Set(
           Json("name" := "f1", "type" := "file", "mount" := "view"),
           Json(

--- a/js/src/test/scala/quasar/jscore/jscore.scala
+++ b/js/src/test/scala/quasar/jscore/jscore.scala
@@ -22,10 +22,9 @@ import quasar.TreeMatchers
 import quasar.fp._
 import quasar.javascript.Js
 
-import org.specs2.scalaz._
 import scalaz._, Scalaz._
 
-class JsCoreSpecs extends quasar.Qspec with TreeMatchers with ScalazMatchers {
+class JsCoreSpecs extends quasar.Qspec with TreeMatchers {
   "toJs" should {
     "de-sugar Let as AnonFunDecl" in {
       val let =

--- a/marklogic/src/test/scala/quasar/physical/marklogic/fs/MarkLogicConfigSpec.scala
+++ b/marklogic/src/test/scala/quasar/physical/marklogic/fs/MarkLogicConfigSpec.scala
@@ -71,13 +71,13 @@ final class MarkLogicConfigSpec extends quasar.Qspec with MarkLogicConfigArbitra
       "when the host is not specified" >> {
         MarkLogicConfig.fromUriString[ErrorMessages \/ ?](
           "xcc://someone:somepass@:6643/db"
-        ) must beLeftDisjunction(NonEmptyList("Missing host", "Missing port"))
+        ) must be_-\/(NonEmptyList("Missing host", "Missing port"))
       }
 
       "when the port is not specified" >> {
         MarkLogicConfig.fromUriString[ErrorMessages \/ ?](
         "xcc://ml.example.com/db"
-        ) must beLeftDisjunction(NonEmptyList("Missing port"))
+        ) must be_-\/(NonEmptyList("Missing port"))
       }
     }
   }

--- a/mongodb/src/test/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutionSpec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/JavaScriptWorkflowExecutionSpec.scala
@@ -40,13 +40,13 @@ class JavaScriptWorkflowExecutionSpec extends quasar.Qspec {
     "write trivial workflow to JS" in {
       val wf = $read[WorkflowF](collection("db", "zips"))
 
-      toJS(wf) must beRightDisjunction("db.zips.find();\n")
+      toJS(wf) must be_\/-("db.zips.find();\n")
     }
 
     "write trivial workflow to JS with fancy collection name" in {
       val wf = $read[WorkflowF](collection("db", "tmp.123"))
 
-      toJS(wf) must beRightDisjunction("db.getCollection(\"tmp.123\").find();\n")
+      toJS(wf) must be_\/-("db.getCollection(\"tmp.123\").find();\n")
     }
 
     "be empty for pure values" in {
@@ -54,7 +54,7 @@ class JavaScriptWorkflowExecutionSpec extends quasar.Qspec {
         Bson.Doc(ListMap("foo" -> Bson.Int64(1))),
         Bson.Doc(ListMap("bar" -> Bson.Int64(2))))))
 
-        toJS(wf) must beRightDisjunction("")
+        toJS(wf) must be_\/-("")
     }
 
     "write simple query to JS" in {
@@ -63,7 +63,7 @@ class JavaScriptWorkflowExecutionSpec extends quasar.Qspec {
         $match[WorkflowF](Selector.Doc(
           BsonField.Name("pop") -> Selector.Gte(Bson.Int64(1000)))))
 
-      toJS(wf) must beRightDisjunction(
+      toJS(wf) must be_\/-(
         """db.zips.find({ "pop": { "$gte": NumberLong("1000") } });
           |""".stripMargin)
     }
@@ -73,7 +73,7 @@ class JavaScriptWorkflowExecutionSpec extends quasar.Qspec {
         $read[WorkflowF](collection("db", "zips")),
         $limit[WorkflowF](10))
 
-      toJS(wf) must beRightDisjunction(
+      toJS(wf) must be_\/-(
         """db.zips.find().limit(10);
           |""".stripMargin)
     }
@@ -87,7 +87,7 @@ class JavaScriptWorkflowExecutionSpec extends quasar.Qspec {
             BsonField.Name("city") -> $include().right)),
           ExcludeId))
 
-      toJS(wf) must beRightDisjunction(
+      toJS(wf) must be_\/-(
         """db.zips.find({ "city": true, "_id": false }).limit(10);
           |""".stripMargin)
     }
@@ -103,7 +103,7 @@ class JavaScriptWorkflowExecutionSpec extends quasar.Qspec {
             BsonField.Name("city") -> $include().right)),
           ExcludeId))
 
-      toJS(wf) must beRightDisjunction(
+      toJS(wf) must be_\/-(
         """db.zips.find(
           |  { "pop": { "$lt": NumberLong("1000") } },
           |  { "city": true, "_id": false }).limit(
@@ -121,7 +121,7 @@ class JavaScriptWorkflowExecutionSpec extends quasar.Qspec {
             BsonField.Name("num") -> $sum($literal(Bson.Int32(1))))),
           $literal(Bson.Null).right))
 
-      toJS(wf) must beRightDisjunction(
+      toJS(wf) must be_\/-(
         """db.zips.count({ "pop": { "$gte": NumberLong("1000") } });
           |""".stripMargin)
     }
@@ -135,7 +135,7 @@ class JavaScriptWorkflowExecutionSpec extends quasar.Qspec {
           $literal(Bson.Null).right),
         $limit[WorkflowF](11))
 
-      toJS(wf) must beRightDisjunction(
+      toJS(wf) must be_\/-(
         """db.zips.count();
           |""".stripMargin)
     }
@@ -152,7 +152,7 @@ class JavaScriptWorkflowExecutionSpec extends quasar.Qspec {
             BsonField.Name("c") -> $field("_id", "0").right)),
           ExcludeId))
 
-      toJS(wf) must beRightDisjunction(
+      toJS(wf) must be_\/-(
         """db.zips.distinct("city").map(function (elem) { return { "c": elem } });
           |""".stripMargin)
     }
@@ -171,7 +171,7 @@ class JavaScriptWorkflowExecutionSpec extends quasar.Qspec {
             BsonField.Name("c") -> $field("_id", "0").right)),
           ExcludeId))
 
-      toJS(wf) must beRightDisjunction(
+      toJS(wf) must be_\/-(
         """db.zips.distinct("city", { "pop": { "$gte": NumberLong("1000") } }).map(
           |  function (elem) { return { "c": elem } });
           |""".stripMargin)
@@ -183,7 +183,7 @@ class JavaScriptWorkflowExecutionSpec extends quasar.Qspec {
         $match[WorkflowF](Selector.Doc(
           BsonField.Name("pop") -> Selector.Gte(Bson.Int64(1000)))))
 
-      toJS(wf) must beRightDisjunction(
+      toJS(wf) must be_\/-(
         """db.zips.find({ "pop": { "$gte": NumberLong("1000") } });
           |""".stripMargin)
     }
@@ -197,7 +197,7 @@ class JavaScriptWorkflowExecutionSpec extends quasar.Qspec {
           BsonField.Name("pop") -> Selector.Gte(Bson.Int64(100)))),
         $sort[WorkflowF](NonEmptyList(BsonField.Name("city") -> SortDir.Ascending)))
 
-      toJS(wf) must beRightDisjunction(
+      toJS(wf) must be_\/-(
         """db.zips.find(
           |  {
           |    "$and": [
@@ -221,7 +221,7 @@ class JavaScriptWorkflowExecutionSpec extends quasar.Qspec {
           $field("city").right),
         $sort[WorkflowF](NonEmptyList(BsonField.Name("_id") -> SortDir.Ascending)))
 
-      toJS(wf) must beRightDisjunction(
+      toJS(wf) must be_\/-(
         """db.zips.aggregate(
           |  [
           |    {
@@ -250,7 +250,7 @@ class JavaScriptWorkflowExecutionSpec extends quasar.Qspec {
             List(Js.Ident("values")))))),
           ListMap()))
 
-      toJS(wf) must beRightDisjunction(
+      toJS(wf) must be_\/-(
         s"""db.zips.mapReduce(
           |  function () {
           |    emit.apply(
@@ -272,7 +272,7 @@ class JavaScriptWorkflowExecutionSpec extends quasar.Qspec {
         $read[WorkflowF](collection("db", "zips2")),
         $match[WorkflowF](Selector.Where(Js.Ident("foo"))))
 
-      toJS(wf) must beRightDisjunction(
+      toJS(wf) must be_\/-(
         """db.zips2.mapReduce(
           |  function () {
           |    emit.apply(
@@ -308,7 +308,7 @@ class JavaScriptWorkflowExecutionSpec extends quasar.Qspec {
                 List(Js.Ident("values")))))),
               ListMap())))
 
-      toJS(wf) must beRightDisjunction(
+      toJS(wf) must be_\/-(
         """db.zips1.aggregate(
           |  [
           |    { "$match": { "city": "BOULDER" } },

--- a/mongodb/src/test/scala/quasar/physical/mongodb/ServerVersionSpec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/ServerVersionSpec.scala
@@ -18,54 +18,55 @@ package quasar.physical.mongodb
 
 import slamdata.Predef._
 import quasar.QuasarSpecification
+import quasar.contrib.specs2.Spec
 
 import scalaz._, Scalaz._
 import scalaz.scalacheck.ScalazProperties._
 
-class ServerVersionSpec extends org.specs2.scalaz.Spec with QuasarSpecification with ArbitraryServerVersion {
+class ServerVersionSpec extends Spec with QuasarSpecification with ArbitraryServerVersion {
   "ServerVersion" should {
     "parse simple version" >> {
-      ServerVersion.fromString("2.6.11") must beRightDisjunction(ServerVersion(2, 6, Some(11), ""))
+      ServerVersion.fromString("2.6.11") must be_\/-(ServerVersion(2, 6, Some(11), ""))
     }
 
     "parse truncated version" >> {
-      ServerVersion.fromString("2.6") must beRightDisjunction(ServerVersion(2, 6, None, ""))
+      ServerVersion.fromString("2.6") must be_\/-(ServerVersion(2, 6, None, ""))
     }
 
     "parse multiple digits" >> {
-      ServerVersion.fromString("22.67.174") must beRightDisjunction(ServerVersion(22, 67, Some(174), ""))
+      ServerVersion.fromString("22.67.174") must be_\/-(ServerVersion(22, 67, Some(174), ""))
     }
 
     "parse with extra" >> {
-      ServerVersion.fromString("3.2.7-50-g67602c7") must beRightDisjunction(ServerVersion(3, 2, Some(7), "50-g67602c7"))
+      ServerVersion.fromString("3.2.7-50-g67602c7") must be_\/-(ServerVersion(3, 2, Some(7), "50-g67602c7"))
     }
 
     "parse with extra (space-separated)" >> {
-      ServerVersion.fromString("0.11.5 RC1") must beRightDisjunction(ServerVersion(0, 11, Some(5), "RC1"))
+      ServerVersion.fromString("0.11.5 RC1") must be_\/-(ServerVersion(0, 11, Some(5), "RC1"))
     }
 
     "parse with extra (_-separated)" >> {
-      ServerVersion.fromString("0.11.5_00") must beRightDisjunction(ServerVersion(0, 11, Some(5), "00"))
+      ServerVersion.fromString("0.11.5_00") must be_\/-(ServerVersion(0, 11, Some(5), "00"))
     }
 
     "parse with extra and no revision" >> {
-      ServerVersion.fromString("3.2-foo") must beRightDisjunction(ServerVersion(3, 2, None, "foo"))
+      ServerVersion.fromString("3.2-foo") must be_\/-(ServerVersion(3, 2, None, "foo"))
     }
 
     "parse with unexpected non-revision" >> {
-      ServerVersion.fromString("3.2.foo") must beRightDisjunction(ServerVersion(3, 2, None, "foo"))
+      ServerVersion.fromString("3.2.foo") must be_\/-(ServerVersion(3, 2, None, "foo"))
     }
 
     "fail with missing minor version" >> {
-      ServerVersion.fromString("4.abc") must beLeftDisjunction("Unable to parse server version: 4.abc")
+      ServerVersion.fromString("4.abc") must be_-\/("Unable to parse server version: 4.abc")
     }
 
     "never throw during parsing" >> prop { (str: String) =>
-        \/.fromTryCatchNonFatal(ServerVersion.fromString(str)) must beRightDisjunction
+        \/.fromTryCatchNonFatal(ServerVersion.fromString(str)) must be_\/-
     }
 
     "round-trip any" >> prop { (vers: ServerVersion) =>
-      ServerVersion.fromString(vers.shows) must beRightDisjunction(vers)
+      ServerVersion.fromString(vers.shows) must be_\/-(vers)
     }
 
     implicit val ord: scala.math.Ordering[ServerVersion] = Order[ServerVersion].toScalaOrdering

--- a/mongodb/src/test/scala/quasar/physical/mongodb/accumulator/spec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/accumulator/spec.scala
@@ -17,11 +17,11 @@
 package quasar.physical.mongodb.accumulator
 
 import quasar.fp._
+import quasar.contrib.specs2.Spec
 
 import org.scalacheck._
 import org.scalacheck.rng.Seed
 
-import org.specs2.scalaz._
 import scalaz._, Scalaz._
 import scalaz.scalacheck.ScalazProperties._
 

--- a/mongodb/src/test/scala/quasar/physical/mongodb/bsoncodec.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/bsoncodec.scala
@@ -39,7 +39,7 @@ abstract class BsonCodecSpecs(v: BsonVersion) extends quasar.Qspec {
 
   "fromData" should {
     "fail with bad Id" in {
-      fromData(v, Data.Id("invalid")) must beLeftDisjunction
+      fromData(v, Data.Id("invalid")) must be_-\/
     }
 
     "of double does convert to Bson.Dec not Bson.Dec128" >> prop { (d: Double) =>
@@ -77,7 +77,7 @@ abstract class BsonCodecSpecs(v: BsonVersion) extends quasar.Qspec {
       }
 
       preserved(data) ==> {
-        fromData(v, data).map(toData) must beRightDisjunction(data)
+        fromData(v, data).map(toData) must be_\/-(data)
       }
     }
 
@@ -87,7 +87,7 @@ abstract class BsonCodecSpecs(v: BsonVersion) extends quasar.Qspec {
       // (toData >=> fromData >=> toData) == toData
 
       val data = toData(bson)
-      fromData(v, data).map(toData _) must beRightDisjunction(data)
+      fromData(v, data).map(toData _) must be_\/-(data)
     }
   }
 

--- a/mongodb/src/test/scala/quasar/physical/mongodb/collection.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/collection.scala
@@ -30,101 +30,101 @@ class CollectionSpec extends quasar.Qspec {
 
     "handle simple name" in {
       Collection.fromFile(rootDir </> dir("db") </> file("foo")) must
-        beRightDisjunction(collection("db", "foo"))
+        be_\/-(collection("db", "foo"))
     }
 
     "handle simple relative path" in {
       Collection.fromFile(rootDir </> dir("db") </> dir("foo") </> file("bar")) must
-        beRightDisjunction(collection("db", "foo.bar"))
+        be_\/-(collection("db", "foo.bar"))
     }
 
     "escape leading '.'" in {
       Collection.fromFile(rootDir </> dir("db") </> file(".hidden")) must
-        beRightDisjunction(collection("db", "\\.hidden"))
+        be_\/-(collection("db", "\\.hidden"))
     }
 
     "escape '.' with path separators" in {
       Collection.fromFile(rootDir </> dir("db") </> dir("foo") </> file("bar.baz")) must
-        beRightDisjunction(collection("db", "foo.bar\\.baz"))
+        be_\/-(collection("db", "foo.bar\\.baz"))
     }
 
     "escape '$'" in {
       Collection.fromFile(rootDir </> dir("db") </> file("foo$")) must
-        beRightDisjunction(collection("db", "foo\\d"))
+        be_\/-(collection("db", "foo\\d"))
     }
 
     "escape '\\'" in {
       Collection.fromFile(rootDir </> dir("db") </> file("foo\\bar")) must
-        beRightDisjunction(collection("db", "foo\\\\bar"))
+        be_\/-(collection("db", "foo\\\\bar"))
     }
 
     "accept path with 120 characters" in {
       val longName = Stream.continually("A").take(117).mkString
       Collection.fromFile(rootDir </> dir("db") </> file(longName)) must
-        beRightDisjunction(collection("db", longName))
+        be_\/-(collection("db", longName))
     }
 
     "reject path longer than 120 characters" in {
       val longName = Stream.continually("B").take(118).mkString
-      Collection.fromFile(rootDir </> dir("db") </> file(longName)) must beLeftDisjunction
+      Collection.fromFile(rootDir </> dir("db") </> file(longName)) must be_-\/
     }
 
     "reject path that translates to more than 120 characters" in {
       val longName = "." + Stream.continually("C").take(116).mkString
-      Collection.fromFile(rootDir </> dir("db") </> file(longName)) must beLeftDisjunction
+      Collection.fromFile(rootDir </> dir("db") </> file(longName)) must be_-\/
     }
 
     "preserve space" in {
       Collection.fromFile(rootDir </> dir("db") </> dir("foo") </> file("bar baz")) must
-        beRightDisjunction(collection("db", "foo.bar baz"))
+        be_\/-(collection("db", "foo.bar baz"))
     }
 
     "reject path with db but no collection" in {
-      Collection.fromFile(rootDir </> file("db")) must beLeftDisjunction
+      Collection.fromFile(rootDir </> file("db")) must be_-\/
     }
 
     "escape space in db name" in {
       Collection.fromFile(rootDir </> dir("db 1") </> file("foo")) must
-        beRightDisjunction(collection("db+1", "foo"))
+        be_\/-(collection("db+1", "foo"))
     }
 
     "escape leading dot in db name" in {
       Collection.fromFile(rootDir </> dir(".trash") </> file("foo")) must
-        beRightDisjunction(collection("~trash", "foo"))
+        be_\/-(collection("~trash", "foo"))
     }
 
     "escape MongoDB-reserved chars in db name" in {
       Collection.fromFile(rootDir </> dir("db/\\\"") </> file("foo")) must
-        beRightDisjunction(collection("db%div%esc%quot", "foo"))
+        be_\/-(collection("db%div%esc%quot", "foo"))
     }
 
     "escape Windows-only MongoDB-reserved chars in db name" in {
       Collection.fromFile(rootDir </> dir("db*<>:|?") </> file("foo")) must
-        beRightDisjunction(collection("db%mul%lt%gt%colon%bar%qmark", "foo"))
+        be_\/-(collection("db%mul%lt%gt%colon%bar%qmark", "foo"))
     }
 
     "escape escape characters in db name" in {
       Collection.fromFile(rootDir </> dir("db%+~") </> file("foo")) must
-        beRightDisjunction(collection("db%%%add%tilde", "foo"))
+        be_\/-(collection("db%%%add%tilde", "foo"))
     }
 
     "fail with sequence of escapes exceeding maximum length" in {
-      Collection.fromFile(rootDir </> dir("~:?~:?~:?~:") </> file("foo")) must beLeftDisjunction
+      Collection.fromFile(rootDir </> dir("~:?~:?~:?~:") </> file("foo")) must be_-\/
     }
 
     "succeed with db name of exactly 64 bytes when encoded" in {
       val dbName = List.fill(64/4)("💩").mkString
-      Collection.fromFile(rootDir </> dir(dbName) </> file("foo")) must beRightDisjunction
+      Collection.fromFile(rootDir </> dir(dbName) </> file("foo")) must be_\/-
     }
 
     "fail with db name exceeding 64 bytes when encoded" in {
       val dbName = List.fill(64/4 + 1)("💩").mkString
-      Collection.fromFile(rootDir </> dir(dbName) </> file("foo")) must beLeftDisjunction
+      Collection.fromFile(rootDir </> dir(dbName) </> file("foo")) must be_-\/
     }
 
     "succeed with crazy char" in {
       Collection.fromFile(rootDir </> dir("*_") </> dir("_ⶡ\\݅ ᐠ") </> file("儨")) must
-        beRightDisjunction
+        be_\/-
     }
 
     "never emit an invalid db name" >> prop { (db: SpecialStr, c: SpecialStr) =>
@@ -158,15 +158,15 @@ class CollectionSpec extends quasar.Qspec {
 
   "Collection.prefixFromDir" should {
     "return a collection prefix" in {
-      Collection.prefixFromDir(rootDir </> dir("foo") </> dir("bar")) must beRightDisjunction(CollectionName("bar"))
+      Collection.prefixFromDir(rootDir </> dir("foo") </> dir("bar")) must be_\/-(CollectionName("bar"))
     }
 
     "reject path without collection" in {
-      Collection.prefixFromDir(rootDir </> dir("foo")) must beLeftDisjunction
+      Collection.prefixFromDir(rootDir </> dir("foo")) must be_-\/
     }
 
     "reject path without db or collection" in {
-      Collection.prefixFromDir(rootDir) must beLeftDisjunction
+      Collection.prefixFromDir(rootDir) must be_-\/
     }
   }
 
@@ -227,7 +227,7 @@ class CollectionSpec extends quasar.Qspec {
     val name = Collection.dbNameFromPath(rootDir </> dir(db.str))
     // NB: can fail if the path has enough multi-byte chars to exceed 64 bytes
     name.isRight ==> {
-      name.map(Collection.dirNameFromDbName(_)) must beRightDisjunction(DirName(db.str))
+      name.map(Collection.dirNameFromDbName(_)) must be_\/-(DirName(db.str))
     }
   }.set(maxSize = 20)
 }

--- a/mongodb/src/test/scala/quasar/physical/mongodb/workflowop.scala
+++ b/mongodb/src/test/scala/quasar/physical/mongodb/workflowop.scala
@@ -20,6 +20,7 @@ import slamdata.Predef._
 import quasar.RenderTree
 import quasar.TreeMatchers
 import quasar.common.SortDir
+import quasar.contrib.specs2.Spec
 import quasar.fp._
 import quasar.javascript._
 import quasar.jscore, jscore._
@@ -35,7 +36,7 @@ import org.specs2.matcher.MustMatchers._
 import scalaz.{Name => _, _}, Scalaz._
 import scalaz.scalacheck.ScalazProperties._
 
-class WorkflowFSpec extends org.specs2.scalaz.Spec {
+class WorkflowFSpec extends Spec {
   implicit val arbIdHandling: Arbitrary[IdHandling] =
     Arbitrary(Gen.oneOf(ExcludeId, IncludeId, IgnoreId))
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -58,9 +58,9 @@ object Dependencies {
     "org.typelevel"              %% "spire-laws"                % spireVersion                         % Test,
     "org.specs2"                 %% "specs2-core"               % specsVersion                         % Test,
     "org.specs2"                 %% "specs2-scalacheck"         % specsVersion                         % Test,
+    "org.specs2"                 %% "specs2-scalaz"             % specsVersion                         % Test,
     "org.scalaz"                 %% "scalaz-scalacheck-binding" % (scalazVersion + "-scalacheck-1.13") % Test,
-    "org.typelevel"              %% "shapeless-scalacheck"      % "0.6.1"                              % Test,
-    "org.typelevel"              %% "scalaz-specs2"             % "0.5.2"                              % Test
+    "org.typelevel"              %% "shapeless-scalacheck"      % "0.6.1"                              % Test
   )
 
   def api = Seq(

--- a/qscript/src/test/scala/quasar/qscript/analysis/CardinalitySpec.scala
+++ b/qscript/src/test/scala/quasar/qscript/analysis/CardinalitySpec.scala
@@ -25,10 +25,9 @@ import quasar.common.{JoinType, SortDir}
 
 import matryoshka.data.Fix
 import pathy.Path._
-import org.specs2.scalaz.DisjunctionMatchers
 import scalaz._, Scalaz._
 
-class CardinalitySpec extends quasar.Qspec with QScriptHelpers with DisjunctionMatchers {
+class CardinalitySpec extends quasar.Qspec with QScriptHelpers {
 
   sequential
 

--- a/sql/src/test/scala/quasar/sql/SqlParserSpec.scala
+++ b/sql/src/test/scala/quasar/sql/SqlParserSpec.scala
@@ -146,7 +146,7 @@ class SQLParserSpec extends quasar.Qspec {
 
     "parse basic select" in {
       parse("select foo from bar") must
-        beRightDisjunction(
+        be_\/-(
           SelectR(
             SelectAll,
             List(Proj(IdentR("foo"), None)),
@@ -157,7 +157,7 @@ class SQLParserSpec extends quasar.Qspec {
     "parse expression relation" >> {
       "with no alias" >> {
         parse("select * from (1+1)") must
-          beRightDisjunction(
+          be_\/-(
             SelectR(
               SelectAll,
               List(Proj(SpliceR(None), None)),
@@ -166,7 +166,7 @@ class SQLParserSpec extends quasar.Qspec {
       }
       "with alias" >> {
         parse("select * from (1+1) as t0") must
-          beRightDisjunction(
+          be_\/-(
             SelectR(
               SelectAll,
               List(Proj(SpliceR(None), None)),
@@ -261,25 +261,25 @@ class SQLParserSpec extends quasar.Qspec {
 
     "not parse variable with '_' as the name" in {
       parse(""":_""") must
-        beLeftDisjunction(
+        be_-\/(
           GenericParsingError("quotedIdent expected; but found `:'"))
     }
 
     "not parse variable with digit as the name" in {
       parse(""":8""") must
-        beLeftDisjunction(
+        be_-\/(
           GenericParsingError("quotedIdent expected; but found `:'"))
     }
 
     "not parse variable with digit at the start of the name" in {
       parse(""":8_""") must
-        beLeftDisjunction(
+        be_-\/(
           GenericParsingError("quotedIdent expected; but found `:'"))
     }
 
     "not parse variable with '_' at the start of the name" in {
       parse(""":_8""") must
-        beLeftDisjunction(
+        be_-\/(
           GenericParsingError("quotedIdent expected; but found `:'"))
     }
 
@@ -326,7 +326,7 @@ class SQLParserSpec extends quasar.Qspec {
     }
 
     "parse numeric literals" in {
-      parse("select 1, 2.0, 3000000, 2.998e8, -1.602E-19, 1e+6") should beRightDisjunction
+      parse("select 1, 2.0, 3000000, 2.998e8, -1.602E-19, 1e+6") should be_\/-
     }
 
     "parse date, time, timestamp, and id literals" in {
@@ -336,7 +336,7 @@ class SQLParserSpec extends quasar.Qspec {
                   and ts < timestamp("2014-11-16T03:00:00Z") + interval("PT1H")
                   and `_id` != oid("abc123")"""
 
-      parse(q) must beRightDisjunction
+      parse(q) must be_\/-
     }
 
     "parse IS and IS NOT" in {
@@ -346,7 +346,7 @@ class SQLParserSpec extends quasar.Qspec {
                   and c IS TRUE
                   and d IS NOT FALSE"""
 
-      parse(q) must beRightDisjunction
+      parse(q) must be_\/-
     }
 
     "parse is (not) as (!)=" in {
@@ -375,7 +375,7 @@ class SQLParserSpec extends quasar.Qspec {
 
     "parse nested joins with parens" in {
       val q = "select * from a cross join (b cross join c)"
-      parse(q) must beRightDisjunction(
+      parse(q) must be_\/-(
         SelectR(
           SelectAll,
           List(Proj(SpliceR(None), None)),
@@ -389,7 +389,7 @@ class SQLParserSpec extends quasar.Qspec {
     }
 
     "parse array constructor and concat op" in {
-      parse("select loc || [ pop ] from zips") must beRightDisjunction(
+      parse("select loc || [ pop ] from zips") must be_\/-(
         SelectR(SelectAll,
           List(
             Proj(
@@ -413,7 +413,7 @@ class SQLParserSpec extends quasar.Qspec {
 
     "parse offset" in {
       val q = s"$selectString offset 6"
-      parse(q) must beRightDisjunction(
+      parse(q) must be_\/-(
         Offset(expectedSelect, IntLiteralR(6)).embed
       )
     }
@@ -421,25 +421,25 @@ class SQLParserSpec extends quasar.Qspec {
     "parse limit" should {
       "normal" in {
         val q = s"$selectString limit 6"
-        parse(q) must beRightDisjunction(
+        parse(q) must be_\/-(
           Limit(expectedSelect, IntLiteralR(6)).embed
         )
       }
       "multiple limits" in {
         val q = s"$selectString limit 6 limit 3"
-        parse(q) must beRightDisjunction(
+        parse(q) must be_\/-(
           Limit(Limit(expectedSelect, IntLiteralR(6)).embed, IntLiteralR(3)).embed
         )
       }
       "should not allow single limit" in {
         val q = "limit 6"
-        parse(q) must beLeftDisjunction
+        parse(q) must be_-\/
       }
 
       "limited join" in {
         val q = "select * from a inner join b on a.id = b.id limit 10"
 
-        parse(q) must beRightDisjunction(
+        parse(q) must be_\/-(
           Limit(
             SelectR(
               SelectAll,
@@ -468,13 +468,13 @@ class SQLParserSpec extends quasar.Qspec {
     "parse limit and offset" should {
       "limit before" in {
         val q = s"$selectString limit 6 offset 3"
-        parse(q) must beRightDisjunction(
+        parse(q) must be_\/-(
           Offset(Limit(expectedSelect, IntLiteralR(6)).embed, IntLiteralR(3)).embed
         )
       }
       "limit after" in {
         val q = s"$selectString offset 6 limit 3"
-        parse(q) must beRightDisjunction(
+        parse(q) must be_\/-(
           Limit(Offset(expectedSelect, IntLiteralR(6)).embed, IntLiteralR(3)).embed
         )
       }
@@ -482,50 +482,50 @@ class SQLParserSpec extends quasar.Qspec {
 
     "should refuse a semicolon not at the end" in {
       val q = "select foo from (select 5 as foo;) where foo = 7"
-      parse(q) must beLeftDisjunction(
+      parse(q) must be_-\/(
         GenericParsingError("operator ')' expected; but found `;'")
       )
     }
 
     "parse basic let" in {
       parse("""foo := 5; foo""") must
-        beRightDisjunction(
+        be_\/-(
           LetR(CIName("foo"), IntLiteralR(5), IdentR("foo")))
     }
 
     "parse basic let with quoted identifier starting with '_'" in {
       parse("""`_8` := 5; `_8`""") must
-        beRightDisjunction(
+        be_\/-(
           LetR(CIName("_8"), IntLiteralR(5), IdentR("_8")))
     }
 
     "not parse basic let with '_' as the identifier" in {
       parse("""_ := 5; _""") must
-        beLeftDisjunction(
+        be_-\/(
           GenericParsingError("quotedIdent expected; but found `*** error: '!' expected but _ found'"))
     }
 
     "not parse basic let with digit as the identifier" in {
       parse("""8 := 5; 8""") must
-        beLeftDisjunction(
+        be_-\/(
           GenericParsingError("keyword 'except' expected; but found `:='"))
     }
 
     "not parse basic let with digit at the start of the identifier" in {
       parse("""8_ := 5; 8_""") must
-        beLeftDisjunction(
+        be_-\/(
           GenericParsingError("keyword 'except' expected; but found `*** error: '!' expected but _ found'"))
     }
 
     "not parse basic let with '_' at the start of the identifier" in {
       parse("""_8 := 5; _8""") must
-        beLeftDisjunction(
+        be_-\/(
           GenericParsingError("quotedIdent expected; but found `*** error: '!' expected but _ found'"))
     }
 
     "parse nested lets" in {
       parse("""foo := 5; bar := "hello"; bar + foo""") must
-        beRightDisjunction(
+        be_\/-(
           LetR(
             CIName("foo"),
             IntLiteralR(5),
@@ -537,7 +537,7 @@ class SQLParserSpec extends quasar.Qspec {
 
     "parse let inside select" in {
       parse("select foo from (bar := 12; baz)") must
-        beRightDisjunction(
+        be_\/-(
           SelectR(
             SelectAll,
             List(Proj(IdentR("foo"), None)),
@@ -554,7 +554,7 @@ class SQLParserSpec extends quasar.Qspec {
 
     "parse select inside body of let" in {
       parse("""foo := (1,2,3); select * from foo""") must
-        beRightDisjunction(
+        be_\/-(
           LetR(
             CIName("foo"),
             SetLiteralR(
@@ -570,7 +570,7 @@ class SQLParserSpec extends quasar.Qspec {
 
     "parse select inside body of let" in {
       parse("""foo := (1,2,3); select foo from bar""") must
-        beRightDisjunction(
+        be_\/-(
           LetR(
             CIName("foo"),
             SetLiteralR(
@@ -600,7 +600,7 @@ class SQLParserSpec extends quasar.Qspec {
             None))
 
       parse("""select (foo := (1,2,3); select * from foo) from baz""") must
-        beRightDisjunction(
+        be_\/-(
           SelectR(
             SelectAll,
             List(Proj(innerLet, None)),
@@ -612,12 +612,12 @@ class SQLParserSpec extends quasar.Qspec {
 
     "should parse a single-quoted character" in {
       val q = "'c'"
-      parse(q) must beRightDisjunction(StringLiteralR("c"))
+      parse(q) must be_\/-(StringLiteralR("c"))
     }
 
     "should parse escaped characters" in {
       val q = raw"select '\'', '\\', '\u1234'"
-      parse(q) must beRightDisjunction(
+      parse(q) must be_\/-(
         SelectR(SelectAll, List(
           Proj(StringLiteralR("'"), None),
           Proj(StringLiteralR(raw"\"), None),
@@ -626,24 +626,24 @@ class SQLParserSpec extends quasar.Qspec {
     }
     "should parse escaped characters in a string" in {
       val q = raw""""'\\\u1234""""
-      parse(q) must beRightDisjunction(StringLiteralR(raw"'\ሴ"))
+      parse(q) must be_\/-(StringLiteralR(raw"'\ሴ"))
     }
 
     "should not parse multiple expressions seperated incorrectly" in {
       val q = "select foo from bar limit 6 select biz from baz"
-      parse(q) must beLeftDisjunction
+      parse(q) must be_-\/
     }
 
     "parse function declaration" in {
       val funcDeclString = "CREATE FUNCTION ARRAY_LENGTH(:foo) BEGIN COUNT(:foo[_]) END"
-      fixParser.parseWithParser(funcDeclString, fixParser.func_def) must beRightDisjunction(
-        FunctionDecl(CIName("ARRAY_LENGTH"),List(CIName("foo")),Fix(invokeFunction(CIName("count"),List(Fix(Unop(Fix(vari[Fix[Sql]]("foo")),ShiftArrayValues)))))))
+      fixParser.parseWithParser(funcDeclString, fixParser.func_def) must be_\/-(
+        equalTo(FunctionDecl(CIName("ARRAY_LENGTH"),List(CIName("foo")),Fix(invokeFunction(CIName("count"),List(Fix(Unop(Fix(vari[Fix[Sql]]("foo")),ShiftArrayValues))))))))
     }
 
     "parse import statement" in {
       val importString = "import `/foo/bar/baz/`"
-      fixParser.parseWithParser(importString, fixParser.import_) must beRightDisjunction(
-        Import(rootDir </> dir("foo") </> dir("bar") </> dir("baz")))
+      fixParser.parseWithParser(importString, fixParser.import_) must be_\/-(
+        equalTo(Import(rootDir </> dir("foo") </> dir("bar") </> dir("baz"))))
     }
 
     "parse module" >> {
@@ -686,22 +686,22 @@ class SQLParserSpec extends quasar.Qspec {
     }
 
     "parse array literal at top level" in {
-      parse("""["X", "Y"]""") must beRightDisjunction(
+      parse("""["X", "Y"]""") must be_\/-(
         ArrayLiteralR(List(StringLiteralR("X"), StringLiteralR("Y"))))
     }
 
     "parse empty set literal" in {
-      parse("()") must beRightDisjunction(
+      parse("()") must be_\/-(
         SetLiteralR(Nil))
     }
 
     "parse parenthesized simple expression (which is syntactically identical to a 1-element set literal)" in {
-      parse("(a)") must beRightDisjunction(
+      parse("(a)") must be_\/-(
         IdentR("a"))
     }
 
     "parse 2-element set literal" in {
-      parse("(a, b)") must beRightDisjunction(
+      parse("(a, b)") must be_\/-(
         SetLiteralR(List(IdentR("a"), IdentR("b"))))
     }
 
@@ -710,16 +710,16 @@ class SQLParserSpec extends quasar.Qspec {
       // left-recursive expression with many unneeded parens, which
       // happens to be exactly what pprint produces.
       val q = """(select distinct topArr, topObj from `/demo/demo/nested` where ((((((((((((((((((((((((((((((search((((topArr)[:*])[:*])[:*], "^.*$", true)) or (search((((topArr)[:*])[:*]).a, "^.*$", true)))) or (search((((topArr)[:*])[:*]).b, "^.*$", true)))) or (search((((topArr)[:*])[:*]).c, "^.*$", true)))) or (search((((topArr)[:*]).botObj).a, "^.*$", true)))) or (search((((topArr)[:*]).botObj).b, "^.*$", true)))) or (search((((topArr)[:*]).botObj).c, "^.*$", true)))) or (search((((topArr)[:*]).botArr)[:*], "^.*$", true)))) or (search((((topObj).midArr)[:*])[:*], "^.*$", true)))) or (search((((topObj).midArr)[:*]).a, "^.*$", true)))) or (search((((topObj).midArr)[:*]).b, "^.*$", true)))) or (search((((topObj).midArr)[:*]).c, "^.*$", true)))) or (search((((topObj).midObj).botArr)[:*], "^.*$", true)))) or (search((((topObj).midObj).botObj).a, "^.*$", true)))) or (search((((topObj).midObj).botObj).b, "^.*$", true)))) or (search((((topObj).midObj).botObj).c, "^.*$", true))))"""
-      parse(q).map(pprint[Fix[Sql]]) must beRightDisjunction(q)
+      parse(q).map(pprint[Fix[Sql]]) must be_\/-(q)
     }
 
     "should not parse query with a single backslash in an identifier" should {
       "in table relation" in {
-        parse(raw"select * from `\bar`") should beLeftDisjunction
+        parse(raw"select * from `\bar`") should be_-\/
       }.pendingUntilFixed("SD-1536")
 
       "in identifier" in {
-        parse(raw"`\bar`") should beLeftDisjunction
+        parse(raw"`\bar`") should be_-\/
       }.pendingUntilFixed("SD-1536")
     }
 
@@ -750,7 +750,7 @@ class SQLParserSpec extends quasar.Qspec {
       def roundTrip(q: String) = {
         val ast = parse(q)
 
-        ast should beRightDisjunction
+        ast should be_\/-
 
         ast.map(pprint[Fix[Sql]] _).flatMap(parse) must_=== ast
       }

--- a/sql/src/test/scala/quasar/sql/SqlParserSpec.scala
+++ b/sql/src/test/scala/quasar/sql/SqlParserSpec.scala
@@ -637,13 +637,13 @@ class SQLParserSpec extends quasar.Qspec {
     "parse function declaration" in {
       val funcDeclString = "CREATE FUNCTION ARRAY_LENGTH(:foo) BEGIN COUNT(:foo[_]) END"
       fixParser.parseWithParser(funcDeclString, fixParser.func_def) must be_\/-(
-        equalTo(FunctionDecl(CIName("ARRAY_LENGTH"),List(CIName("foo")),Fix(invokeFunction(CIName("count"),List(Fix(Unop(Fix(vari[Fix[Sql]]("foo")),ShiftArrayValues))))))))
+        FunctionDecl(CIName("ARRAY_LENGTH"),List(CIName("foo")),Fix(invokeFunction(CIName("count"),List(Fix(Unop(Fix(vari[Fix[Sql]]("foo")),ShiftArrayValues)))))))
     }
 
     "parse import statement" in {
       val importString = "import `/foo/bar/baz/`"
       fixParser.parseWithParser(importString, fixParser.import_) must be_\/-(
-        equalTo(Import(rootDir </> dir("foo") </> dir("bar") </> dir("baz"))))
+        Import[Fix[Sql]](rootDir </> dir("foo") </> dir("bar") </> dir("baz")))
     }
 
     "parse module" >> {

--- a/sst/src/test/scala/quasar/sst/StructuralTypeSpec.scala
+++ b/sst/src/test/scala/quasar/sst/StructuralTypeSpec.scala
@@ -19,6 +19,7 @@ package quasar.sst
 import slamdata.Predef._
 import quasar.contrib.matryoshka._
 import quasar.contrib.matryoshka.arbitrary._
+import quasar.contrib.specs2.Spec
 import quasar.{ejson => ejs}
 import quasar.ejson.{Decoded, DecodeEJson, EJson, EJsonArbitrary, EncodeEJson}
 import quasar.ejson.implicits._
@@ -32,13 +33,11 @@ import matryoshka.data._
 import matryoshka.implicits._
 import monocle.syntax.fields._
 import org.specs2.scalacheck._
-import org.specs2.scalaz._
 import scalaz._, Scalaz._
 import scalaz.scalacheck.{ScalazProperties => propz}
 import scalaz.scalacheck.ScalazArbitrary._
 
 final class StructuralTypeSpec extends Spec
-  with ScalazMatchers
   with StructuralTypeArbitrary
   with EJsonArbitrary
   with SimpleTypeArbitrary {

--- a/sst/src/test/scala/quasar/sst/TaggedSpec.scala
+++ b/sst/src/test/scala/quasar/sst/TaggedSpec.scala
@@ -18,14 +18,14 @@ package quasar.sst
 
 import slamdata.Predef._
 import quasar.contrib.matryoshka.arbitrary._
+import quasar.contrib.specs2.Spec
 import quasar.fp._
 
 import matryoshka._
-import org.specs2.scalaz._
 import scalaz._, Scalaz._
-import scalaz.scalacheck.ScalazProperties._
+import scalaz.scalacheck.{ScalazProperties => propz}
 
 final class TaggedSpec extends Spec with TaggedArbitrary {
-  checkAll(equal.laws[Tagged[Int]])
-  checkAll(traverse1.laws[Tagged])
+  checkAll(propz.equal.laws[Tagged[Int]])
+  checkAll(propz.traverse1.laws[Tagged])
 }

--- a/sst/src/test/scala/quasar/sst/TypeStatSpec.scala
+++ b/sst/src/test/scala/quasar/sst/TypeStatSpec.scala
@@ -18,10 +18,10 @@ package quasar.sst
 
 import slamdata.Predef._
 import quasar.contrib.algebra._
+import quasar.contrib.specs2.Spec
 import quasar.ejson.{Decoded, DecodeEJson, EJson, EncodeEJson}
 
 import matryoshka.data.Fix
-import org.specs2.scalaz._
 import scalaz.Show
 import scalaz.std.anyVal._
 import scalaz.scalacheck.{ScalazProperties => propz}
@@ -29,7 +29,7 @@ import spire.laws.arb._
 import spire.math.Real
 import spire.std.double._
 
-final class TypeStatSpec extends Spec with ScalazMatchers with TypeStatArbitrary {
+final class TypeStatSpec extends Spec with TypeStatArbitrary {
   import TypeStat._
 
   implicit val realShow: Show[Real] = Show.showFromToString

--- a/web/src/test/scala/quasar/api/matchers.scala
+++ b/web/src/test/scala/quasar/api/matchers.scala
@@ -17,18 +17,18 @@
 package quasar.api
 
 import slamdata.Predef._
+import quasar.contrib.specs2.ScalazEqualityMatchers
 
 import argonaut._, Argonaut._
 import argonaut.ArgonautScalaz._
 import org.http4s.Status, Status._
 import org.specs2.matcher._
-import org.specs2.scalaz._
 import scalaz.std.anyVal._
 import scalaz.std.string._
 
 object matchers {
   import MustMatchers._
-  import ScalazMatchers._
+  import ScalazEqualityMatchers._
   import ApiError.apiError
 
   def beApiErrorLike[A](a: A)(implicit A: ToApiError[A]): Matcher[ApiError] =

--- a/web/src/test/scala/quasar/api/zip.scala
+++ b/web/src/test/scala/quasar/api/zip.scala
@@ -152,7 +152,7 @@ class ZipSpecs extends quasar.Qspec {
       val z = zipFiles(filesAndBytes)
 
       val exp = filesAndBytes.mapValues(_.runFoldMap(ι).unsafePerformSync)
-      unzipFiles(z).map(_.toMap).run.unsafePerformSync must beRightDisjunction(exp)
+      unzipFiles(z).map(_.toMap).run.unsafePerformSync must be_\/-(exp)
     }.set(minTestsOk = 10) // This test is relatively slow
   }
 }

--- a/web/src/test/scala/quasar/server/StaticContentSpec.scala
+++ b/web/src/test/scala/quasar/server/StaticContentSpec.scala
@@ -27,22 +27,22 @@ class StaticContentSpec extends quasar.Qspec {
 
   "fromCliOptions" should {
     "be empty with defaults" in {
-      fromCliOptions(defLoc, CliOptions.default).run.unsafePerformSync must beRightDisjunction(None)
+      fromCliOptions(defLoc, CliOptions.default).run.unsafePerformSync must be_\/-(None)
     }
 
     "fail with loc and no path" in {
       val opts = CliOptions.default.copy(contentLoc = Some("foo"))
-      fromCliOptions(defLoc, opts).run.unsafePerformSync must beLeftDisjunction
+      fromCliOptions(defLoc, opts).run.unsafePerformSync must be_-\/
     }
 
     "use supplied default location when none specified" in {
       val opts = CliOptions.default.copy(contentPath = Some("foo"))
-      fromCliOptions(defLoc, opts).run.unsafePerformSync must beRightDisjunction(Some(StaticContent("/static", "foo")))
+      fromCliOptions(defLoc, opts).run.unsafePerformSync must be_\/-(Some(StaticContent("/static", "foo")))
     }
 
     "handle loc and path" in {
       val opts = CliOptions.default.copy(contentLoc = Some("/foo"), contentPath = Some("bar"))
-      fromCliOptions(defLoc, opts).run.unsafePerformSync must beRightDisjunction(Some(StaticContent("/foo", "bar")))
+      fromCliOptions(defLoc, opts).run.unsafePerformSync must be_\/-(Some(StaticContent("/foo", "bar")))
     }
 
     "relative" in {

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/vfs/FreeVFSSpecs.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/vfs/FreeVFSSpecs.scala
@@ -22,7 +22,7 @@ import quasar.fs.MoveSemantics
 import fs2.{Stream, Sink}
 
 import org.specs2.mutable._
-import org.specs2.scalaz.ScalazMatchers._
+import org.specs2.matcher.DisjunctionMatchers
 
 import pathy.Path
 
@@ -37,7 +37,7 @@ import smock._
 
 import java.util.UUID
 
-object FreeVFSSpecs extends Specification {
+object FreeVFSSpecs extends Specification with DisjunctionMatchers {
   import POSIXOp._
   import StreamTestUtils._
 
@@ -263,7 +263,7 @@ object FreeVFSSpecs extends Specification {
 
       val vfs = interp(FreeVFS.init[S](BaseDir)).unsafePerformSyncAttempt
 
-      vfs.leftMap(_.getMessage) must beLeftDisjunction("Unexpected VERSION, 0100000000000000")
+      vfs.leftMap(_.getMessage) must be_-\/("Unexpected VERSION, 0100000000000000")
     }
 
     "initialize from an empty state with pre-existing directory" in {


### PR DESCRIPTION
Adds an implementation of `DataSources` based on primitive components. Includes a generic specification for `DataSources` along with implementation-specific tests.

#qz-3811 Done