### PR TITLE
Iotaz migration 2

### DIFF
--- a/couchbase/src/main/scala/quasar/physical/couchbase/planner/MapFuncCorePlanner.scala
+++ b/couchbase/src/main/scala/quasar/physical/couchbase/planner/MapFuncCorePlanner.scala
@@ -29,6 +29,7 @@ import quasar.DataCodec, DataCodec.PreciseKeys.{
 import quasar.{Data => QData, Type => QType}
 import quasar.effect.NameGenerator
 import quasar.fp._
+import quasar.contrib.iota._
 import quasar.physical.couchbase._, N1QL.{Eq, Split, _}, Case._, Select.{Value, _}
 import quasar.fs.Planner.PlannerErrorME
 import quasar.qscript, qscript.{MapFuncCore, MapFuncsCore => MF}

--- a/datagen/src/main/scala/quasar/datagen/Main.scala
+++ b/datagen/src/main/scala/quasar/datagen/Main.scala
@@ -21,6 +21,7 @@ import quasar.RenderedTree
 import quasar.ejson.EJson
 import quasar.ejson.implicits._
 import quasar.sst._
+import quasar.contrib.iota.copkTraverse
 
 import java.io.File
 import scala.Console, Console.{RED, RESET}

--- a/datagen/src/main/scala/quasar/datagen/codec.scala
+++ b/datagen/src/main/scala/quasar/datagen/codec.scala
@@ -19,6 +19,7 @@ package quasar.datagen
 import slamdata.Predef.{Stream => _, _}
 import quasar.{Data, DataCodec}
 import quasar.ejson.{optics => eoptics, EJson}
+import quasar.contrib.iota.copkTraverse
 
 import argonaut.{Json, Parse}
 import fs2.{Pipe, Stream}

--- a/datagen/src/main/scala/quasar/datagen/dist.scala
+++ b/datagen/src/main/scala/quasar/datagen/dist.scala
@@ -21,6 +21,7 @@ import quasar.contrib.spire.random.dist._
 import quasar.ejson.{DecodeEJson, EJson, Type => EType}
 import quasar.fp.numeric.SampleStats
 import quasar.fp.ski.ι
+import quasar.fp.{copkTraverse, TwoElemCopKOps}
 import quasar.sst.{strings, Population, PopulationSST, SST, StructuralType, Tagged, TypeStat}
 import quasar.tpe.TypeF
 
@@ -98,7 +99,7 @@ object dist {
       JC: Corecursive.Aux[J, EJson],
       JR: Recursive.Aux[J, EJson])
       : Algebra[STF[J, (A, TypeStat[A]), ?], Option[(A, Dist[J])]] =
-    _.run.traverse(_.run.swap) map {
+    _.run.traverse(_.toDisjunction.swap) map {
       case (_, TypeF.Bottom()) =>
         none
 

--- a/datagen/src/main/scala/quasar/datagen/dist.scala
+++ b/datagen/src/main/scala/quasar/datagen/dist.scala
@@ -21,7 +21,7 @@ import quasar.contrib.spire.random.dist._
 import quasar.ejson.{DecodeEJson, EJson, Type => EType}
 import quasar.fp.numeric.SampleStats
 import quasar.fp.ski.ι
-import quasar.fp.{copkTraverse, TwoElemCopKOps}
+import quasar.fp.copkTraverse
 import quasar.sst.{strings, Population, PopulationSST, SST, StructuralType, Tagged, TypeStat}
 import quasar.tpe.TypeF
 
@@ -40,6 +40,7 @@ import spire.random.{Dist, Gaussian}
 import spire.syntax.convertableFrom._
 import spire.syntax.field._
 import spire.syntax.isReal._
+import iotaz.CopK
 
 object dist {
   import StructuralType.{ST, STF}
@@ -98,8 +99,14 @@ object dist {
       implicit
       JC: Corecursive.Aux[J, EJson],
       JR: Recursive.Aux[J, EJson])
-      : Algebra[STF[J, (A, TypeStat[A]), ?], Option[(A, Dist[J])]] =
-    _.run.traverse(_.toDisjunction.swap) map {
+      : Algebra[STF[J, (A, TypeStat[A]), ?], Option[(A, Dist[J])]] = {
+    val TF = CopK.Inject[TypeF[J, ?], ST[J, ?]]
+    val TA = CopK.Inject[Tagged, ST[J, ?]]
+
+    _.run.traverse {
+      case TF(a) => \/-(a)
+      case TA(a) => -\/(a)
+    } map {
       case (_, TypeF.Bottom()) =>
         none
 
@@ -168,7 +175,7 @@ object dist {
       case Tagged(t, dist) =>
         dist.map(_.map(_.map(EJson.meta(_, EType(t)))))
     }
-
+  }
   ////
 
   private def clamp[A: Order](min: A, max: A): A => A =

--- a/datagen/src/main/scala/quasar/datagen/dist.scala
+++ b/datagen/src/main/scala/quasar/datagen/dist.scala
@@ -21,7 +21,7 @@ import quasar.contrib.spire.random.dist._
 import quasar.ejson.{DecodeEJson, EJson, Type => EType}
 import quasar.fp.numeric.SampleStats
 import quasar.fp.ski.ι
-import quasar.fp.copkTraverse
+import quasar.contrib.iota.copkTraverse
 import quasar.sst.{strings, Population, PopulationSST, SST, StructuralType, Tagged, TypeStat}
 import quasar.tpe.TypeF
 

--- a/datagen/src/test/scala/quasar/datagen/GenerateSpec.scala
+++ b/datagen/src/test/scala/quasar/datagen/GenerateSpec.scala
@@ -23,6 +23,7 @@ import quasar.contrib.spire.random.dist._
 import quasar.ejson.{EJson, Fixed}
 import quasar.ejson.implicits._
 import quasar.fp._
+import quasar.contrib.iota._
 import quasar.fp.numeric.SampleStats
 import quasar.sst.{strings, SST, StructuralType, TypeStat}
 import quasar.tpe.{SimpleType, TypeF}

--- a/ejson/src/main/scala/quasar/contrib/argonaut/package.scala
+++ b/ejson/src/main/scala/quasar/contrib/argonaut/package.scala
@@ -18,16 +18,18 @@ package quasar.contrib
 
 import quasar.ejson
 import quasar.RenderTree
+import quasar.contrib.iota.copkTraverse
 
 import scala.collection.immutable.ListMap
 
 import _root_.argonaut._, Argonaut._
 import _root_.matryoshka._
 import _root_.scalaz._
+import iotaz.CopK
 
 package object argonaut {
-  private val CJ = Inject[ejson.Common, ejson.Json]
-  private val OJ = Inject[ejson.Obj,    ejson.Json]
+  private val CJ = CopK.Inject[ejson.Common, ejson.Json]
+  private val OJ = CopK.Inject[ejson.Obj,    ejson.Json]
 
   implicit def jsonRecursive: Recursive.Aux[Json, ejson.Json] =
     new Recursive[Json] {

--- a/ejson/src/main/scala/quasar/ejson/DecodeEJson.scala
+++ b/ejson/src/main/scala/quasar/ejson/DecodeEJson.scala
@@ -20,6 +20,7 @@ import slamdata.Predef.{Int => SInt, Char => SChar, Byte => SByte, _}
 import quasar.RenderedTree
 import quasar.contrib.argonaut._
 import quasar.ejson.implicits._
+import quasar.contrib.iota.copkTraverse
 
 import argonaut.{DecodeJson, Json => AJson}
 import matryoshka._

--- a/ejson/src/main/scala/quasar/ejson/DecodeEJsonK.scala
+++ b/ejson/src/main/scala/quasar/ejson/DecodeEJsonK.scala
@@ -18,7 +18,7 @@ package quasar.ejson
 
 import slamdata.Predef._
 import quasar.contrib.matryoshka.{envT => cenvT}
-
+import quasar.contrib.iota.copkTraverse
 import matryoshka._
 import matryoshka.implicits._
 import matryoshka.patterns.EnvT

--- a/ejson/src/main/scala/quasar/ejson/Decoded.scala
+++ b/ejson/src/main/scala/quasar/ejson/Decoded.scala
@@ -19,6 +19,7 @@ package quasar.ejson
 import slamdata.Predef.{Option, String}
 import quasar.{RenderTree, RenderedTree}
 import quasar.fp.ski.κ
+import quasar.contrib.iota.copkTraverse
 
 import matryoshka.Recursive
 import scalaz.{\/, -\/, \/-, Applicative, Cord, Equal, Monad, Plus, Show, Traverse}

--- a/ejson/src/main/scala/quasar/ejson/EncodeEJson.scala
+++ b/ejson/src/main/scala/quasar/ejson/EncodeEJson.scala
@@ -18,6 +18,7 @@ package quasar.ejson
 
 import slamdata.Predef.{Int => SInt, Char => SChar, Byte => SByte, _}
 import quasar.contrib.argonaut._
+import quasar.contrib.iota.copkTraverse
 
 import argonaut.EncodeJson
 import matryoshka._

--- a/ejson/src/main/scala/quasar/ejson/EncodeEJsonK.scala
+++ b/ejson/src/main/scala/quasar/ejson/EncodeEJsonK.scala
@@ -18,6 +18,7 @@ package quasar.ejson
 
 import slamdata.Predef._
 import quasar.ejson.implicits._
+import quasar.contrib.iota.copkTraverse
 
 import matryoshka._
 import matryoshka.implicits._

--- a/ejson/src/main/scala/quasar/ejson/Fixed.scala
+++ b/ejson/src/main/scala/quasar/ejson/Fixed.scala
@@ -19,6 +19,7 @@ package quasar.ejson
 import slamdata.Predef.{Byte => SByte, Char => SChar, Int => _, Map => _, _}
 import quasar.contrib.matryoshka.birecursiveIso
 import quasar.ejson.implicits._
+import quasar.contrib.iota.copkTraverse
 
 import matryoshka._
 import monocle.Prism

--- a/ejson/src/main/scala/quasar/ejson/JsonCodec.scala
+++ b/ejson/src/main/scala/quasar/ejson/JsonCodec.scala
@@ -19,6 +19,7 @@ package quasar.ejson
 import slamdata.Predef.{Char => SChar, _}
 import quasar.contrib.matryoshka._
 import quasar.fp.ski.κ
+import quasar.contrib.iota.copkTraverse
 
 import matryoshka._
 import matryoshka.implicits._
@@ -139,7 +140,7 @@ object JsonCodec {
 
   ////
 
-  private def CJ[A] = Prism[Json[A], Common[A]](CommonJson.prj)(CommonJson.inj)
+  private def CJ[A] = Prism[Json[A], Common[A]](CommonJson.prj.apply)(CommonJson.inj.apply)
 
   private def extractC[A, B](p: Prism[Common[A], B], j: Json[A]): Option[B] =
     CJ[A].composePrism(p).getOption(j)

--- a/ejson/src/main/scala/quasar/ejson/SizedType.scala
+++ b/ejson/src/main/scala/quasar/ejson/SizedType.scala
@@ -17,6 +17,7 @@
 package quasar.ejson
 
 import slamdata.Predef._
+import quasar.contrib.iota.copkTraverse
 
 import matryoshka._
 import scalaz.std.option._

--- a/ejson/src/main/scala/quasar/ejson/Type.scala
+++ b/ejson/src/main/scala/quasar/ejson/Type.scala
@@ -17,6 +17,7 @@
 package quasar.ejson
 
 import slamdata.Predef._
+import quasar.contrib.iota.copkTraverse
 
 import matryoshka._
 import scalaz.std.option._

--- a/ejson/src/main/scala/quasar/ejson/implicits.scala
+++ b/ejson/src/main/scala/quasar/ejson/implicits.scala
@@ -18,6 +18,7 @@ package quasar.ejson
 
 import slamdata.Predef._
 import quasar.contrib.matryoshka.{project => projectg, _}
+import quasar.contrib.iota.{copkTraverse, copkOrder}
 
 import matryoshka._
 import matryoshka.implicits._

--- a/ejson/src/main/scala/quasar/ejson/jsonParser.scala
+++ b/ejson/src/main/scala/quasar/ejson/jsonParser.scala
@@ -17,15 +17,16 @@
 package quasar.ejson
 
 import slamdata.Predef.{Map => SMap, _}
+import quasar.fp.{:<<:, ACopK}
 
 import jawn.{Facade, SimpleFacade, SupportParser}
 import matryoshka._
 import matryoshka.implicits._
-import scalaz.{:<:, Functor}
+import scalaz.Functor
 
 object jsonParser {
-  def apply[T, F[_]: Functor]
-    (implicit T: Corecursive.Aux[T, F], C: Common :<: F, O: Obj :<: F)
+  def apply[T, F[a] <: ACopK[a] : Functor]
+    (implicit T: Corecursive.Aux[T, F], C: Common :<<: F, O: Obj :<<: F)
       : SupportParser[T] =
     new SupportParser[T] {
       implicit val facade: Facade[T] =

--- a/ejson/src/main/scala/quasar/ejson/optics.scala
+++ b/ejson/src/main/scala/quasar/ejson/optics.scala
@@ -27,10 +27,10 @@ object optics {
   import Extension.{Optics => EO}
 
   def com[A]: Prism[EJson[A], Common[A]] =
-    PrismNT.inject[Common, EJson].asPrism[A]
+    PrismNT.injectCopK[Common, EJson].asPrism[A]
 
   def ext[A]: Prism[EJson[A], Extension[A]] =
-    PrismNT.inject[Extension, EJson].asPrism[A]
+    PrismNT.injectCopK[Extension, EJson].asPrism[A]
 
   def arr[A]: Prism[EJson[A], List[A]] =
     com composePrism CO.arr

--- a/ejson/src/main/scala/quasar/ejson/package.scala
+++ b/ejson/src/main/scala/quasar/ejson/package.scala
@@ -27,7 +27,8 @@ package object ejson {
   val ObjJson     = CopK.Inject[Obj, Json]
   val CommonJson  = CopK.Inject[Common, Json]
 
-  type EJson[A]   = CopK[Extension ::: Common ::: TNilK, A]
+  type EJsonL     = Extension ::: Common ::: TNilK
+  type EJson[A]   = CopK[EJsonL, A]
   val ExtEJson    = CopK.Inject[Extension, EJson]
   val CommonEJson = CopK.Inject[Common, EJson]
 }

--- a/ejson/src/main/scala/quasar/ejson/package.scala
+++ b/ejson/src/main/scala/quasar/ejson/package.scala
@@ -16,17 +16,18 @@
 
 package quasar
 
-import scalaz.{Coproduct, Inject}
+import iotaz.TListK.:::
+import iotaz.{ CopK, TNilK }
 
 package object ejson {
 
   /** For _strict_ JSON, you want something like `Obj[Mu[Json]]`.
     */
-  type Json[A]    = Coproduct[Obj, Common, A]
-  val ObjJson     = Inject[Obj, Json]
-  val CommonJson  = Inject[Common, Json]
+  type Json[A]    = CopK[Obj ::: Common ::: TNilK, A]
+  val ObjJson     = CopK.Inject[Obj, Json]
+  val CommonJson  = CopK.Inject[Common, Json]
 
-  type EJson[A]   = Coproduct[Extension, Common, A]
-  val ExtEJson    = Inject[Extension, EJson]
-  val CommonEJson = Inject[Common, EJson]
+  type EJson[A]   = CopK[Extension ::: Common ::: TNilK, A]
+  val ExtEJson    = CopK.Inject[Extension, EJson]
+  val CommonEJson = CopK.Inject[Common, EJson]
 }

--- a/ejson/src/test/scala/quasar/ejson/EJson.scala
+++ b/ejson/src/test/scala/quasar/ejson/EJson.scala
@@ -22,6 +22,7 @@ import quasar.contrib.matryoshka.arbitrary._
 import quasar.contrib.specs2.Spec
 import quasar.ejson.implicits._
 import quasar.fp._, Helpers._
+import quasar.contrib.iota._
 
 import scala.Predef.implicitly
 import scala.Predef.$conforms

--- a/ejson/src/test/scala/quasar/ejson/JsonCodecSpec.scala
+++ b/ejson/src/test/scala/quasar/ejson/JsonCodecSpec.scala
@@ -21,7 +21,7 @@ import quasar.Qspec
 import quasar.contrib.matryoshka._
 import quasar.contrib.matryoshka.arbitrary._
 import quasar.ejson.implicits._
-import quasar.fp._
+import quasar.fp._, Helpers._
 
 import matryoshka.{equalTEqual => _, _}
 import matryoshka.data.Fix

--- a/ejson/src/test/scala/quasar/ejson/JsonCodecSpec.scala
+++ b/ejson/src/test/scala/quasar/ejson/JsonCodecSpec.scala
@@ -22,6 +22,7 @@ import quasar.contrib.matryoshka._
 import quasar.contrib.matryoshka.arbitrary._
 import quasar.ejson.implicits._
 import quasar.fp._, Helpers._
+import quasar.contrib.iota._
 
 import matryoshka.{equalTEqual => _, _}
 import matryoshka.data.Fix

--- a/ejson/src/test/scala/quasar/ejson/JsonParserSpec.scala
+++ b/ejson/src/test/scala/quasar/ejson/JsonParserSpec.scala
@@ -23,13 +23,13 @@ import quasar.fp._
 import matryoshka._
 import matryoshka.data.Fix
 import matryoshka.implicits._
-import scalaz.Inject
+import iotaz.CopK
 
 final class JsonParserSpec extends Qspec {
   type J = Fix[Json]
 
-  val C = Inject[Common, Json]
-  val O = Inject[Obj,    Json]
+  val C = CopK.Inject[Common, Json]
+  val O = CopK.Inject[Obj,    Json]
 
   "EJson JSON parser" should {
     "properly construct values" >> {

--- a/ejson/src/test/scala/quasar/ejson/JsonParserSpec.scala
+++ b/ejson/src/test/scala/quasar/ejson/JsonParserSpec.scala
@@ -18,7 +18,7 @@ package quasar.ejson
 
 import slamdata.Predef._
 import quasar.Qspec
-import quasar.fp._
+import quasar.contrib.iota._
 
 import matryoshka._
 import matryoshka.data.Fix

--- a/foundation/src/main/scala/quasar/contrib/iota/OrderKMaterializer.scala
+++ b/foundation/src/main/scala/quasar/contrib/iota/OrderKMaterializer.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.contrib.iota
+
+import slamdata.Predef._
+import iotaz.TListK.:::
+import iotaz.{ CopK, TNilK, TListK }
+import matryoshka.Delay
+import scalaz._
+
+sealed trait OrderKMaterializer[LL <: TListK] {
+  def materialize(offset: Int): Delay[Order, CopK[LL, ?]]
+}
+
+object OrderKMaterializer {
+
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  implicit def base[F[_]](
+    implicit
+    F: Delay[Order, F]
+  ): OrderKMaterializer[F ::: TNilK] = new OrderKMaterializer[F ::: TNilK] {
+    override def materialize(offset: Int): Delay[Order, CopK[F ::: TNilK, ?]] = {
+      val I = mkInject[F, F ::: TNilK](offset)
+      Delay.fromNT(new (Order ~> λ[a => Order[CopK[F ::: TNilK, a]]]) {
+        override def apply[A](ord: Order[A]): Order[CopK[F ::: TNilK, A]] = {
+          Order.order[CopK[F ::: TNilK, A]] {
+            case (I(left), I(right)) => F(ord).order(left, right)
+            case (I(left),   right)  => Ordering.LT
+            case (  left,  I(right)) => Ordering.GT
+          }
+        }
+      })
+    }
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  implicit def induct[F[_], LL <: TListK](
+    implicit
+    F: Delay[Order, F],
+    LL: OrderKMaterializer[LL]
+  ): OrderKMaterializer[F ::: LL] = new OrderKMaterializer[F ::: LL] {
+    override def materialize(offset: Int): Delay[Order, CopK[F ::: LL, ?]] = {
+      val I = mkInject[F, F ::: LL](offset)
+      Delay.fromNT(new (Order ~> λ[a => Order[CopK[F ::: LL, a]]]) {
+        override def apply[A](ord: Order[A]): Order[CopK[F ::: LL, A]] = {
+          Order.order[CopK[F ::: LL, A]] {
+            case (I(left), I(right)) => F(ord).order(left, right)
+            case (I(left),   right)  => Ordering.LT
+            case (  left,  I(right)) => Ordering.GT
+            case (left, right) => LL.materialize(offset + 1)(ord).order(left.asInstanceOf[CopK[LL, A]], right.asInstanceOf[CopK[LL, A]])
+          }
+        }
+      })
+    }
+  }
+
+}

--- a/foundation/src/main/scala/quasar/contrib/iota/package.scala
+++ b/foundation/src/main/scala/quasar/contrib/iota/package.scala
@@ -18,7 +18,7 @@ package quasar.contrib
 
 import slamdata.Predef.Int
 import _root_.matryoshka.Delay
-import _root_.scalaz.{Show, Functor, Equal, Traverse}
+import _root_.scalaz.{Show, Functor, Equal, Traverse, Order}
 import _root_.iotaz.{CopK, TListK}
 
 package object iota {
@@ -26,6 +26,7 @@ package object iota {
   implicit def copkTraverse[LL <: TListK](implicit M: TraverseMaterializer[LL]): Traverse[CopK[LL, ?]] = M.materialize(offset = 0)
   implicit def copkEqual[LL <: TListK](implicit M: EqualKMaterializer[LL]): Delay[Equal, CopK[LL, ?]] = M.materialize(offset = 0)
   implicit def copkShow[LL <: TListK](implicit M: ShowKMaterializer[LL]): Delay[Show, CopK[LL, ?]] = M.materialize(offset = 0)
+  implicit def copkOrder[LL <: TListK](implicit M: OrderKMaterializer[LL]): Delay[Order, CopK[LL, ?]] = M.materialize(offset = 0)
 
   def mkInject[F[_], LL <: TListK](i: Int): CopK.Inject[F, CopK[LL, ?]] = {
     CopK.Inject.injectFromInjectL[F, LL](

--- a/foundation/src/main/scala/quasar/fp/free/lift.scala
+++ b/foundation/src/main/scala/quasar/fp/free/lift.scala
@@ -16,12 +16,15 @@
 
 package quasar.fp.free
 
+import quasar.fp.{:<<:, ACopK}
 import scalaz._
 
 object lift {
   final class LifterAux[F[_], A](fa: F[A]) {
 
     def into[G[_]](implicit I: F :<: G): Free[G, A] =
+      Free.liftF(I.inj(fa))
+    def intoCopK[G[a] <: ACopK[a]](implicit I: F :<<: G): Free[G, A] =
       Free.liftF(I.inj(fa))
   }
 

--- a/foundation/src/main/scala/quasar/fp/free/package.scala
+++ b/foundation/src/main/scala/quasar/fp/free/package.scala
@@ -34,6 +34,8 @@ package object free {
   /** `Inject#inj` as a natural transformation. */
   def injectNT[F[_], G[_]](implicit I: F :<: G) = λ[F ~> G](I inj _)
 
+  def injectNTCopK[F[_], G[a] <: ACopK[a]](implicit I: F :<<: G) = λ[F ~> G](I inj _)
+
   /** `Inject#prj` as a natural transformation. */
   def projectNT[F[_], G[_]](implicit I: F :<: G) = λ[G ~> λ[a => Option[F[a]]]](I prj _)
 

--- a/foundation/src/main/scala/quasar/fp/free/package.scala
+++ b/foundation/src/main/scala/quasar/fp/free/package.scala
@@ -34,8 +34,6 @@ package object free {
   /** `Inject#inj` as a natural transformation. */
   def injectNT[F[_], G[_]](implicit I: F :<: G) = λ[F ~> G](I inj _)
 
-  def injectNTCopK[F[_], G[a] <: ACopK[a]](implicit I: F :<<: G) = λ[F ~> G](I inj _)
-
   /** `Inject#prj` as a natural transformation. */
   def projectNT[F[_], G[_]](implicit I: F :<: G) = λ[G ~> λ[a => Option[F[a]]]](I prj _)
 

--- a/foundation/src/test/scala/quasar/contrib/matryoshka/UnionWidth.scala
+++ b/foundation/src/test/scala/quasar/contrib/matryoshka/UnionWidth.scala
@@ -34,8 +34,6 @@ sealed abstract class UWidthInstances extends UWidthInstances0 {
   implicit def copkUWidthInduct[F[_], LL <: TListK](implicit U: UnionWidth[CopK[LL, ?]]): UnionWidth[CopK[F ::: LL, ?]] =
     new UnionWidth[CopK[F ::: LL, ?]] { val width = U.width + 1 }
 
-  implicit def copkUWidthBase: UnionWidth[CopK[TNilK, ?]] = new UnionWidth[CopK[TNilK, ?]] { val width = 0 }
-
   implicit def coproductUWidth[F[_], G[_]](
     implicit
     F: UnionWidth[F],
@@ -49,4 +47,7 @@ sealed abstract class UWidthInstances extends UWidthInstances0 {
 sealed abstract class UWidthInstances0 {
   implicit def defaultUWidth[F[_]]: UnionWidth[F] =
     new UnionWidth[F] { val width = 1 }
+
+  implicit def copkUWidthBase[F[_]]: UnionWidth[CopK[F ::: TNilK, ?]] =
+    new UnionWidth[CopK[F ::: TNilK, ?]] { val width = 1 }
 }

--- a/foundation/src/test/scala/quasar/contrib/matryoshka/UnionWidth.scala
+++ b/foundation/src/test/scala/quasar/contrib/matryoshka/UnionWidth.scala
@@ -19,6 +19,8 @@ package quasar.contrib.matryoshka
 import slamdata.Predef._
 
 import scalaz._
+import iotaz.{TListK, CopK, TNilK}
+import iotaz.TListK.:::
 
 /** Calculates the width of a typelevel union (coproduct). */
 sealed abstract class UnionWidth[F[_]] {
@@ -28,6 +30,12 @@ sealed abstract class UnionWidth[F[_]] {
 object UnionWidth extends UWidthInstances
 
 sealed abstract class UWidthInstances extends UWidthInstances0 {
+
+  implicit def copkUWidthInduct[F[_], LL <: TListK](implicit U: UnionWidth[CopK[LL, ?]]): UnionWidth[CopK[F ::: LL, ?]] =
+    new UnionWidth[CopK[F ::: LL, ?]] { val width = U.width + 1 }
+
+  implicit def copkUWidthBase: UnionWidth[CopK[TNilK, ?]] = new UnionWidth[CopK[TNilK, ?]] { val width = 0 }
+
   implicit def coproductUWidth[F[_], G[_]](
     implicit
     F: UnionWidth[F],

--- a/foundation/src/test/scala/quasar/fp/ArbitraryKMaterializer.scala
+++ b/foundation/src/test/scala/quasar/fp/ArbitraryKMaterializer.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.fp
+
+import slamdata.Predef._
+
+import quasar.contrib.matryoshka.UnionWidth
+
+import matryoshka.Delay
+import org.scalacheck._
+import iotaz.{TListK, CopK, TNilK}
+import iotaz.TListK.:::
+
+sealed trait ArbitraryKMaterializer[LL <: TListK] {
+  def materialize(offset: Int): Delay[Arbitrary, CopK[LL, ?]]
+}
+
+object ArbitraryKMaterializer {
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+  implicit val base: ArbitraryKMaterializer[TNilK] = new ArbitraryKMaterializer[TNilK] {
+    override def materialize(offset: Int): Delay[Arbitrary, CopK[TNilK, ?]] =
+      new Delay[Arbitrary, CopK[TNilK, ?]] {
+        override def apply[A](fa: Arbitrary[A]): Arbitrary[CopK[TNilK, A]] = Arbitrary(Gen.delay(???))
+      }
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  implicit def induct[F[_], LL <: TListK](
+    implicit
+    FA: Delay[Arbitrary, F],
+    LW: UnionWidth[CopK[LL, ?]],
+    LL: ArbitraryKMaterializer[LL]
+  ): ArbitraryKMaterializer[F ::: LL] = new ArbitraryKMaterializer[F ::: LL] {
+    override def materialize(offset: Int): Delay[Arbitrary, CopK[F ::: LL, ?]] = {
+      val I = mkInject[F, F ::: LL](offset)
+      new Delay[Arbitrary, CopK[F ::: LL, ?]] {
+        override def apply[A](arb: Arbitrary[A]): Arbitrary[CopK[F ::: LL, A]] = {
+          Arbitrary(Gen.frequency(
+            (1, FA(arb).arbitrary.map(I(_))),
+            (LW.width, LL.materialize(offset + 1)(arb).arbitrary.asInstanceOf[Gen[CopK[F ::: LL, A]]])
+          ))
+        }
+      }
+    }
+  }
+}

--- a/foundation/src/test/scala/quasar/fp/helpers.scala
+++ b/foundation/src/test/scala/quasar/fp/helpers.scala
@@ -31,6 +31,7 @@ object Helpers {
       Arbitrary[F[A]] =
     F(A)
 
+  // TODO provide actual instance
   @SuppressWarnings(Array("org.wartremover.warts.Null"))
   implicit def copkDelayArbitrary[X <: TListK]: Delay[Arbitrary, CopK[X, ?]] = null
 

--- a/foundation/src/test/scala/quasar/fp/helpers.scala
+++ b/foundation/src/test/scala/quasar/fp/helpers.scala
@@ -16,9 +16,11 @@
 
 package quasar.fp
 
-import matryoshka.∘
+import matryoshka.{Delay, ∘}
 import org.scalacheck._
 import scalaz._
+import slamdata.Predef.{Array, SuppressWarnings}
+import iotaz.{CopK, TListK}
 
 object Helpers {
   // NB: Should be exposed via matryoshka-scalacheck, which doesn’t yet exist.
@@ -28,4 +30,8 @@ object Helpers {
     implicit F: Arbitrary ~> (Arbitrary ∘ F)#λ, A: Arbitrary[A]):
       Arbitrary[F[A]] =
     F(A)
+
+  @SuppressWarnings(Array("org.wartremover.warts.Null"))
+  implicit def copkDelayArbitrary[X <: TListK]: Delay[Arbitrary, CopK[X, ?]] = null
+
 }

--- a/foundation/src/test/scala/quasar/fp/helpers.scala
+++ b/foundation/src/test/scala/quasar/fp/helpers.scala
@@ -19,8 +19,7 @@ package quasar.fp
 import matryoshka.{Delay, ∘}
 import org.scalacheck._
 import scalaz._
-import slamdata.Predef.{Array, SuppressWarnings}
-import iotaz.{CopK, TListK}
+import iotaz.{TListK, CopK}
 
 object Helpers {
   // NB: Should be exposed via matryoshka-scalacheck, which doesn’t yet exist.
@@ -31,8 +30,7 @@ object Helpers {
       Arbitrary[F[A]] =
     F(A)
 
-  // TODO provide actual instance
-  @SuppressWarnings(Array("org.wartremover.warts.Null"))
-  implicit def copkDelayArbitrary[X <: TListK]: Delay[Arbitrary, CopK[X, ?]] = null
+  implicit def copkArbitrary[LL <: TListK](implicit M: ArbitraryKMaterializer[LL]): Delay[Arbitrary, CopK[LL, ?]] =
+    M.materialize(offset = 0)
 
 }

--- a/frontend/src/main/scala/quasar/Data.scala
+++ b/frontend/src/main/scala/quasar/Data.scala
@@ -508,12 +508,12 @@ object Data {
 
   // TODO: Data should be replaced with EJson. These just exist to bridge the
   //       gap in the meantime.
-  val fromEJson: Algebra[EJson, Data] = _.run.fold(fromExtension, fromCommon)
+  val fromEJson: Algebra[EJson, Data] = _.toDisjunction.fold(fromExtension, fromCommon)
 
   /** Converts the parts of `Data` that it can, then stores the rest in,
     * effectively, `Free.Pure`.
     */
-  def toEJson[F[_]](implicit C: Common :<: F, E: Extension :<: F):
+  def toEJson[F[a] <: ACopK[a]](implicit C: Common :<<: F, E: Extension :<<: F):
       Coalgebra[CoEnv[Data, F, ?], Data] =
     ed => CoEnv(ed match {
       case Arr(value)       => C.inj(ejson.Arr(value)).right

--- a/frontend/src/main/scala/quasar/Data.scala
+++ b/frontend/src/main/scala/quasar/Data.scala
@@ -23,7 +23,9 @@ import quasar.ejson.{
   Extension,
   SizedType,
   Type => EType,
-  TypeTag
+  TypeTag,
+  ExtEJson,
+  CommonEJson
 }
 import quasar.fp._
 import quasar.javascript.Js
@@ -508,7 +510,10 @@ object Data {
 
   // TODO: Data should be replaced with EJson. These just exist to bridge the
   //       gap in the meantime.
-  val fromEJson: Algebra[EJson, Data] = _.toDisjunction.fold(fromExtension, fromCommon)
+  val fromEJson: Algebra[EJson, Data] = {
+    case ExtEJson(ext) => fromExtension(ext)
+    case CommonEJson(com) => fromCommon(com)
+  }
 
   /** Converts the parts of `Data` that it can, then stores the rest in,
     * effectively, `Free.Pure`.

--- a/frontend/src/main/scala/quasar/tpe/normalization.scala
+++ b/frontend/src/main/scala/quasar/tpe/normalization.scala
@@ -19,6 +19,7 @@ package quasar.tpe
 import slamdata.Predef._
 import quasar.contrib.matryoshka._
 import quasar.ejson.{Arr => JArr, CommonEJson, EJson, ExtEJson, Map => JMap}
+import quasar.contrib.iota.copkTraverse
 
 import matryoshka._
 import matryoshka.implicits._

--- a/frontend/src/main/scala/quasar/tpe/package.scala
+++ b/frontend/src/main/scala/quasar/tpe/package.scala
@@ -20,6 +20,7 @@ import slamdata.Predef._
 import quasar.contrib.matryoshka._
 import quasar.{ejson => ejs}
 import quasar.ejson.{CommonEJson => C, EJson, ExtEJson => E}
+import quasar.contrib.iota.copkTraverse
 
 import algebra.PartialOrder
 import algebra.lattice._

--- a/frontend/src/test/scala/quasar/DataSpec.scala
+++ b/frontend/src/test/scala/quasar/DataSpec.scala
@@ -19,6 +19,7 @@ package quasar
 import slamdata.Predef._
 import quasar.ejson.EJson
 import quasar.time.DateTimeInterval
+import quasar.contrib.iota.copkTraverse
 
 import matryoshka.implicits._
 import matryoshka.patterns._

--- a/frontend/src/test/scala/quasar/tpe/NormalizationSpec.scala
+++ b/frontend/src/test/scala/quasar/tpe/NormalizationSpec.scala
@@ -22,6 +22,7 @@ import quasar.contrib.matryoshka.arbitrary._
 import quasar.ejson.{EJson, EJsonArbitrary}
 import quasar.ejson.implicits._
 import quasar.fp._, Helpers._
+import quasar.contrib.iota._
 
 import scala.Predef.$conforms
 

--- a/frontend/src/test/scala/quasar/tpe/TypeFSpec.scala
+++ b/frontend/src/test/scala/quasar/tpe/TypeFSpec.scala
@@ -24,6 +24,7 @@ import quasar.contrib.specs2.Spec
 import quasar.ejson.{Decoded, DecodeEJson, EncodeEJson, EJson, EJsonArbitrary, Fixed}
 import quasar.ejson.implicits._
 import quasar.fp._, Helpers._
+import quasar.contrib.iota._
 
 import scala.Predef.$conforms
 

--- a/interface/src/main/scala/quasar/main/analysis.scala
+++ b/interface/src/main/scala/quasar/main/analysis.scala
@@ -25,6 +25,7 @@ import quasar.contrib.pathy._
 import quasar.ejson.{EJson, EncodeEJson}
 import quasar.ejson.implicits._
 import quasar.fp.numeric.{Natural, Positive}
+import quasar.contrib.iota.copkTraverse
 import quasar.fs._
 import quasar.fs.mount.Mounting
 import quasar.fs.mount.module.resolveImports_

--- a/interface/src/test/scala/quasar/main/ExtractSchemaSpec.scala
+++ b/interface/src/test/scala/quasar/main/ExtractSchemaSpec.scala
@@ -23,6 +23,7 @@ import quasar.contrib.matryoshka._
 import quasar.ejson.{EJson, Fixed}
 import quasar.ejson.implicits._
 import quasar.fp._
+import quasar.contrib.iota._
 import quasar.fp.numeric.SampleStats
 import quasar.sst._
 import quasar.tpe._

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -187,7 +187,7 @@ abstract class QueryRegressionTest[S[_]](
     λ[EndoK[ejson.Common]](CO.dec.modify(_.round(TestContext))(_))
 
   val normalizeJson: Json => Json =
-    j => Recursive[Json, ejson.Json].transCata(j)(liftFF(reducePrecision[Json]))
+    j => Recursive[Json, ejson.Json].transCata(j)(liftFFCopK(reducePrecision[Json]))
 
   /** Verify the given results according to the provided expectation. */
   def verifyResults(

--- a/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
+++ b/it/src/test/scala/quasar/regression/QueryRegressionTest.scala
@@ -29,6 +29,7 @@ import quasar.ejson
 import quasar.ejson.Common.{Optics => CO}
 import quasar.contrib.pathy._
 import quasar.fp._, free._
+import quasar.contrib.iota._
 import quasar.fp.ski._
 import quasar.fs._
 import quasar.main.{physicalFileSystems, CompExec, FilesystemQueries}

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/EJsonPlanner.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/EJsonPlanner.scala
@@ -19,6 +19,7 @@ package quasar.physical.marklogic.qscript
 import quasar.Data
 import quasar.ejson._
 import quasar.physical.marklogic.xquery._
+import quasar.contrib.iota.copkTraverse
 
 import matryoshka._
 import matryoshka.implicits._

--- a/marklogic/src/main/scala/quasar/physical/marklogic/qscript/package.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/qscript/package.scala
@@ -19,8 +19,7 @@ package quasar.physical.marklogic
 import slamdata.Predef._
 import quasar.contrib.scalaz.MonadError_
 import quasar.ejson.{EJson, Str}
-import quasar.fp.coproductShow
-import quasar.contrib.iota.copkTraverse
+import quasar.contrib.iota.{copkTraverse, copkShow}
 import quasar.fp.ski.κ
 import quasar.contrib.matryoshka.totally
 import quasar.contrib.pathy.{AFile, UriPathCodec}

--- a/mimir/src/main/scala/quasar/mimir/MapFuncCorePlanner.scala
+++ b/mimir/src/main/scala/quasar/mimir/MapFuncCorePlanner.scala
@@ -22,6 +22,7 @@ import quasar.precog.common._
 import quasar.yggdrasil.bytecode._
 import matryoshka.{AlgebraM, RecursiveT}
 import matryoshka.implicits._
+import quasar.contrib.iota.copkTraverse
 
 import scalaz.Applicative
 import scalaz.syntax.applicative._

--- a/mongodb/src/main/scala/quasar/physical/mongodb/bsoncodec.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/bsoncodec.scala
@@ -207,12 +207,12 @@ object BsonCodec {
   }
 
   def fromEJson(v: BsonVersion): AlgebraM[PlannerError \/ ?, EJson, Bson] =
-    _.run.fold(fromExtension, fromCommon(v)(_).right)
+    _.toDisjunction.fold(fromExtension, fromCommon(v)(_).right)
 
   /** Converts the parts of `Bson` that it can, then stores the rest in,
     * effectively, `Free.Pure`.
     */
-  def toEJson[F[_]](implicit C: ejson.Common :<: F, E: ejson.Extension :<: F):
+  def toEJson[F[a] <: ACopK[a]](implicit C: ejson.Common :<<: F, E: ejson.Extension :<<: F):
       ElgotCoalgebra[Bson \/ ?, F, Bson] = {
     case Bson.Arr(value)       => C.inj(ejson.Arr(value)).right
     case Bson.Doc(value)       =>

--- a/mongodb/src/main/scala/quasar/physical/mongodb/bsoncodec.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/bsoncodec.scala
@@ -21,6 +21,7 @@ import quasar._
 import quasar.Data.DateTimeConstants
 import quasar.ejson.{EJson, TypeTag, ExtEJson, CommonEJson}
 import quasar.fp._
+import quasar.contrib.iota._
 import quasar.fp.ski._
 import quasar.fs.Planner, Planner._
 

--- a/mongodb/src/main/scala/quasar/physical/mongodb/bsoncodec.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/bsoncodec.scala
@@ -19,7 +19,7 @@ package quasar.physical.mongodb
 import slamdata.Predef._
 import quasar._
 import quasar.Data.DateTimeConstants
-import quasar.ejson.{EJson, TypeTag}
+import quasar.ejson.{EJson, TypeTag, ExtEJson, CommonEJson}
 import quasar.fp._
 import quasar.fp.ski._
 import quasar.fs.Planner, Planner._
@@ -206,8 +206,10 @@ object BsonCodec {
     }
   }
 
-  def fromEJson(v: BsonVersion): AlgebraM[PlannerError \/ ?, EJson, Bson] =
-    _.toDisjunction.fold(fromExtension, fromCommon(v)(_).right)
+  def fromEJson(v: BsonVersion): AlgebraM[PlannerError \/ ?, EJson, Bson] = {
+    case ExtEJson(ext) => fromExtension(ext)
+    case CommonEJson(com) => fromCommon(v)(com).right
+  }
 
   /** Converts the parts of `Bson` that it can, then stores the rest in,
     * effectively, `Free.Pure`.

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/FuncHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/FuncHandler.scala
@@ -19,6 +19,7 @@ package quasar.physical.mongodb.planner
 import slamdata.Predef._
 import quasar.Type
 import quasar.fp._
+import quasar.contrib.iota._
 import quasar.contrib.iota.mkInject
 import quasar.fp.ski._
 import quasar.fs.MonadFsErr

--- a/mongodb/src/main/scala/quasar/physical/mongodb/planner/JsFuncHandler.scala
+++ b/mongodb/src/main/scala/quasar/physical/mongodb/planner/JsFuncHandler.scala
@@ -20,6 +20,7 @@ import slamdata.Predef._
 import quasar.{Data, Type}, Type.{Coproduct => _, _}
 import quasar.ejson.EJson
 import quasar.fp._
+import quasar.contrib.iota._
 import quasar.contrib.iota.mkInject
 import quasar.fp.ski._
 import quasar.fs.MonadFsErr

--- a/qscript/src/main/scala/quasar/qscript/MapFuncCore.scala
+++ b/qscript/src/main/scala/quasar/qscript/MapFuncCore.scala
@@ -35,6 +35,7 @@ import matryoshka.implicits._
 import matryoshka.patterns._
 import monocle.macros.Lenses
 import scalaz._, Scalaz._
+import iotaz.CopK
 
 sealed abstract class MapFuncCore[T[_[_]], A]
 
@@ -57,8 +58,8 @@ sealed abstract class Ternary[T[_[_]], A] extends MapFuncCore[T, A] {
 object MapFuncCore {
   import MapFuncsCore._
 
-  val EC = Inject[Common,    EJson]
-  val EX = Inject[Extension, EJson]
+  val EC = CopK.Inject[Common,    EJson]
+  val EX = CopK.Inject[Extension, EJson]
 
   type CoMapFuncR[T[_[_]], A] = CoEnv[A, MapFunc[T, ?], FreeMapA[T, A]]
   type StaticAssoc[T[_[_]], A] = (T[EJson], FreeMapA[T, A])

--- a/qscript/src/main/scala/quasar/qscript/RenderQScriptDSL.scala
+++ b/qscript/src/main/scala/quasar/qscript/RenderQScriptDSL.scala
@@ -22,7 +22,7 @@ import matryoshka.{Hole => _, _}
 import matryoshka.implicits._
 import quasar.{Data, DSLTree, RenderDSL, Type, ejson}
 import quasar.contrib.pathy.{ADir, AFile}
-import quasar.ejson.EJson
+import quasar.ejson.{EJson, ExtEJson, CommonEJson}
 import quasar.fp._
 import quasar.contrib.iota._
 import quasar.fp.ski._
@@ -117,20 +117,23 @@ object RenderQScriptDSL {
     def apply[A](fa: RenderQScriptDSL[A]): RenderQScriptDSL[EJson[A]] = {
       (base: String, a: EJson[A]) =>
         val base = "json"
-        val (label, children) = a.toDisjunction.fold({
-          case ejson.Meta(value, meta) => ("meta", fa(base, value).right :: fa(base, meta).right :: Nil)
-          case ejson.Map(value)        => ("map",
-            DSLTree("", "List", (value.map(t => DSLTree("", "", t.umap(fa(base, _).right).toIndexedSeq.toList.some).right).some)).right :: Nil)
-          case ejson.Byte(value)       => ("byte", value.toString.left :: Nil)
-          case ejson.Char(value)       => ("char", ("'" + value.toString + "'").left :: Nil)
-          case ejson.Int(value)        => ("int", value.toString.left :: Nil)
-        }, {
-          case ejson.Arr(value)  => ("arr", DSLTree("", "List", value.map(fa(base, _).right).some).right :: Nil)
-          case ejson.Null()      => ("nul", Nil)
-          case ejson.Bool(value) => ("bool", value.toString.left :: Nil)
-          case ejson.Str(value)  => ("str", ("\"" + value + "\"").left :: Nil)
-          case ejson.Dec(value)  => ("dec", value.toString.left :: Nil)
-        })
+        val (label, children) = a match {
+          case ExtEJson(ext) => ext match {
+            case ejson.Meta(value, meta) => ("meta", fa(base, value).right :: fa(base, meta).right :: Nil)
+            case ejson.Map(value)        => ("map",
+              DSLTree("", "List", (value.map(t => DSLTree("", "", t.umap(fa(base, _).right).toIndexedSeq.toList.some).right).some)).right :: Nil)
+            case ejson.Byte(value)       => ("byte", value.toString.left :: Nil)
+            case ejson.Char(value)       => ("char", ("'" + value.toString + "'").left :: Nil)
+            case ejson.Int(value)        => ("int", value.toString.left :: Nil)
+          }
+          case CommonEJson(com) => com match {
+            case ejson.Arr(value)  => ("arr", DSLTree("", "List", value.map(fa(base, _).right).some).right :: Nil)
+            case ejson.Null()      => ("nul", Nil)
+            case ejson.Bool(value) => ("bool", value.toString.left :: Nil)
+            case ejson.Str(value)  => ("str", ("\"" + value + "\"").left :: Nil)
+            case ejson.Dec(value)  => ("dec", value.toString.left :: Nil)
+          }
+        }
         DSLTree(base, label, children.some)
     }
   }

--- a/qscript/src/main/scala/quasar/qscript/RenderQScriptDSL.scala
+++ b/qscript/src/main/scala/quasar/qscript/RenderQScriptDSL.scala
@@ -117,7 +117,7 @@ object RenderQScriptDSL {
     def apply[A](fa: RenderQScriptDSL[A]): RenderQScriptDSL[EJson[A]] = {
       (base: String, a: EJson[A]) =>
         val base = "json"
-        val (label, children) = a.run.fold({
+        val (label, children) = a.toDisjunction.fold({
           case ejson.Meta(value, meta) => ("meta", fa(base, value).right :: fa(base, meta).right :: Nil)
           case ejson.Map(value)        => ("map",
             DSLTree("", "List", (value.map(t => DSLTree("", "", t.umap(fa(base, _).right).toIndexedSeq.toList.some).right).some)).right :: Nil)

--- a/qscript/src/main/scala/quasar/qscript/rewrites/PreferProjection.scala
+++ b/qscript/src/main/scala/quasar/qscript/rewrites/PreferProjection.scala
@@ -154,7 +154,6 @@ sealed abstract class PreferProjectionInstances {
         val I = mkInject[F, F ::: TNilK](offset)
         new PreferProjection[CopK[F ::: TNilK, ?], T, B] {
           type C[A] = CopK[F ::: TNilK, A]
-          type D[A] = CopK[TNilK, A]
 
           def preferProjectionƒ(BtoC: PrismNT[B, C]): C[(Outline.Shape, T)] => B[T] = {
             case I(fa) => F.preferProjectionƒ(BtoC andThen PrismNT.injectCopK[F, C](I))(fa)

--- a/qscript/src/test/scala/quasar/qscript/MapFuncCoreSpec.scala
+++ b/qscript/src/test/scala/quasar/qscript/MapFuncCoreSpec.scala
@@ -21,7 +21,6 @@ import quasar.{Qspec, TreeMatchers, Type}
 import quasar.ejson.{EJson, Fixed}
 import quasar.ejson.implicits._
 import quasar.contrib.iota.{copkEqual, copkTraverse, copkShow}
-import quasar.fp.coproductShow
 
 import matryoshka.{delayEqual, delayShow}
 import matryoshka.data.Fix

--- a/qscript/src/test/scala/quasar/qscript/MapFuncStdLibTestRunner.scala
+++ b/qscript/src/test/scala/quasar/qscript/MapFuncStdLibTestRunner.scala
@@ -19,6 +19,7 @@ package quasar.qscript
 import slamdata.Predef._
 import quasar.{Data, NullaryFunc, UnaryFunc, BinaryFunc, TernaryFunc, Mapping}
 import quasar.fp._
+import quasar.contrib.iota._
 import quasar.fp.ski.κ
 import quasar.fp.tree.{UnaryArg, BinaryArg, TernaryArg}
 import quasar.frontend.{logicalplan => lp}, lp.{LogicalPlan => LP, LogicalPlanR}

--- a/qscript/src/test/scala/quasar/qscript/analysis/OutlineSpec.scala
+++ b/qscript/src/test/scala/quasar/qscript/analysis/OutlineSpec.scala
@@ -20,7 +20,7 @@ import slamdata.Predef.{Map => _, _}
 import quasar.common.{JoinType, JoinTypeArbitrary, SortDir}
 import quasar.contrib.matryoshka._
 import quasar.contrib.matryoshka.arbitrary._
-import quasar.fp._
+import quasar.fp._, Helpers._
 import quasar.contrib.iota._
 import quasar.fp.ski.κ
 import quasar.ejson

--- a/qscript/src/test/scala/quasar/qscript/rewrites/PreferProjectionSpec.scala
+++ b/qscript/src/test/scala/quasar/qscript/rewrites/PreferProjectionSpec.scala
@@ -22,6 +22,7 @@ import quasar.contrib.matryoshka._
 import quasar.contrib.matryoshka.arbitrary._
 import quasar.contrib.pathy._
 import quasar.fp._
+import quasar.fp.Helpers._
 import quasar.contrib.iota._
 import quasar.fp.ski.κ
 import quasar.ejson.{EJson, EJsonArbitrary}

--- a/qsu/src/main/scala/quasar/qsu/ApplyProvenance.scala
+++ b/qsu/src/main/scala/quasar/qsu/ApplyProvenance.scala
@@ -24,6 +24,7 @@ import quasar.ejson
 import quasar.ejson.EJson
 import quasar.ejson.implicits._
 import quasar.fp._
+import quasar.contrib.iota._
 import quasar.fp.ski.ι
 import quasar.qscript.{construction, ExcludeId, IdOnly, IdStatus, OnUndefined}
 

--- a/qsu/src/main/scala/quasar/qsu/ApplyProvenance.scala
+++ b/qsu/src/main/scala/quasar/qsu/ApplyProvenance.scala
@@ -23,7 +23,7 @@ import quasar.contrib.scalaz.MonadState_
 import quasar.ejson
 import quasar.ejson.EJson
 import quasar.ejson.implicits._
-import quasar.fp._
+import quasar.fp.{copkEqual => _, _}
 import quasar.fp.ski.ι
 import quasar.qscript.{construction, ExcludeId, IdOnly, IdStatus, OnUndefined}
 

--- a/qsu/src/main/scala/quasar/qsu/ApplyProvenance.scala
+++ b/qsu/src/main/scala/quasar/qsu/ApplyProvenance.scala
@@ -23,7 +23,7 @@ import quasar.contrib.scalaz.MonadState_
 import quasar.ejson
 import quasar.ejson.EJson
 import quasar.ejson.implicits._
-import quasar.fp.{copkEqual => _, _}
+import quasar.fp._
 import quasar.fp.ski.ι
 import quasar.qscript.{construction, ExcludeId, IdOnly, IdStatus, OnUndefined}
 

--- a/qsu/src/main/scala/quasar/qsu/QAuth.scala
+++ b/qsu/src/main/scala/quasar/qsu/QAuth.scala
@@ -20,7 +20,7 @@ import slamdata.Predef._
 import quasar.fs.Planner.{InternalError, PlannerErrorME}
 import quasar.ejson.implicits._
 import quasar.contrib.iota.{copkEqual, copkShow, copkTraverse}
-import quasar.fp.{coproductEqual, coproductShow, symbolOrder, symbolShow}
+import quasar.fp.{symbolOrder, symbolShow}
 import quasar.qscript.FreeMap
 
 import matryoshka._

--- a/qsu/src/main/scala/quasar/qsu/QProv.scala
+++ b/qsu/src/main/scala/quasar/qsu/QProv.scala
@@ -20,7 +20,7 @@ import slamdata.Predef.{Eq => _, Int => SInt, _}
 import quasar.contrib.scalaz.MonadState_
 import quasar.ejson._
 import quasar.ejson.implicits._
-import quasar.fp._
+import quasar.fp.{copkEqual => _, _}
 import quasar.qscript.provenance._
 
 import matryoshka.{Hole => _, _}

--- a/qsu/src/main/scala/quasar/qsu/QProv.scala
+++ b/qsu/src/main/scala/quasar/qsu/QProv.scala
@@ -20,7 +20,7 @@ import slamdata.Predef.{Eq => _, Int => SInt, _}
 import quasar.contrib.scalaz.MonadState_
 import quasar.ejson._
 import quasar.ejson.implicits._
-import quasar.fp.{copkEqual => _, _}
+import quasar.fp._
 import quasar.qscript.provenance._
 
 import matryoshka.{Hole => _, _}

--- a/qsu/src/main/scala/quasar/qsu/ReadLP.scala
+++ b/qsu/src/main/scala/quasar/qsu/ReadLP.scala
@@ -33,6 +33,7 @@ import quasar.contrib.scalaz.MonadState_
 import quasar.effect.NameGenerator
 import quasar.ejson.EJson
 import quasar.fp._
+import quasar.contrib.iota._
 import quasar.frontend.{logicalplan => lp}
 import quasar.std.{IdentityLib, SetLib, StructuralLib}
 import quasar.qscript.{

--- a/qsu/src/main/scala/quasar/qsu/ReifyAutoJoins.scala
+++ b/qsu/src/main/scala/quasar/qsu/ReifyAutoJoins.scala
@@ -21,7 +21,6 @@ import slamdata.Predef._
 import quasar.fs.Planner, Planner.PlannerErrorME
 import quasar.effect.NameGenerator
 import quasar.ejson.implicits._
-import quasar.fp.coproductEqual
 import quasar.qscript.{
   construction,
   Center,

--- a/qsu/src/test/scala/quasar/qsu/ApplyProvenanceSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/ApplyProvenanceSpec.scala
@@ -24,6 +24,7 @@ import quasar.contrib.pathy.AFile
 import quasar.ejson.{EJson, Fixed}
 import quasar.ejson.implicits._
 import quasar.fp._
+import quasar.contrib.iota._
 import quasar.qscript.construction
 import quasar.qscript.ReduceFuncs
 import quasar.qscript.MapFuncsCore.RecIntLit

--- a/qsu/src/test/scala/quasar/qsu/ApplyProvenanceSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/ApplyProvenanceSpec.scala
@@ -23,7 +23,7 @@ import quasar.fs.Planner.PlannerError
 import quasar.contrib.pathy.AFile
 import quasar.ejson.{EJson, Fixed}
 import quasar.ejson.implicits._
-import quasar.fp._
+import quasar.fp.{copkEqual => _, _}
 import quasar.qscript.construction
 import quasar.qscript.ReduceFuncs
 import quasar.qscript.MapFuncsCore.RecIntLit

--- a/qsu/src/test/scala/quasar/qsu/ApplyProvenanceSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/ApplyProvenanceSpec.scala
@@ -23,7 +23,7 @@ import quasar.fs.Planner.PlannerError
 import quasar.contrib.pathy.AFile
 import quasar.ejson.{EJson, Fixed}
 import quasar.ejson.implicits._
-import quasar.fp.{copkEqual => _, _}
+import quasar.fp._
 import quasar.qscript.construction
 import quasar.qscript.ReduceFuncs
 import quasar.qscript.MapFuncsCore.RecIntLit

--- a/qsu/src/test/scala/quasar/qsu/ReifyBucketsSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/ReifyBucketsSpec.scala
@@ -22,8 +22,7 @@ import quasar.{Qspec, TreeMatchers}
 import quasar.fs.Planner.PlannerError
 import quasar.ejson.{EJson, Fixed}
 import quasar.ejson.implicits._
-import quasar.contrib.iota.{copkEqual, copkTraverse}
-import quasar.fp.coproductShow
+import quasar.contrib.iota.{copkEqual, copkTraverse, copkShow}
 import quasar.qscript.{construction, ExcludeId, Hole, MapFuncsCore, ReduceFuncs, SrcHole}
 
 import matryoshka.{delayEqual, delayShow, showTShow, Embed}

--- a/sst/src/main/scala/quasar/sst/ExtractPrimary.scala
+++ b/sst/src/main/scala/quasar/sst/ExtractPrimary.scala
@@ -34,6 +34,10 @@ trait ExtractPrimary[F[_]] {
 object ExtractPrimary {
   import ops._
 
+  // TODO provide actual instance
+  @SuppressWarnings(Array("org.wartremover.warts.Null"))
+  implicit def copkExtractPrimary[X <: iotaz.TListK]: ExtractPrimary[iotaz.CopK[X, ?]] = null
+
   implicit def coproductExtractPrimary[F[_]: ExtractPrimary, G[_]: ExtractPrimary]
     : ExtractPrimary[Coproduct[F, G, ?]] =
     new ExtractPrimary[Coproduct[F, G, ?]] {

--- a/sst/src/main/scala/quasar/sst/StructuralMerge.scala
+++ b/sst/src/main/scala/quasar/sst/StructuralMerge.scala
@@ -44,6 +44,10 @@ object StructuralMerge {
       mergePF[V, T].lift(pp)
   }
 
+  // TODO provide actual instance
+  @SuppressWarnings(Array("org.wartremover.warts.Null"))
+  implicit def copkStructuralMerge[X <: iotaz.TListK]: StructuralMerge[iotaz.CopK[X, ?]] = null
+
   implicit def coproductStructuralMerge[F[_]: Functor, G[_]: Functor](
     implicit
     F: StructuralMerge[F],

--- a/sst/src/main/scala/quasar/sst/StructuralMerge.scala
+++ b/sst/src/main/scala/quasar/sst/StructuralMerge.scala
@@ -71,6 +71,7 @@ object StructuralMerge {
               case (EnvT((x, I(l))), EnvT((y, I(r)))) =>
                 F.merge[V, T]((envT(x, l), envT(y, r)))
                   .map(EnvT.hmap(I.inj)(_))
+              case _ => none
             }
           }
         }

--- a/sst/src/main/scala/quasar/sst/StructuralType.scala
+++ b/sst/src/main/scala/quasar/sst/StructuralType.scala
@@ -32,7 +32,7 @@ import quasar.ejson.{
   TypeTag
 }
 import quasar.ejson.implicits._
-import quasar.fp.{coproductEqual, coproductShow}
+import quasar.fp.{coproductEqual, coproductShow, copkTraverse}
 import quasar.fp.ski.κ
 import quasar.tpe._
 

--- a/sst/src/main/scala/quasar/sst/StructuralType.scala
+++ b/sst/src/main/scala/quasar/sst/StructuralType.scala
@@ -32,7 +32,8 @@ import quasar.ejson.{
   TypeTag
 }
 import quasar.ejson.implicits._
-import quasar.fp.{coproductEqual, coproductShow, copkTraverse}
+import quasar.fp.{copkEqual, copkShow, copkTraverse}
+import quasar.fp.{:<<:, ACopK}
 import quasar.fp.ski.κ
 import quasar.tpe._
 
@@ -42,6 +43,8 @@ import matryoshka.implicits._
 import matryoshka.patterns.EnvT
 import monocle.Lens
 import scalaz._, Scalaz._
+import iotaz.{CopK, TNilK}
+import iotaz.TListK.:::
 
 /** A measure annotated Type focused on structure over semantics.
   *
@@ -63,15 +66,15 @@ final case class StructuralType[L, V](toCofree: Cofree[StructuralType.ST[L, ?], 
 }
 
 object StructuralType extends StructuralTypeInstances {
-  type ST[L, A]     = Coproduct[TypeF[L, ?], Tagged, A]
+  type ST[L, A]     = CopK[TypeF[L, ?] ::: Tagged ::: TNilK, A]
   type STF[L, V, A] = EnvT[V, ST[L, ?], A]
 
   object TypeST {
     def apply[L, A](tf: TypeF[L, A]): ST[L, A] =
-      Inject[TypeF[L, ?], ST[L, ?]].inj(tf)
+      CopK.Inject[TypeF[L, ?], ST[L, ?]].inj(tf)
 
     def unapply[L, A](st: ST[L, A]): Option[TypeF[L, A]] =
-      Inject[TypeF[L, ?], ST[L, ?]].prj(st)
+      CopK.Inject[TypeF[L, ?], ST[L, ?]].prj(st)
   }
 
   object TagST {
@@ -79,11 +82,11 @@ object StructuralType extends StructuralTypeInstances {
 
     final class PartiallyApplied[L] {
       def apply[A](tg: Tagged[A]): ST[L, A] =
-        Inject[Tagged, ST[L, ?]].inj(tg)
+        CopK.Inject[Tagged, ST[L, ?]].inj(tg)
     }
 
     def unapply[L, A](st: ST[L, A]): Option[Tagged[A]] =
-      Inject[Tagged, ST[L, ?]].prj(st)
+      CopK.Inject[Tagged, ST[L, ?]].prj(st)
   }
 
   object ConstST {
@@ -152,9 +155,9 @@ object StructuralType extends StructuralTypeInstances {
     ConstST.unapply(st.project).isDefined
 
   /** Unfold a pair of structural types into their deep structural merge. */
-  def mergeƒ[L, V: Semigroup, F[_]: Functor, T](
+  def mergeƒ[L, V: Semigroup, F[a] <: ACopK[a]: Functor, T](
     implicit
-    I: TypeF[L, ?] :<: F,
+    I: TypeF[L, ?] :<<: F,
     F: StructuralMerge[F],
     TC: Corecursive.Aux[T, EnvT[V, F, ?]],
     TR: Recursive.Aux[T, EnvT[V, F, ?]]
@@ -174,9 +177,9 @@ object StructuralType extends StructuralTypeInstances {
     }
 
   /** A transform ensuring unions are disjoint by merging their members. */
-  def disjoinUnionsƒ[L, V: Semigroup, F[_]: Functor, T](
+  def disjoinUnionsƒ[L, V: Semigroup, F[a] <: ACopK[a]: Functor, T](
     implicit
-    I: TypeF[L, ?] :<: F,
+    I: TypeF[L, ?] :<<: F,
     F: StructuralMerge[F],
     TC: Corecursive.Aux[T, EnvT[V, F, ?]],
     TR: Recursive.Aux[T, EnvT[V, F, ?]]

--- a/sst/src/main/scala/quasar/sst/StructuralType.scala
+++ b/sst/src/main/scala/quasar/sst/StructuralType.scala
@@ -32,7 +32,7 @@ import quasar.ejson.{
   TypeTag
 }
 import quasar.ejson.implicits._
-import quasar.fp.{copkEqual, copkShow, copkTraverse}
+import quasar.contrib.iota.{copkEqual, copkShow, copkTraverse}
 import quasar.fp.{:<<:, ACopK}
 import quasar.fp.ski.κ
 import quasar.tpe._

--- a/sst/src/main/scala/quasar/sst/Tagged.scala
+++ b/sst/src/main/scala/quasar/sst/Tagged.scala
@@ -20,6 +20,7 @@ import slamdata.Predef._
 import quasar.{ejson => ejs}
 import quasar.ejson.{Decoded, DecodeEJsonK, EJson, EncodeEJsonK, ExtEJson => E, TypeTag}
 import quasar.ejson.implicits._
+import quasar.contrib.iota.copkTraverse
 
 import matryoshka._
 import scalaz._, Scalaz._

--- a/sst/src/main/scala/quasar/sst/TypeStat.scala
+++ b/sst/src/main/scala/quasar/sst/TypeStat.scala
@@ -20,6 +20,7 @@ import slamdata.Predef.{Byte => SByte, Char => SChar, _}
 import quasar.{ejson => ejs}, ejs.{CommonEJson => C, Decoded, DecodeEJson, EJson, ExtEJson => E, EncodeEJson}
 import quasar.ejson.implicits._
 import quasar.fp.numeric.SampleStats
+import quasar.contrib.iota.copkTraverse
 import quasar.tpe.TypeF
 
 import matryoshka._

--- a/sst/src/main/scala/quasar/sst/compression.scala
+++ b/sst/src/main/scala/quasar/sst/compression.scala
@@ -20,6 +20,7 @@ import slamdata.Predef._
 import quasar.contrib.matryoshka._
 import quasar.ejson.{EJson, CommonEJson => C, Str}
 import quasar.fp.numeric._
+import quasar.contrib.iota.copkTraverse
 import quasar.tpe._
 
 import scala.Byte

--- a/sst/src/main/scala/quasar/sst/package.scala
+++ b/sst/src/main/scala/quasar/sst/package.scala
@@ -34,6 +34,7 @@ import quasar.ejson.{
 import quasar.ejson.implicits._
 import quasar.fp.ski.κ
 import quasar.fp._
+import quasar.contrib.iota._
 import quasar.tpe._
 
 import matryoshka._

--- a/sst/src/main/scala/quasar/sst/strings.scala
+++ b/sst/src/main/scala/quasar/sst/strings.scala
@@ -20,6 +20,7 @@ import slamdata.Predef._
 import quasar.contrib.matryoshka.envT
 import quasar.ejson.{EJson, TypeTag}
 import quasar.tpe.{SimpleType, TypeF}
+import quasar.fp.copkTraverse
 
 import matryoshka.{Corecursive, Recursive}
 import scalaz.{IList, Order}

--- a/sst/src/main/scala/quasar/sst/strings.scala
+++ b/sst/src/main/scala/quasar/sst/strings.scala
@@ -20,7 +20,7 @@ import slamdata.Predef._
 import quasar.contrib.matryoshka.envT
 import quasar.ejson.{EJson, TypeTag}
 import quasar.tpe.{SimpleType, TypeF}
-import quasar.fp.copkTraverse
+import quasar.contrib.iota.copkTraverse
 
 import matryoshka.{Corecursive, Recursive}
 import scalaz.{IList, Order}

--- a/sst/src/test/scala/quasar/sst/CompressionSpec.scala
+++ b/sst/src/test/scala/quasar/sst/CompressionSpec.scala
@@ -23,6 +23,7 @@ import quasar.contrib.matryoshka.arbitrary._
 import quasar.ejson, ejson.{EJsonArbitrary, TypeTag, z85}
 import quasar.ejson.implicits._
 import quasar.fp._
+import quasar.contrib.iota._
 import quasar.fp.numeric.{Natural, Positive}
 import quasar.tpe._
 

--- a/sst/src/test/scala/quasar/sst/StringsSpec.scala
+++ b/sst/src/test/scala/quasar/sst/StringsSpec.scala
@@ -22,6 +22,7 @@ import quasar.contrib.matryoshka.envT
 import quasar.ejson.EJson
 import quasar.ejson.implicits._
 import quasar.fp._
+import quasar.contrib.iota._
 import quasar.tpe.{SimpleType, TypeF}
 import StructuralType.{TagST, TypeST}
 

--- a/sst/src/test/scala/quasar/sst/StringsSpec.scala
+++ b/sst/src/test/scala/quasar/sst/StringsSpec.scala
@@ -21,7 +21,7 @@ import quasar.contrib.algebra._
 import quasar.contrib.matryoshka.envT
 import quasar.ejson.EJson
 import quasar.ejson.implicits._
-import quasar.fp._
+import quasar.fp.{copkEqual => _, _}
 import quasar.tpe.{SimpleType, TypeF}
 import StructuralType.{TagST, TypeST}
 

--- a/sst/src/test/scala/quasar/sst/StringsSpec.scala
+++ b/sst/src/test/scala/quasar/sst/StringsSpec.scala
@@ -21,7 +21,7 @@ import quasar.contrib.algebra._
 import quasar.contrib.matryoshka.envT
 import quasar.ejson.EJson
 import quasar.ejson.implicits._
-import quasar.fp.{copkEqual => _, _}
+import quasar.fp._
 import quasar.tpe.{SimpleType, TypeF}
 import StructuralType.{TagST, TypeST}
 

--- a/sst/src/test/scala/quasar/sst/StructuralTypeSpec.scala
+++ b/sst/src/test/scala/quasar/sst/StructuralTypeSpec.scala
@@ -24,6 +24,7 @@ import quasar.{ejson => ejs}
 import quasar.ejson.{Decoded, DecodeEJson, EJson, EJsonArbitrary, EncodeEJson}
 import quasar.ejson.implicits._
 import quasar.fp._, Helpers._
+import quasar.contrib.iota._
 import quasar.tpe._
 
 import scala.Predef.$conforms

--- a/sst/src/test/scala/quasar/sst/StructuralTypeSpec.scala
+++ b/sst/src/test/scala/quasar/sst/StructuralTypeSpec.scala
@@ -23,7 +23,7 @@ import quasar.contrib.specs2.Spec
 import quasar.{ejson => ejs}
 import quasar.ejson.{Decoded, DecodeEJson, EJson, EJsonArbitrary, EncodeEJson}
 import quasar.ejson.implicits._
-import quasar.fp.{copkEqual => _, _}, Helpers._
+import quasar.fp._, Helpers._
 import quasar.tpe._
 
 import scala.Predef.$conforms

--- a/sst/src/test/scala/quasar/sst/StructuralTypeSpec.scala
+++ b/sst/src/test/scala/quasar/sst/StructuralTypeSpec.scala
@@ -23,7 +23,7 @@ import quasar.contrib.specs2.Spec
 import quasar.{ejson => ejs}
 import quasar.ejson.{Decoded, DecodeEJson, EJson, EJsonArbitrary, EncodeEJson}
 import quasar.ejson.implicits._
-import quasar.fp._
+import quasar.fp.{copkEqual => _, _}, Helpers._
 import quasar.tpe._
 
 import scala.Predef.$conforms

--- a/sst/src/test/scala/quasar/sst/TypedEJson.scala
+++ b/sst/src/test/scala/quasar/sst/TypedEJson.scala
@@ -26,13 +26,14 @@ import quasar.ejson.{
   Extension,
   CommonEJson,
   ExtEJson,
+  EJsonArbitrary,
   Meta,
   Type => EType,
   SizedType => ESizedType,
   Null => ENull
 }
 import quasar.ejson.implicits._
-import quasar.fp.{copkTraverse => _,_}, Helpers._
+import quasar.fp._, Helpers._
 import quasar.pkg.tests._
 
 import matryoshka._
@@ -67,7 +68,7 @@ object TypedEJson extends TypedEJsonInstances {
 }
 
 sealed abstract class TypedEJsonInstances extends TypedEJsonInstances0 {
-  //  import EJsonArbitrary._ will be needed when actual instance for copk is implemented
+  import EJsonArbitrary._
   import quasar.contrib.iota.copkTraverse
 
   implicit def arbitrary[T[_[_]]: BirecursiveT]: Arbitrary[TypedEJson[T]] =
@@ -94,7 +95,7 @@ sealed abstract class TypedEJsonInstances0 {
       type Base[B] = EJson[B]
 
       def embed(bt: EJson[TypedEJson[T]])(implicit BF: Functor[EJson]) =
-        TypedEJson(bt.map(_.ejson).embed)
+        TypedEJson(Functor[EJson].map(bt)(_.ejson).embed)
     }
 
   implicit def recursive[T[_[_]]: RecursiveT]: Recursive.Aux[TypedEJson[T], EJson] =

--- a/sst/src/test/scala/quasar/sst/TypedEJson.scala
+++ b/sst/src/test/scala/quasar/sst/TypedEJson.scala
@@ -34,6 +34,7 @@ import quasar.ejson.{
 }
 import quasar.ejson.implicits._
 import quasar.fp._, Helpers._
+import quasar.contrib.iota.copkShow
 import quasar.pkg.tests._
 
 import matryoshka._

--- a/sst/src/test/scala/quasar/sst/TypedEJson.scala
+++ b/sst/src/test/scala/quasar/sst/TypedEJson.scala
@@ -19,6 +19,7 @@ package quasar.sst
 import quasar.contrib.matryoshka.arbitrary._
 import quasar.ejson.{
   DecodeEJson,
+  EJsonL,
   EJson,
   EncodeEJson,
   Common,
@@ -28,23 +29,26 @@ import quasar.ejson.{
   Meta,
   Type => EType,
   SizedType => ESizedType,
-  EJsonArbitrary,
   Null => ENull
 }
 import quasar.ejson.implicits._
-import quasar.fp._
+import quasar.fp.{copkTraverse => _,_}, Helpers._
 import quasar.pkg.tests._
 
 import matryoshka._
 import matryoshka.implicits._
 import scalaz.scalacheck.ScalaCheckBinding._
 import scalaz._, Scalaz._
+import iotaz.CopK
+import iotaz.TListK.:::
 
 /** EJson that contains `_ejson.type` metadata. */
 final case class TypedEJson[T[_[_]]](ejson: T[EJson])
 
 object TypedEJson extends TypedEJsonInstances {
-  type TEJson[A] = Coproduct[TypeMetadata, EJson, A]
+  import quasar.contrib.iota.copkTraverse
+
+  type TEJson[A] = CopK[TypeMetadata ::: EJsonL, A]
 
   def absorbMetadata[J](implicit J: Birecursive.Aux[J, EJson]): Transform[J, TEJson, EJson] = {
     case TM(TypeMetadata.Type(tag, j))            => ExtEJson(Meta(j, EType(tag)))
@@ -57,13 +61,14 @@ object TypedEJson extends TypedEJsonInstances {
 
   ////
 
-  private val TM = Inject[TypeMetadata, TEJson]
-  private val CJ = Inject[Common, TEJson]
-  private val EJ = Inject[Extension, TEJson]
+  private val TM = CopK.Inject[TypeMetadata, TEJson]
+  private val CJ = CopK.Inject[Common, TEJson]
+  private val EJ = CopK.Inject[Extension, TEJson]
 }
 
 sealed abstract class TypedEJsonInstances extends TypedEJsonInstances0 {
-  import EJsonArbitrary._
+  //  import EJsonArbitrary._ will be needed when actual instance for copk is implemented
+  import quasar.contrib.iota.copkTraverse
 
   implicit def arbitrary[T[_[_]]: BirecursiveT]: Arbitrary[TypedEJson[T]] =
     corecursiveArbitrary[T[TypedEJson.TEJson], TypedEJson.TEJson] map { v =>

--- a/sst/src/test/scala/quasar/sst/TypedEJson.scala
+++ b/sst/src/test/scala/quasar/sst/TypedEJson.scala
@@ -95,7 +95,7 @@ sealed abstract class TypedEJsonInstances0 {
       type Base[B] = EJson[B]
 
       def embed(bt: EJson[TypedEJson[T]])(implicit BF: Functor[EJson]) =
-        TypedEJson(Functor[EJson].map(bt)(_.ejson).embed)
+        TypedEJson(bt.map(_.ejson).embed)
     }
 
   implicit def recursive[T[_[_]]: RecursiveT]: Recursive.Aux[TypedEJson[T], EJson] =

--- a/web/src/main/scala/quasar/api/services/package.scala
+++ b/web/src/main/scala/quasar/api/services/package.scala
@@ -22,6 +22,7 @@ import quasar.Data
 import quasar.contrib.argonaut._
 import quasar.effect.Failure
 import quasar.ejson.{EJson, JsonCodec}
+import quasar.contrib.iota.copkTraverse
 import quasar.fp.ski._
 import quasar.fp.numeric._
 import quasar.contrib.pathy.AFile

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/POSIX.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/POSIX.scala
@@ -17,10 +17,11 @@
 package quasar.yggdrasil.vfs
 
 import quasar.contrib.pathy.{ADir, AFile, APath, RPath}
+import quasar.fp.{:<<:, ACopK}
 
 import fs2.{Sink, Stream}
 
-import scalaz.{:<:, Free}
+import scalaz.Free
 
 import scodec.bits.ByteVector
 
@@ -29,33 +30,33 @@ import java.util.UUID
 object POSIX {
   import POSIXOp._
 
-  def genUUID[S[_]](implicit S: POSIXOp :<: S): Free[S, UUID] =
+  def genUUID[S[a] <: ACopK[a]](implicit S: POSIXOp :<<: S): Free[S, UUID] =
     Free.liftF(S.inj(GenUUID))
 
-  def openW[S[_]](target: AFile)(implicit S: POSIXOp :<: S): Free[S, Sink[POSIXWithTask, ByteVector]] =
+  def openW[S[a] <: ACopK[a]](target: AFile)(implicit S: POSIXOp :<<: S): Free[S, Sink[POSIXWithTask, ByteVector]] =
     Free.liftF(S.inj(OpenW(target)))
 
-  def openR[S[_]](target: AFile)(implicit S: POSIXOp :<: S): Free[S, Stream[POSIXWithTask, ByteVector]] =
+  def openR[S[a] <: ACopK[a]](target: AFile)(implicit S: POSIXOp :<<: S): Free[S, Stream[POSIXWithTask, ByteVector]] =
     Free.liftF(S.inj(OpenR(target)))
 
-  def ls[S[_]](target: ADir)(implicit S: POSIXOp :<: S): Free[S, List[RPath]] =
+  def ls[S[a] <: ACopK[a]](target: ADir)(implicit S: POSIXOp :<<: S): Free[S, List[RPath]] =
     Free.liftF(S.inj(Ls(target)))
 
-  def mkDir[S[_]](target: ADir)(implicit S: POSIXOp :<: S): Free[S, Unit] =
+  def mkDir[S[a] <: ACopK[a]](target: ADir)(implicit S: POSIXOp :<<: S): Free[S, Unit] =
     Free.liftF(S.inj(MkDir(target)))
 
-  def linkDir[S[_]](src: ADir, target: ADir)(implicit S: POSIXOp :<: S): Free[S, Boolean] =
+  def linkDir[S[a] <: ACopK[a]](src: ADir, target: ADir)(implicit S: POSIXOp :<<: S): Free[S, Boolean] =
     Free.liftF(S.inj(LinkDir(src, target)))
 
-  def linkFile[S[_]](src: AFile, target: AFile)(implicit S: POSIXOp :<: S): Free[S, Boolean] =
+  def linkFile[S[a] <: ACopK[a]](src: AFile, target: AFile)(implicit S: POSIXOp :<<: S): Free[S, Boolean] =
     Free.liftF(S.inj(LinkFile(src, target)))
 
-  def move[S[_]](src: AFile, target: AFile)(implicit S: POSIXOp :<: S): Free[S, Unit] =
+  def move[S[a] <: ACopK[a]](src: AFile, target: AFile)(implicit S: POSIXOp :<<: S): Free[S, Unit] =
     Free.liftF(S.inj(Move(src, target)))
 
-  def exists[S[_]](target: APath)(implicit S: POSIXOp :<: S): Free[S, Boolean] =
+  def exists[S[a] <: ACopK[a]](target: APath)(implicit S: POSIXOp :<<: S): Free[S, Boolean] =
     Free.liftF(S.inj(Exists(target)))
 
-  def delete[S[_]](target: APath)(implicit S: POSIXOp :<: S): Free[S, Unit] =
+  def delete[S[a] <: ACopK[a]](target: APath)(implicit S: POSIXOp :<<: S): Free[S, Unit] =
     Free.liftF(S.inj(Delete(target)))
 }

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/RealPOSIX.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/RealPOSIX.scala
@@ -26,10 +26,11 @@ import fs2.util.Suspendable
 
 import pathy.Path
 
-import scalaz.{~>, -\/, \/-, Coproduct, Free, Inject}
+import scalaz.{~>, -\/, \/-, Free}
 import scalaz.concurrent.Task
 import scalaz.std.list._
 import scalaz.syntax.traverse._
+import iotaz.CopK
 
 import scodec.bits.ByteVector
 
@@ -148,7 +149,7 @@ object RealPOSIX {
 
   private implicit def pwtSuspendable: Suspendable[POSIXWithTask] =
     new Suspendable[POSIXWithTask] {
-      val I = Inject[Task, Coproduct[POSIXOp, Task, ?]]
+      val I = CopK.Inject[Task, POSIXWithTaskCopK]
 
       def pure[A](a: A): POSIXWithTask[A] =
         Free.pure(a)

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/VersionLog.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/VersionLog.scala
@@ -18,7 +18,6 @@ package quasar.yggdrasil.vfs
 
 import quasar.contrib.pathy.{ADir, RDir, RFile}
 import quasar.contrib.scalaz.stateT, stateT._
-import quasar.contrib.scalaz.catchable, catchable._
 import quasar.fp.{:<<:, ACopK}
 
 import argonaut.{Argonaut, Parse}

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/VersionLog.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/VersionLog.scala
@@ -18,6 +18,7 @@ package quasar.yggdrasil.vfs
 
 import quasar.contrib.pathy.{ADir, RDir, RFile}
 import quasar.contrib.scalaz.stateT, stateT._
+import quasar.contrib.scalaz.catchable, catchable._
 import quasar.fp.{:<<:, ACopK}
 
 import argonaut.{Argonaut, Parse}

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/package.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/package.scala
@@ -23,7 +23,7 @@ import argonaut.{Argonaut, CodecJson, DecodeResult}
 
 import fs2.util.Catchable
 
-import scalaz.{~>, Free, :<:}
+import scalaz.{~>, Free}
 import scalaz.concurrent.Task
 import iotaz.{CopK, TNilK}
 import iotaz.TListK.:::

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/vfs.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/vfs/vfs.scala
@@ -131,7 +131,7 @@ object FreeVFS {
       for {
         verStream <- POSIX.openR[S](path)
         verBV <- verStream.runFoldMap(ι).mapSuspension(
-          CopK.NaturalTransformation.of[POSIXWithTaskCopK, S](injectNTCopK[POSIXOp, S], injectNTCopK[Task, S]))
+          CopK.NaturalTransformation.of[POSIXWithTaskCopK, S](S0.inj, S1.inj))
         ver <- lift(
           C.decode(verBV.toBitVector).fold(
             e => Task.fail(new RuntimeException(e.message)),

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/vfs/FreeVFSSpecs.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/vfs/FreeVFSSpecs.scala
@@ -18,7 +18,6 @@ package quasar.yggdrasil.vfs
 
 import quasar.contrib.pathy.{ADir, RPath}
 import quasar.fs.MoveSemantics
-import quasar.fp.TwoElemCopKOps
 
 import fs2.{Stream, Sink}
 
@@ -30,6 +29,7 @@ import pathy.Path
 import scalaz.Need
 import scalaz.concurrent.Task
 import scalaz.syntax.monad._
+import iotaz.CopK
 
 import scodec.Codec
 import scodec.bits.ByteVector
@@ -1321,13 +1321,6 @@ object FreeVFSSpecs extends Specification with DisjunctionMatchers {
     } yield ()
   }
 
-  object CPR {
-    def unapply[A](cp: S[A]): Option[Task[A]] =
-      cp.toDisjunction.toOption
-  }
-
-  object CPL {
-    def unapply[A](cp: S[A]): Option[POSIXOp[A]] =
-      cp.toDisjunction.swap.toOption
-  }
+  val CPR = CopK.Inject[Task, S]
+  val CPL = CopK.Inject[POSIXOp, S]
 }

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/vfs/FreeVFSSpecs.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/vfs/FreeVFSSpecs.scala
@@ -18,6 +18,7 @@ package quasar.yggdrasil.vfs
 
 import quasar.contrib.pathy.{ADir, RPath}
 import quasar.fs.MoveSemantics
+import quasar.fp.TwoElemCopKOps
 
 import fs2.{Stream, Sink}
 
@@ -26,7 +27,7 @@ import org.specs2.matcher.DisjunctionMatchers
 
 import pathy.Path
 
-import scalaz.{Coproduct, Need}
+import scalaz.Need
 import scalaz.concurrent.Task
 import scalaz.syntax.monad._
 
@@ -41,7 +42,7 @@ object FreeVFSSpecs extends Specification with DisjunctionMatchers {
   import POSIXOp._
   import StreamTestUtils._
 
-  type S[A] = Coproduct[POSIXOp, Task, A]
+  type S[A] = POSIXWithTaskCopK[A]
 
   val H = Harness[S, Task]
 
@@ -1321,12 +1322,12 @@ object FreeVFSSpecs extends Specification with DisjunctionMatchers {
   }
 
   object CPR {
-    def unapply[A](cp: Coproduct[POSIXOp, Task, A]): Option[Task[A]] =
-      cp.run.toOption
+    def unapply[A](cp: S[A]): Option[Task[A]] =
+      cp.toDisjunction.toOption
   }
 
   object CPL {
-    def unapply[A](cp: Coproduct[POSIXOp, Task, A]): Option[POSIXOp[A]] =
-      cp.run.swap.toOption
+    def unapply[A](cp: S[A]): Option[POSIXOp[A]] =
+      cp.toDisjunction.swap.toOption
   }
 }

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/vfs/RealPOSIXSpecs.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/vfs/RealPOSIXSpecs.scala
@@ -25,13 +25,15 @@ import org.specs2.mutable._
 
 import pathy.Path
 
-import scalaz.{~>, Coproduct, NaturalTransformation}
+import scalaz.{~>, NaturalTransformation}
 import scalaz.concurrent.Task
 
 import scodec.bits.ByteVector
 
 import java.nio.file.Files
 import java.io.{File, FileInputStream, FileOutputStream}
+
+import iotaz.CopK
 
 object RealPOSIXSpecs extends Specification {
   import POSIXOp._
@@ -302,7 +304,7 @@ object RealPOSIXSpecs extends Specification {
 
     val nt = λ[UF1[POSIXWithTask, Task]] { pwt =>
       val fullInt =
-        λ[Coproduct[POSIXOp, Task, ?] ~> Task](_.fold(interp, NaturalTransformation.refl[Task]))
+        CopK.NaturalTransformation.of[POSIXWithTaskCopK, Task](interp, NaturalTransformation.refl[Task])
 
       pwt.foldMap(fullInt)
     }

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/vfs/StreamTestUtils.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/vfs/StreamTestUtils.scala
@@ -18,8 +18,10 @@ package quasar.yggdrasil.vfs
 
 import fs2.{Sink, Stream}
 
-import scalaz.{Coproduct, Free, Inject}
+import scalaz.Free
 import scalaz.concurrent.Task
+
+import iotaz.CopK
 
 import scodec.bits.ByteVector
 
@@ -29,7 +31,7 @@ private[vfs] object StreamTestUtils {
       Stream suspend {
         pred(bv)
 
-        val I = Inject[Task, Coproduct[POSIXOp, Task, ?]]
+        val I = CopK.Inject[Task, POSIXWithTaskCopK]
 
         // this is tricky, but we're doing it specifically so that the
         // number of Task suspensions is equal between failure and

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/vfs/VersionLogSpecs.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/vfs/VersionLogSpecs.scala
@@ -17,7 +17,6 @@
 package quasar.yggdrasil.vfs
 
 import quasar.contrib.pathy.RPath
-import quasar.fp.TwoElemCopKOps
 
 import fs2.{Sink, Stream}
 import fs2.interop.scalaz._
@@ -28,6 +27,7 @@ import pathy.Path
 
 import scalaz.concurrent.Task
 import scalaz.syntax.monad._
+import iotaz.CopK
 
 import scodec.bits.ByteVector
 
@@ -336,13 +336,6 @@ object VersionLogSpecs extends Specification {
     }
   }
 
-  object CPR {
-    def unapply[A](cp: POSIXWithTaskCopK[A]): Option[Task[A]] =
-      cp.toDisjunction.toOption
-  }
-
-  object CPL {
-    def unapply[A](cp: POSIXWithTaskCopK[A]): Option[POSIXOp[A]] =
-      cp.toDisjunction.swap.toOption
-  }
+  val CPR = CopK.Inject[Task, POSIXWithTaskCopK]
+  val CPL = CopK.Inject[POSIXOp, POSIXWithTaskCopK]
 }


### PR DESCRIPTION
In this PR I refactored rest of the coproducts to iotaz (except those in mongo (Workflow and ExprOp) and anything that depends on quasar.fs).

My two small concerns are
* location of copkArbitrary needed for tests. I put it in quasar.fp.Helpers.
* `:<<:` and `ACopK` types from previous PR are in quasar.fp. Should I maybe move them to `quasar.contrib.iota`?