### PR TITLE
Add language flags and feature warnings to precog projects

### DIFF
--- a/project/Precog.scala
+++ b/project/Precog.scala
@@ -10,13 +10,18 @@ object Build {
     //"-g:vars",
     //"-deprecation",
     //"-unchecked",
+    "-feature",
     //"-Ywarn-value-discard",
     //"-Ywarn-numeric-widen",
     //"-Ywarn-unused",
     "-Ywarn-unused-import")
 
   val defaultArgSet = Seq(
-    "-Ypartial-unification")
+    "-Ypartial-unification",
+    "-language:higherKinds",
+    "-language:postfixOps",
+    "-language:implicitConversions",
+    "-language:existentials")
 
   /** Watch out Jonesy! It's the ol' double-cross!
    *  Why, you...


### PR DESCRIPTION
Thinking about enabling `-deprecation` next. `-unchecked` has to wait until parts of the cake are broken out - the generated `equals` of case classes inside of traits trigger warnings due to there being no way to compare outer references.